### PR TITLE
fix(arch): isolate API Presentation from Infrastructure concrete types (F-01)

### DIFF
--- a/Financial.Api/Controllers/DiagnosticsController.cs
+++ b/Financial.Api/Controllers/DiagnosticsController.cs
@@ -1,4 +1,4 @@
-using Financial.Infrastructure.Persistence;
+using Financial.Application.Configuration;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
@@ -12,7 +12,6 @@ public sealed class DiagnosticsController : ControllerBase
 {
     private readonly IConfiguration _configuration;
     private readonly IHostEnvironment _environment;
-    private const string RepositoryProviderConfigurationKey = "Repository:Provider";
 
     public DiagnosticsController(IConfiguration configuration, IHostEnvironment environment)
     {
@@ -39,10 +38,10 @@ public sealed class DiagnosticsController : ControllerBase
 
         return Ok(new
         {
-            provider = _configuration[RepositoryProviderConfigurationKey],
-            dataJsonFile = _configuration[LocalJsonStorage.DataJsonFileConfigurationKey],
-            googleDriveCredentialsPath = _configuration[GoogleDriveJsonStorage.CredentialsPathConfigurationKey],
-            googleDriveFilePath = _configuration[GoogleDriveJsonStorage.FilePathConfigurationKey]
+            provider = _configuration[RepositoryConfigurationKeys.Provider],
+            dataJsonFile = _configuration[RepositoryConfigurationKeys.LocalJsonDataFile],
+            googleDriveCredentialsPath = _configuration[RepositoryConfigurationKeys.GoogleDriveCredentialsPath],
+            googleDriveFilePath = _configuration[RepositoryConfigurationKeys.GoogleDriveFilePath]
         });
     }
 }

--- a/Financial.Api/Program.cs
+++ b/Financial.Api/Program.cs
@@ -1,19 +1,13 @@
-using Financial.Application.Interfaces;
-using Financial.Infrastructure.Persistence;
-using Financial.Infrastructure.Repositories;
-using Financial.Infrastructure.Services;
+using Financial.Infrastructure.DependencyInjection;
 using System;
 
 var builder = WebApplication.CreateBuilder(args);
 var configuration = builder.Configuration;
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddProblemDetails();
 builder.Services.AddOpenApi();
 builder.Services.AddControllers();
 
-const string RepositoryProviderConfigurationKey = "Repository:Provider";
 const string CorsOriginsConfigurationKey = "Cors:AllowedOrigins";
 
 var allowedOrigins = configuration.GetSection(CorsOriginsConfigurationKey).Get<string[]>() ?? Array.Empty<string>();
@@ -34,39 +28,10 @@ builder.Services.AddCors(options =>
     });
 });
 
-builder.Services.AddSingleton<IRepositoryFactory, RepositoryFactory>();
-builder.Services.AddSingleton<IRepository>(sp =>
-{
-    var providerValue = configuration[RepositoryProviderConfigurationKey]
-        ?? nameof(RepositoryProvider.LocalJson);
-    if (!Enum.TryParse(providerValue, true, out RepositoryProvider provider))
-    {
-        throw new InvalidOperationException(
-            $"Repository provider '{providerValue}' is not supported. " +
-            $"Valid values: {string.Join(", ", Enum.GetNames<RepositoryProvider>())}.");
-    }
-
-    var dataJsonFile = configuration[LocalJsonStorage.DataJsonFileConfigurationKey];
-    var credentialsPath = configuration[GoogleDriveJsonStorage.CredentialsPathConfigurationKey];
-
-    var options = new RepositorySelectionOptions(
-        provider,
-        dataJsonFile,
-        credentialsPath,
-        configuration[GoogleDriveJsonStorage.FilePathConfigurationKey]);
-
-    var factory = sp.GetRequiredService<IRepositoryFactory>();
-    return factory.Create(options);
-});
-builder.Services.AddSingleton<INavigationService, NavigationService>();
-builder.Services.AddSingleton<ITransactionService, TransactionService>();
-builder.Services.AddSingleton<ICreditService, CreditService>();
-builder.Services.AddSingleton<IAssetPriceService, AssetPriceService>();
-builder.Services.AddSingleton<IDividendService, DividendService>();
+builder.Services.AddFinancialInfrastructure(configuration);
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();

--- a/Financial.Application/Configuration/RepositoryConfigurationKeys.cs
+++ b/Financial.Application/Configuration/RepositoryConfigurationKeys.cs
@@ -1,0 +1,9 @@
+namespace Financial.Application.Configuration;
+
+public static class RepositoryConfigurationKeys
+{
+    public const string Provider = "Repository:Provider";
+    public const string LocalJsonDataFile = "DataJsonFile";
+    public const string GoogleDriveCredentialsPath = "GoogleDrive:CredentialsPath";
+    public const string GoogleDriveFilePath = "GoogleDrive:FilePath";
+}

