### PR TITLE
fix(F-03): move JSON serialization out of Domain into Infrastructure

### DIFF
--- a/Financial.Domain/Entities/Investments.cs
+++ b/Financial.Domain/Entities/Investments.cs
@@ -1,8 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using System.Text.Json;
-using Financial.Common;
-using System;
 
 namespace Financial.Domain.Entities;
 
@@ -21,30 +18,6 @@ public class Investments
     private Investments() {}
 
     public static Investments Create() => new();
-
-    public string Serialize()
-    {
-        var options = new JsonSerializerOptions()
-        {
-            Converters = { new JsonStringEnumConverter() },
-            WriteIndented = true,
-            TypeInfoResolver = new PrivateConstructorContractResolver()
-        };
-        options.Converters.Add(new JsonStringEnumConverter());
-        return JsonSerializer.Serialize(this, options);
-    }
-
-    public static Investments Deserialize(string json)
-    {
-        var options = new JsonSerializerOptions()
-        {
-            Converters = { new JsonStringEnumConverter() },
-            WriteIndented = true,
-            TypeInfoResolver = new PrivateConstructorContractResolver()
-        };
-        var investments = JsonSerializer.Deserialize<Investments>(json, options);
-        return investments;
-    }
 
     public void AddBroker(Broker broker)
     {

--- a/Financial.Infrastructure/Persistence/InvestmentsJsonSerializer.cs
+++ b/Financial.Infrastructure/Persistence/InvestmentsJsonSerializer.cs
@@ -1,0 +1,25 @@
+using Financial.Common;
+using Financial.Domain.Entities;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Financial.Infrastructure.Persistence;
+
+public static class InvestmentsJsonSerializer
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = true,
+        TypeInfoResolver = new PrivateConstructorContractResolver()
+    };
+
+    public static string Serialize(Investments investments) =>
+        JsonSerializer.Serialize(investments, Options);
+
+    public static Investments Deserialize(string json)
+    {
+        var investments = JsonSerializer.Deserialize<Investments>(json, Options);
+        return investments!;
+    }
+}

--- a/Financial.Infrastructure/Repositories/JSONRepository.cs
+++ b/Financial.Infrastructure/Repositories/JSONRepository.cs
@@ -1,6 +1,7 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
+using Financial.Infrastructure.Persistence;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -100,7 +101,7 @@ public sealed class JSONRepository : IRepository
 
     public void SaveChanges()
     {
-        var json = _investiments.Serialize();
+        var json = InvestmentsJsonSerializer.Serialize(_investiments);
         _storage.WriteAsync(json)
             .ConfigureAwait(false)
             .GetAwaiter()
@@ -114,7 +115,7 @@ public sealed class JSONRepository : IRepository
             .GetAwaiter()
             .GetResult();
 
-        return Investments.Deserialize(json);
+        return InvestmentsJsonSerializer.Deserialize(json);
     }
 
     private IEnumerable<Broker> GetBrokersByName(string brokerName) =>

--- a/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
@@ -1,3 +1,4 @@
+using Financial.Common;
 using Financial.Domain.Entities;
 using Financial.Infrastructure.Integrations.FinancialToolSupport;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport.DTO;
@@ -5,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
@@ -205,9 +208,16 @@ public class GoogleGenerator : IGenerator
         };
     }
 
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = true,
+        TypeInfoResolver = new PrivateConstructorContractResolver()
+    };
+
     private void Save(Investments data)
     {
-        string json = data.Serialize();
+        string json = JsonSerializer.Serialize(data, _serializerOptions);
         File.WriteAllText(Path.Combine(_path, "data.json"), json);
     }
 

