### PR TITLE
fix(C-08,C-15): named constants and dash array loop in GoogleFinanceParsing

### DIFF
--- a/Integrations/WebPageParser/GoogleFinanceParsing.cs
+++ b/Integrations/WebPageParser/GoogleFinanceParsing.cs
@@ -5,19 +5,27 @@ namespace Financial.Infrastructure.Integrations.WebPageParser;
 
 internal static class GoogleFinanceParsing
 {
+    private const string GbxCurrencyCode = "GBX";
+    private const decimal GbxPenceToGbpDivisor = 100m;
+
+    private static readonly char[] UnicodeDashes =
+    {
+        '−', '‐', '‑', '‒', '–', '—'
+    };
+
     internal static decimal ParsePriceValue(string rawValue)
     {
         var cleaned = rawValue
             .Replace("R$", "")
             .Replace("?", "")
             .Replace("$", "")
-            .Replace("GBX", "")
+            .Replace(GbxCurrencyCode, "")
             .Replace("£", "")
             .Trim();
         var value = decimal.Parse(cleaned);
-        if (rawValue.Contains("GBX"))
+        if (rawValue.Contains(GbxCurrencyCode))
         {
-            value /= 100;
+            value /= GbxPenceToGbpDivisor;
         }
 
         return value;
@@ -106,13 +114,12 @@ internal static class GoogleFinanceParsing
     {
         var candidate = value.Trim()
             .Replace('\u202F', ' ')
-            .Replace('\u00A0', ' ')
-            .Replace('\u2212', '-')
-            .Replace('\u2010', '-')
-            .Replace('\u2011', '-')
-            .Replace('\u2012', '-')
-            .Replace('\u2013', '-')
-            .Replace('\u2014', '-');
+            .Replace('\u00A0', ' ');
+
+        foreach (var dash in UnicodeDashes)
+        {
+            candidate = candidate.Replace(dash, '-');
+        }
 
         var asOfIndex = candidate.IndexOf("As of", StringComparison.OrdinalIgnoreCase);
         if (asOfIndex >= 0)


### PR DESCRIPTION
## Summary

- **C-15**: `"GBX"` extracted to `GbxCurrencyCode` constant; magic `100` extracted to `GbxPenceToGbpDivisor` constant in `ParsePriceValue`
- **C-08**: The 6 individual Unicode dash `.Replace` calls in `NormalizeAsOfCandidate` replaced with a `UnicodeDashes` static array iterated by a `foreach` loop

## Test plan

- [x] Build succeeds with 0 errors, 0 warnings
- [x] All 164 tests pass (35 Domain, 36 Application, 15 API, 78 Infrastructure with 3 pre-existing skips)
- [x] No behaviour changes — pure Clean Code refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)