### PR TITLE
fix(S-04,S-05): replace provider switch with registry and move config parsing to RepositoryFactory

### DIFF
--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -6,7 +6,6 @@ using Financial.Infrastructure.Repositories;
 using Financial.Infrastructure.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 
 namespace Financial.Infrastructure.DependencyInjection;
 
@@ -20,7 +19,9 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IInvestmentsSerializer, InvestmentsSerializerAdapter>();
         services.AddSingleton<IDividendDataSource, DividendDataSourceAdapter>();
         services.AddSingleton<IAssetSnapshotSource, AssetSnapshotSourceAdapter>();
-        services.AddSingleton<IRepository>(sp => CreateRepository(configuration, sp.GetRequiredService<IInvestmentsSerializer>()));
+        services.AddSingleton<IRepository>(sp =>
+            new RepositoryFactory(sp.GetRequiredService<IInvestmentsSerializer>())
+                .CreateFromConfiguration(configuration));
         services.AddSingleton<INavigationService, NavigationService>();
         services.AddSingleton<ITransactionService, TransactionService>();
         services.AddSingleton<ICreditService, CreditService>();
@@ -28,26 +29,5 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IDividendService, DividendService>();
 
         return services;
-    }
-
-    private static IRepository CreateRepository(IConfiguration configuration, IInvestmentsSerializer serializer)
-    {
-        var providerValue = configuration[RepositoryConfigurationKeys.Provider]
-            ?? nameof(RepositoryProvider.LocalJson);
-
-        if (!Enum.TryParse(providerValue, true, out RepositoryProvider provider))
-        {
-            throw new InvalidOperationException(
-                $"Repository provider '{providerValue}' is not supported. " +
-                $"Valid values: {string.Join(", ", Enum.GetNames<RepositoryProvider>())}.");
-        }
-
-        var options = new RepositorySelectionOptions(
-            provider,
-            configuration[RepositoryConfigurationKeys.LocalJsonDataFile],
-            configuration[RepositoryConfigurationKeys.GoogleDriveCredentialsPath],
-            configuration[RepositoryConfigurationKeys.GoogleDriveFilePath]);
-
-        return new RepositoryFactory(serializer).Create(options);
     }
 }

--- a/Financial.Infrastructure/Repositories/RepositoryFactory.cs
+++ b/Financial.Infrastructure/Repositories/RepositoryFactory.cs
@@ -1,11 +1,20 @@
 using Financial.Application.Interfaces;
+using Financial.Infrastructure.Configuration;
 using Financial.Infrastructure.Persistence;
+using Microsoft.Extensions.Configuration;
 using System;
+using System.Collections.Generic;
 
 namespace Financial.Infrastructure.Repositories;
 
 public sealed class RepositoryFactory
 {
+    private static readonly Dictionary<RepositoryProvider, Func<RepositorySelectionOptions, IJsonStorage>> StorageFactoryRegistry = new()
+    {
+        [RepositoryProvider.LocalJson] = opts => new LocalJsonStorage(opts.LocalDataPath),
+        [RepositoryProvider.GoogleDriveJson] = opts => new GoogleDriveJsonStorage(opts.GoogleDriveCredentialsPath, opts.GoogleDriveFilePath),
+    };
+
     private readonly IInvestmentsSerializer _serializer;
 
     public RepositoryFactory(IInvestmentsSerializer serializer)
@@ -25,11 +34,39 @@ public sealed class RepositoryFactory
         return new JSONRepository(investments, storage, _serializer);
     }
 
-    private static IJsonStorage CreateStorage(RepositorySelectionOptions options) =>
-        options.Provider switch
+    public IRepository CreateFromConfiguration(IConfiguration configuration)
+    {
+        if (configuration is null)
         {
-            RepositoryProvider.LocalJson => new LocalJsonStorage(options.LocalDataPath),
-            RepositoryProvider.GoogleDriveJson => new GoogleDriveJsonStorage(options.GoogleDriveCredentialsPath, options.GoogleDriveFilePath),
-            _ => throw new ArgumentOutOfRangeException(nameof(options.Provider), options.Provider, "Unsupported repository provider.")
-        };
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        var providerValue = configuration[RepositoryConfigurationKeys.Provider]
+            ?? nameof(RepositoryProvider.LocalJson);
+
+        if (!Enum.TryParse(providerValue, true, out RepositoryProvider provider))
+        {
+            throw new InvalidOperationException(
+                $"Repository provider '{providerValue}' is not supported. " +
+                $"Valid values: {string.Join(", ", Enum.GetNames<RepositoryProvider>())}.");
+        }
+
+        var options = new RepositorySelectionOptions(
+            provider,
+            configuration[RepositoryConfigurationKeys.LocalJsonDataFile],
+            configuration[RepositoryConfigurationKeys.GoogleDriveCredentialsPath],
+            configuration[RepositoryConfigurationKeys.GoogleDriveFilePath]);
+
+        return Create(options);
+    }
+
+    private static IJsonStorage CreateStorage(RepositorySelectionOptions options)
+    {
+        if (!StorageFactoryRegistry.TryGetValue(options.Provider, out var factory))
+        {
+            throw new ArgumentOutOfRangeException(nameof(options.Provider), options.Provider, "Unsupported repository provider.");
+        }
+
+        return factory(options);
+    }
 }

