### PR TITLE
fix(F-12,F-16,F-21): Application-layer interface and constants hygiene

### DIFF
--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -110,7 +110,7 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
 
     private static TreeNodeDTO? FilterTreeNode(TreeNodeDTO node, GlobalAssetClass filter)
     {
-        if (node.NodeType == "Asset")
+        if (node.NodeType == TreeNodeTypes.Asset)
         {
             if (node.Metadata.TryGetValue("GlobalAssetClass", out var value) && value is GlobalAssetClass assetClass)
             {
@@ -216,13 +216,13 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
             return;
         }
 
-        if (selectedNode.NodeType == "Portfolio")
+        if (selectedNode.NodeType == TreeNodeTypes.Portfolio)
         {
             LoadPortfolioCredits(selectedNode);
             return;
         }
 
-        if (selectedNode.NodeType == "Broker")
+        if (selectedNode.NodeType == TreeNodeTypes.Broker)
         {
             LoadBrokerCredits(selectedNode);
             return;

--- a/Financial.Application/DTOs/TreeNodeTypes.cs
+++ b/Financial.Application/DTOs/TreeNodeTypes.cs
@@ -1,0 +1,9 @@
+namespace Financial.Application.DTOs;
+
+public static class TreeNodeTypes
+{
+    public const string Investments = "Investments";
+    public const string Broker = "Broker";
+    public const string Portfolio = "Portfolio";
+    public const string Asset = "Asset";
+}

--- a/Financial.Application/Interfaces/IRepository.cs
+++ b/Financial.Application/Interfaces/IRepository.cs
@@ -5,7 +5,7 @@ namespace Financial.Application.Interfaces;
 
 public interface IRepository
 {
-    List<string> GetAllAssetsFullName();
+    IReadOnlyList<string> GetAllAssetsFullName();
     IEnumerable<Asset> GetAssetsByBroker(string name);
     IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio);
     IEnumerable<Asset> GetAssetsByPortfolio(string name);

--- a/Financial.Infrastructure/Persistence/LocalJsonStorage.cs
+++ b/Financial.Infrastructure/Persistence/LocalJsonStorage.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Configuration;
 using Financial.Application.Interfaces;
 using System;
 using System.IO;
@@ -7,7 +8,6 @@ namespace Financial.Infrastructure.Persistence;
 
 public sealed class LocalJsonStorage : IJsonStorage
 {
-    public const string DataJsonFileConfigurationKey = "DataJsonFile";
     public const string DefaultDataFileName = "data.json";
 
     private readonly string _dataFilePath;
@@ -22,7 +22,7 @@ public sealed class LocalJsonStorage : IJsonStorage
         if (!File.Exists(_dataFilePath))
         {
             throw new FileNotFoundException(
-                $"Data file not found at '{_dataFilePath}'. Configure '{DataJsonFileConfigurationKey}' or place '{DefaultDataFileName}' in the application directory.",
+                $"Data file not found at '{_dataFilePath}'. Configure '{RepositoryConfigurationKeys.LocalJsonDataFile}' or place '{DefaultDataFileName}' in the application directory.",
                 _dataFilePath);
         }
 

--- a/Financial.Infrastructure/Repositories/JSONRepository.cs
+++ b/Financial.Infrastructure/Repositories/JSONRepository.cs
@@ -19,7 +19,7 @@ public sealed class JSONRepository : IRepository
         _investiments = LoadInvestments(_storage);
     }
 
-    public List<string> GetAllAssetsFullName()
+    public IReadOnlyList<string> GetAllAssetsFullName()
     {
         return _investiments.Brokers
             .SelectMany(b => b.Portfolios.SelectMany(p => p.Assets.Select(a => $"{b.Name}/{p.Name}/{a.Name}")))

--- a/Financial.Infrastructure/Services/NavigationService.cs
+++ b/Financial.Infrastructure/Services/NavigationService.cs
@@ -27,7 +27,7 @@ public class NavigationService : INavigationService
 
         var rootNode = new TreeNodeDTO
         {
-            NodeType = "Investments",
+            NodeType = TreeNodeTypes.Investments,
             DisplayName = "All Investments"
         };
 
@@ -143,7 +143,7 @@ public class NavigationService : INavigationService
     {
         var brokerNode = new TreeNodeDTO
         {
-            NodeType = "Broker",
+            NodeType = TreeNodeTypes.Broker,
             DisplayName = $"{broker.Name} ({broker.Currency})",
             Metadata = new Dictionary<string, object>
             {
@@ -166,7 +166,7 @@ public class NavigationService : INavigationService
     {
         var portfolioNode = new TreeNodeDTO
         {
-            NodeType = "Portfolio",
+            NodeType = TreeNodeTypes.Portfolio,
             DisplayName = $"{portfolio.Name} ({portfolio.AssetCount} assets)",
             Metadata = new Dictionary<string, object>
             {
@@ -188,7 +188,7 @@ public class NavigationService : INavigationService
     {
         return new TreeNodeDTO
         {
-            NodeType = "Asset",
+            NodeType = TreeNodeTypes.Asset,
             DisplayName = asset.Name,
             Metadata = new Dictionary<string, object>
             {

--- a/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
@@ -451,7 +451,7 @@ public class NavigationServiceTests
             _brokers = brokers.ToList();
         }
 
-        public List<string> GetAllAssetsFullName() => throw new NotImplementedException();
+        public IReadOnlyList<string> GetAllAssetsFullName() => throw new NotImplementedException();
 
         public IEnumerable<Asset> GetAssetsByBroker(string name) => throw new NotImplementedException();
 


### PR DESCRIPTION
## Findings

### F-12 — Magic node-type strings
`"Investments"`, `"Broker"`, `"Portfolio"`, `"Asset"` were typed independently in `NavigationService` (4 sites) and `MainNavigationViewModelBase` (4 sites). A single typo in any comparison would silently break tree navigation.

**Fix**: new `TreeNodeTypes` static class in `Financial.Application/DTOs/` — both the Infrastructure service and the Presentation ViewModel reference the same constants.

### F-16 — `IRepository.GetAllAssetsFullName()` returns `List<string>`
An interface method should not expose a concrete mutable collection. All other `IRepository` methods return `IEnumerable<T>`.

**Fix**: return type changed to `IReadOnlyList<string>` on the interface and the `JSONRepository` implementation; test stub updated.

### F-21 — Duplicate configuration key constant
`LocalJsonStorage.DataJsonFileConfigurationKey = "DataJsonFile"` duplicated `RepositoryConfigurationKeys.LocalJsonDataFile = "DataJsonFile"` from the Application layer. Both encoding the same string in two places means a rename would silently break configuration resolution.

**Fix**: removed `DataJsonFileConfigurationKey` from `LocalJsonStorage`; error message now references `RepositoryConfigurationKeys.LocalJsonDataFile`.

## Definition of Done
- [x] No layer violations
- [x] No magic strings
- [x] Build: 0 errors, 0 warnings
- [x] All 160 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)