### PR TITLE
fix(V-01): remove JSON attributes from Domain entities

### DIFF
--- a/Financial.Domain/Entities/Asset.cs
+++ b/Financial.Domain/Entities/Asset.cs
@@ -1,43 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace Financial.Domain.Entities;
 
 public class Asset
 {
-    [JsonInclude]
     public string Name { get; private set; }
 
-    [JsonInclude]
     public string ISIN { get; private set; }
 
-    [JsonInclude]
     public string Exchange{ get; private set; }
 
-    [JsonInclude]
     public string Ticker { get; private set; }
 
-    [JsonInclude]
     public CountryCode Country { get; private set; } = CountryCode.Unknown;
 
-    [JsonInclude]
     public string LocalTypeCode { get; private set; } = string.Empty;
 
-    [JsonInclude]
     public GlobalAssetClass Class { get; private set; } = GlobalAssetClass.Unknown;
 
-    [JsonIgnore]
     public decimal AveragePrice { get; private set; } = 0;
 
-    [JsonIgnore]
     public decimal Quantity { get; private set; }
 
-    [JsonIgnore]
     public bool Active => Quantity > 0;
 
     private List<Transaction> _transactions = new List<Transaction>();
-    [JsonInclude]
     public IReadOnlyCollection<Transaction> Transactions { get => _transactions.AsReadOnly(); set => SetTransactions(value); }
     private void SetTransactions(IReadOnlyCollection<Transaction> data)
     {
@@ -57,7 +45,6 @@ public class Asset
     }
 
     private List<Credit> _credits = new List<Credit>();
-    [JsonInclude]
     public IReadOnlyCollection<Credit> Credits { get => _credits.AsReadOnly(); set => SetCredits(value); }
     private void SetCredits(IReadOnlyCollection<Credit> data)
     {
@@ -68,7 +55,6 @@ public class Asset
         }
     }
 
-    [JsonConstructor]
     private Asset() {}
 
     private Asset(string name, string isin, string exchange, string ticker, CountryCode country, string localTypeCode, GlobalAssetClass assetClass) : this()

