### PR TITLE
fix(V-04): move DividendValuationRules from Application to Domain

### DIFF
--- a/Financial.App/Financial.App.csproj
+++ b/Financial.App/Financial.App.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Financial.Application\Financial.Application.csproj" />
+    <ProjectReference Include="..\Financial.Domain\Financial.Domain.csproj" />
     <ProjectReference Include="..\Financial.Infrastructure\Financial.Infrastructure.csproj" />
   </ItemGroup>
 </Project>

--- a/Financial.App/MainWindow.xaml.cs
+++ b/Financial.App/MainWindow.xaml.cs
@@ -1,5 +1,5 @@
-using Financial.Application.Configuration;
 using Financial.Application.DTOs;
+using Financial.Domain.Rules;
 using Financial.Application.Interfaces;
 using Financial.Presentation.App.Components;
 using Financial.Presentation.App.ViewModels;

--- a/Financial.Application/Services/DividendService.cs
+++ b/Financial.Application/Services/DividendService.cs
@@ -1,7 +1,7 @@
-using Financial.Application.Configuration;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
+using Financial.Domain.Rules;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Financial.Domain/Rules/DividendValuationRules.cs
+++ b/Financial.Domain/Rules/DividendValuationRules.cs
@@ -1,4 +1,4 @@
-namespace Financial.Application.Configuration;
+namespace Financial.Domain.Rules;
 
 public static class DividendValuationRules
 {


### PR DESCRIPTION
## Summary

- `DividendValuationRules` (`RequiredYield = 0.06`, `DividendYearsLookback = 5`) are business policy constants — they answer *"what yield is acceptable?"* and *"how many years of history matter?"*, which is Domain knowledge, not Application configuration
- Moved from `Financial.Application/Configuration/` to `Financial.Domain/Rules/` with namespace `Financial.Domain.Rules`
- `DividendService` (Application) and `MainWindow.xaml.cs` (Presentation) updated to import from the new location
- `Financial.App.csproj` gains an explicit `ProjectReference` to `Financial.Domain` since it now uses Domain types directly (previously only transitively)

## Architecture compliance

| Rule | Status |
|------|--------|
| Business rules live in Domain | ✅ |
| Application references Domain (correct direction) | ✅ |
| Presentation references Domain (correct direction) | ✅ |
| All 160 tests pass | ✅ |

## Test plan

- [ ] Build solution — 0 errors, 0 warnings
- [ ] `dotnet test` — 160 passed, 3 pre-existing skips, 0 failures
- [ ] Confirm `Financial.Application/Configuration/DividendValuationRules.cs` is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)