### PR TITLE
fix(C-18,C-19,C-20): logger param, app name constant, remove personal path default

### DIFF
--- a/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
+++ b/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
@@ -9,7 +9,6 @@ public sealed class GoogleDriveJsonStorage : IJsonStorage
 {
     public const string CredentialsPathConfigurationKey = "GoogleDrive:CredentialsPath";
     public const string FilePathConfigurationKey = "GoogleDrive:FilePath";
-    public const string DefaultDriveFilePath = "Pessoais/Gleison/Financeiros";
 
     private readonly GoogleService _service;
     private readonly string _driveFilePath;
@@ -26,6 +25,10 @@ public sealed class GoogleDriveJsonStorage : IJsonStorage
     public Task WriteAsync(string json) =>
         Task.Run(() => _service.UploadFileContent(_driveFilePath, json));
 
-    private static string ResolveDriveFilePath(string? driveFilePath) =>
-        string.IsNullOrWhiteSpace(driveFilePath) ? DefaultDriveFilePath : driveFilePath;
+    private static string ResolveDriveFilePath(string? driveFilePath)
+    {
+        if (string.IsNullOrWhiteSpace(driveFilePath))
+            throw new ArgumentException($"Drive file path must be configured via '{FilePathConfigurationKey}'.", nameof(driveFilePath));
+        return driveFilePath;
+    }
 }

--- a/Integrations/GoogleFinancialSupport/GoogleCredentialFactory.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleCredentialFactory.cs
@@ -6,6 +6,8 @@ namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 
 internal sealed class GoogleCredentialFactory
 {
+    private const string GoogleApplicationName = "Financial";
+
     private readonly string _credentialsFilePath;
 
     internal GoogleCredentialFactory(string credentialsFilePath)
@@ -24,7 +26,7 @@ internal sealed class GoogleCredentialFactory
         return new BaseClientService.Initializer
         {
             HttpClientInitializer = credential,
-            ApplicationName = "Financial",
+            ApplicationName = GoogleApplicationName,
         };
     }
 }

--- a/Integrations/GoogleFinancialSupport/GoogleRetryPolicy.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleRetryPolicy.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using Google;
 using System;
 using System.Net;
@@ -8,7 +9,7 @@ namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 
 internal static class GoogleRetryPolicy
 {
-    internal static async Task<T> ExecuteWithRetryAsync<T>(Func<Task<T>> action, int maxRetries = 5)
+    internal static async Task<T> ExecuteWithRetryAsync<T>(Func<Task<T>> action, int maxRetries = 5, Action<string>? logger = null)
     {
         int retryCount = 0;
         const int initialDelayMs = 2000;
@@ -23,7 +24,7 @@ internal static class GoogleRetryPolicy
             {
                 retryCount++;
                 var waitTime = initialDelayMs * (int)Math.Pow(2, retryCount - 1);
-                Console.WriteLine($"Rate limit hit. Retry {retryCount}/{maxRetries}. Waiting {waitTime}ms...");
+                logger?.Invoke($"Rate limit hit. Retry {retryCount}/{maxRetries}. Waiting {waitTime}ms...");
                 await Task.Delay(waitTime);
             }
             catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.TooManyRequests)


### PR DESCRIPTION
## Summary

- **C-18** (`GoogleRetryPolicy`): `Console.WriteLine` replaced with an `Action<string>? logger = null` optional parameter; `#nullable enable` added to scope the nullable annotation without touching other files in the project
- **C-19** (`GoogleCredentialFactory`): `"Financial"` extracted to `private const string GoogleApplicationName`
- **C-20** (`GoogleDriveJsonStorage`): `public const string DefaultDriveFilePath = "Pessoais/Gleison/Financeiros"` removed; `ResolveDriveFilePath` now throws `ArgumentException` with a clear message pointing to the `GoogleDrive:FilePath` configuration key — callers must always provide a path via config

## Test plan

- [x] Build succeeds with 0 errors, 0 warnings
- [x] All 164 tests pass (35 Domain, 36 Application, 15 API, 78 Infrastructure with 3 pre-existing skips)
- [x] No behaviour changes for properly configured deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)