### PR TITLE
fix(F-11): rename AvargePrice to AveragePrice on Asset entity

### DIFF
--- a/Financial.Domain/Entities/Asset.cs
+++ b/Financial.Domain/Entities/Asset.cs
@@ -28,7 +28,7 @@ public class Asset
     public GlobalAssetClass Class { get; private set; } = GlobalAssetClass.Unknown;
 
     [JsonIgnore]
-    public decimal AvargePrice { get; private set; } = 0;
+    public decimal AveragePrice { get; private set; } = 0;
 
     [JsonIgnore]
     public decimal Quantity { get; private set; }
@@ -48,7 +48,7 @@ public class Asset
     {
         var transactionList = new List<Transaction>(transactions);
         _transactions.Clear();
-        AvargePrice = 0;
+        AveragePrice = 0;
         Quantity = 0;
         foreach (var transaction in transactionList)
         {
@@ -115,7 +115,7 @@ public class Asset
         transaction.EnsureId();
         if (transaction.Type == Transaction.TransactionType.Buy)
         {
-            AvargePrice = (AvargePrice * Quantity + transaction.TotalPrice) / (Quantity + transaction.Quantity);
+            AveragePrice = (AveragePrice * Quantity + transaction.TotalPrice) / (Quantity + transaction.Quantity);
         }
         Quantity += (transaction.Type == Transaction.TransactionType.Buy
             ? transaction.Quantity : -transaction.Quantity);

--- a/Financial.Infrastructure/Services/NavigationService.cs
+++ b/Financial.Infrastructure/Services/NavigationService.cs
@@ -83,7 +83,7 @@ public class NavigationService : INavigationService
             LocalTypeCode = asset.LocalTypeCode,
             Class = asset.Class,
             Quantity = asset.Quantity,
-            AveragePrice = asset.AvargePrice,
+            AveragePrice = asset.AveragePrice,
             IsActive = asset.Active,
             TotalBought = totalBought,
             TotalSold = totalSold,
@@ -255,7 +255,7 @@ public class NavigationService : INavigationService
             LocalTypeCode = asset.LocalTypeCode,
             Class = asset.Class,
             Quantity = asset.Quantity,
-            AveragePrice = asset.AvargePrice,
+            AveragePrice = asset.AveragePrice,
             IsActive = asset.Active,
             TransactionCount = asset.Transactions.Count,
             CreditCount = asset.Credits.Count

--- a/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
@@ -32,7 +32,7 @@ public class AssetTests
         asset.AddTransaction(second);
 
         asset.Quantity.Should().Be(20m);
-        asset.AvargePrice.Should().Be(6m);
+        asset.AveragePrice.Should().Be(6m);
         asset.Active.Should().BeTrue();
     }
 
@@ -45,7 +45,7 @@ public class AssetTests
         asset.AddTransaction(Transaction.Create(new DateTime(2024, 1, 2), Transaction.TransactionType.Sell, 5m, 12m, 0m));
 
         asset.Quantity.Should().Be(0m);
-        asset.AvargePrice.Should().Be(10m);
+        asset.AveragePrice.Should().Be(10m);
         asset.Active.Should().BeFalse();
     }
 
@@ -65,7 +65,7 @@ public class AssetTests
         result.Should().BeTrue();
         asset.Quantity.Should().Be(30m);
         var expected = (20m * 5m + 10m * 7m) / 30m;
-        asset.AvargePrice.Should().Be(expected);
+        asset.AveragePrice.Should().Be(expected);
     }
 
     [Fact]


### PR DESCRIPTION
## Finding
`Asset.AvargePrice` is a public domain entity property with a typo that has propagated to every consumer. Every caller had to mentally translate the misspelling.

## Changes
- `Asset.cs`: renamed property declaration + two internal usages in `RebuildTransactions` and `AddTransaction`
- `NavigationService.cs`: updated both `AveragePrice = asset.AvargePrice` call sites (already used the correct name on the left-hand side)
- `AssetTests.cs`: updated three assertions

`[JsonIgnore]` is present on the property, so no existing data files are affected.

## Definition of Done
- [x] No layer violations
- [x] Build: 0 errors, 0 warnings
- [x] All 160 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)