### PR TITLE
fix(S-09): split GoogleService into focused credential, Drive, Sheets, and retry types (SRP)

### DIFF
--- a/Integrations/GoogleFinancialSupport/GoogleCredentialFactory.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleCredentialFactory.cs
@@ -1,0 +1,30 @@
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Services;
+using System.IO;
+
+namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+
+internal sealed class GoogleCredentialFactory
+{
+    private readonly string _credentialsFilePath;
+
+    internal GoogleCredentialFactory(string credentialsFilePath)
+    {
+        _credentialsFilePath = credentialsFilePath;
+    }
+
+    internal GoogleCredential Create(string[] scopes)
+    {
+        using var stream = new FileStream(_credentialsFilePath, FileMode.Open, FileAccess.Read);
+        return GoogleCredential.FromStream(stream).CreateScoped(scopes);
+    }
+
+    internal static BaseClientService.Initializer CreateInitializer(GoogleCredential credential)
+    {
+        return new BaseClientService.Initializer
+        {
+            HttpClientInitializer = credential,
+            ApplicationName = "Financial",
+        };
+    }
+}

--- a/Integrations/GoogleFinancialSupport/GoogleDriveClient.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleDriveClient.cs
@@ -1,0 +1,131 @@
+using Google.Apis.Drive.v3;
+using Google.Apis.Upload;
+using Financial.Infrastructure.Integrations.GoogleFinancialSupport.DTO;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+
+internal sealed class GoogleDriveClient
+{
+    private static readonly string[] ReadOnlyScopes = { DriveService.Scope.DriveReadonly };
+    private static readonly string[] ReadWriteScopes = { DriveService.Scope.Drive };
+    private const string ShortcutMimeType = "application/vnd.google-apps.shortcut";
+
+    private readonly GoogleCredentialFactory _credentialFactory;
+
+    internal GoogleDriveClient(GoogleCredentialFactory credentialFactory)
+    {
+        _credentialFactory = credentialFactory;
+    }
+
+    internal async Task<List<SpreadSheetDTO>> GetFilesAsync()
+    {
+        return await GoogleRetryPolicy.ExecuteWithRetryAsync(async () =>
+        {
+            var service = CreateService(ReadOnlyScopes);
+            var request = service.Files.List();
+            request.PageSize = 100;
+            request.Fields = "nextPageToken, files(webViewLink, name, id)";
+            var response = await request.ExecuteAsync();
+            return response.Files
+                .Select(f => new SpreadSheetDTO { Name = f.Name, Id = f.Id })
+                .ToList();
+        });
+    }
+
+    internal string DownloadFileContent(string drivePath)
+    {
+        if (string.IsNullOrWhiteSpace(drivePath))
+        {
+            throw new ArgumentException("Drive path must be provided.", nameof(drivePath));
+        }
+
+        var service = CreateService(ReadOnlyScopes);
+        var fileId = ResolveFileId(service, drivePath);
+
+        using var stream = new MemoryStream();
+        service.Files.Get(fileId).Download(stream);
+        stream.Position = 0;
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    internal void UploadFileContent(string drivePath, string content)
+    {
+        if (string.IsNullOrWhiteSpace(drivePath))
+        {
+            throw new ArgumentException("Drive path must be provided.", nameof(drivePath));
+        }
+
+        var service = CreateService(ReadWriteScopes);
+        var fileId = ResolveFileId(service, drivePath);
+
+        var payload = Encoding.UTF8.GetBytes(content ?? string.Empty);
+        using var stream = new MemoryStream(payload);
+        var request = service.Files.Update(new Google.Apis.Drive.v3.Data.File(), fileId, stream, "application/json");
+        var result = request.Upload();
+        if (result.Status != UploadStatus.Completed)
+        {
+            throw new InvalidOperationException(
+                $"Failed to upload file to '{drivePath}' (status: {result.Status}).",
+                result.Exception);
+        }
+    }
+
+    private DriveService CreateService(string[] scopes)
+    {
+        var credential = _credentialFactory.Create(scopes);
+        return new DriveService(GoogleCredentialFactory.CreateInitializer(credential));
+    }
+
+    private static string ResolveFileId(DriveService service, string drivePath)
+    {
+        var segments = drivePath.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+        {
+            throw new ArgumentException("Drive path must include at least one segment.", nameof(drivePath));
+        }
+
+        var segment = segments.Last();
+        var file = FindFileByName(service, segment)
+            ?? throw new FileNotFoundException($"Drive path segment '{segment}' not found in '{drivePath}'.");
+
+        return ResolveShortcutTargetId(file);
+    }
+
+    private static Google.Apis.Drive.v3.Data.File FindFileByName(DriveService service, string name)
+    {
+        var listRequest = service.Files.List();
+        listRequest.PageSize = 10;
+        listRequest.Fields = "files(id, name, mimeType, shortcutDetails(targetId, targetMimeType))";
+        listRequest.Q = $"name = '{EscapeQuery(name)}' and trashed = false";
+        listRequest.SupportsAllDrives = true;
+        listRequest.IncludeItemsFromAllDrives = true;
+        listRequest.Spaces = "drive";
+
+        var result = listRequest.Execute();
+        if (result.Files.Count > 1)
+        {
+            throw new InvalidOperationException($"Multiple files '{name}' found when only one was expected.");
+        }
+
+        return result.Files.FirstOrDefault();
+    }
+
+    private static string ResolveShortcutTargetId(Google.Apis.Drive.v3.Data.File file)
+    {
+        if (file.MimeType == ShortcutMimeType && !string.IsNullOrWhiteSpace(file.ShortcutDetails?.TargetId))
+        {
+            return file.ShortcutDetails.TargetId;
+        }
+
+        return file.Id;
+    }
+
+    private static string EscapeQuery(string value) => value.Replace("'", "\\'");
+}

--- a/Integrations/GoogleFinancialSupport/GoogleRetryPolicy.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleRetryPolicy.cs
@@ -1,0 +1,36 @@
+using Google;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+
+internal static class GoogleRetryPolicy
+{
+    internal static async Task<T> ExecuteWithRetryAsync<T>(Func<Task<T>> action, int maxRetries = 5)
+    {
+        int retryCount = 0;
+        const int initialDelayMs = 2000;
+
+        while (true)
+        {
+            try
+            {
+                return await action();
+            }
+            catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.TooManyRequests && retryCount < maxRetries)
+            {
+                retryCount++;
+                var waitTime = initialDelayMs * (int)Math.Pow(2, retryCount - 1);
+                Console.WriteLine($"Rate limit hit. Retry {retryCount}/{maxRetries}. Waiting {waitTime}ms...");
+                await Task.Delay(waitTime);
+            }
+            catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.TooManyRequests)
+            {
+                throw new HttpRequestException(
+                    $"API rate limit exceeded after {maxRetries} retries. Please wait a few minutes and try again.", ex);
+            }
+        }
+    }
+}

