### PR TITLE
fix(C-01): replace magic string "Asset" with TreeNodeTypes.Asset constant

### DIFF
--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -215,7 +215,7 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
 
     private void LoadSelectionDetails(TreeNodeViewModel selectedNode)
     {
-        if (selectedNode.NodeType == "Asset")
+        if (selectedNode.NodeType == TreeNodeTypes.Asset)
         {
             LoadAssetDetails(selectedNode);
             return;


### PR DESCRIPTION
## Summary
- Replace bare string literal `"Asset"` at line 218 of `MainNavigationViewModelBase` with the existing `TreeNodeTypes.Asset` constant — consistent with the two sibling comparisons in the same method that already used the constant.

## Test plan
- All tests pass (no behavioural change — same string value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)