### PR TITLE
fix(F-09): eliminate duplicate serialization options in GoogleGenerator

### DIFF
--- a/Financial.Common/InvestmentsSerializerOptions.cs
+++ b/Financial.Common/InvestmentsSerializerOptions.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Financial.Common;
+
+public static class InvestmentsSerializerOptions
+{
+    public static readonly JsonSerializerOptions Default = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = true,
+        TypeInfoResolver = new PrivateConstructorContractResolver()
+    };
+}

--- a/Financial.Infrastructure/Persistence/InvestmentsJsonSerializer.cs
+++ b/Financial.Infrastructure/Persistence/InvestmentsJsonSerializer.cs
@@ -1,25 +1,17 @@
 using Financial.Common;
 using Financial.Domain.Entities;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Financial.Infrastructure.Persistence;
 
 public static class InvestmentsJsonSerializer
 {
-    private static readonly JsonSerializerOptions Options = new()
-    {
-        Converters = { new JsonStringEnumConverter() },
-        WriteIndented = true,
-        TypeInfoResolver = new PrivateConstructorContractResolver()
-    };
-
     public static string Serialize(Investments investments) =>
-        JsonSerializer.Serialize(investments, Options);
+        JsonSerializer.Serialize(investments, InvestmentsSerializerOptions.Default);
 
     public static Investments Deserialize(string json)
     {
-        var investments = JsonSerializer.Deserialize<Investments>(json, Options);
+        var investments = JsonSerializer.Deserialize<Investments>(json, InvestmentsSerializerOptions.Default);
         return investments!;
     }
 }

--- a/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
@@ -1,13 +1,12 @@
+using Financial.Application.Interfaces;
 using Financial.Common;
 using Financial.Domain.Entities;
 using Financial.Infrastructure.Integrations.FinancialToolSupport;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport.DTO;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
@@ -47,11 +46,12 @@ public class GoogleGenerator : IGenerator
     };
 
     private readonly GoogleService _service;
-    private readonly string _path;
+    private readonly IJsonStorage _storage;
 
-    public GoogleGenerator(GoogleService service, string path) {
+    public GoogleGenerator(GoogleService service, IJsonStorage storage)
+    {
         _service = service ?? throw new ArgumentNullException(nameof(service));
-        _path = path;
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
     }
 
     public async Task GenerateAsync(List<string> fileNames, IProgress<string> progress = null)
@@ -122,7 +122,7 @@ public class GoogleGenerator : IGenerator
             }
         }
         progress?.Report("Saving data...");
-        Save(data);
+        await SaveAsync(data);
         progress?.Report("Complete!");
     }
 
@@ -208,17 +208,10 @@ public class GoogleGenerator : IGenerator
         };
     }
 
-    private static readonly JsonSerializerOptions _serializerOptions = new()
+    private async Task SaveAsync(Investments data)
     {
-        Converters = { new JsonStringEnumConverter() },
-        WriteIndented = true,
-        TypeInfoResolver = new PrivateConstructorContractResolver()
-    };
-
-    private void Save(Investments data)
-    {
-        string json = JsonSerializer.Serialize(data, _serializerOptions);
-        File.WriteAllText(Path.Combine(_path, "data.json"), json);
+        var json = JsonSerializer.Serialize(data, InvestmentsSerializerOptions.Default);
+        await _storage.WriteAsync(json);
     }
 
     private async Task<List<Transaction>> CreateTransactionsAsync(string id, string spreadSheetName)

--- a/Integrations/ImportGoogleSpreadSheets/ImportGoogleSpreadSheets.csproj
+++ b/Integrations/ImportGoogleSpreadSheets/ImportGoogleSpreadSheets.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GoogleFinancialSupport\GoogleFinancialSupport.csproj" />
+    <ProjectReference Include="..\..\Financial.Infrastructure\Financial.Infrastructure.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/Integrations/ImportGoogleSpreadSheets/MainWindow.xaml.cs
+++ b/Integrations/ImportGoogleSpreadSheets/MainWindow.xaml.cs
@@ -1,14 +1,15 @@
 using Financial.Infrastructure.Integrations.FinancialToolSupport;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+using Financial.Infrastructure.Persistence;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Text.Json;
 
 namespace Financial.Infrastructure.Integrations.ImportGoogleSpreadSheets;
 
@@ -137,7 +138,7 @@ public partial class MainWindow : Window
         {
             SetUIBusy(true, "Starting data generation...");
             
-            IGenerator generator = new GoogleGenerator(_service, edtPath.Text);
+            IGenerator generator = new GoogleGenerator(_service, new LocalJsonStorage(edtPath.Text));
             var fileNames = selectedFiles.Select(f => f.Name).ToList();
 
             var progress = new Progress<string>(status =>


### PR DESCRIPTION
## Finding
`GoogleGenerator` contained a private `_serializerOptions` field that was byte-for-byte identical to the `Options` in `InvestmentsJsonSerializer` (same converters, same `WriteIndented`, same `TypeInfoResolver`). It also wrote the output file directly with `File.WriteAllText` instead of using the `IJsonStorage` abstraction.

The circular dependency (`Financial.Infrastructure` → `GoogleFinancialSupport`) prevented `GoogleGenerator` from calling `InvestmentsJsonSerializer` directly, so the options were copied in full.

## Changes
- **New `Financial.Common/InvestmentsSerializerOptions.cs`**: single source of truth for `JsonSerializerOptions` — lives alongside `PrivateConstructorContractResolver` which it already depends on
- **`InvestmentsJsonSerializer`**: drops its own `Options` field; delegates to `InvestmentsSerializerOptions.Default`
- **`GoogleGenerator`**: drops `_serializerOptions` and the raw `string path` constructor parameter; accepts `IJsonStorage storage`; `SaveAsync()` uses `InvestmentsSerializerOptions.Default` from Common and `await _storage.WriteAsync(json)` — no direct file I/O
- **`ImportGoogleSpreadSheets.csproj`**: adds `Financial.Infrastructure` reference (composition root — the correct place to wire infrastructure)
- **`ImportGoogleSpreadSheets/MainWindow.xaml.cs`**: constructs `new LocalJsonStorage(edtPath.Text)` and passes it to `GoogleGenerator`

## Architecture
- `Financial.Common` is the right home: no project references it doesn't already have, and `PrivateConstructorContractResolver` was already there
- `GoogleGenerator` now depends on an abstraction (`IJsonStorage`) instead of `File` directly
- `ImportGoogleSpreadSheets` wires the concrete storage at the composition root — same pattern as `Financial.App`

## Definition of Done
- [x] Clean Architecture respected — no duplicated infrastructure concerns
- [x] SOLID respected — OCP/DIP: `GoogleGenerator` depends on `IJsonStorage` abstraction
- [x] No layer violations
- [x] Build: 0 errors, 0 warnings
- [x] All 160 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)