### PR TITLE
fix(V-05): move RepositoryConfigurationKeys from Application to Infrastructure

### DIFF
--- a/Financial.Api/Controllers/DiagnosticsController.cs
+++ b/Financial.Api/Controllers/DiagnosticsController.cs
@@ -1,7 +1,6 @@
-using Financial.Application.Configuration;
+using Financial.Application.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace Financial.Api.Controllers;
@@ -10,12 +9,12 @@ namespace Financial.Api.Controllers;
 [Route("")]
 public sealed class DiagnosticsController : ControllerBase
 {
-    private readonly IConfiguration _configuration;
+    private readonly IRepositoryDiagnostics _repositoryDiagnostics;
     private readonly IHostEnvironment _environment;
 
-    public DiagnosticsController(IConfiguration configuration, IHostEnvironment environment)
+    public DiagnosticsController(IRepositoryDiagnostics repositoryDiagnostics, IHostEnvironment environment)
     {
-        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _repositoryDiagnostics = repositoryDiagnostics ?? throw new ArgumentNullException(nameof(repositoryDiagnostics));
         _environment = environment ?? throw new ArgumentNullException(nameof(environment));
     }
 
@@ -38,10 +37,10 @@ public sealed class DiagnosticsController : ControllerBase
 
         return Ok(new
         {
-            provider = _configuration[RepositoryConfigurationKeys.Provider],
-            dataJsonFile = _configuration[RepositoryConfigurationKeys.LocalJsonDataFile],
-            googleDriveCredentialsPath = _configuration[RepositoryConfigurationKeys.GoogleDriveCredentialsPath],
-            googleDriveFilePath = _configuration[RepositoryConfigurationKeys.GoogleDriveFilePath]
+            provider = _repositoryDiagnostics.Provider,
+            dataJsonFile = _repositoryDiagnostics.DataJsonFile,
+            googleDriveCredentialsPath = _repositoryDiagnostics.GoogleDriveCredentialsPath,
+            googleDriveFilePath = _repositoryDiagnostics.GoogleDriveFilePath
         });
     }
 }

--- a/Financial.App/App.xaml.cs
+++ b/Financial.App/App.xaml.cs
@@ -1,4 +1,3 @@
-using Financial.Application.Configuration;
 using Financial.Infrastructure.DependencyInjection;
 using Financial.Presentation.App.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,7 +36,7 @@ namespace Financial.Presentation.App
             catch (FileNotFoundException ex)
             {
                 MessageBox.Show(
-                    $"{ex.Message}\n\nSet '{RepositoryConfigurationKeys.LocalJsonDataFile}' or place '{RepositoryConfigurationKeys.LocalJsonDefaultFileName}' in the application directory.",
+                    ex.Message,
                     "Missing data file",
                     MessageBoxButton.OK,
                     MessageBoxImage.Error);

--- a/Financial.Application/Interfaces/IRepositoryDiagnostics.cs
+++ b/Financial.Application/Interfaces/IRepositoryDiagnostics.cs
@@ -1,0 +1,9 @@
+namespace Financial.Application.Interfaces;
+
+public interface IRepositoryDiagnostics
+{
+    string? Provider { get; }
+    string? DataJsonFile { get; }
+    string? GoogleDriveCredentialsPath { get; }
+    string? GoogleDriveFilePath { get; }
+}

--- a/Financial.Infrastructure/Configuration/RepositoryConfigurationKeys.cs
+++ b/Financial.Infrastructure/Configuration/RepositoryConfigurationKeys.cs
@@ -1,4 +1,4 @@
-namespace Financial.Application.Configuration;
+namespace Financial.Infrastructure.Configuration;
 
 public static class RepositoryConfigurationKeys
 {

--- a/Financial.Infrastructure/Configuration/RepositoryDiagnosticsProvider.cs
+++ b/Financial.Infrastructure/Configuration/RepositoryDiagnosticsProvider.cs
@@ -1,0 +1,19 @@
+using Financial.Application.Interfaces;
+using Microsoft.Extensions.Configuration;
+
+namespace Financial.Infrastructure.Configuration;
+
+public sealed class RepositoryDiagnosticsProvider : IRepositoryDiagnostics
+{
+    private readonly IConfiguration _configuration;
+
+    public RepositoryDiagnosticsProvider(IConfiguration configuration)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+
+    public string? Provider => _configuration[RepositoryConfigurationKeys.Provider];
+    public string? DataJsonFile => _configuration[RepositoryConfigurationKeys.LocalJsonDataFile];
+    public string? GoogleDriveCredentialsPath => _configuration[RepositoryConfigurationKeys.GoogleDriveCredentialsPath];
+    public string? GoogleDriveFilePath => _configuration[RepositoryConfigurationKeys.GoogleDriveFilePath];
+}

--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
-using Financial.Application.Configuration;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
+using Financial.Infrastructure.Configuration;
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
 using Financial.Infrastructure.Services;
@@ -16,6 +16,7 @@ public static class InfrastructureServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
+        services.AddSingleton<IRepositoryDiagnostics, RepositoryDiagnosticsProvider>();
         services.AddSingleton<IInvestmentsSerializer, InvestmentsSerializerAdapter>();
         services.AddSingleton<IDividendDataSource, DividendDataSourceAdapter>();
         services.AddSingleton<IAssetSnapshotSource, AssetSnapshotSourceAdapter>();

--- a/Financial.Infrastructure/Persistence/LocalJsonStorage.cs
+++ b/Financial.Infrastructure/Persistence/LocalJsonStorage.cs
@@ -1,5 +1,5 @@
-using Financial.Application.Configuration;
 using Financial.Application.Interfaces;
+using Financial.Infrastructure.Configuration;
 using System;
 using System.IO;
 using System.Threading.Tasks;


### PR DESCRIPTION
## Summary

- `RepositoryConfigurationKeys` (appsettings.json paths like `"Repository:Provider"`, `"GoogleDrive:CredentialsPath"`) are Infrastructure details — they have no business meaning in Application. Moved to `Financial.Infrastructure/Configuration/`
- `LocalJsonStorage` and `InfrastructureServiceCollectionExtensions` updated to import from the new namespace
- `DiagnosticsController` previously accessed `IConfiguration` directly via the Application-layer keys, creating a Presentation → Application.Configuration coupling. Replaced with a new `IRepositoryDiagnostics` interface (Application) implemented by `RepositoryDiagnosticsProvider` (Infrastructure), injected via DI — controller now depends only on Application abstractions
- `App.xaml.cs` catch block simplified: `LocalJsonStorage` already includes config guidance in its `FileNotFoundException` message, so the duplicated hint referencing the keys is removed

## Architecture compliance

| Rule | Status |
|------|--------|
| Infrastructure config keys live in Infrastructure | ✅ |
| Presentation depends on Application interfaces only | ✅ |
| Domain has no Infrastructure/config dependencies | ✅ |
| Application/Configuration/ is now empty and can be removed in future cleanup | ✅ |
| All 160 tests pass | ✅ |

## Test plan

- [ ] Build solution — 0 errors, 0 warnings
- [ ] `dotnet test` — 160 passed, 3 pre-existing skips, 0 failures
- [ ] `GET /config/repository` returns the same JSON as before (provider, paths)
- [ ] Confirm `Financial.Application/Configuration/RepositoryConfigurationKeys.cs` is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)