### PR TITLE
fix(F-08): remove duplicated dividend calculation from MainWindow

### DIFF
--- a/Financial.App/MainWindow.xaml.cs
+++ b/Financial.App/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Configuration;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Presentation.App.Components;
@@ -5,7 +6,6 @@ using Financial.Presentation.App.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -99,40 +99,18 @@ namespace Financial.Presentation.App
         private void btnCheck_Click(object sender, RoutedEventArgs e)
         {
             var ticker = txtTicker.Text.ToUpperInvariant();
+            var request = new DividendLookupRequestDTO { Exchange = BvmfExchange, Ticker = ticker };
 
-            var value = _assetPriceService.GetCurrentPrice(new AssetPriceRequestDTO
-            {
-                Exchange = BvmfExchange,
-                Ticker = ticker,
-            });
+            var summary = _dividendService.GetDividendSummary(request);
 
-            var dividends = _dividendService.GetDividendHistory(new DividendLookupRequestDTO
-            {
-                Exchange = BvmfExchange,
-                Ticker = ticker,
-            });
+            dividendDataGrid.ItemsSource = summary.History;
+            dividendByYearDataGrid.ItemsSource = summary.YearTotals;
 
-            dividendDataGrid.ItemsSource = dividends;
-
-            var dividendsByYear = dividends
-                .GroupBy(d => d.Date.Year)
-                .Select(g => new
-                {
-                    Year = g.Key,
-                    Total = g.Sum(gi => gi.Value)
-                })
-                .OrderByDescending(dy => dy.Year);
-            dividendByYearDataGrid.ItemsSource = dividendsByYear;
-
-            var averageDividend = dividendsByYear.Where(dy => dy.Year < DateTime.Now.Year).Take(5).Average(dy => dy.Total);
-            var priceMax = averageDividend / (decimal)0.06;
-            var priceDiscountPer = (1 - value.Price / priceMax) * 100;
-
-            lblName.Text = $"{value.Ticker} - {value.Name}";
-            lblPrice.Text = $"Current price: {value.Price:N2}";
-            lblAverageDividend.Text = $"Average Dividend: {averageDividend:F2} (last 5 years)";
-            lblPriceMax.Text = $"Price max buy: {priceMax:F2}   Discount {priceDiscountPer:F2}%";
-            lblPriceMax.Foreground = priceMax > value.Price ? Brushes.Green : Brushes.Red;
+            lblName.Text = $"{summary.Ticker} - {summary.Name}";
+            lblPrice.Text = $"Current price: {summary.CurrentPrice:N2}";
+            lblAverageDividend.Text = $"Average Dividend: {summary.AverageDividendPerYear:F2} (last {DividendValuationRules.DividendYearsLookback} years)";
+            lblPriceMax.Text = $"Price max buy: {summary.PriceMaxBuy:F2}   Discount {summary.DiscountPercent:F2}%";
+            lblPriceMax.Foreground = summary.PriceMaxBuy > summary.CurrentPrice ? Brushes.Green : Brushes.Red;
         }
 
         private void DividendDataGrid_AutoGeneratingColumn(object sender, DataGridAutoGeneratingColumnEventArgs e)

--- a/Financial.Application/DTOs/DividendSummaryDTO.cs
+++ b/Financial.Application/DTOs/DividendSummaryDTO.cs
@@ -10,5 +10,6 @@ public class DividendSummaryDTO
     public decimal AverageDividendPerYear { get; set; }
     public decimal PriceMaxBuy { get; set; }
     public decimal DiscountPercent { get; set; }
+    public required IReadOnlyList<DividendHistoryItemDTO> History { get; set; }
     public required IReadOnlyList<DividendYearTotalDTO> YearTotals { get; set; }
 }

--- a/Financial.Infrastructure/Services/DividendService.cs
+++ b/Financial.Infrastructure/Services/DividendService.cs
@@ -30,6 +30,17 @@ public sealed class DividendService : IDividendService
     {
         var values = LoadDividends(request);
         var snapshot = GoogleFinance.GetFinancialInfoSnapshot(request.Exchange, request.Ticker);
+
+        var history = values
+            .OrderByDescending(dividend => dividend.Date)
+            .Select(dividend => new DividendHistoryItemDTO
+            {
+                Type = dividend.Type.ToString(),
+                Date = dividend.Date,
+                Value = dividend.Value
+            })
+            .ToList();
+
         var yearTotals = values
             .GroupBy(dividend => dividend.Date.Year)
             .Select(group => new DividendYearTotalDTO
@@ -61,6 +72,7 @@ public sealed class DividendService : IDividendService
             AverageDividendPerYear = averageDividend,
             PriceMaxBuy = priceMax,
             DiscountPercent = discountPercent,
+            History = history,
             YearTotals = yearTotals
         };
     }

--- a/Tests/Financial.Api.Tests/DividendEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/DividendEndpointsTests.cs
@@ -84,6 +84,15 @@ public class DividendEndpointsTests
                 AverageDividendPerYear = 4m,
                 PriceMaxBuy = 66.67m,
                 DiscountPercent = 20m,
+                History = new[]
+                {
+                    new DividendHistoryItemDTO
+                    {
+                        Type = "Dividend",
+                        Date = new DateTime(2023, 6, 1),
+                        Value = 4m
+                    }
+                },
                 YearTotals = new[]
                 {
                     new DividendYearTotalDTO


### PR DESCRIPTION
## Finding
`MainWindow.btnCheck_Click` duplicated the dividend valuation logic that already lives in `DividendService`:
- Manually grouped dividend history by year
- Averaged the last 5 years with a magic `5`
- Applied the 6% yield threshold with a magic `0.06`
- Made two separate external API calls (`_assetPriceService.GetCurrentPrice` + `_dividendService.GetDividendHistory`) when `GetDividendSummary` already fetches both in one shot

## Changes
- **`DividendSummaryDTO`**: added `History` (`IReadOnlyList<DividendHistoryItemDTO>`) so the summary carries individual entries alongside year totals — single service call covers everything
- **`DividendService.GetDividendSummary`**: populates `History` from the already-loaded dividend values (no additional I/O)
- **`MainWindow.btnCheck_Click`**: replaced ~20 lines of manual grouping + magic-number calculation with a single `GetDividendSummary` call; binds `summary.History`, `summary.YearTotals`, and uses `DividendValuationRules.DividendYearsLookback` in the label text
- **`DividendEndpointsTests`**: updated stub to satisfy the new `required History` property

## Architecture
- Presentation layer now contains zero business logic — it delegates and displays
- `GetDividendHistory` (still exposed on `IDividendService`) remains for the REST API endpoint; `GetDividendSummary` is the richer call used by the WPF view

## Definition of Done
- [x] Clean Architecture respected — no business logic in Presentation
- [x] SOLID respected — SRP: MainWindow only orchestrates UI, not calculations
- [x] No layer violations
- [x] Build: 0 errors, 0 warnings
- [x] All 160 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)