### PR TITLE
test: add satisfies type annotations to all web test mock data

### DIFF
--- a/Financial.Web/src/App.test.tsx
+++ b/Financial.Web/src/App.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
 import AssetDetailPage from './pages/AssetDetailPage'
+import type { FinancialApiClient } from './api/financialApiClient'
 import type { AssetDetailsDto, TreeNodeDto } from './api/types'
 
 const getNavigationTreeMock = vi.fn()
@@ -12,7 +13,7 @@ vi.mock('./api/financialApiClient', () => ({
   createFinancialApiClient: () => ({
     getNavigationTree: getNavigationTreeMock,
     getAssetDetails: getAssetDetailsMock,
-  }),
+  } satisfies Partial<FinancialApiClient>),
 }))
 
 describe('App', () => {

--- a/Financial.Web/src/App.test.tsx
+++ b/Financial.Web/src/App.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
 import AssetDetailPage from './pages/AssetDetailPage'
+import type { AssetDetailsDto, TreeNodeDto } from './api/types'
 
 const getNavigationTreeMock = vi.fn()
 const getAssetDetailsMock = vi.fn()
@@ -23,7 +24,7 @@ describe('App', () => {
       displayName: 'All Investments',
       metadata: {},
       children: [],
-    })
+    } satisfies TreeNodeDto)
   })
 
   it('renders the app header', () => {
@@ -78,7 +79,7 @@ describe('App', () => {
           ],
         },
       ],
-    })
+    } satisfies TreeNodeDto)
     getAssetDetailsMock.mockResolvedValue({
       name: 'BCIA11',
       brokerName: 'XPI',
@@ -97,7 +98,7 @@ describe('App', () => {
       totalCredits: 0,
       transactions: [],
       credits: [],
-    })
+    } satisfies AssetDetailsDto)
 
     render(
       <MemoryRouter initialEntries={['/brokers']}>

--- a/Financial.Web/src/pages/__tests__/AssetDetailPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/AssetDetailPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import AssetDetailPage from '../AssetDetailPage'
+import type { AssetDetailsDto } from '../../api/types'
 
 const getAssetDetailsMock = vi.fn()
 const addTransactionMock = vi.fn()
@@ -50,7 +51,7 @@ describe('AssetDetailPage', () => {
       totalCredits: 11,
       transactions: [],
       credits: [],
-    })
+    } satisfies AssetDetailsDto)
 
     render(
       <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
@@ -90,7 +91,7 @@ describe('AssetDetailPage', () => {
           value: 5,
         },
       ],
-    })
+    } satisfies AssetDetailsDto)
 
     render(
       <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
@@ -128,7 +129,7 @@ describe('AssetDetailPage', () => {
       totalCredits: 11,
       transactions: [],
       credits: [],
-    })
+    } satisfies AssetDetailsDto)
     addTransactionMock.mockResolvedValue({
       name: 'BCIA11',
       brokerName: 'XPI',
@@ -157,7 +158,7 @@ describe('AssetDetailPage', () => {
         },
       ],
       credits: [],
-    })
+    } satisfies AssetDetailsDto)
 
     render(
       <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
@@ -220,7 +221,7 @@ describe('AssetDetailPage', () => {
         },
       ],
       credits: [],
-    })
+    } satisfies AssetDetailsDto)
     updateTransactionMock.mockResolvedValue({
       name: 'BCIA11',
       brokerName: 'XPI',
@@ -249,7 +250,7 @@ describe('AssetDetailPage', () => {
         },
       ],
       credits: [],
-    })
+    } satisfies AssetDetailsDto)
 
     render(
       <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
@@ -312,7 +313,7 @@ describe('AssetDetailPage', () => {
         },
       ],
       credits: [],
-    })
+    } satisfies AssetDetailsDto)
     deleteTransactionMock.mockResolvedValue({
       name: 'BCIA11',
       brokerName: 'XPI',
@@ -331,7 +332,7 @@ describe('AssetDetailPage', () => {
       totalCredits: 11,
       transactions: [],
       credits: [],
-    })
+    } satisfies AssetDetailsDto)
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
     render(
@@ -385,7 +386,7 @@ describe('AssetDetailPage', () => {
           value: 5,
         },
       ],
-    })
+    } satisfies AssetDetailsDto)
     updateCreditMock.mockResolvedValue({
       name: 'BCIA11',
       brokerName: 'XPI',
@@ -411,7 +412,7 @@ describe('AssetDetailPage', () => {
           value: 7,
         },
       ],
-    })
+    } satisfies AssetDetailsDto)
 
     render(
       <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
@@ -469,7 +470,7 @@ describe('AssetDetailPage', () => {
           value: 4,
         },
       ],
-    })
+    } satisfies AssetDetailsDto)
     deleteCreditMock.mockResolvedValue({
       name: 'BCIA11',
       brokerName: 'XPI',
@@ -488,7 +489,7 @@ describe('AssetDetailPage', () => {
       totalCredits: 11,
       transactions: [],
       credits: [],
-    })
+    } satisfies AssetDetailsDto)
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
     render(

--- a/Financial.Web/src/pages/__tests__/AssetDetailPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/AssetDetailPage.test.tsx
@@ -2,25 +2,64 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import AssetDetailPage from '../AssetDetailPage'
+import type { FinancialApiClient } from '../../api/financialApiClient'
 import type { AssetDetailsDto } from '../../api/types'
 
 const getAssetDetailsMock = vi.fn()
 const addTransactionMock = vi.fn()
 const updateTransactionMock = vi.fn()
 const deleteTransactionMock = vi.fn()
+const addCreditMock = vi.fn()
 const updateCreditMock = vi.fn()
 const deleteCreditMock = vi.fn()
 
 vi.mock('../../api/financialApiClient', () => ({
-  createFinancialApiClient: () => ({
+  createFinancialApiClient: (): FinancialApiClient => ({
+    getNavigationTree: vi.fn(),
+    getBrokers: vi.fn(),
     getAssetDetails: getAssetDetailsMock,
+    getCreditsByBroker: vi.fn(),
+    getCreditsByPortfolio: vi.fn(),
     addTransaction: addTransactionMock,
     updateTransaction: updateTransactionMock,
     deleteTransaction: deleteTransactionMock,
+    addCredit: addCreditMock,
     updateCredit: updateCreditMock,
     deleteCredit: deleteCreditMock,
+    getDividendHistory: vi.fn(),
+    getDividendSummary: vi.fn(),
+    getCurrentPrice: vi.fn(),
   }),
 }))
+
+const baseAsset: AssetDetailsDto = {
+  name: 'BCIA11',
+  brokerName: 'XPI',
+  portfolioName: 'Default',
+  ticker: 'BCIA11',
+  isin: 'TEST',
+  exchange: 'BVMF',
+  country: 0,
+  localTypeCode: '',
+  class: 0,
+  quantity: 10,
+  averagePrice: 100,
+  isActive: true,
+  totalBought: 1000,
+  totalSold: 0,
+  totalCredits: 11,
+  transactions: [],
+  credits: [],
+}
+
+const renderAssetDetail = () =>
+  render(
+    <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
+      <Routes>
+        <Route path="/assets/:brokerName/:portfolioName/:assetName" element={<AssetDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
 
 describe('AssetDetailPage', () => {
   beforeEach(() => {
@@ -28,38 +67,15 @@ describe('AssetDetailPage', () => {
     addTransactionMock.mockReset()
     updateTransactionMock.mockReset()
     deleteTransactionMock.mockReset()
+    addCreditMock.mockReset()
     updateCreditMock.mockReset()
     deleteCreditMock.mockReset()
   })
 
   it('renders asset details', async () => {
-    getAssetDetailsMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
-      quantity: 10,
-      averagePrice: 100,
-      isActive: true,
-      totalBought: 1000,
-      totalSold: 0,
-      totalCredits: 11,
-      transactions: [],
-      credits: [],
-    } satisfies AssetDetailsDto)
+    getAssetDetailsMock.mockResolvedValue(baseAsset)
 
-    render(
-      <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
-        <Routes>
-          <Route path="/assets/:brokerName/:portfolioName/:assetName" element={<AssetDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    renderAssetDetail()
 
     expect(await screen.findByRole('heading', { name: 'BCIA11' })).toBeInTheDocument()
     expect(screen.getByText(/Ticker/)).toBeInTheDocument()
@@ -67,39 +83,11 @@ describe('AssetDetailPage', () => {
 
   it('renders credit chart controls', async () => {
     getAssetDetailsMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
-      quantity: 10,
-      averagePrice: 100,
-      isActive: true,
-      totalBought: 1000,
-      totalSold: 0,
-      totalCredits: 11,
-      transactions: [],
-      credits: [
-        {
-          id: 'cr-0',
-          date: '2024-02-01T00:00:00',
-          type: 'Dividend',
-          value: 5,
-        },
-      ],
+      ...baseAsset,
+      credits: [{ id: 'cr-0', date: '2024-02-01T00:00:00', type: 'Dividend', value: 5 }],
     } satisfies AssetDetailsDto)
 
-    render(
-      <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
-        <Routes>
-          <Route path="/assets/:brokerName/:portfolioName/:assetName" element={<AssetDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    renderAssetDetail()
 
     expect(await screen.findByRole('heading', { name: 'BCIA11' })).toBeInTheDocument()
 
@@ -111,62 +99,16 @@ describe('AssetDetailPage', () => {
   })
 
   it('submits a new transaction', async () => {
-    getAssetDetailsMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
-      quantity: 10,
-      averagePrice: 100,
-      isActive: true,
-      totalBought: 1000,
-      totalSold: 0,
-      totalCredits: 11,
-      transactions: [],
-      credits: [],
-    } satisfies AssetDetailsDto)
+    getAssetDetailsMock.mockResolvedValue(baseAsset)
     addTransactionMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
+      ...baseAsset,
       quantity: 12,
       averagePrice: 102,
-      isActive: true,
       totalBought: 1200,
-      totalSold: 0,
-      totalCredits: 11,
-      transactions: [
-        {
-          id: 'new-op',
-          date: '2024-01-02T00:00:00',
-          type: 'Buy',
-          quantity: 2,
-          unitPrice: 10,
-          fees: 1,
-          totalPrice: 21,
-        },
-      ],
-      credits: [],
+      transactions: [{ id: 'new-op', date: '2024-01-02T00:00:00', type: 'Buy', quantity: 2, unitPrice: 10, fees: 1, totalPrice: 21 }],
     } satisfies AssetDetailsDto)
 
-    render(
-      <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
-        <Routes>
-          <Route path="/assets/:brokerName/:portfolioName/:assetName" element={<AssetDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    renderAssetDetail()
 
     expect(await screen.findByRole('heading', { name: 'BCIA11' })).toBeInTheDocument()
 
@@ -194,71 +136,18 @@ describe('AssetDetailPage', () => {
 
   it('updates a transaction', async () => {
     getAssetDetailsMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
-      quantity: 10,
-      averagePrice: 100,
-      isActive: true,
-      totalBought: 1000,
-      totalSold: 0,
-      totalCredits: 11,
-      transactions: [
-        {
-          id: 'op-1',
-          date: '2024-01-05T00:00:00',
-          type: 'Buy',
-          quantity: 1,
-          unitPrice: 10,
-          fees: 0,
-          totalPrice: 10,
-        },
-      ],
-      credits: [],
+      ...baseAsset,
+      transactions: [{ id: 'op-1', date: '2024-01-05T00:00:00', type: 'Buy', quantity: 1, unitPrice: 10, fees: 0, totalPrice: 10 }],
     } satisfies AssetDetailsDto)
     updateTransactionMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
+      ...baseAsset,
       quantity: 11,
       averagePrice: 101,
-      isActive: true,
       totalBought: 1010,
-      totalSold: 0,
-      totalCredits: 11,
-      transactions: [
-        {
-          id: 'op-1',
-          date: '2024-01-05T00:00:00',
-          type: 'Buy',
-          quantity: 2,
-          unitPrice: 12,
-          fees: 1,
-          totalPrice: 25,
-        },
-      ],
-      credits: [],
+      transactions: [{ id: 'op-1', date: '2024-01-05T00:00:00', type: 'Buy', quantity: 2, unitPrice: 12, fees: 1, totalPrice: 25 }],
     } satisfies AssetDetailsDto)
 
-    render(
-      <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
-        <Routes>
-          <Route path="/assets/:brokerName/:portfolioName/:assetName" element={<AssetDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    renderAssetDetail()
 
     expect(await screen.findByRole('heading', { name: 'BCIA11' })).toBeInTheDocument()
 
@@ -286,62 +175,13 @@ describe('AssetDetailPage', () => {
 
   it('deletes a transaction after confirmation', async () => {
     getAssetDetailsMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
-      quantity: 10,
-      averagePrice: 100,
-      isActive: true,
-      totalBought: 1000,
-      totalSold: 0,
-      totalCredits: 11,
-      transactions: [
-        {
-          id: 'op-2',
-          date: '2024-01-06T00:00:00',
-          type: 'Sell',
-          quantity: 1,
-          unitPrice: 15,
-          fees: 0,
-          totalPrice: 15,
-        },
-      ],
-      credits: [],
+      ...baseAsset,
+      transactions: [{ id: 'op-2', date: '2024-01-06T00:00:00', type: 'Sell', quantity: 1, unitPrice: 15, fees: 0, totalPrice: 15 }],
     } satisfies AssetDetailsDto)
-    deleteTransactionMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
-      quantity: 9,
-      averagePrice: 100,
-      isActive: true,
-      totalBought: 1000,
-      totalSold: 0,
-      totalCredits: 11,
-      transactions: [],
-      credits: [],
-    } satisfies AssetDetailsDto)
+    deleteTransactionMock.mockResolvedValue({ ...baseAsset, quantity: 9 } satisfies AssetDetailsDto)
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
-    render(
-      <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
-        <Routes>
-          <Route path="/assets/:brokerName/:portfolioName/:assetName" element={<AssetDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    renderAssetDetail()
 
     expect(await screen.findByRole('heading', { name: 'BCIA11' })).toBeInTheDocument()
 
@@ -362,65 +202,16 @@ describe('AssetDetailPage', () => {
 
   it('updates a credit', async () => {
     getAssetDetailsMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
-      quantity: 10,
-      averagePrice: 100,
-      isActive: true,
-      totalBought: 1000,
-      totalSold: 0,
-      totalCredits: 11,
-      transactions: [],
-      credits: [
-        {
-          id: 'cr-1',
-          date: '2024-02-01T00:00:00',
-          type: 'Dividend',
-          value: 5,
-        },
-      ],
+      ...baseAsset,
+      credits: [{ id: 'cr-1', date: '2024-02-01T00:00:00', type: 'Dividend', value: 5 }],
     } satisfies AssetDetailsDto)
     updateCreditMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
-      quantity: 10,
-      averagePrice: 100,
-      isActive: true,
-      totalBought: 1000,
-      totalSold: 0,
+      ...baseAsset,
       totalCredits: 12,
-      transactions: [],
-      credits: [
-        {
-          id: 'cr-1',
-          date: '2024-02-01T00:00:00',
-          type: 'Rent',
-          value: 7,
-        },
-      ],
+      credits: [{ id: 'cr-1', date: '2024-02-01T00:00:00', type: 'Rent', value: 7 }],
     } satisfies AssetDetailsDto)
 
-    render(
-      <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
-        <Routes>
-          <Route path="/assets/:brokerName/:portfolioName/:assetName" element={<AssetDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    renderAssetDetail()
 
     expect(await screen.findByRole('heading', { name: 'BCIA11' })).toBeInTheDocument()
 
@@ -446,59 +237,13 @@ describe('AssetDetailPage', () => {
 
   it('deletes a credit after confirmation', async () => {
     getAssetDetailsMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
-      quantity: 10,
-      averagePrice: 100,
-      isActive: true,
-      totalBought: 1000,
-      totalSold: 0,
-      totalCredits: 11,
-      transactions: [],
-      credits: [
-        {
-          id: 'cr-2',
-          date: '2024-02-03T00:00:00',
-          type: 'Dividend',
-          value: 4,
-        },
-      ],
+      ...baseAsset,
+      credits: [{ id: 'cr-2', date: '2024-02-03T00:00:00', type: 'Dividend', value: 4 }],
     } satisfies AssetDetailsDto)
-    deleteCreditMock.mockResolvedValue({
-      name: 'BCIA11',
-      brokerName: 'XPI',
-      portfolioName: 'Default',
-      ticker: 'BCIA11',
-      isin: 'TEST',
-      exchange: 'BVMF',
-      country: 0,
-      localTypeCode: '',
-      class: 0,
-      quantity: 10,
-      averagePrice: 100,
-      isActive: true,
-      totalBought: 1000,
-      totalSold: 0,
-      totalCredits: 11,
-      transactions: [],
-      credits: [],
-    } satisfies AssetDetailsDto)
+    deleteCreditMock.mockResolvedValue(baseAsset)
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
-    render(
-      <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
-        <Routes>
-          <Route path="/assets/:brokerName/:portfolioName/:assetName" element={<AssetDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    renderAssetDetail()
 
     expect(await screen.findByRole('heading', { name: 'BCIA11' })).toBeInTheDocument()
 
@@ -520,13 +265,7 @@ describe('AssetDetailPage', () => {
   it('shows error state when request fails', async () => {
     getAssetDetailsMock.mockRejectedValue(new Error('Boom'))
 
-    render(
-      <MemoryRouter initialEntries={['/assets/XPI/Default/BCIA11']}>
-        <Routes>
-          <Route path="/assets/:brokerName/:portfolioName/:assetName" element={<AssetDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    renderAssetDetail()
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Boom')
   })

--- a/Financial.Web/src/pages/__tests__/BrokerDetailPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/BrokerDetailPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import BrokerDetailPage from '../BrokerDetailPage'
+import type { FinancialApiClient } from '../../api/financialApiClient'
 import type { BrokerNodeDto } from '../../api/types'
 
 const getBrokersMock = vi.fn()
@@ -9,7 +10,7 @@ const getBrokersMock = vi.fn()
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: () => ({
     getBrokers: getBrokersMock,
-  }),
+  } satisfies Partial<FinancialApiClient>),
 }))
 
 describe('BrokerDetailPage', () => {

--- a/Financial.Web/src/pages/__tests__/BrokerDetailPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/BrokerDetailPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import BrokerDetailPage from '../BrokerDetailPage'
+import type { BrokerNodeDto } from '../../api/types'
 
 const getBrokersMock = vi.fn()
 
@@ -47,7 +48,7 @@ describe('BrokerDetailPage', () => {
           },
         ],
       },
-    ])
+    ] satisfies BrokerNodeDto[])
 
     render(
       <MemoryRouter initialEntries={['/brokers/XPI']}>

--- a/Financial.Web/src/pages/__tests__/BrokersPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/BrokersPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import BrokersPage from '../BrokersPage'
+import type { FinancialApiClient } from '../../api/financialApiClient'
 import type { BrokerNodeDto } from '../../api/types'
 
 const getBrokersMock = vi.fn()
@@ -9,7 +10,7 @@ const getBrokersMock = vi.fn()
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: () => ({
     getBrokers: getBrokersMock,
-  }),
+  } satisfies Partial<FinancialApiClient>),
 }))
 
 describe('BrokersPage', () => {

--- a/Financial.Web/src/pages/__tests__/BrokersPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/BrokersPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import BrokersPage from '../BrokersPage'
+import type { BrokerNodeDto } from '../../api/types'
 
 const getBrokersMock = vi.fn()
 
@@ -25,7 +26,7 @@ describe('BrokersPage', () => {
         totalAssets: 2,
         portfolios: [],
       },
-    ])
+    ] satisfies BrokerNodeDto[])
 
     render(
       <MemoryRouter>

--- a/Financial.Web/src/pages/__tests__/CreditsPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/CreditsPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CreditsPage from '../CreditsPage'
+import type { CreditDto } from '../../api/types'
 
 const getCreditsByBrokerMock = vi.fn()
 const getCreditsByPortfolioMock = vi.fn()
@@ -27,7 +28,7 @@ describe('CreditsPage', () => {
         type: 'Dividend',
         value: 12.5,
       },
-    ])
+    ] satisfies CreditDto[])
 
     render(
       <MemoryRouter initialEntries={['/credits/XPI']}>
@@ -50,7 +51,7 @@ describe('CreditsPage', () => {
         type: 'Fee Refund',
         value: 4.2,
       },
-    ])
+    ] satisfies CreditDto[])
 
     render(
       <MemoryRouter initialEntries={['/credits/XPI/Default']}>

--- a/Financial.Web/src/pages/__tests__/CreditsPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/CreditsPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CreditsPage from '../CreditsPage'
+import type { FinancialApiClient } from '../../api/financialApiClient'
 import type { CreditDto } from '../../api/types'
 
 const getCreditsByBrokerMock = vi.fn()
@@ -11,7 +12,7 @@ vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: () => ({
     getCreditsByBroker: getCreditsByBrokerMock,
     getCreditsByPortfolio: getCreditsByPortfolioMock,
-  }),
+  } satisfies Partial<FinancialApiClient>),
 }))
 
 describe('CreditsPage', () => {

--- a/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CurrentValuesPage from '../CurrentValuesPage'
+import type { FinancialApiClient } from '../../api/financialApiClient'
 import type { AssetPriceDto, BrokerNodeDto } from '../../api/types'
 
 const getBrokersMock = vi.fn()
@@ -10,7 +11,7 @@ vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: () => ({
     getBrokers: getBrokersMock,
     getCurrentPrice: getCurrentPriceMock,
-  }),
+  } satisfies Partial<FinancialApiClient>),
 }))
 
 describe('CurrentValuesPage', () => {

--- a/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CurrentValuesPage from '../CurrentValuesPage'
+import type { AssetPriceDto, BrokerNodeDto } from '../../api/types'
 
 const getBrokersMock = vi.fn()
 const getCurrentPriceMock = vi.fn()
@@ -49,14 +50,14 @@ describe('CurrentValuesPage', () => {
           },
         ],
       },
-    ])
+    ] satisfies BrokerNodeDto[])
     getCurrentPriceMock.mockResolvedValue({
       exchange: 'BVMF',
       ticker: 'BCIA11',
       name: 'Sample Asset',
       price: 10.5,
       asOf: '2024-02-01T00:00:00Z',
-    })
+    } satisfies AssetPriceDto)
 
     render(<CurrentValuesPage />)
 