--- a/Tests/Financial.Domain.Tests/Domain/InvestmentsTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/InvestmentsTests.cs
@@ -6,20 +6,21 @@ namespace Financial.Domain.Tests;
 public class InvestmentsTests
 {
     [Fact]
-    public void SerializeDeserialize_RoundTripPreservesStructure()
+    public void AddBroker_AddsBrokerToCollection()
     {
         var investments = Investments.Create();
         var broker = Broker.Create("Broker A", "USD");
-        var portfolio = broker.AddPortfolio("Default");
-        portfolio.AddAsset(Asset.Create("Asset A", "ISIN123", "NYSE", "AAA"));
+
         investments.AddBroker(broker);
 
-        var json = investments.Serialize();
-        var result = Investments.Deserialize(json);
+        investments.Brokers.Should().ContainSingle().Which.Name.Should().Be("Broker A");
+    }
 
-        result.Should().NotBeNull();
-        var brokerResult = result!.Brokers.Should().ContainSingle().Which;
-        var portfolioResult = brokerResult.Portfolios.Should().ContainSingle().Which;
-        portfolioResult.Assets.Should().ContainSingle();
+    [Fact]
+    public void Create_ReturnsEmptyInvestments()
+    {
+        var investments = Investments.Create();
+
+        investments.Brokers.Should().BeEmpty();
     }
 }

--- a/Tests/Financial.Infrastructure.Tests/Persistence/InvestmentsJsonSerializerTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Persistence/InvestmentsJsonSerializerTests.cs
@@ -1,0 +1,38 @@
+using Financial.Domain.Entities;
+using Financial.Infrastructure.Persistence;
+using FluentAssertions;
+
+namespace Financial.Infrastructure.Tests.Persistence;
+
+public class InvestmentsJsonSerializerTests
+{
+    [Fact]
+    public void SerializeDeserialize_RoundTripPreservesStructure()
+    {
+        var investments = Investments.Create();
+        var broker = Broker.Create("Broker A", "USD");
+        var portfolio = broker.AddPortfolio("Default");
+        portfolio.AddAsset(Asset.Create("Asset A", "ISIN123", "NYSE", "AAA"));
+        investments.AddBroker(broker);
+
+        var json = InvestmentsJsonSerializer.Serialize(investments);
+        var result = InvestmentsJsonSerializer.Deserialize(json);
+
+        result.Should().NotBeNull();
+        var brokerResult = result.Brokers.Should().ContainSingle().Which;
+        var portfolioResult = brokerResult.Portfolios.Should().ContainSingle().Which;
+        portfolioResult.Assets.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Serialize_ProducesValidJson()
+    {
+        var investments = Investments.Create();
+        investments.AddBroker(Broker.Create("Broker A", "BRL"));
+
+        var json = InvestmentsJsonSerializer.Serialize(investments);
+
+        json.Should().NotBeNullOrWhiteSpace();
+        json.Should().Contain("Broker A");
+    }
+}


### PR DESCRIPTION
## Summary

- Removes `Serialize()` / `Deserialize()` methods from `Investments.cs` — a Domain entity had no business containing JSON serialization logic
- Adds `InvestmentsJsonSerializer` static class in `Financial.Infrastructure/Persistence/` with the shared `JsonSerializerOptions` (indented, enum-as-string, private constructor support)
- `JSONRepository` now delegates to `InvestmentsJsonSerializer` instead of calling entity methods
- `GoogleGenerator.Save()` inlines the serialization directly — a circular dependency (Infrastructure → GoogleFinancialSupport already exists) prevents sharing the Infrastructure serializer there
- Replaces the serialization round-trip test in `Domain.Tests` with pure domain behavior tests (`Create`, `AddBroker`)
- Adds `InvestmentsJsonSerializerTests` in `Infrastructure.Tests` covering the round-trip and basic output validation

## Architecture

`Financial.Domain` no longer depends on `System.Text.Json` for behavior — only the `[JsonConstructor]` / `[JsonInclude]` BCL attributes remain as serialization hints on the entity. All JSON logic lives in Infrastructure.

## Test plan

- [x] Domain tests: 35 passed (2 new domain-behavior tests, 1 serialization test removed)
- [x] Infrastructure tests: 76 passed (2 new serializer tests added), 3 skipped
- [x] Application tests: 36 passed
- [x] API tests: 15 passed
- [x] Build: 0 errors, 0 warnings across all projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)