### PR TITLE
fix(F-05): replace sync-over-async with genuine async throughout the mutation path

### DIFF
--- a/Financial.Api/Controllers/CreditsController.cs
+++ b/Financial.Api/Controllers/CreditsController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Financial.Api.Controllers;
 
@@ -23,14 +24,14 @@ public sealed class CreditsController : ControllerBase
     [HttpPost]
     [ProducesResponseType(typeof(AssetDetailsDTO), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public ActionResult<AssetDetailsDTO> AddCredit([FromBody] CreditCreateDTO request)
+    public async Task<ActionResult<AssetDetailsDTO>> AddCredit([FromBody] CreditCreateDTO request)
     {
         if (request is null)
         {
             return BadRequest();
         }
 
-        var asset = _creditService.AddCredit(request);
+        var asset = await _creditService.AddCreditAsync(request);
         if (asset is null)
         {
             return BadRequest();
@@ -42,14 +43,14 @@ public sealed class CreditsController : ControllerBase
     [HttpPut]
     [ProducesResponseType(typeof(AssetDetailsDTO), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public ActionResult<AssetDetailsDTO> UpdateCredit([FromBody] CreditUpdateDTO request)
+    public async Task<ActionResult<AssetDetailsDTO>> UpdateCredit([FromBody] CreditUpdateDTO request)
     {
         if (request is null)
         {
             return BadRequest();
         }
 
-        var asset = _creditService.UpdateCredit(request);
+        var asset = await _creditService.UpdateCreditAsync(request);
         if (asset is null)
         {
             return BadRequest();
@@ -61,14 +62,14 @@ public sealed class CreditsController : ControllerBase
     [HttpDelete]
     [ProducesResponseType(typeof(AssetDetailsDTO), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public ActionResult<AssetDetailsDTO> DeleteCredit([FromBody] CreditDeleteDTO request)
+    public async Task<ActionResult<AssetDetailsDTO>> DeleteCredit([FromBody] CreditDeleteDTO request)
     {
         if (request is null)
         {
             return BadRequest();
         }
 
-        var asset = _creditService.DeleteCredit(request);
+        var asset = await _creditService.DeleteCreditAsync(request);
         if (asset is null)
         {
             return BadRequest();

--- a/Financial.Api/Controllers/TransactionsController.cs
+++ b/Financial.Api/Controllers/TransactionsController.cs
@@ -3,6 +3,7 @@ using Financial.Application.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Threading.Tasks;
 
 namespace Financial.Api.Controllers;
 
@@ -20,14 +21,14 @@ public sealed class TransactionsController : ControllerBase
     [HttpPost]
     [ProducesResponseType(typeof(AssetDetailsDTO), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public ActionResult<AssetDetailsDTO> AddTransaction([FromBody] TransactionCreateDTO request)
+    public async Task<ActionResult<AssetDetailsDTO>> AddTransaction([FromBody] TransactionCreateDTO request)
     {
         if (request is null)
         {
             return BadRequest();
         }
 
-        var asset = _transactionService.AddTransaction(request);
+        var asset = await _transactionService.AddTransactionAsync(request);
         if (asset is null)
         {
             return BadRequest();
@@ -39,14 +40,14 @@ public sealed class TransactionsController : ControllerBase
     [HttpPut]
     [ProducesResponseType(typeof(AssetDetailsDTO), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public ActionResult<AssetDetailsDTO> UpdateTransaction([FromBody] TransactionUpdateDTO request)
+    public async Task<ActionResult<AssetDetailsDTO>> UpdateTransaction([FromBody] TransactionUpdateDTO request)
     {
         if (request is null)
         {
             return BadRequest();
         }
 
-        var asset = _transactionService.UpdateTransaction(request);
+        var asset = await _transactionService.UpdateTransactionAsync(request);
         if (asset is null)
         {
             return BadRequest();
@@ -58,14 +59,14 @@ public sealed class TransactionsController : ControllerBase
     [HttpDelete]
     [ProducesResponseType(typeof(AssetDetailsDTO), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public ActionResult<AssetDetailsDTO> DeleteTransaction([FromBody] TransactionDeleteDTO request)
+    public async Task<ActionResult<AssetDetailsDTO>> DeleteTransaction([FromBody] TransactionDeleteDTO request)
     {
         if (request is null)
         {
             return BadRequest();
         }
 
-        var asset = _transactionService.DeleteTransaction(request);
+        var asset = await _transactionService.DeleteTransactionAsync(request);
         if (asset is null)
         {
             return BadRequest();

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -1000,54 +1000,54 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private static string BuildBrokerKey(string brokerName) =>
         $"Broker|{brokerName}";
 
-    private void AddTransaction()
+    private async void AddTransaction()
     {
-        _transactionActions.Add(ShowAddTransactionDialog);
+        await _transactionActions.Add(ShowAddTransactionDialog);
     }
 
-    private void AddCredit()
+    private async void AddCredit()
     {
-        _creditActions.Add(ShowAddCreditDialog);
+        await _creditActions.Add(ShowAddCreditDialog);
     }
 
-    private void UpdateTransaction(object? parameter)
+    private async void UpdateTransaction(object? parameter)
     {
         if (parameter is TransactionDTO transaction)
         {
             SelectedTransaction = transaction;
         }
 
-        _transactionActions.Update(SelectedTransaction, ShowUpdateTransactionDialog);
+        await _transactionActions.Update(SelectedTransaction, ShowUpdateTransactionDialog);
     }
 
-    private void UpdateCredit(object? parameter)
+    private async void UpdateCredit(object? parameter)
     {
         if (parameter is CreditDTO credit)
         {
             SelectedCredit = credit;
         }
 
-        _creditActions.Update(SelectedCredit, ShowUpdateCreditDialog);
+        await _creditActions.Update(SelectedCredit, ShowUpdateCreditDialog);
     }
 
-    private void DeleteTransaction(object? parameter)
+    private async void DeleteTransaction(object? parameter)
     {
         if (parameter is TransactionDTO transaction)
         {
             SelectedTransaction = transaction;
         }
 
-        _transactionActions.Delete(SelectedTransaction, ShowDeleteTransactionDialog);
+        await _transactionActions.Delete(SelectedTransaction, ShowDeleteTransactionDialog);
     }
 
-    private void DeleteCredit(object? parameter)
+    private async void DeleteCredit(object? parameter)
     {
         if (parameter is CreditDTO credit)
         {
             SelectedCredit = credit;
         }
 
-        _creditActions.Delete(SelectedCredit, ShowDeleteCreditDialog);
+        await _creditActions.Delete(SelectedCredit, ShowDeleteCreditDialog);
     }
 
     private void UpdateCommandStates()

--- a/Financial.App/ViewModels/CreditActions.cs
+++ b/Financial.App/ViewModels/CreditActions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using System.Windows;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
@@ -34,7 +35,7 @@ public sealed class CreditActions
         _showMessage = showMessage ?? throw new ArgumentNullException(nameof(showMessage));
     }
 
-    public void Add(Func<CreditDialogData?> showDialog)
+    public async Task Add(Func<CreditDialogData?> showDialog)
     {
         if (!_hasContext())
         {
@@ -59,7 +60,7 @@ public sealed class CreditActions
             return;
         }
 
-        var updatedDetails = _service.AddCredit(new CreditCreateDTO
+        var updatedDetails = await _service.AddCreditAsync(new CreditCreateDTO
         {
             BrokerName = _brokerName(),
             PortfolioName = _portfolioName(),
@@ -78,7 +79,7 @@ public sealed class CreditActions
         _applyDetails(updatedDetails);
     }
 
-    public void Update(CreditDTO? selectedCredit, Func<CreditDialogData?> showDialog)
+    public async Task Update(CreditDTO? selectedCredit, Func<CreditDialogData?> showDialog)
     {
         if (_service == null || selectedCredit == null)
         {
@@ -103,7 +104,7 @@ public sealed class CreditActions
             return;
         }
 
-        var updatedDetails = _service.UpdateCredit(new CreditUpdateDTO
+        var updatedDetails = await _service.UpdateCreditAsync(new CreditUpdateDTO
         {
             BrokerName = _brokerName(),
             PortfolioName = _portfolioName(),
@@ -123,7 +124,7 @@ public sealed class CreditActions
         _applyDetails(updatedDetails);
     }
 
-    public void Delete(CreditDTO? selectedCredit, Func<bool> confirmDialog)
+    public async Task Delete(CreditDTO? selectedCredit, Func<bool> confirmDialog)
     {
         if (selectedCredit == null)
         {
@@ -146,7 +147,7 @@ public sealed class CreditActions
             return;
         }
 
-        var updatedDetails = _service.DeleteCredit(new CreditDeleteDTO
+        var updatedDetails = await _service.DeleteCreditAsync(new CreditDeleteDTO
         {
             BrokerName = _brokerName(),
             PortfolioName = _portfolioName(),
@@ -179,4 +180,3 @@ public readonly record struct CreditDialogData(
     DateTime Date,
     string Type,
     decimal Value);
-

--- a/Financial.App/ViewModels/TransactionActions.cs
+++ b/Financial.App/ViewModels/TransactionActions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using System.Windows;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
@@ -34,7 +35,7 @@ public sealed class TransactionActions
         _showMessage = showMessage ?? throw new ArgumentNullException(nameof(showMessage));
     }
 
-    public void Add(Func<TransactionDialogData?> showDialog)
+    public async Task Add(Func<TransactionDialogData?> showDialog)
     {
         if (!_hasContext())
         {
@@ -59,7 +60,7 @@ public sealed class TransactionActions
             return;
         }
 
-        var updatedDetails = _service.AddTransaction(new TransactionCreateDTO
+        var updatedDetails = await _service.AddTransactionAsync(new TransactionCreateDTO
         {
             BrokerName = _brokerName(),
             PortfolioName = _portfolioName(),
@@ -80,7 +81,7 @@ public sealed class TransactionActions
         _applyDetails(updatedDetails);
     }
 
-    public void Update(TransactionDTO? selectedTransaction, Func<TransactionDialogData?> showDialog)
+    public async Task Update(TransactionDTO? selectedTransaction, Func<TransactionDialogData?> showDialog)
     {
         if (_service == null || selectedTransaction == null)
         {
@@ -105,7 +106,7 @@ public sealed class TransactionActions
             return;
         }
 
-        var updatedDetails = _service.UpdateTransaction(new TransactionUpdateDTO
+        var updatedDetails = await _service.UpdateTransactionAsync(new TransactionUpdateDTO
         {
             BrokerName = _brokerName(),
             PortfolioName = _portfolioName(),
@@ -127,7 +128,7 @@ public sealed class TransactionActions
         _applyDetails(updatedDetails);
     }
 
-    public void Delete(TransactionDTO? selectedTransaction, Func<bool> confirmDialog)
+    public async Task Delete(TransactionDTO? selectedTransaction, Func<bool> confirmDialog)
     {
         if (selectedTransaction == null)
         {
@@ -150,7 +151,7 @@ public sealed class TransactionActions
             return;
         }
 
-        var updatedDetails = _service.DeleteTransaction(new TransactionDeleteDTO
+        var updatedDetails = await _service.DeleteTransactionAsync(new TransactionDeleteDTO
         {
             BrokerName = _brokerName(),
             PortfolioName = _portfolioName(),

--- a/Financial.Application/Interfaces/ICreditService.cs
+++ b/Financial.Application/Interfaces/ICreditService.cs
@@ -1,10 +1,11 @@
 using Financial.Application.DTOs;
+using System.Threading.Tasks;
 
 namespace Financial.Application.Interfaces;
 
 public interface ICreditService
 {
-    AssetDetailsDTO? AddCredit(CreditCreateDTO request);
-    AssetDetailsDTO? UpdateCredit(CreditUpdateDTO request);
-    AssetDetailsDTO? DeleteCredit(CreditDeleteDTO request);
+    Task<AssetDetailsDTO?> AddCreditAsync(CreditCreateDTO request);
+    Task<AssetDetailsDTO?> UpdateCreditAsync(CreditUpdateDTO request);
+    Task<AssetDetailsDTO?> DeleteCreditAsync(CreditDeleteDTO request);
 }

--- a/Financial.Application/Interfaces/IRepository.cs
+++ b/Financial.Application/Interfaces/IRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Financial.Domain.Entities;
+using System.Threading.Tasks;
 
 namespace Financial.Application.Interfaces;
 
@@ -12,5 +13,5 @@ public interface IRepository
     IEnumerable<Broker> GetBrokerList();
     Asset? GetAsset(string brokerName, string portfolioName, string assetName);
 
-    void SaveChanges();
+    Task SaveChangesAsync();
 }

--- a/Financial.Application/Interfaces/ITransactionService.cs
+++ b/Financial.Application/Interfaces/ITransactionService.cs
@@ -1,10 +1,11 @@
 using Financial.Application.DTOs;
+using System.Threading.Tasks;
 
 namespace Financial.Application.Interfaces;
 
 public interface ITransactionService
 {
-    AssetDetailsDTO? AddTransaction(TransactionCreateDTO request);
-    AssetDetailsDTO? UpdateTransaction(TransactionUpdateDTO request);
-    AssetDetailsDTO? DeleteTransaction(TransactionDeleteDTO request);
+    Task<AssetDetailsDTO?> AddTransactionAsync(TransactionCreateDTO request);
+    Task<AssetDetailsDTO?> UpdateTransactionAsync(TransactionUpdateDTO request);
+    Task<AssetDetailsDTO?> DeleteTransactionAsync(TransactionDeleteDTO request);
 }

--- a/Financial.Infrastructure/Repositories/JSONRepository.cs
+++ b/Financial.Infrastructure/Repositories/JSONRepository.cs
@@ -4,6 +4,7 @@ using Financial.Infrastructure.Persistence;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Repositories;
 
@@ -60,13 +61,10 @@ public sealed class JSONRepository : IRepository
         return _investiments.Brokers;
     }
 
-    public void SaveChanges()
+    public async Task SaveChangesAsync()
     {
         var json = InvestmentsJsonSerializer.Serialize(_investiments);
-        _storage.WriteAsync(json)
-            .ConfigureAwait(false)
-            .GetAwaiter()
-            .GetResult();
+        await _storage.WriteAsync(json).ConfigureAwait(false);
     }
 
     private static Investments LoadInvestments(IJsonStorage storage)

--- a/Financial.Infrastructure/Services/AssetServiceHelper.cs
+++ b/Financial.Infrastructure/Services/AssetServiceHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
@@ -16,7 +17,7 @@ internal static class AssetServiceHelper
                string.IsNullOrWhiteSpace(assetName);
     }
 
-    public static AssetDetailsDTO? ExecuteParsedMutation<TEnum>(
+    public static async Task<AssetDetailsDTO?> ExecuteParsedMutationAsync<TEnum>(
         IRepository repository,
         INavigationService navigationService,
         string? brokerName,
@@ -31,16 +32,16 @@ internal static class AssetServiceHelper
             return null;
         }
 
-        return ExecuteAssetMutation(
+        return await ExecuteAssetMutationAsync(
             repository,
             navigationService,
             brokerName,
             portfolioName,
             assetName,
-            asset => mutation(asset, parsed));
+            asset => mutation(asset, parsed)).ConfigureAwait(false);
     }
 
-    public static AssetDetailsDTO? ExecuteAssetMutation(
+    public static async Task<AssetDetailsDTO?> ExecuteAssetMutationAsync(
         IRepository repository,
         INavigationService navigationService,
         string? brokerName,
@@ -64,8 +65,7 @@ internal static class AssetServiceHelper
             return null;
         }
 
-        repository.SaveChanges();
+        await repository.SaveChangesAsync().ConfigureAwait(false);
         return navigationService.GetAssetDetails(brokerName!, portfolioName!, assetName!);
     }
 }
-

--- a/Financial.Infrastructure/Services/CreditService.cs
+++ b/Financial.Infrastructure/Services/CreditService.cs
@@ -3,6 +3,7 @@ using Financial.Application.Interfaces;
 using Financial.Application.Validation;
 using Financial.Domain.Entities;
 using System;
+using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Services;
 
@@ -17,9 +18,9 @@ public sealed class CreditService : ICreditService
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
     }
 
-    public AssetDetailsDTO? AddCredit(CreditCreateDTO request)
+    public Task<AssetDetailsDTO?> AddCreditAsync(CreditCreateDTO request)
     {
-        return AssetServiceHelper.ExecuteParsedMutation<Credit.CreditType>(
+        return AssetServiceHelper.ExecuteParsedMutationAsync<Credit.CreditType>(
             _repository,
             _navigationService,
             request.BrokerName,
@@ -35,14 +36,14 @@ public sealed class CreditService : ICreditService
             });
     }
 
-    public AssetDetailsDTO? UpdateCredit(CreditUpdateDTO request)
+    public Task<AssetDetailsDTO?> UpdateCreditAsync(CreditUpdateDTO request)
     {
         if (request.Id == Guid.Empty)
         {
-            return null;
+            return Task.FromResult<AssetDetailsDTO?>(null);
         }
 
-        return AssetServiceHelper.ExecuteParsedMutation<Credit.CreditType>(
+        return AssetServiceHelper.ExecuteParsedMutationAsync<Credit.CreditType>(
             _repository,
             _navigationService,
             request.BrokerName,
@@ -57,14 +58,14 @@ public sealed class CreditService : ICreditService
             });
     }
 
-    public AssetDetailsDTO? DeleteCredit(CreditDeleteDTO request)
+    public Task<AssetDetailsDTO?> DeleteCreditAsync(CreditDeleteDTO request)
     {
         if (request.Id == Guid.Empty)
         {
-            return null;
+            return Task.FromResult<AssetDetailsDTO?>(null);
         }
 
-        return AssetServiceHelper.ExecuteAssetMutation(
+        return AssetServiceHelper.ExecuteAssetMutationAsync(
             _repository,
             _navigationService,
             request.BrokerName,
@@ -73,4 +74,3 @@ public sealed class CreditService : ICreditService
             asset => asset.RemoveCredit(request.Id));
     }
 }
-

--- a/Financial.Infrastructure/Services/TransactionService.cs
+++ b/Financial.Infrastructure/Services/TransactionService.cs
@@ -3,6 +3,7 @@ using Financial.Application.Interfaces;
 using Financial.Application.Validation;
 using Financial.Domain.Entities;
 using System;
+using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Services;
 
@@ -17,9 +18,9 @@ public sealed class TransactionService : ITransactionService
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
     }
 
-    public AssetDetailsDTO? AddTransaction(TransactionCreateDTO request)
+    public Task<AssetDetailsDTO?> AddTransactionAsync(TransactionCreateDTO request)
     {
-        return AssetServiceHelper.ExecuteParsedMutation<Transaction.TransactionType>(
+        return AssetServiceHelper.ExecuteParsedMutationAsync<Transaction.TransactionType>(
             _repository,
             _navigationService,
             request.BrokerName,
@@ -35,14 +36,14 @@ public sealed class TransactionService : ITransactionService
             });
     }
 
-    public AssetDetailsDTO? UpdateTransaction(TransactionUpdateDTO request)
+    public Task<AssetDetailsDTO?> UpdateTransactionAsync(TransactionUpdateDTO request)
     {
         if (request.Id == Guid.Empty)
         {
-            return null;
+            return Task.FromResult<AssetDetailsDTO?>(null);
         }
 
-        return AssetServiceHelper.ExecuteParsedMutation<Transaction.TransactionType>(
+        return AssetServiceHelper.ExecuteParsedMutationAsync<Transaction.TransactionType>(
             _repository,
             _navigationService,
             request.BrokerName,
@@ -57,14 +58,14 @@ public sealed class TransactionService : ITransactionService
             });
     }
 
-    public AssetDetailsDTO? DeleteTransaction(TransactionDeleteDTO request)
+    public Task<AssetDetailsDTO?> DeleteTransactionAsync(TransactionDeleteDTO request)
     {
         if (request.Id == Guid.Empty)
         {
-            return null;
+            return Task.FromResult<AssetDetailsDTO?>(null);
         }
 
-        return AssetServiceHelper.ExecuteAssetMutation(
+        return AssetServiceHelper.ExecuteAssetMutationAsync(
             _repository,
             _navigationService,
             request.BrokerName,

--- a/Tests/Financial.Infrastructure.Tests/Services/CreditServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/CreditServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Financial.Application.DTOs;
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
@@ -12,7 +13,7 @@ namespace Financial.Infrastructure.Tests.Services;
 public class CreditServiceTests
 {
     [Fact]
-    public void AddCredit_WithValidRequest_ReturnsDetailsWithNewCredit()
+    public async Task AddCredit_WithValidRequest_ReturnsDetailsWithNewCredit()
     {
         var (service, tempFile) = CreateService();
         try
@@ -27,7 +28,7 @@ public class CreditServiceTests
                 Value = 12.5m
             };
 
-            var result = service.AddCredit(request);
+            var result = await service.AddCreditAsync(request);
 
             result.Should().NotBeNull();
             result!.Credits.Should().ContainSingle(credit =>
@@ -43,12 +44,12 @@ public class CreditServiceTests
     }
 
     [Fact]
-    public void UpdateCredit_WithValidRequest_UpdatesCredit()
+    public async Task UpdateCredit_WithValidRequest_UpdatesCredit()
     {
         var (service, tempFile) = CreateService();
         try
         {
-            var created = service.AddCredit(new CreditCreateDTO
+            var created = await service.AddCreditAsync(new CreditCreateDTO
             {
                 BrokerName = "XPI",
                 PortfolioName = "Default",
@@ -60,7 +61,7 @@ public class CreditServiceTests
 
             var creditId = created!.Credits.First(credit => credit.Date == new DateTime(2024, 2, 2)).Id;
 
-            var updated = service.UpdateCredit(new CreditUpdateDTO
+            var updated = await service.UpdateCreditAsync(new CreditUpdateDTO
             {
                 BrokerName = "XPI",
                 PortfolioName = "Default",
@@ -83,12 +84,12 @@ public class CreditServiceTests
     }
 
     [Fact]
-    public void DeleteCredit_WithValidRequest_RemovesCredit()
+    public async Task DeleteCredit_WithValidRequest_RemovesCredit()
     {
         var (service, tempFile) = CreateService();
         try
         {
-            var created = service.AddCredit(new CreditCreateDTO
+            var created = await service.AddCreditAsync(new CreditCreateDTO
             {
                 BrokerName = "XPI",
                 PortfolioName = "Default",
@@ -100,7 +101,7 @@ public class CreditServiceTests
 
             var creditId = created!.Credits.First(credit => credit.Date == new DateTime(2024, 2, 3)).Id;
 
-            var updated = service.DeleteCredit(new CreditDeleteDTO
+            var updated = await service.DeleteCreditAsync(new CreditDeleteDTO
             {
                 BrokerName = "XPI",
                 PortfolioName = "Default",
@@ -129,5 +130,3 @@ public class CreditServiceTests
         return (service, tempFile);
     }
 }
-
-

--- a/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using Financial.Infrastructure.Repositories;
@@ -464,7 +465,7 @@ public class NavigationServiceTests
 
         public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => throw new NotImplementedException();
 
-        public void SaveChanges() => throw new NotImplementedException();
+        public Task SaveChangesAsync() => throw new NotImplementedException();
     }
 }
 

--- a/Tests/Financial.Infrastructure.Tests/Services/TransactionServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/TransactionServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Financial.Application.DTOs;
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
@@ -12,7 +13,7 @@ namespace Financial.Infrastructure.Tests.Services;
 public class TransactionServiceTests
 {
     [Fact]
-    public void AddTransaction_WithValidRequest_ReturnsDetailsWithNewTransaction()
+    public async Task AddTransaction_WithValidRequest_ReturnsDetailsWithNewTransaction()
     {
         var (service, tempFile) = CreateService();
         try
@@ -29,7 +30,7 @@ public class TransactionServiceTests
                 Fees = 2.5m
             };
 
-            var result = service.AddTransaction(request);
+            var result = await service.AddTransactionAsync(request);
 
             result.Should().NotBeNull();
             result!.Transactions.Should().ContainSingle(t =>
@@ -47,12 +48,12 @@ public class TransactionServiceTests
     }
 
     [Fact]
-    public void UpdateTransaction_WithValidRequest_UpdatesTransaction()
+    public async Task UpdateTransaction_WithValidRequest_UpdatesTransaction()
     {
         var (service, tempFile) = CreateService();
         try
         {
-            var created = service.AddTransaction(new TransactionCreateDTO
+            var created = await service.AddTransactionAsync(new TransactionCreateDTO
             {
                 BrokerName = "XPI",
                 PortfolioName = "Default",
@@ -66,7 +67,7 @@ public class TransactionServiceTests
 
             var transactionId = created!.Transactions.First(t => t.Date == new DateTime(2024, 1, 3)).Id;
 
-            var updated = service.UpdateTransaction(new TransactionUpdateDTO
+            var updated = await service.UpdateTransactionAsync(new TransactionUpdateDTO
             {
                 BrokerName = "XPI",
                 PortfolioName = "Default",
@@ -92,12 +93,12 @@ public class TransactionServiceTests
     }
 
     [Fact]
-    public void DeleteTransaction_WithValidRequest_RemovesTransaction()
+    public async Task DeleteTransaction_WithValidRequest_RemovesTransaction()
     {
         var (service, tempFile) = CreateService();
         try
         {
-            var created = service.AddTransaction(new TransactionCreateDTO
+            var created = await service.AddTransactionAsync(new TransactionCreateDTO
             {
                 BrokerName = "XPI",
                 PortfolioName = "Default",
@@ -111,7 +112,7 @@ public class TransactionServiceTests
 
             var transactionId = created!.Transactions.First(t => t.Date == new DateTime(2024, 1, 4)).Id;
 
-            var updated = service.DeleteTransaction(new TransactionDeleteDTO
+            var updated = await service.DeleteTransactionAsync(new TransactionDeleteDTO
             {
                 BrokerName = "XPI",
                 PortfolioName = "Default",


### PR DESCRIPTION
## Summary

- `IRepository.SaveChanges()` → `Task SaveChangesAsync()` — repository no longer blocks a thread-pool thread during file writes
- `JSONRepository.SaveChangesAsync()` now properly `await`s `IJsonStorage.WriteAsync()` (which uses `File.WriteAllTextAsync` under `LocalJsonStorage`)
- `AssetServiceHelper.ExecuteAssetMutationAsync` / `ExecuteParsedMutationAsync` — async variants replace the sync versions
- `ITransactionService` / `ICreditService` — all mutation methods renamed with `Async` suffix and return `Task<AssetDetailsDTO?>`
- `TransactionService` / `CreditService` — implementations updated to propagate the task
- `TransactionsController` / `CreditsController` — mutation actions become `async Task<ActionResult<>>`
- `TransactionActions` / `CreditActions` (WPF) — `Add`, `Update`, `Delete` become `async Task`
- `AssetDetailsViewModel` command handlers — `async void` (the standard WPF ICommand-bound method pattern)
- All test files updated: service tests become `async Task`, mock `IRepository` updated to `Task SaveChangesAsync()`

## What was NOT changed

`JSONRepository` constructor keeps sync-over-async for the initial data load (`LoadInvestments`). Constructors cannot be `async` in C#, and the load happens once at startup before any synchronisation context is active — deadlock risk is negligible there. The hot path (every save) is now genuinely async.

## Test plan

- [x] Build: 0 errors, 0 warnings (WPF + API)
- [x] Domain tests: 35 passed
- [x] Infrastructure tests: 74 passed, 3 skipped
- [x] Application tests: 36 passed
- [x] API tests: 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)