### PR TITLE
fix(S-08): replace IConfiguration with IOptions<DividendOptions> in DividendsController

### DIFF
--- a/Financial.Api/Controllers/DividendsController.cs
+++ b/Financial.Api/Controllers/DividendsController.cs
@@ -3,7 +3,7 @@ using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 
@@ -16,10 +16,10 @@ public sealed class DividendsController : ControllerBase
     private readonly IDividendService _dividendService;
     private readonly string _defaultExchange;
 
-    public DividendsController(IDividendService dividendService, IConfiguration configuration)
+    public DividendsController(IDividendService dividendService, IOptions<DividendOptions> dividendOptions)
     {
         _dividendService = dividendService ?? throw new ArgumentNullException(nameof(dividendService));
-        _defaultExchange = configuration[DividendConfigurationKeys.DefaultExchange] ?? "BVMF";
+        _defaultExchange = (dividendOptions ?? throw new ArgumentNullException(nameof(dividendOptions))).Value.DefaultExchange;
     }
 
     [HttpGet("{ticker}/history")]

--- a/Financial.Api/Program.cs
+++ b/Financial.Api/Program.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Configuration;
 using Financial.Infrastructure.DependencyInjection;
 using System;
 
@@ -28,6 +29,7 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.Configure<DividendOptions>(configuration.GetSection(DividendOptions.SectionName));
 builder.Services.AddFinancialInfrastructure(configuration);
 
 var app = builder.Build();

--- a/Financial.Application/Configuration/DividendConfigurationKeys.cs
+++ b/Financial.Application/Configuration/DividendConfigurationKeys.cs
@@ -1,6 +1,0 @@
-namespace Financial.Application.Configuration;
-
-public static class DividendConfigurationKeys
-{
-    public const string DefaultExchange = "Dividends:DefaultExchange";
-}

--- a/Financial.Application/Configuration/DividendOptions.cs
+++ b/Financial.Application/Configuration/DividendOptions.cs
@@ -1,0 +1,7 @@
+namespace Financial.Application.Configuration;
+
+public sealed class DividendOptions
+{
+    public const string SectionName = "Dividends";
+    public string DefaultExchange { get; init; } = "BVMF";
+}


### PR DESCRIPTION
## Summary
- S-08 (DIP): DividendsController injected IConfiguration directly to read Dividends:DefaultExchange
- Introduced DividendOptions (Application layer) with DefaultExchange property (default BVMF)
- Registered Configure<DividendOptions> in Program.cs
- DividendsController now injects IOptions<DividendOptions>
- Removed now-dead DividendConfigurationKeys class

## Test plan
- All 164 tests pass (3 pre-existing skips unchanged)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>