### PR TITLE
fix(f14,f17): extract AssetActionsBase and GoogleGeneratorOptions

### DIFF
--- a/Financial.App/ViewModels/AssetActionsBase.cs
+++ b/Financial.App/ViewModels/AssetActionsBase.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Windows;
+using Financial.Application.DTOs;
+
+namespace Financial.Presentation.App.ViewModels;
+
+public abstract class AssetActionsBase
+{
+    protected readonly Func<bool> _hasContext;
+    protected readonly Func<string> _brokerName;
+    protected readonly Func<string> _portfolioName;
+    protected readonly Func<string> _assetName;
+    protected readonly Action<AssetDetailsDTO> _applyDetails;
+    private readonly Action<string, string, MessageBoxImage> _showMessage;
+    private readonly string _title;
+
+    protected AssetActionsBase(
+        Func<bool> hasContext,
+        Func<string> brokerName,
+        Func<string> portfolioName,
+        Func<string> assetName,
+        Action<AssetDetailsDTO> applyDetails,
+        Action<string, string, MessageBoxImage> showMessage,
+        string title)
+    {
+        _hasContext = hasContext ?? throw new ArgumentNullException(nameof(hasContext));
+        _brokerName = brokerName ?? throw new ArgumentNullException(nameof(brokerName));
+        _portfolioName = portfolioName ?? throw new ArgumentNullException(nameof(portfolioName));
+        _assetName = assetName ?? throw new ArgumentNullException(nameof(assetName));
+        _applyDetails = applyDetails ?? throw new ArgumentNullException(nameof(applyDetails));
+        _showMessage = showMessage ?? throw new ArgumentNullException(nameof(showMessage));
+        _title = title;
+    }
+
+    protected void ShowInfo(string message) =>
+        _showMessage(message, _title, MessageBoxImage.Information);
+
+    protected void ShowWarning(string message) =>
+        _showMessage(message, _title, MessageBoxImage.Warning);
+}

--- a/Financial.App/ViewModels/CreditActions.cs
+++ b/Financial.App/ViewModels/CreditActions.cs
@@ -7,15 +7,9 @@ using Financial.Application.Validation;
 
 namespace Financial.Presentation.App.ViewModels;
 
-public sealed class CreditActions
+public sealed class CreditActions : AssetActionsBase
 {
     private readonly ICreditService? _service;
-    private readonly Func<bool> _hasContext;
-    private readonly Func<string> _brokerName;
-    private readonly Func<string> _portfolioName;
-    private readonly Func<string> _assetName;
-    private readonly Action<AssetDetailsDTO> _applyDetails;
-    private readonly Action<string, string, MessageBoxImage> _showMessage;
 
     public CreditActions(
         ICreditService? service,
@@ -25,14 +19,9 @@ public sealed class CreditActions
         Func<string> assetName,
         Action<AssetDetailsDTO> applyDetails,
         Action<string, string, MessageBoxImage> showMessage)
+        : base(hasContext, brokerName, portfolioName, assetName, applyDetails, showMessage, "Credit")
     {
         _service = service;
-        _hasContext = hasContext ?? throw new ArgumentNullException(nameof(hasContext));
-        _brokerName = brokerName ?? throw new ArgumentNullException(nameof(brokerName));
-        _portfolioName = portfolioName ?? throw new ArgumentNullException(nameof(portfolioName));
-        _assetName = assetName ?? throw new ArgumentNullException(nameof(assetName));
-        _applyDetails = applyDetails ?? throw new ArgumentNullException(nameof(applyDetails));
-        _showMessage = showMessage ?? throw new ArgumentNullException(nameof(showMessage));
     }
 
     public async Task Add(Func<CreditDialogData?> showDialog)
@@ -164,15 +153,6 @@ public sealed class CreditActions
         _applyDetails(updatedDetails);
     }
 
