### PR TITLE
fix(C-07): extract CountryCodeResolver to eliminate duplicated country mapping switches

### DIFF
--- a/Integrations/GoogleFinancialSupport/AssetMetadataResolver.cs
+++ b/Integrations/GoogleFinancialSupport/AssetMetadataResolver.cs
@@ -59,13 +59,7 @@ internal sealed class AssetMetadataResolver
             return CountryCode.Unknown;
         }
 
-        return currency.ToUpperInvariant() switch
-        {
-            "BRL" => CountryCode.BR,
-            "GBP" => CountryCode.UK,
-            "USD" => CountryCode.US,
-            _ => CountryCode.Unknown
-        };
+        return CountryCodeResolver.FromCurrency(currency);
     }
 
     private static AssetClassificationEntry ResolveAssetClassification(string assetName, CountryCode brokerCountry)

--- a/Integrations/GoogleFinancialSupport/AssetTypeLookup.cs
+++ b/Integrations/GoogleFinancialSupport/AssetTypeLookup.cs
@@ -46,10 +46,9 @@ public sealed class AssetTypeLookup : IAssetTypeLookup
         var googleType = await TryResolveGoogleFinanceTypeAsync(request, ticker);
         if (!string.IsNullOrWhiteSpace(googleType))
         {
-            var inferredCountry = ResolveCountryFromExchange(request.Exchange);
             return new AssetTypeLookupResultDTO
             {
-                Country = inferredCountry,
+                Country = CountryCodeResolver.FromExchange(request.Exchange),
                 LocalTypeCode = googleType
             };
         }
@@ -146,21 +145,5 @@ public sealed class AssetTypeLookup : IAssetTypeLookup
     private static string NormalizeTicker(string ticker)
     {
         return string.IsNullOrWhiteSpace(ticker) ? string.Empty : ticker.Trim();
-    }
-
-    private static CountryCode ResolveCountryFromExchange(string exchange)
-    {
-        if (string.IsNullOrWhiteSpace(exchange))
-        {
-            return CountryCode.Unknown;
-        }
-
-        return exchange.Trim().ToUpperInvariant() switch
-        {
-            "BVMF" => CountryCode.BR,
-            "LON" or "LSE" => CountryCode.UK,
-            "NYSE" or "NASDAQ" or "AMEX" => CountryCode.US,
-            _ => CountryCode.Unknown
-        };
     }
 }

--- a/Integrations/GoogleFinancialSupport/CountryCodeResolver.cs
+++ b/Integrations/GoogleFinancialSupport/CountryCodeResolver.cs
@@ -1,0 +1,31 @@
+using Financial.Domain.Entities;
+
+namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+
+internal static class CountryCodeResolver
+{
+    internal static CountryCode FromCurrency(string currency) =>
+        currency.ToUpperInvariant() switch
+        {
+            "BRL" => CountryCode.BR,
+            "GBP" => CountryCode.UK,
+            "USD" => CountryCode.US,
+            _ => CountryCode.Unknown
+        };
+
+    internal static CountryCode FromExchange(string exchange)
+    {
+        if (string.IsNullOrWhiteSpace(exchange))
+        {
+            return CountryCode.Unknown;
+        }
+
+        return exchange.Trim().ToUpperInvariant() switch
+        {
+            "BVMF" => CountryCode.BR,
+            "LON" or "LSE" => CountryCode.UK,
+            "NYSE" or "NASDAQ" or "AMEX" => CountryCode.US,
+            _ => CountryCode.Unknown
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Created `CountryCodeResolver` (internal static class in `GoogleFinancialSupport`) with two methods: `FromCurrency(string)` and `FromExchange(string)`
- `AssetMetadataResolver.ResolveBrokerCountry` now calls `CountryCodeResolver.FromCurrency` instead of its own switch
- `AssetTypeLookup.ResolveCountryFromExchange` private method removed; call site replaced with `CountryCodeResolver.FromExchange`

## Test plan

- [x] Build succeeds with 0 errors, 0 warnings
- [x] All 164 tests pass (35 Domain, 36 Application, 15 API, 78 Infrastructure with 3 pre-existing skips)
- [x] No behaviour changes — pure Clean Code refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)