--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using Financial.Application.Configuration;
+using Financial.Application.Interfaces;
+using Financial.Infrastructure.Persistence;
+using Financial.Infrastructure.Repositories;
+using Financial.Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Financial.Infrastructure.DependencyInjection;
+
+public static class InfrastructureServiceCollectionExtensions
+{
+    public static IServiceCollection AddFinancialInfrastructure(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddSingleton<IRepositoryFactory, RepositoryFactory>();
+        services.AddSingleton<IRepository>(sp => CreateRepository(sp, configuration));
+        services.AddSingleton<INavigationService, NavigationService>();
+        services.AddSingleton<ITransactionService, TransactionService>();
+        services.AddSingleton<ICreditService, CreditService>();
+        services.AddSingleton<IAssetPriceService, AssetPriceService>();
+        services.AddSingleton<IDividendService, DividendService>();
+
+        return services;
+    }
+
+    private static IRepository CreateRepository(IServiceProvider sp, IConfiguration configuration)
+    {
+        var providerValue = configuration[RepositoryConfigurationKeys.Provider]
+            ?? nameof(RepositoryProvider.LocalJson);
+
+        if (!Enum.TryParse(providerValue, true, out RepositoryProvider provider))
+        {
+            throw new InvalidOperationException(
+                $"Repository provider '{providerValue}' is not supported. " +
+                $"Valid values: {string.Join(", ", Enum.GetNames<RepositoryProvider>())}.");
+        }
+
+        var options = new RepositorySelectionOptions(
+            provider,
+            configuration[RepositoryConfigurationKeys.LocalJsonDataFile],
+            configuration[RepositoryConfigurationKeys.GoogleDriveCredentialsPath],
+            configuration[RepositoryConfigurationKeys.GoogleDriveFilePath]);
+
+        return sp.GetRequiredService<IRepositoryFactory>().Create(options);
+    }
+}

--- a/Financial.Infrastructure/Financial.Infrastructure.csproj
+++ b/Financial.Infrastructure/Financial.Infrastructure.csproj
@@ -20,6 +20,11 @@
     <None Remove="Integrations\**\*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+  </ItemGroup>
+
 </Project>
 
 


### PR DESCRIPTION
## Problem (F-01)

`Financial.Api` was importing Infrastructure namespaces directly in both `Program.cs` and `DiagnosticsController.cs`, violating the Clean Architecture dependency rule: **Presentation must only depend on Application**.

```csharp
// Before — scattered across Program.cs
using Financial.Infrastructure.Persistence;
using Financial.Infrastructure.Repositories;
using Financial.Infrastructure.Services;
```

Controllers should never know about `RepositoryFactory`, `NavigationService`, `LocalJsonStorage`, etc.

## Solution

### New: `RepositoryConfigurationKeys` (Application layer)
Configuration key string constants moved to `Financial.Application/Configuration/`, making them accessible to any layer without an Infrastructure reference.

### New: `InfrastructureServiceCollectionExtensions` (Infrastructure layer)
Single extension method `AddFinancialInfrastructure(IServiceCollection, IConfiguration)` that owns all concrete service registration logic — the composition root pattern.

### Updated: `Program.cs`
Down from 3 Infrastructure `using` statements + 10 lines of service wiring to a single call:
```csharp
builder.Services.AddFinancialInfrastructure(configuration);
```

### Updated: `DiagnosticsController.cs`
Removed `using Financial.Infrastructure.Persistence`. Config keys now reference `RepositoryConfigurationKeys` from Application.

## Architecture compliance

- Controllers import **zero** Infrastructure namespaces
- All concrete wiring stays inside Infrastructure
- Adding a new storage backend requires changing only `InfrastructureServiceCollectionExtensions`, not `Program.cs`
- `Financial.Api.csproj` still references Infrastructure — this is correct for the composition root (entry point)

## Test results

| Suite | Result |
|---|---|
| Financial.Domain.Tests | ✅ 34/34 passed |
| Financial.Application.Tests | ✅ 36/36 passed |
| Financial.Infrastructure.Tests | ✅ 74/77 passed (3 skipped, 0 failed) |
| Financial.Api.Tests | ⚠️ Could not run (API exe was locked) — verify after stop |

## Risk assessment

| Risk | Likelihood | Impact | Mitigation |
|---|---|---|---|
| Config key string mismatch between old and new constants | Low | Runtime startup failure | Constants are string literals — identical values, verified by grep |
| Missing service registration in extension method | Low | Runtime DI resolution failure | API tests cover full DI graph via WebApplicationFactory |
| Infrastructure now depends on DI/Config abstractions | None | New NuGet deps are Microsoft.Extensions abstractions, same family as ASP.NET | Already in the transitive dependency tree |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)