### PR TITLE
fix(C-11,C-12,C-13,C-14): name column index constants and type literals in sheet/dividend parsers

### DIFF
--- a/Integrations/GoogleFinancialSupport/GoogleSheetsAssetReader.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleSheetsAssetReader.cs
@@ -8,6 +8,22 @@ namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 
 internal sealed class GoogleSheetsAssetReader
 {
+    private const int AssetExchangeIdColumn = 0;
+    private const int AssetTickerColumn = 1;
+    private const int AssetIsinColumn = 2;
+
+    private const int TransactionDateColumn = 0;
+    private const int TransactionTypeColumn = 2;
+    private const int TransactionQuantityColumn = 3;
+    private const int TransactionUnitPriceColumn = 5;
+    private const int TransactionFeesColumn = 6;
+    private const string SellTransactionCode = "V";
+
+    private const int CreditDateColumn = 0;
+    private const int CreditValueColumn = 1;
+    private const int CreditTypeColumn = 3;
+    private const string RentCreditType = "Aluguel";
+
     private readonly GoogleService _service;
 
     internal GoogleSheetsAssetReader(GoogleService service)
@@ -26,9 +42,9 @@ internal sealed class GoogleSheetsAssetReader
             if (values is not null)
             {
                 var row = values.FirstOrDefault();
-                exchangeId = (string)row[0];
-                ticker = (string)row[1];
-                isin = (string)row[2];
+                exchangeId = (string)row[AssetExchangeIdColumn];
+                ticker = (string)row[AssetTickerColumn];
+                isin = (string)row[AssetIsinColumn];
             }
         }
         catch (InvalidCastException) { }
@@ -44,16 +60,16 @@ internal sealed class GoogleSheetsAssetReader
 
         foreach (var value in values)
         {
-            var date = value[0] is long ? (long)value[0] : previousDate;
+            var date = value[TransactionDateColumn] is long ? (long)value[TransactionDateColumn] : previousDate;
             previousDate = date;
-            var type = (string)value[2];
-            var quantity = GoogleSheetValueParser.ToDecimal(value[3]);
-            var unitPrice = GoogleSheetValueParser.ToDecimal(value[5]);
-            var fees = GoogleSheetValueParser.ToDecimal(value[6]) - (unitPrice * quantity);
+            var type = (string)value[TransactionTypeColumn];
+            var quantity = GoogleSheetValueParser.ToDecimal(value[TransactionQuantityColumn]);
+            var unitPrice = GoogleSheetValueParser.ToDecimal(value[TransactionUnitPriceColumn]);
+            var fees = GoogleSheetValueParser.ToDecimal(value[TransactionFeesColumn]) - (unitPrice * quantity);
 
             transactions.Add(Transaction.Create(
                 DateTime.FromOADate(date),
-                type == "V" ? Transaction.TransactionType.Sell : Transaction.TransactionType.Buy,
+                type == SellTransactionCode ? Transaction.TransactionType.Sell : Transaction.TransactionType.Buy,
                 quantity,
                 unitPrice,
                 fees < 0 ? 0 : fees));
@@ -73,13 +89,13 @@ internal sealed class GoogleSheetsAssetReader
 
         foreach (var value in values)
         {
-            if (value.Count > 0 && !string.IsNullOrWhiteSpace(value[0].ToString()))
+            if (value.Count > 0 && !string.IsNullOrWhiteSpace(value[CreditDateColumn].ToString()))
             {
-                var type = value.Count > 3 ? (string)value[3] : string.Empty;
+                var type = value.Count > CreditTypeColumn ? (string)value[CreditTypeColumn] : string.Empty;
                 credits.Add(Credit.Create(
-                    DateTime.FromOADate((long)value[0]),
-                    type == "Aluguel" ? Credit.CreditType.Rent : Credit.CreditType.Dividend,
-                    GoogleSheetValueParser.ToDecimal(value[1])));
+                    DateTime.FromOADate((long)value[CreditDateColumn]),
+                    type == RentCreditType ? Credit.CreditType.Rent : Credit.CreditType.Dividend,
+                    GoogleSheetValueParser.ToDecimal(value[CreditValueColumn])));
             }
         }
         return credits;

--- a/Integrations/WebPageParser/DadosMercadoDividend.cs
+++ b/Integrations/WebPageParser/DadosMercadoDividend.cs
@@ -9,6 +9,12 @@ namespace Financial.Infrastructure.Integrations.WebPageParser;
 
 public sealed class DadosMercadoDividend
 {
+    private const int DividendTypeColumn = 0;
+    private const int DividendValueColumn = 1;
+    private const int DividendDateColumn = 4;
+    private const int MinimumColumnCount = 5;
+    private const string DividendTypeCode = "Dividendo";
+
     public static List<DividendValue> GetDividendInfo(string ticker)
     {
         var googleTickerSearch = $"https://www.dadosdemercado.com.br/bolsa/acoes/{ticker}/dividendos";
@@ -32,15 +38,15 @@ public sealed class DadosMercadoDividend
 
     internal static DividendValue ParseDividendRow(IReadOnlyList<HtmlNode> cells)
     {
-        if (cells.Count < 5)
+        if (cells.Count < MinimumColumnCount)
         {
             throw new InvalidOperationException("Dividend row does not contain expected columns.");
         }
 
-        var dividendType = cells[0].InnerText == "Dividendo" ? DividendType.Dividend : DividendType.JCP;
-        var date = DateTime.Parse(cells[4].InnerText);
+        var dividendType = cells[DividendTypeColumn].InnerText == DividendTypeCode ? DividendType.Dividend : DividendType.JCP;
+        var date = DateTime.Parse(cells[DividendDateColumn].InnerText);
         var value = decimal.Parse(
-            cells[1].InnerText.Replace(",", ".").Replace("* ", ""),
+            cells[DividendValueColumn].InnerText.Replace(",", ".").Replace("* ", ""),
             CultureInfo.InvariantCulture);
 
         return new DividendValue(dividendType, date, value);


### PR DESCRIPTION
## Summary

- **C-11**: Transaction column indices (`0, 2, 3, 5, 6`) and sell code `"V"` replaced with named constants in `GoogleSheetsAssetReader`
- **C-12**: Credit column indices (`0, 1, 3`) replaced with named constants; count guard uses `CreditTypeColumn`
- **C-13**: `"Aluguel"` replaced with `RentCreditType` constant
- **C-14**: `DadosMercadoDividend.ParseDividendRow` — column indices `0, 1, 4`, minimum count `5`, and `"Dividendo"` replaced with `DividendTypeColumn`, `DividendValueColumn`, `DividendDateColumn`, `MinimumColumnCount`, `DividendTypeCode`

Note: C-15 and C-16 were already addressed in PR #65 and PR #63 respectively.

## Test plan

- [x] Build succeeds with 0 errors, 0 warnings
- [x] All 164 tests pass (35 Domain, 36 Application, 15 API, 78 Infrastructure with 3 pre-existing skips)
- [x] No behaviour changes — pure Clean Code refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)