-    private void ShowInfo(string message)
-    {
-        _showMessage(message, "Credit", MessageBoxImage.Information);
-    }
-
-    private void ShowWarning(string message)
-    {
-        _showMessage(message, "Credit", MessageBoxImage.Warning);
-    }
 }
 
 public readonly record struct CreditDialogData(

--- a/Financial.App/ViewModels/TransactionActions.cs
+++ b/Financial.App/ViewModels/TransactionActions.cs
@@ -7,15 +7,9 @@ using Financial.Application.Validation;
 
 namespace Financial.Presentation.App.ViewModels;
 
-public sealed class TransactionActions
+public sealed class TransactionActions : AssetActionsBase
 {
     private readonly ITransactionService? _service;
-    private readonly Func<bool> _hasContext;
-    private readonly Func<string> _brokerName;
-    private readonly Func<string> _portfolioName;
-    private readonly Func<string> _assetName;
-    private readonly Action<AssetDetailsDTO> _applyDetails;
-    private readonly Action<string, string, MessageBoxImage> _showMessage;
 
     public TransactionActions(
         ITransactionService? service,
@@ -25,14 +19,9 @@ public sealed class TransactionActions
         Func<string> assetName,
         Action<AssetDetailsDTO> applyDetails,
         Action<string, string, MessageBoxImage> showMessage)
+        : base(hasContext, brokerName, portfolioName, assetName, applyDetails, showMessage, "Transaction")
     {
         _service = service;
-        _hasContext = hasContext ?? throw new ArgumentNullException(nameof(hasContext));
-        _brokerName = brokerName ?? throw new ArgumentNullException(nameof(brokerName));
-        _portfolioName = portfolioName ?? throw new ArgumentNullException(nameof(portfolioName));
-        _assetName = assetName ?? throw new ArgumentNullException(nameof(assetName));
-        _applyDetails = applyDetails ?? throw new ArgumentNullException(nameof(applyDetails));
-        _showMessage = showMessage ?? throw new ArgumentNullException(nameof(showMessage));
     }
 
     public async Task Add(Func<TransactionDialogData?> showDialog)
@@ -168,15 +157,6 @@ public sealed class TransactionActions
         _applyDetails(updatedDetails);
     }
 
-    private void ShowInfo(string message)
-    {
-        _showMessage(message, "Transaction", MessageBoxImage.Information);
-    }
-
-    private void ShowWarning(string message)
-    {
-        _showMessage(message, "Transaction", MessageBoxImage.Warning);
-    }
 }
 
 public readonly record struct TransactionDialogData(

--- a/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
@@ -11,47 +11,22 @@ using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 
-public class GoogleGenerator : IGenerator
+public sealed class GoogleGenerator : IGenerator
 {
-    // Rate limiting configuration to avoid API quota issues
-    private const int DelayBetweenSheetsMs = 3000;  // 3 seconds between each sheet
-    private const int DelayBetweenBrokersMs = 5000; // 5 seconds between each broker
-    private const int DelayBetweenOperationsMs = 1500; // 1.5 seconds between reading operations and credits
+    private const int DelayBetweenSheetsMs = 3000;
+    private const int DelayBetweenBrokersMs = 5000;
+    private const int DelayBetweenOperationsMs = 1500;
     private const string DefaultPortfolioName = "Default";
-
-    public List<string> IgnoreSpreadSheet = new List<string> {
-        "Totais",
-        "Totais com cotacao",
-        "Recomendacoes",
-        "Fundos de Investimento",
-        "Opcoes"
-    };
-
-    public Dictionary<string, string> PortfolioName = new Dictionary<string, string>() {
-        {"Trading 212_76a5af", "Fantastic Five Divid" },
-        {"Trading 212_ffd966", "Almost Daily Dividen" },
-        {"XPI_f4cccc", "Gold" },
-        {"XPI_ffff", "Acoes" },
-        {"XPI_cc0000", "Fundos Investimento" },
-        {"XPI_222222", "Encerradas" },
-        {"FreeTrade_222222", "Encerradas" },
-        {"Trading 212_222222", "Encerradas" },
-    };
-
-    public Dictionary<string, string> ExchangeCurrency = new Dictionary<string, string>() {
-        {"Trading 212", "GBP" },
-        {"XPI", "BRL" },
-        {"FreeTrade", "GBP" },
-        {"Coinbase", "GBP" },
-    };
 
     private readonly GoogleService _service;
     private readonly IJsonStorage _storage;
+    private readonly GoogleGeneratorOptions _options;
 
-    public GoogleGenerator(GoogleService service, IJsonStorage storage)
+    public GoogleGenerator(GoogleService service, IJsonStorage storage, GoogleGeneratorOptions options)
     {
         _service = service ?? throw new ArgumentNullException(nameof(service));
         _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
     }
 
     public async Task GenerateAsync(List<string> fileNames, IProgress<string> progress = null)
@@ -72,7 +47,7 @@ public class GoogleGenerator : IGenerator
                 await Task.Delay(DelayBetweenBrokersMs);
             }
             
-            var exchange = Broker.Create(fileName, ExchangeCurrency[fileName]);
+            var exchange = Broker.Create(fileName, _options.BrokerCurrencyMap[fileName]);
             data.AddBroker(exchange);
             var file = files.FirstOrDefault(f => f.Name == fileName);
 
@@ -80,11 +55,11 @@ public class GoogleGenerator : IGenerator
             var spreadSheets = await _service.GetSpreadSheetAsync(file.Id);
             
             int sheetCount = 0;
-            int totalSheets = spreadSheets.Count(s => !IgnoreSpreadSheet.Contains(s.Name));
-            
+            int totalSheets = spreadSheets.Count(s => !_options.IgnoreSheetNames.Contains(s.Name));
+
             foreach (var spreadsheet in spreadSheets)
             {
-                if (IgnoreSpreadSheet.Contains(spreadsheet.Name))
+                if (_options.IgnoreSheetNames.Contains(spreadsheet.Name))
                 {
                     continue;
                 }
@@ -150,7 +125,7 @@ public class GoogleGenerator : IGenerator
     private string ResolvePortfolioName(string brokerName, SheetDTO spreadsheet)
     {
         var portfolioName = string.IsNullOrWhiteSpace(spreadsheet.Color) ? DefaultPortfolioName : spreadsheet.Color;
-        if (PortfolioName.TryGetValue($"{brokerName}_{portfolioName}", out var name))
+        if (_options.PortfolioNameMap.TryGetValue($"{brokerName}_{portfolioName}", out var name))
         {
             portfolioName = name;
         }
@@ -194,7 +169,7 @@ public class GoogleGenerator : IGenerator
 
     private CountryCode ResolveBrokerCountry(string brokerName)
     {
-        if (!ExchangeCurrency.TryGetValue(brokerName, out var currency))
+        if (!_options.BrokerCurrencyMap.TryGetValue(brokerName, out var currency))
         {
             return CountryCode.Unknown;
         }

--- a/Integrations/GoogleFinancialSupport/GoogleGeneratorOptions.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleGeneratorOptions.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+
+public sealed record GoogleGeneratorOptions(
+    IReadOnlyList<string> IgnoreSheetNames,
+    IReadOnlyDictionary<string, string> PortfolioNameMap,
+    IReadOnlyDictionary<string, string> BrokerCurrencyMap);

--- a/Integrations/ImportGoogleSpreadSheets/MainWindow.xaml.cs
+++ b/Integrations/ImportGoogleSpreadSheets/MainWindow.xaml.cs
@@ -138,7 +138,27 @@ public partial class MainWindow : Window
         {
             SetUIBusy(true, "Starting data generation...");
             
-            IGenerator generator = new GoogleGenerator(_service, new LocalJsonStorage(edtPath.Text));
+            var options = new GoogleGeneratorOptions(
+                IgnoreSheetNames: new List<string> { "Totais", "Totais com cotacao", "Recomendacoes", "Fundos de Investimento", "Opcoes" },
+                PortfolioNameMap: new Dictionary<string, string>
+                {
+                    { "Trading 212_76a5af", "Fantastic Five Divid" },
+                    { "Trading 212_ffd966", "Almost Daily Dividen" },
+                    { "XPI_f4cccc", "Gold" },
+                    { "XPI_ffff", "Acoes" },
+                    { "XPI_cc0000", "Fundos Investimento" },
+                    { "XPI_222222", "Encerradas" },
+                    { "FreeTrade_222222", "Encerradas" },
+                    { "Trading 212_222222", "Encerradas" },
+                },
+                BrokerCurrencyMap: new Dictionary<string, string>
+                {
+                    { "Trading 212", "GBP" },
+                    { "XPI", "BRL" },
+                    { "FreeTrade", "GBP" },
+                    { "Coinbase", "GBP" },
+                });
+            IGenerator generator = new GoogleGenerator(_service, new LocalJsonStorage(edtPath.Text), options);
             var fileNames = selectedFiles.Select(f => f.Name).ToList();
 
             var progress = new Progress<string>(status =>


### PR DESCRIPTION
## Summary
- **F-14**: `TransactionActions` and `CreditActions` had identical constructor signatures and `ShowInfo`/`ShowWarning` helpers. Extracted `AssetActionsBase` with the shared state (5 delegates) and message helpers; both classes now inherit from it, eliminating ~20 lines of duplication.
- **F-17**: `GoogleGenerator` exposed personal brokerage config (`IgnoreSpreadSheet`, `PortfolioName`, `ExchangeCurrency`) as public mutable fields. Extracted to a `GoogleGeneratorOptions` record injected via constructor; the composition root (`ImportGoogleSpreadSheets/MainWindow.xaml.cs`) now owns and constructs the options.

## Architecture
- `AssetActionsBase` lives in Presentation — no layer violations
- `GoogleGeneratorOptions` lives alongside `GoogleGenerator` in Infrastructure/Integrations
- `GoogleGenerator` made `sealed` (was missing from earlier pass)

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 160 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)