### PR TITLE
fix(F-13,F-15,F-22,F-23): mechanical Presentation and Infrastructure fixes

### DIFF
--- a/Financial.App/ViewModels/CreditDialogValidation.cs
+++ b/Financial.App/ViewModels/CreditDialogValidation.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Validation;
 using System;
 using System.Collections.Generic;
 
@@ -5,7 +6,7 @@ namespace Financial.Presentation.App.ViewModels;
 
 public static class CreditDialogValidation
 {
-public static string BuildValidationMessage(bool isDeleteMode, DateTime date, string? type, decimal value)
+    public static string BuildValidationMessage(bool isDeleteMode, DateTime date, string? type, decimal value)
     {
         if (isDeleteMode)
         {
@@ -32,10 +33,6 @@ public static string BuildValidationMessage(bool isDeleteMode, DateTime date, st
         return string.Join(Environment.NewLine, errors);
     }
 
-    public static bool IsValidCreditType(string? value)
-    {
-        return string.Equals(value, "Dividend", StringComparison.OrdinalIgnoreCase) ||
-               string.Equals(value, "Rent", StringComparison.OrdinalIgnoreCase);
-    }
+    public static bool IsValidCreditType(string? value) =>
+        CreditTypeParser.TryNormalize(value, out _);
 }
-

--- a/Financial.App/ViewModels/CreditDialogViewModel.cs
+++ b/Financial.App/ViewModels/CreditDialogViewModel.cs
@@ -1,5 +1,5 @@
 using System;
-using Financial.Presentation.App.ViewModels;
+
 namespace Financial.Presentation.App.ViewModels;
 
 public enum CreditDialogMode

--- a/Financial.App/ViewModels/TransactionDialogValidation.cs
+++ b/Financial.App/ViewModels/TransactionDialogValidation.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Validation;
 using System;
 using System.Collections.Generic;
 
@@ -5,7 +6,7 @@ namespace Financial.Presentation.App.ViewModels;
 
 public static class TransactionDialogValidation
 {
-public static string BuildValidationMessage(bool isDeleteMode, DateTime date, string? type, decimal quantity, decimal unitPrice, decimal fees)
+    public static string BuildValidationMessage(bool isDeleteMode, DateTime date, string? type, decimal quantity, decimal unitPrice, decimal fees)
     {
         if (isDeleteMode)
         {
@@ -42,9 +43,6 @@ public static string BuildValidationMessage(bool isDeleteMode, DateTime date, st
         return string.Join(Environment.NewLine, errors);
     }
 
-    public static bool IsValidTransactionType(string? value)
-    {
-        return string.Equals(value, "Buy", StringComparison.OrdinalIgnoreCase) ||
-               string.Equals(value, "Sell", StringComparison.OrdinalIgnoreCase);
-    }
+    public static bool IsValidTransactionType(string? value) =>
+        TransactionTypeParser.TryNormalize(value, out _);
 }

--- a/Financial.Infrastructure/Services/NavigationService.cs
+++ b/Financial.Infrastructure/Services/NavigationService.cs
@@ -8,7 +8,7 @@ namespace Financial.Infrastructure.Services;
 /// Implementation of INavigationService that provides hierarchical navigation
 /// over financial data using the repository pattern
 /// </summary>
-public class NavigationService : INavigationService
+public sealed class NavigationService : INavigationService
 {
     private const string EncerradasName = "Encerradas";
     private readonly IRepository _repository;

--- a/Integrations/GoogleFinancialSupport/GoogleService.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleService.cs
@@ -16,7 +16,7 @@ using System.Text;
 
 namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 
-public class GoogleService
+public sealed class GoogleService
 {
     private static readonly string[] SheetsScopes = { SheetsService.Scope.Spreadsheets };
     private static readonly string[] DriveReadOnlyScopes = { DriveService.Scope.DriveReadonly };

--- a/Integrations/WebPageParser/DadosMercadoDividend.cs
+++ b/Integrations/WebPageParser/DadosMercadoDividend.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Financial.Infrastructure.Integrations.WebPageParser;
 
-public class DadosMercadoDividend
+public sealed class DadosMercadoDividend
 {
     public static List<DividendValue> GetDividendInfo(string ticker)
     {


### PR DESCRIPTION
## Findings

### F-13 — Validation duplicates type-parser logic
`IsValidTransactionType` checked `"Buy"/"Sell"` and `IsValidCreditType` checked `"Dividend"/"Rent"` with independent `string.Equals` calls, duplicating what `TransactionTypeParser.TryNormalize` and `CreditTypeParser.TryNormalize` already own in the Application layer. Adding a new transaction or credit type would require updating three files.

**Fix**: Both helpers now delegate to the Application-layer parsers: `TransactionTypeParser.TryNormalize(value, out _)` / `CreditTypeParser.TryNormalize(value, out _)`.

### F-15 — Missing `sealed` on concrete Infrastructure classes
`NavigationService`, `DadosMercadoDividend`, and `GoogleService` were the only concrete Infrastructure classes without `sealed`, inconsistent with `TransactionService`, `CreditService`, `AssetPriceService`, and `JSONRepository`. None have virtual members or intended extension points.

`GoogleFinanceAssetTypeParser` was left `public` — it is referenced cross-assembly from `GoogleFinancialSupport`.

### F-22 — Self-referencing `using` in `CreditDialogViewModel`
Line 2 imported `Financial.Presentation.App.ViewModels` — the same namespace the file is declared in. Dead import removed.

### F-23 — Method body at column 0 in validation classes
`BuildValidationMessage` in both `TransactionDialogValidation` and `CreditDialogValidation` had its opening brace flush with the left margin instead of indented inside the class. Re-indented to match the enclosing class scope.

## Definition of Done
- [x] No layer violations
- [x] Build: 0 errors, 0 warnings
- [x] All 160 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)