--- a/Integrations/GoogleFinancialSupport/GoogleService.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleService.cs
@@ -1,261 +1,36 @@
-using Google.Apis.Auth.OAuth2;
-using Google.Apis.Drive.v3;
-using Google.Apis.Services;
-using Google.Apis.Sheets.v4;
-using Google.Apis.Upload;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport.DTO;
 using System.Collections.Generic;
-using System.IO;
-using System.Drawing;
 using System.Threading.Tasks;
-using System;
-using Google;
-using System.Net;
-using System.Net.Http;
-using System.Linq;
-using System.Text;
 
 namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 
 public sealed class GoogleService
 {
-    private static readonly string[] SheetsScopes = { SheetsService.Scope.Spreadsheets };
-    private static readonly string[] DriveReadOnlyScopes = { DriveService.Scope.DriveReadonly };
-    private static readonly string[] DriveReadWriteScopes = { DriveService.Scope.Drive };
-    private const string DefaultDataFileName = "data.json";
-    private const string FolderMimeType = "application/vnd.google-apps.folder";
-    private const string ShortcutMimeType = "application/vnd.google-apps.shortcut";
+    private readonly GoogleDriveClient _driveClient;
+    private readonly GoogleSheetsClient _sheetsClient;
+
     public string FileName { get; }
 
     public GoogleService(string fileName)
     {
         FileName = fileName;
+        var credentialFactory = new GoogleCredentialFactory(fileName);
+        _driveClient = new GoogleDriveClient(credentialFactory);
+        _sheetsClient = new GoogleSheetsClient(credentialFactory);
     }
 
-    public async Task<List<SpreadSheetDTO>> GetFilesNameAsync()
-    {
-        return await ExecuteWithRetryAsync(async () =>
-        {
-            var service = GetDriveService();
-            var request = service.Files.List();
-            request.PageSize = 100;
-            request.Fields = "nextPageToken, files(webViewLink, name, id)";
-            var result = new List<SpreadSheetDTO>();
-            var response = await request.ExecuteAsync();
-            foreach (var file in response.Files)
-            {
-                result.Add(new SpreadSheetDTO() { Name = file.Name, Id = file.Id });
-            }
-            return result;
-        });
-    }
+    public Task<List<SpreadSheetDTO>> GetFilesNameAsync() =>
+        _driveClient.GetFilesAsync();
 
-    public async Task<List<SheetDTO>> GetSpreadSheetAsync(string spreadSheetLink)
-    {
-        return await ExecuteWithRetryAsync(async () =>
-        {
-            var result = new List<SheetDTO>();
-            var service = GetSheetsService();
-            var request = service.Spreadsheets.Get(spreadSheetLink);
-            request.Fields = "sheets(properties/sheetId,properties/title,properties/tabColor)";
-            var response = await request.ExecuteAsync();
-            foreach (var sheet in response.Sheets)
-            {
-                var nearestColor = GetTabColorName(sheet.Properties.TabColor);
-                result.Add(new SheetDTO() { Name = sheet.Properties.Title, Id = sheet.Properties.SheetId ?? 0, Color = nearestColor });
-            }
-            return result;
-        });
-    }
+    public Task<List<SheetDTO>> GetSpreadSheetAsync(string spreadSheetId) =>
+        _sheetsClient.GetSpreadSheetAsync(spreadSheetId);
 
+    public Task<IList<IList<object>>> GetSpreadSheetDataAsync(string spreadSheetId, string range) =>
+        _sheetsClient.GetSpreadSheetDataAsync(spreadSheetId, range);
 
-    public async Task<IList<IList<object>>> GetSpreadSheetDataAsync(string spreadSheetId, string range)
-    {
-        return await ExecuteWithRetryAsync(async () =>
-        {
-            var service = GetSheetsService();
-            var request = service.Spreadsheets.Values.Get(spreadSheetId, range);
-            request.ValueRenderOption = SpreadsheetsResource.ValuesResource.GetRequest.ValueRenderOptionEnum.UNFORMATTEDVALUE;
-            var response = await request.ExecuteAsync();
-            IList<IList<object>> values = response.Values;
-            return values;
-        });
-    }
+    public string DownloadFileContent(string drivePath) =>
+        _driveClient.DownloadFileContent(drivePath);
 
-    public string DownloadFileContent(string drivePath)
-    {
-        if (string.IsNullOrWhiteSpace(drivePath))
-        {
-            throw new ArgumentException("Drive path must be provided.", nameof(drivePath));
-        }
-
-        var service = GetDriveService();
-        var fileId = ResolveFileId(service, drivePath);
-
-        using var stream = new MemoryStream();
-        var request = service.Files.Get(fileId);
-        request.Download(stream);
-        stream.Position = 0;
-        using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
-    }
-
-    public void UploadFileContent(string drivePath, string content)
-    {
-        if (string.IsNullOrWhiteSpace(drivePath))
-        {
-            throw new ArgumentException("Drive path must be provided.", nameof(drivePath));
-        }
-
-        var service = GetDriveServiceWithWriteAccess();
-        var fileId = ResolveFileId(service, drivePath);
-
-        var payload = Encoding.UTF8.GetBytes(content ?? string.Empty);
-        using var stream = new MemoryStream(payload);
-        var fileMetadata = new Google.Apis.Drive.v3.Data.File();
-        var request = service.Files.Update(fileMetadata, fileId, stream, "application/json");
-        var result = request.Upload();
-        if (result.Status != UploadStatus.Completed)
-        {
-            throw new InvalidOperationException(
-                $"Failed to upload file to '{drivePath}' (status: {result.Status}).",
-                result.Exception);
-        }
-    }
-
-    private static string ResolveFileId(DriveService service, string drivePath)
-    {
-        var segments = drivePath.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
-        if (segments.Length == 0)
-        {
-            throw new ArgumentException("Drive path must include at least one segment.", nameof(drivePath));
-        }
-
-        // for now try get based on file name directly, but this only works if there is only one file with the name at google drive
-        var segment = segments.Last();
-        var file = FindFileByName(service, segment);
-        if (file == null)
-        {
-            throw new FileNotFoundException($"Drive path segment '{segment}' not found in '{drivePath}'.");
-        }
-
-        return ResolveShortcutTargetId(file);
-    }
-
-    private static string EscapeDriveQuery(string value)
-    {
-        return value.Replace("'", "\\'");
-    }
-
-    private static Google.Apis.Drive.v3.Data.File FindFileByName(DriveService service, string name)
-    {
-        var listRequest = service.Files.List();
-        listRequest.PageSize = 10;
-        listRequest.Fields = "files(id, name, mimeType, shortcutDetails(targetId, targetMimeType))";
-        listRequest.Q = $"name = '{EscapeDriveQuery(name)}' and trashed = false";
-        listRequest.SupportsAllDrives = true;
-        listRequest.IncludeItemsFromAllDrives = true;
-        listRequest.Spaces = "drive";
-
-        var result = listRequest.Execute();
-        if(result.Files.Count>1)
-        {
-            throw new InvalidOperationException($"Multiple files '{name}' found when only one was expected.");
-        }
-        return result.Files.FirstOrDefault();
-    }
-
-    private static string ResolveShortcutTargetId(Google.Apis.Drive.v3.Data.File file)
-    {
-        if (file.MimeType == ShortcutMimeType && !string.IsNullOrWhiteSpace(file.ShortcutDetails?.TargetId))
-        {
-            return file.ShortcutDetails.TargetId;
-        }
-
-        return file.Id;
-    }
-
-    private DriveService GetDriveService()
-    {
-        return CreateDriveService(DriveReadOnlyScopes);
-    }
-
-    private DriveService GetDriveServiceWithWriteAccess()
-    {
-        return CreateDriveService(DriveReadWriteScopes);
-    }
-
-    private DriveService CreateDriveService(string[] scopes)
-    {
-        var credential = CreateCredential(scopes);
-        return new DriveService(CreateInitializer(credential));
-    }
-
-    private SheetsService GetSheetsService()
-    {
-        return CreateSheetsService(SheetsScopes);
-    }
-
-    private GoogleCredential CreateCredential(string[] scopes)
-    {
-        using var stream = new FileStream(FileName, FileMode.Open, FileAccess.Read);
-        return GoogleCredential.FromStream(stream)
-            .CreateScoped(scopes);
-    }
-
-    private SheetsService CreateSheetsService(string[] scopes)
-    {
-        var credential = CreateCredential(scopes);
-        return new SheetsService(CreateInitializer(credential));
-    }
-
-    private static BaseClientService.Initializer CreateInitializer(GoogleCredential credential)
-    {
-        return new BaseClientService.Initializer()
-        {
-            HttpClientInitializer = credential,
-            ApplicationName = "Financial",
-        };
-    }
-
-    private static string GetTabColorName(Google.Apis.Sheets.v4.Data.Color tabColor)
-    {
-        if (tabColor == null)
-        {
-            return string.Empty;
-        }
-
-        var color = Color.FromArgb(
-            (int)((tabColor.Alpha ?? 0) * 255),
-            (int)((tabColor.Red ?? 0) * 255),
-            (int)((tabColor.Green ?? 0) * 255),
-            (int)((tabColor.Blue ?? 0) * 255));
-        return color.Name;
-    }
-
-    private async Task<T> ExecuteWithRetryAsync<T>(Func<Task<T>> action, int maxRetries = 5)
-    {
-        int retryCount = 0;
-        int delayMs = 2000; // Start with 2 seconds
-
-        while (true)
-        {
-            try
-            {
-                return await action();
-            }
-            catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.TooManyRequests && retryCount < maxRetries)
-            {
-                retryCount++;
-                var waitTime = delayMs * (int)Math.Pow(2, retryCount - 1); // Exponential backoff
-                Console.WriteLine($"Rate limit hit. Retry {retryCount}/{maxRetries}. Waiting {waitTime}ms...");
-                await Task.Delay(waitTime);
-            }
-            catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.TooManyRequests)
-            {
-                throw new HttpRequestException($"API rate limit exceeded after {maxRetries} retries. Please wait a few minutes and try again.", ex);
-            }
-        }
-    }
+    public void UploadFileContent(string drivePath, string content) =>
+        _driveClient.UploadFileContent(drivePath, content);
 }
