### PR TITLE
fix(F-07): move dividend business rules out of Infrastructure

### DIFF
--- a/Financial.Application/Configuration/DividendValuationRules.cs
+++ b/Financial.Application/Configuration/DividendValuationRules.cs
@@ -1,0 +1,7 @@
+namespace Financial.Application.Configuration;
+
+public static class DividendValuationRules
+{
+    public const decimal RequiredYield = 0.06m;
+    public const int DividendYearsLookback = 5;
+}

--- a/Financial.Application/DTOs/DividendSummaryDTO.cs
+++ b/Financial.Application/DTOs/DividendSummaryDTO.cs
@@ -7,7 +7,7 @@ public class DividendSummaryDTO
     public required string Name { get; set; }
     public decimal CurrentPrice { get; set; }
     public DateTimeOffset PriceAsOf { get; set; }
-    public decimal AverageDividendLastFiveYears { get; set; }
+    public decimal AverageDividendPerYear { get; set; }
     public decimal PriceMaxBuy { get; set; }
     public decimal DiscountPercent { get; set; }
     public required IReadOnlyList<DividendYearTotalDTO> YearTotals { get; set; }

--- a/Financial.Infrastructure/Services/DividendService.cs
+++ b/Financial.Infrastructure/Services/DividendService.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Configuration;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Common;
@@ -10,7 +11,6 @@ namespace Financial.Infrastructure.Services;
 
 public sealed class DividendService : IDividendService
 {
-    private const decimal RequiredYield = 0.06m;
 
     public IReadOnlyList<DividendHistoryItemDTO> GetDividendHistory(DividendLookupRequestDTO request)
     {
@@ -43,12 +43,12 @@ public sealed class DividendService : IDividendService
         var averageDividend = yearTotals
             .Where(total => total.Year < DateTime.Today.Year)
             .OrderByDescending(total => total.Year)
-            .Take(5)
+            .Take(DividendValuationRules.DividendYearsLookback)
             .Select(total => total.Total)
             .DefaultIfEmpty(0m)
             .Average();
 
-        var priceMax = averageDividend > 0m ? averageDividend / RequiredYield : 0m;
+        var priceMax = averageDividend > 0m ? averageDividend / DividendValuationRules.RequiredYield : 0m;
         var discountPercent = priceMax > 0m ? (1m - (snapshot.Price / priceMax)) * 100m : 0m;
 
         return new DividendSummaryDTO
@@ -58,7 +58,7 @@ public sealed class DividendService : IDividendService
             Name = snapshot.Name,
             CurrentPrice = snapshot.Price,
             PriceAsOf = snapshot.AsOf,
-            AverageDividendLastFiveYears = averageDividend,
+            AverageDividendPerYear = averageDividend,
             PriceMaxBuy = priceMax,
             DiscountPercent = discountPercent,
             YearTotals = yearTotals

--- a/Tests/Financial.Api.Tests/DividendEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/DividendEndpointsTests.cs
@@ -81,7 +81,7 @@ public class DividendEndpointsTests
                 Name = "Sample Asset",
                 CurrentPrice = 10.5m,
                 PriceAsOf = new DateTimeOffset(2024, 2, 1, 0, 0, 0, TimeSpan.Zero),
-                AverageDividendLastFiveYears = 4m,
+                AverageDividendPerYear = 4m,
                 PriceMaxBuy = 66.67m,
                 DiscountPercent = 20m,
                 YearTotals = new[]


### PR DESCRIPTION
## Finding
`DividendService` (Infrastructure) owned two business rules:
- `RequiredYield = 0.06m` — the minimum acceptable dividend yield
- `.Take(5)` — years of history to average over

Business rules belong in the Application (or Domain) layer, not in an Infrastructure service whose job is to fetch data.

## Changes
- **New**: `Financial.Application/Configuration/DividendValuationRules.cs` — single source of truth for `RequiredYield` and `DividendYearsLookback`
- **`DividendService`**: removed its own `RequiredYield` constant; now references `DividendValuationRules.RequiredYield` and `DividendValuationRules.DividendYearsLookback`
- **`DividendSummaryDTO`**: renamed `AverageDividendLastFiveYears` → `AverageDividendPerYear` — the property name previously hardcoded the lookback count
- **`DividendEndpointsTests`**: updated to use the renamed DTO property

## Architecture
- Constants that express business policy (yield threshold, lookback window) live in `Financial.Application.Configuration`, consistent with `RepositoryConfigurationKeys`
- Infrastructure service now receives policy from the Application layer rather than defining it
- Clean Architecture: Application → defines rules, Infrastructure → implements data access

## Definition of Done
- [x] Clean Architecture respected — business rules moved from Infrastructure to Application
- [x] SOLID respected — SRP: DividendService now only fetches/aggregates, not owns policy
- [x] No layer violations
- [x] Build: 0 errors, 0 warnings
- [x] All 160 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)