--- a/Tests/Financial.Infrastructure.Tests/Financial.Infrastructure.Tests.csproj
+++ b/Tests/Financial.Infrastructure.Tests/Financial.Infrastructure.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.4" />
     <PackageReference Include="xunit.extensibility.core" Version="2.6.4" />

--- a/Tests/Financial.Infrastructure.Tests/Repositories/RepositoryFactoryTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Repositories/RepositoryFactoryTests.cs
@@ -1,12 +1,17 @@
+using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Financial.Infrastructure.Tests.Repositories;
 
 public class RepositoryFactoryTests
 {
+    private static readonly RepositoryFactory Factory = new(new InvestmentsSerializerAdapter());
+
     [Fact]
     public void Create_WithLocalJsonProvider_ReturnsJsonRepository()
     {
@@ -16,9 +21,7 @@ public class RepositoryFactoryTests
             null,
             null);
 
-        var factory = new RepositoryFactory(new Financial.Infrastructure.Persistence.InvestmentsSerializerAdapter());
-
-        var result = factory.Create(options);
+        var result = Factory.Create(options);
 
         result.Should().BeOfType<JSONRepository>();
     }
@@ -32,12 +35,68 @@ public class RepositoryFactoryTests
             null,
             "Pessoais/Gleison/Financeiros");
 
-        var factory = new RepositoryFactory(new Financial.Infrastructure.Persistence.InvestmentsSerializerAdapter());
-
-        Action act = () => factory.Create(options);
+        Action act = () => Factory.Create(options);
 
         act.Should().Throw<FileNotFoundException>()
             .WithMessage("*Google Drive credentials file path is required*");
     }
-}
 
+    [Fact]
+    public void Create_WithUnsupportedProvider_ThrowsArgumentOutOfRangeException()
+    {
+        var options = new RepositorySelectionOptions(
+            (RepositoryProvider)999,
+            null,
+            null,
+            null);
+
+        Action act = () => Factory.Create(options);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("Provider");
+    }
+
+    [Fact]
+    public void CreateFromConfiguration_WithLocalJsonProvider_ReturnsJsonRepository()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Repository:Provider"] = "LocalJson",
+            ["DataJsonFile"] = TestDataPaths.DataJsonFile
+        });
+
+        var result = Factory.CreateFromConfiguration(configuration);
+
+        result.Should().BeOfType<JSONRepository>();
+    }
+
+    [Fact]
+    public void CreateFromConfiguration_WithNoProvider_DefaultsToLocalJson()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["DataJsonFile"] = TestDataPaths.DataJsonFile
+        });
+
+        var result = Factory.CreateFromConfiguration(configuration);
+
+        result.Should().BeOfType<JSONRepository>();
+    }
+
+    [Fact]
+    public void CreateFromConfiguration_WithUnsupportedProvider_ThrowsInvalidOperationException()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Repository:Provider"] = "Unknown"
+        });
+
+        Action act = () => Factory.CreateFromConfiguration(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Repository provider 'Unknown' is not supported*");
+    }
+
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+}


### PR DESCRIPTION
## Summary
- **S-04 (OCP):** Replaced `CreateStorage` switch expression in `RepositoryFactory` with a static `Dictionary<RepositoryProvider, Func<RepositorySelectionOptions, IJsonStorage>>` registry — adding a new provider now requires only a new registry entry, not modifying the method
- **S-05 (OCP):** Moved configuration-parsing logic from `InfrastructureServiceCollectionExtensions.CreateRepository` into new `RepositoryFactory.CreateFromConfiguration(IConfiguration)` — the DI extension now calls a single factory method
- Added `Microsoft.Extensions.Configuration` package to the infrastructure test project to support new `CreateFromConfiguration` tests

## Test plan
- [ ] `Create_WithLocalJsonProvider_ReturnsJsonRepository` passes
- [ ] `Create_WithGoogleDriveProvider_WithoutCredentials_ThrowsFileNotFoundException` passes
- [ ] `Create_WithUnsupportedProvider_ThrowsArgumentOutOfRangeException` (new) passes
- [ ] `CreateFromConfiguration_WithLocalJsonProvider_ReturnsJsonRepository` (new) passes
- [ ] `CreateFromConfiguration_WithNoProvider_DefaultsToLocalJson` (new) passes
- [ ] `CreateFromConfiguration_WithUnsupportedProvider_ThrowsInvalidOperationException` (new) passes
- [ ] All 164 tests pass (3 pre-existing skips unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)