-

--- a/Integrations/GoogleFinancialSupport/GoogleSheetsClient.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleSheetsClient.cs
@@ -1,0 +1,72 @@
+using Google.Apis.Sheets.v4;
+using Financial.Infrastructure.Integrations.GoogleFinancialSupport.DTO;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+
+internal sealed class GoogleSheetsClient
+{
+    private static readonly string[] SheetsScopes = { SheetsService.Scope.Spreadsheets };
+
+    private readonly GoogleCredentialFactory _credentialFactory;
+
+    internal GoogleSheetsClient(GoogleCredentialFactory credentialFactory)
+    {
+        _credentialFactory = credentialFactory;
+    }
+
+    internal async Task<List<SheetDTO>> GetSpreadSheetAsync(string spreadSheetId)
+    {
+        return await GoogleRetryPolicy.ExecuteWithRetryAsync(async () =>
+        {
+            var service = CreateService();
+            var request = service.Spreadsheets.Get(spreadSheetId);
+            request.Fields = "sheets(properties/sheetId,properties/title,properties/tabColor)";
+            var response = await request.ExecuteAsync();
+            return response.Sheets
+                .Select(s => new SheetDTO
+                {
+                    Name = s.Properties.Title,
+                    Id = s.Properties.SheetId ?? 0,
+                    Color = GetTabColorName(s.Properties.TabColor)
+                })
+                .ToList();
+        });
+    }
+
+    internal async Task<IList<IList<object>>> GetSpreadSheetDataAsync(string spreadSheetId, string range)
+    {
+        return await GoogleRetryPolicy.ExecuteWithRetryAsync(async () =>
+        {
+            var service = CreateService();
+            var request = service.Spreadsheets.Values.Get(spreadSheetId, range);
+            request.ValueRenderOption = SpreadsheetsResource.ValuesResource.GetRequest.ValueRenderOptionEnum.UNFORMATTEDVALUE;
+            var response = await request.ExecuteAsync();
+            return response.Values;
+        });
+    }
+
+    private SheetsService CreateService()
+    {
+        var credential = _credentialFactory.Create(SheetsScopes);
+        return new SheetsService(GoogleCredentialFactory.CreateInitializer(credential));
+    }
+
+    private static string GetTabColorName(Google.Apis.Sheets.v4.Data.Color tabColor)
+    {
+        if (tabColor == null)
+        {
+            return string.Empty;
+        }
+
+        var color = Color.FromArgb(
+            (int)((tabColor.Alpha ?? 0) * 255),
+            (int)((tabColor.Red ?? 0) * 255),
+            (int)((tabColor.Green ?? 0) * 255),
+            (int)((tabColor.Blue ?? 0) * 255));
+        return color.Name;
+    }
+}