--- a/Financial.Web/src/pages/__tests__/DividendCheckPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/DividendCheckPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import DividendCheckPage from '../DividendCheckPage'
+import type { DividendHistoryItemDto, DividendSummaryDto } from '../../api/types'
 
 const getDividendSummaryMock = vi.fn()
 const getDividendHistoryMock = vi.fn()
@@ -29,14 +30,14 @@ describe('DividendCheckPage', () => {
       priceMaxBuy: 66.67,
       discountPercent: 20,
       yearTotals: [{ year: 2023, total: 4 }],
-    })
+    } satisfies DividendSummaryDto)
     getDividendHistoryMock.mockResolvedValue([
       {
         type: 'Dividend',
         date: '2024-02-01T00:00:00Z',
         value: 1.23,
       },
-    ])
+    ] satisfies DividendHistoryItemDto[])
 
     render(<DividendCheckPage />)
 

--- a/Financial.Web/src/pages/__tests__/DividendCheckPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/DividendCheckPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import DividendCheckPage from '../DividendCheckPage'
+import type { FinancialApiClient } from '../../api/financialApiClient'
 import type { DividendHistoryItemDto, DividendSummaryDto } from '../../api/types'
 
 const getDividendSummaryMock = vi.fn()
@@ -10,7 +11,7 @@ vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: () => ({
     getDividendSummary: getDividendSummaryMock,
     getDividendHistory: getDividendHistoryMock,
-  }),
+  } satisfies Partial<FinancialApiClient>),
 }))
 
 describe('DividendCheckPage', () => {

--- a/Financial.Web/src/pages/__tests__/NavigationTreePage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/NavigationTreePage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import NavigationTreePage from '../NavigationTreePage'
+import type { TreeNodeDto } from '../../api/types'
 
 const getNavigationTreeMock = vi.fn()
 
@@ -29,7 +30,7 @@ describe('NavigationTreePage', () => {
           children: [],
         },
       ],
-    })
+    } satisfies TreeNodeDto)
 
     render(
       <MemoryRouter>

--- a/Financial.Web/src/pages/__tests__/NavigationTreePage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/NavigationTreePage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import NavigationTreePage from '../NavigationTreePage'
+import type { FinancialApiClient } from '../../api/financialApiClient'
 import type { TreeNodeDto } from '../../api/types'
 
 const getNavigationTreeMock = vi.fn()
@@ -9,7 +10,7 @@ const getNavigationTreeMock = vi.fn()
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: () => ({
     getNavigationTree: getNavigationTreeMock,
-  }),
+  } satisfies Partial<FinancialApiClient>),
 }))
 
 describe('NavigationTreePage', () => {


### PR DESCRIPTION
## Summary

- Adds TypeScript \`satisfies\` keyword to all \`mockResolvedValue({...})\` calls in 8 frontend test files
- Ensures mock objects are type-checked against the actual DTO interfaces at compile time
- Previously, \`vi.fn().mockResolvedValue(...)\` accepted \`any\`, so renamed fields (e.g. \`operations\` → \`transactions\`) could silently mismatch without a test failure

## Why this matters

The rename of \`Operation\` → \`Transaction\` revealed a gap: the web client tests were using stale field names but tests still passed because \`mockResolvedValue\` accepts \`any\`. Adding \`satisfies DtoType\` turns those silent mismatches into compile errors, preventing the same class of issue in future renames.

## Files changed

- \`App.test.tsx\` — \`satisfies TreeNodeDto\` and \`satisfies AssetDetailsDto\`
- \`AssetDetailPage.test.tsx\` — \`satisfies AssetDetailsDto\` on all mock payloads
- \`BrokerDetailPage.test.tsx\` — \`satisfies BrokerNodeDto[]\`
- \`BrokersPage.test.tsx\` — \`satisfies BrokerNodeDto[]\`
- \`CurrentValuesPage.test.tsx\` — \`satisfies BrokerNodeDto[]\` and \`satisfies AssetPriceDto\`
- \`CreditsPage.test.tsx\` — \`satisfies CreditDto[]\` on both mocks
- \`DividendCheckPage.test.tsx\` — \`satisfies DividendSummaryDto\` and \`satisfies DividendHistoryItemDto[]\`
- \`NavigationTreePage.test.tsx\` — \`satisfies TreeNodeDto\`

## Test plan

- [ ] \`npm test\` passes (26/26 tests)
- [ ] TypeScript compiles cleanly (\`npx tsc --noEmit\`)
- [ ] Verify: renaming a DTO field causes a compile error on the mock (not just a runtime test failure)

## Risk assessment

| Risk | Likelihood | Impact | Mitigation |
|------|-----------|--------|-----------|
| \`satisfies\` syntax not supported by TS version | Low | Build break | TS 4.9+ required; project already uses it |
| False confidence — test logic unchanged | None | N/A | Intent is compile-time safety, not behaviour |
| Merge conflicts if DTOs change in parallel | Low | Easy to resolve | Conflicts are obvious compile errors |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)