--- a/Financial.Domain/Entities/Broker.cs
+++ b/Financial.Domain/Entities/Broker.cs
@@ -1,18 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Serialization;
 
 namespace Financial.Domain.Entities;
 
 public class Broker
 {
-    [JsonInclude]
     public string Name { get; private set; }
-    [JsonInclude]
     public string Currency { get; private set; }
 
     private List<Portfolio> _portfolios = new List<Portfolio>();
-    [JsonInclude]
     public IReadOnlyCollection<Portfolio> Portfolios { get => _portfolios.AsReadOnly(); set => SetPortfolios(value); }
     private void SetPortfolios(IReadOnlyCollection<Portfolio> data)
     {
@@ -20,8 +16,6 @@ public class Broker
         _portfolios.AddRange(data);
     }
 
-
-    [JsonConstructor]
     private Broker() {}
 
     private Broker(string name, string currency) : this()

--- a/Financial.Domain/Entities/Credit.cs
+++ b/Financial.Domain/Entities/Credit.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text.Json.Serialization;
 
 namespace Financial.Domain.Entities;
 
@@ -7,16 +6,11 @@ public class Credit
 {
     public enum CreditType { Dividend, Rent }
 
-    [JsonInclude]
     public Guid Id { get; private set; }
-    [JsonInclude]
     public DateTime Date { get; private set; }
-    [JsonInclude]
     public CreditType Type { get; private set; }
-    [JsonInclude]
     public decimal Value { get; private set; }
 
-    [JsonConstructor]
     private Credit() { }
 
     private Credit(Guid id, DateTime date, CreditType type, decimal value)

--- a/Financial.Domain/Entities/Investments.cs
+++ b/Financial.Domain/Entities/Investments.cs
@@ -1,12 +1,10 @@
 ﻿using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace Financial.Domain.Entities;
 
 public class Investments
 {
     private List<Broker> _brokers = new List<Broker>();
-    [JsonInclude]
     public IReadOnlyCollection<Broker> Brokers { get => _brokers.AsReadOnly(); set => SetBrokers(value); }
     private void SetBrokers(IReadOnlyCollection<Broker> data)
     {
@@ -14,7 +12,6 @@ public class Investments
         _brokers.AddRange(data);
     }
 
-    [JsonConstructor]
     private Investments() {}
 
     public static Investments Create() => new();

--- a/Financial.Domain/Entities/Portfolio.cs
+++ b/Financial.Domain/Entities/Portfolio.cs
@@ -1,15 +1,12 @@
 ﻿using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace Financial.Domain.Entities;
 
 public class Portfolio
 {
-    [JsonInclude]
     public string Name { get; private set; }
 
     private List<Asset> _assets = new List<Asset>();
-    [JsonInclude]
     public IReadOnlyCollection<Asset> Assets { get => _assets.AsReadOnly(); set => SetAssets(value); }
     private void SetAssets(IReadOnlyCollection<Asset> data)
     {
@@ -17,7 +14,6 @@ public class Portfolio
         _assets.AddRange(data);
     }
 
-    [JsonConstructor]
     private Portfolio()
     {
     }

--- a/Financial.Domain/Entities/Transaction.cs
+++ b/Financial.Domain/Entities/Transaction.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.Json.Serialization;
 
 namespace Financial.Domain.Entities;
 
@@ -7,25 +6,15 @@ public class Transaction
 {
     public enum TransactionType { Buy, Sell }
 
-    [JsonInclude]
     public Guid Id { get; private set; }
-    [JsonInclude]
     public DateTime Date { get; private set; }
-    [JsonInclude]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public TransactionType Type { get; private set; }
-    [JsonInclude]
     public decimal Quantity { get; private set; }
-    [JsonInclude]
     public decimal UnitPrice { get; private set; }
-    [JsonInclude]
     public decimal Fees { get; private set; }
 
-    [JsonIgnore]
     public decimal TotalPrice => UnitPrice * Quantity + Fees;
 
-
-    [JsonConstructor]
     private Transaction() { }
 
     private Transaction(Guid id, DateTime date, TransactionType type, decimal quantity, decimal unitPrice, decimal fees)

--- a/Financial.Domain/Financial.Domain.csproj
+++ b/Financial.Domain/Financial.Domain.csproj
@@ -4,10 +4,6 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Financial.Common\Financial.Common.csproj" />
-  </ItemGroup>
-
 </Project>
 
 

--- a/Financial.Infrastructure/Financial.Infrastructure.csproj
+++ b/Financial.Infrastructure/Financial.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Financial.Application\Financial.Application.csproj" />
+    <ProjectReference Include="..\Financial.Common\Financial.Common.csproj" />
     <ProjectReference Include="..\Financial.Domain\Financial.Domain.csproj" />
     <ProjectReference Include="..\Integrations\GoogleFinancialSupport\GoogleFinancialSupport.csproj" />
     <ProjectReference Include="..\Integrations\WebPageParser\WebPageParser.csproj" />

--- a/Financial.Infrastructure/Persistence/InvestmentsJsonSerializer.cs
+++ b/Financial.Infrastructure/Persistence/InvestmentsJsonSerializer.cs
@@ -1,4 +1,3 @@
-using Financial.Common;
 using Financial.Domain.Entities;
 using System.Text.Json;
 

--- a/Financial.Infrastructure/Persistence/InvestmentsSerializerOptions.cs
+++ b/Financial.Infrastructure/Persistence/InvestmentsSerializerOptions.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Financial.Infrastructure.Persistence;
+
+public static class InvestmentsSerializerOptions
+{
+    public static readonly JsonSerializerOptions Default = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = true,
+        TypeInfoResolver = new InvestmentsTypeInfoResolver()
+    };
+}

--- a/Financial.Infrastructure/Persistence/InvestmentsTypeInfoResolver.cs
+++ b/Financial.Infrastructure/Persistence/InvestmentsTypeInfoResolver.cs
@@ -1,0 +1,84 @@
+using Financial.Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Financial.Infrastructure.Persistence;
+
+public class InvestmentsTypeInfoResolver : DefaultJsonTypeInfoResolver
+{
+    private static readonly HashSet<Type> ManagedTypes =
+    [
+        typeof(Investments),
+        typeof(Broker),
+        typeof(Portfolio),
+        typeof(Asset),
+        typeof(Transaction),
+        typeof(Credit)
+    ];
+
+    private static readonly HashSet<(Type, string)> ExcludedProperties =
+    [
+        (typeof(Asset), nameof(Asset.AveragePrice)),
+        (typeof(Asset), nameof(Asset.Quantity)),
+        (typeof(Asset), nameof(Asset.Active)),
+        (typeof(Transaction), nameof(Transaction.TotalPrice))
+    ];
+
+    public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
+    {
+        var typeInfo = base.GetTypeInfo(type, options);
+
+        if (!ManagedTypes.Contains(type) || typeInfo.Kind != JsonTypeInfoKind.Object)
+            return typeInfo;
+
+        EnablePrivateConstructor(type, typeInfo);
+        ConfigureProperties(type, typeInfo);
+
+        return typeInfo;
+    }
+
+    private static void EnablePrivateConstructor(Type type, JsonTypeInfo typeInfo)
+    {
+        if (typeInfo.CreateObject is not null)
+            return;
+
+        typeInfo.CreateObject = () =>
+            Activator.CreateInstance(type, nonPublic: true)
+            ?? throw new InvalidOperationException($"Failed to create instance of {type}.");
+    }
+
+    private static void ConfigureProperties(Type type, JsonTypeInfo typeInfo)
+    {
+        var toRemove = new List<JsonPropertyInfo>();
+
+        foreach (var jsonProp in typeInfo.Properties)
+        {
+            if (ExcludedProperties.Contains((type, jsonProp.Name)))
+            {
+                toRemove.Add(jsonProp);
+                continue;
+            }
+
+            WirePropertySetter(type, jsonProp);
+        }
+
+        foreach (var prop in toRemove)
+            typeInfo.Properties.Remove(prop);
+    }
+
+    private static void WirePropertySetter(Type type, JsonPropertyInfo jsonProp)
+    {
+        var propInfo = type.GetProperty(
+            jsonProp.Name,
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+        if (propInfo?.SetMethod is null)
+            return;
+
+        var setter = propInfo.SetMethod;
+        jsonProp.Set = (obj, value) => setter.Invoke(obj, [value]);
+    }
+}

--- a/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.Json;
 using FluentAssertions;
 using Financial.Domain.Entities;
 
@@ -82,9 +81,8 @@ public class AssetTests
     public void UpdateTransaction_EmptyId_Throws()
     {
         var asset = Asset.Create("Asset A", "ISIN123", "NYSE", "AAA");
-        // Use JSON deserialization to preserve Guid.Empty because Transaction.CreateWithId replaces empty IDs.
-        var transaction = JsonSerializer.Deserialize<Transaction>(
-            "{\"Id\":\"00000000-0000-0000-0000-000000000000\",\"Date\":\"2024-01-01T00:00:00\",\"Type\":\"Buy\",\"Quantity\":1,\"UnitPrice\":1,\"Fees\":0}")!;
+        // Activator bypasses the public factory methods so Id stays Guid.Empty.
+        var transaction = (Transaction)Activator.CreateInstance(typeof(Transaction), nonPublic: true)!;
 
         Action act = () => asset.UpdateTransaction(transaction);
 


### PR DESCRIPTION
## Summary

- Removed all `[JsonInclude]`, `[JsonIgnore]`, `[JsonConstructor]` attributes from 6 Domain entities (`Asset`, `Transaction`, `Credit`, `Broker`, `Portfolio`, `Investments`)
- Dropped `Financial.Common` project reference from `Financial.Domain.csproj` — Domain is now fully framework-free
- Created `InvestmentsTypeInfoResolver` in Infrastructure/Persistence to handle private constructors, wire private property setters, and exclude computed properties (`AveragePrice`, `Quantity`, `Active`, `TotalPrice`) without any Domain knowledge of serialization
- Moved `InvestmentsSerializerOptions` from `Financial.Common` into `Financial.Infrastructure.Persistence`
- Added explicit `Financial.Common` reference to `Financial.Infrastructure.csproj` (needed by `DividendService` until V-02 dissolves that library)
- Updated Domain test that used `JsonSerializer` as a backdoor to create a `Transaction` with `Guid.Empty` — now uses `Activator.CreateInstance(typeof(Transaction), nonPublic: true)` directly

## Architecture compliance

- Domain layer has zero serialization framework references
- Serialization is entirely an Infrastructure concern
- Dependency direction restored: Infrastructure → Domain (not the other way around via Financial.Common)

## Test plan

- [ ] All 160 tests pass (3 skipped are pre-existing live-network integration skips)
- [ ] Round-trip serialize/deserialize test (`InvestmentsJsonSerializerTests`) verifies the new resolver works
- [ ] `JsonRepositoryTests` verifies the repository reads real test data correctly
- [ ] Domain tests pass without any Infrastructure references

🤖 Generated with [Claude Code](https://claude.com/claude-code)