### PR DESCRIPTION
## Summary

`GoogleService` combined four unrelated concerns in one class: OAuth credential creation, Google Drive file operations, Google Sheets reading, and exponential-backoff retry. Any change to the retry policy, the Drive API, the Sheets API, or the credential format required modifying the same 260-line class.

**New internal types:**
| Type | Responsibility |
|------|---------------|
| `GoogleCredentialFactory` | Creates scoped `GoogleCredential` from the credentials file; produces the shared `BaseClientService.Initializer` |
| `GoogleDriveClient` | `GetFilesAsync`, `DownloadFileContent`, `UploadFileContent`, file-ID resolution, shortcut dereferencing |
| `GoogleSheetsClient` | `GetSpreadSheetAsync`, `GetSpreadSheetDataAsync`, tab-color name mapping |
| `GoogleRetryPolicy` | Static exponential-backoff retry for `TooManyRequests` |

`GoogleService` is now a thin public facade (35 lines) that wires the three clients from a single credentials file path. Its public API is unchanged — `MainWindow` and `GoogleGenerator` need no modifications.

## Architecture compliance

| Rule | Status |
|------|--------|
| Each class has one reason to change | ✅ |
| Public API of `GoogleService` unchanged | ✅ |
| Build succeeds — 0 errors, 0 warnings | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)