### PR TITLE
fix(F-06): move RepositoryProvider and RepositorySelectionOptions to Infrastructure

### DIFF
--- a/Financial.Application/Interfaces/IRepositoryFactory.cs
+++ b/Financial.Application/Interfaces/IRepositoryFactory.cs
@@ -1,6 +1,0 @@
-namespace Financial.Application.Interfaces;
-
-public interface IRepositoryFactory
-{
-    IRepository Create(RepositorySelectionOptions options);
-}

--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 using Financial.Application.Configuration;
 using Financial.Application.Interfaces;
-using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
 using Financial.Infrastructure.Services;
 using Microsoft.Extensions.Configuration;
@@ -15,8 +14,7 @@ public static class InfrastructureServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        services.AddSingleton<IRepositoryFactory, RepositoryFactory>();
-        services.AddSingleton<IRepository>(sp => CreateRepository(sp, configuration));
+        services.AddSingleton<IRepository>(sp => CreateRepository(configuration));
         services.AddSingleton<INavigationService, NavigationService>();
         services.AddSingleton<ITransactionService, TransactionService>();
         services.AddSingleton<ICreditService, CreditService>();
@@ -26,7 +24,7 @@ public static class InfrastructureServiceCollectionExtensions
         return services;
     }
 
-    private static IRepository CreateRepository(IServiceProvider sp, IConfiguration configuration)
+    private static IRepository CreateRepository(IConfiguration configuration)
     {
         var providerValue = configuration[RepositoryConfigurationKeys.Provider]
             ?? nameof(RepositoryProvider.LocalJson);
@@ -44,6 +42,6 @@ public static class InfrastructureServiceCollectionExtensions
             configuration[RepositoryConfigurationKeys.GoogleDriveCredentialsPath],
             configuration[RepositoryConfigurationKeys.GoogleDriveFilePath]);
 
-        return sp.GetRequiredService<IRepositoryFactory>().Create(options);
+        return new RepositoryFactory().Create(options);
     }
 }

--- a/Financial.Infrastructure/Repositories/RepositoryFactory.cs
+++ b/Financial.Infrastructure/Repositories/RepositoryFactory.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Financial.Infrastructure.Repositories;
 
-public sealed class RepositoryFactory : IRepositoryFactory
+public sealed class RepositoryFactory
 {
     public IRepository Create(RepositorySelectionOptions options)
     {

--- a/Financial.Infrastructure/Repositories/RepositoryProvider.cs
+++ b/Financial.Infrastructure/Repositories/RepositoryProvider.cs
@@ -1,4 +1,4 @@
-namespace Financial.Application.Interfaces;
+namespace Financial.Infrastructure.Repositories;
 
 public enum RepositoryProvider
 {

--- a/Financial.Infrastructure/Repositories/RepositorySelectionOptions.cs
+++ b/Financial.Infrastructure/Repositories/RepositorySelectionOptions.cs
@@ -1,4 +1,4 @@
-namespace Financial.Application.Interfaces;
+namespace Financial.Infrastructure.Repositories;
 
 public sealed record RepositorySelectionOptions(
     RepositoryProvider Provider,

--- a/Tests/Financial.Infrastructure.Tests/Repositories/RepositoryFactoryTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Repositories/RepositoryFactoryTests.cs
@@ -1,4 +1,3 @@
-using Financial.Application.Interfaces;
 using Financial.Infrastructure.Repositories;
 using FluentAssertions;
 using System;


### PR DESCRIPTION
## Summary

- `RepositoryProvider` (enum naming `LocalJson` / `GoogleDriveJson` storage backends) moved from `Financial.Application/Interfaces` → `Financial.Infrastructure/Repositories`
- `RepositorySelectionOptions` (record with Google Drive path fields) moved to the same location
- `IRepositoryFactory` deleted from Application entirely — it was only ever resolved inside `InfrastructureServiceCollectionExtensions`, so it provided no Application-layer abstraction value
- `RepositoryFactory` drops the `IRepositoryFactory` implementation; it is now used directly inside `InfrastructureServiceCollectionExtensions.CreateRepository()`
- The `IServiceProvider sp` parameter is removed from `CreateRepository` since `IRepositoryFactory` is no longer resolved from the container
- `RepositoryFactoryTests` updated to use the Infrastructure namespace

## Architecture

The Application layer no longer knows that `LocalJson` or `GoogleDrive` storage exist. Adding a new storage backend in the future requires changes only in Infrastructure, satisfying OCP at the layer boundary.

## Test plan

- [x] Build: 0 errors, 0 warnings (all 4 projects)
- [x] Domain tests: 35 passed
- [x] Infrastructure tests: 74 passed, 3 skipped
- [x] Application tests: 36 passed
- [x] API tests: 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)