### PR TITLE
fix(S-07): inject GoogleService into GoogleDriveJsonStorage instead of creating it on each call

### DIFF
--- a/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
+++ b/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
@@ -1,7 +1,6 @@
 using Financial.Application.Interfaces;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using System;
-using System.IO;
 using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Persistence;
@@ -12,59 +11,21 @@ public sealed class GoogleDriveJsonStorage : IJsonStorage
     public const string FilePathConfigurationKey = "GoogleDrive:FilePath";
     public const string DefaultDriveFilePath = "Pessoais/Gleison/Financeiros";
 
-    private readonly string _credentialsPath;
+    private readonly GoogleService _service;
     private readonly string _driveFilePath;
 
-    public GoogleDriveJsonStorage(string? credentialsPath, string? driveFilePath)
+    public GoogleDriveJsonStorage(GoogleService service, string? driveFilePath)
     {
-        _credentialsPath = ResolveCredentialsPath(credentialsPath);
+        _service = service ?? throw new ArgumentNullException(nameof(service));
         _driveFilePath = ResolveDriveFilePath(driveFilePath);
     }
 
-    public Task<string> ReadAsync()
-    {
-        return Task.Run(() =>
-        {
-            var service = new GoogleService(_credentialsPath);
-            return service.DownloadFileContent(_driveFilePath);
-        });
-    }
+    public Task<string> ReadAsync() =>
+        Task.Run(() => _service.DownloadFileContent(_driveFilePath));
 
-    public Task WriteAsync(string json)
-    {
-        return Task.Run(() =>
-        {
-            var service = new GoogleService(_credentialsPath);
-            service.UploadFileContent(_driveFilePath, json);
-        });
-    }
+    public Task WriteAsync(string json) =>
+        Task.Run(() => _service.UploadFileContent(_driveFilePath, json));
 
-    private static string ResolveCredentialsPath(string? credentialsPath)
-    {
-        if (string.IsNullOrWhiteSpace(credentialsPath))
-        {
-            throw new FileNotFoundException(
-                $"Google Drive credentials file path is required. Configure '{CredentialsPathConfigurationKey}'.");
-        }
-
-        var resolvedPath = credentialsPath;
-        if (!Path.IsPathRooted(resolvedPath))
-        {
-            resolvedPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, resolvedPath));
-        }
-
-        if (!File.Exists(resolvedPath))
-        {
-            throw new FileNotFoundException(
-                $"Google Drive credentials file not found at '{resolvedPath}'. Configure '{CredentialsPathConfigurationKey}'.",
-                resolvedPath);
-        }
-
-        return resolvedPath;
-    }
-
-    private static string ResolveDriveFilePath(string? driveFilePath)
-    {
-        return string.IsNullOrWhiteSpace(driveFilePath) ? DefaultDriveFilePath : driveFilePath;
-    }
+    private static string ResolveDriveFilePath(string? driveFilePath) =>
+        string.IsNullOrWhiteSpace(driveFilePath) ? DefaultDriveFilePath : driveFilePath;
 }

--- a/Financial.Infrastructure/Repositories/RepositoryFactory.cs
+++ b/Financial.Infrastructure/Repositories/RepositoryFactory.cs
@@ -1,9 +1,11 @@
 using Financial.Application.Interfaces;
 using Financial.Infrastructure.Configuration;
+using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using Financial.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Financial.Infrastructure.Repositories;
 
@@ -12,7 +14,9 @@ public sealed class RepositoryFactory
     private static readonly Dictionary<RepositoryProvider, Func<RepositorySelectionOptions, IJsonStorage>> StorageFactoryRegistry = new()
     {
         [RepositoryProvider.LocalJson] = opts => new LocalJsonStorage(opts.LocalDataPath),
-        [RepositoryProvider.GoogleDriveJson] = opts => new GoogleDriveJsonStorage(opts.GoogleDriveCredentialsPath, opts.GoogleDriveFilePath),
+        [RepositoryProvider.GoogleDriveJson] = opts => new GoogleDriveJsonStorage(
+            new GoogleService(ResolveGoogleCredentialsPath(opts.GoogleDriveCredentialsPath)),
+            opts.GoogleDriveFilePath),
     };
 
     private readonly IInvestmentsSerializer _serializer;
@@ -68,5 +72,29 @@ public sealed class RepositoryFactory
         }
 
         return factory(options);
+    }
+
+    private static string ResolveGoogleCredentialsPath(string? credentialsPath)
+    {
+        if (string.IsNullOrWhiteSpace(credentialsPath))
+        {
+            throw new FileNotFoundException(
+                $"Google Drive credentials file path is required. Configure '{RepositoryConfigurationKeys.GoogleDriveCredentialsPath}'.");
+        }
+
+        var resolvedPath = credentialsPath;
+        if (!Path.IsPathRooted(resolvedPath))
+        {
+            resolvedPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, resolvedPath));
+        }
+
+        if (!File.Exists(resolvedPath))
+        {
+            throw new FileNotFoundException(
+                $"Google Drive credentials file not found at '{resolvedPath}'. Configure '{RepositoryConfigurationKeys.GoogleDriveCredentialsPath}'.",
+                resolvedPath);
+        }
+
+        return resolvedPath;
     }
 }


### PR DESCRIPTION
## Summary
- **S-07 (DIP):** `GoogleDriveJsonStorage` was calling `new GoogleService(_credentialsPath)` inside both `ReadAsync` and `WriteAsync` — creating a concrete dependency inside the class rather than receiving it from outside
- Constructor now accepts `GoogleService` as an injected dependency; the `ReadAsync`/`WriteAsync` bodies are reduced to single-expression lambdas
- Credentials path validation (formerly in `GoogleDriveJsonStorage.ResolveCredentialsPath`) moved to `RepositoryFactory.ResolveGoogleCredentialsPath` — the natural composition point where `GoogleService` is now constructed

## Test plan
- [ ] `Create_WithGoogleDriveProvider_WithoutCredentials_ThrowsFileNotFoundException` still throws with the same message (validation now in `RepositoryFactory`)
- [ ] All 164 tests pass (3 pre-existing skips unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)