### PR TITLE
fix(R-01,R-10): move Application services to own DI extension; remove IRepository from MainWindow

### DIFF
--- a/Financial.Api/Program.cs
+++ b/Financial.Api/Program.cs
@@ -1,4 +1,5 @@
 using Financial.Application.Configuration;
+using Financial.Application.DependencyInjection;
 using Financial.Infrastructure.DependencyInjection;
 using System;
 
@@ -30,6 +31,7 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.Configure<DividendOptions>(configuration.GetSection(DividendOptions.SectionName));
+builder.Services.AddFinancialApplication();
 builder.Services.AddFinancialInfrastructure(configuration);
 
 var app = builder.Build();

--- a/Financial.App/App.xaml.cs
+++ b/Financial.App/App.xaml.cs
@@ -1,3 +1,4 @@
+using Financial.Application.DependencyInjection;
 using Financial.Infrastructure.DependencyInjection;
 using Financial.Presentation.App.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,6 +18,7 @@ namespace Financial.Presentation.App
             AppHost = Host.CreateDefaultBuilder()
                 .ConfigureServices((context, services) =>
                 {
+                    services.AddFinancialApplication();
                     services.AddFinancialInfrastructure(context.Configuration);
                     services.AddTransient<MainNavigationViewModel>();
                     services.AddTransient<MainWindow>();

--- a/Financial.App/MainWindow.xaml.cs
+++ b/Financial.App/MainWindow.xaml.cs
@@ -17,7 +17,7 @@ namespace Financial.Presentation.App
 {
     public partial class MainWindow : Window
     {
-        private readonly IRepository _repository;
+        private readonly INavigationService _navigationService;
         private readonly IAssetPriceService _assetPriceService;
         private readonly IDividendService _dividendService;
         private readonly MainNavigationViewModel _navigationViewModel;
@@ -43,12 +43,12 @@ namespace Financial.Presentation.App
         public MainNavigationViewModel NavigationViewModel => _navigationViewModel;
 
         public MainWindow(
-            IRepository repository,
+            INavigationService navigationService,
             IAssetPriceService assetPriceService,
             IDividendService dividendService,
             MainNavigationViewModel navigationViewModel)
         {
-            _repository = repository;
+            _navigationService = navigationService;
             _assetPriceService = assetPriceService;
             _dividendService = dividendService;
             _navigationViewModel = navigationViewModel;
@@ -224,8 +224,8 @@ namespace Financial.Presentation.App
 
             try
             {
-                var assets = _repository.GetAssetsByBrokerPortfolio(XpiBrokerName, DefaultPortfolioName).ToList();
-                var acoes = _repository.GetAssetsByBrokerPortfolio(XpiBrokerName, AcoesPortfolioName);
+                var assets = _navigationService.GetAssetsByBrokerPortfolio(XpiBrokerName, DefaultPortfolioName).ToList();
+                var acoes = _navigationService.GetAssetsByBrokerPortfolio(XpiBrokerName, AcoesPortfolioName);
                 assets.AddRange(acoes);
 
                 var list = new List<AssetValue>();

--- a/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+using Financial.Application.Interfaces;
+using Financial.Application.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Financial.Application.DependencyInjection;
+
+public static class ApplicationServiceCollectionExtensions
+{
+    public static IServiceCollection AddFinancialApplication(this IServiceCollection services)
+    {
+        services.AddSingleton<NavigationService>();
+        services.AddSingleton<INavigationService>(sp => sp.GetRequiredService<NavigationService>());
+        services.AddSingleton<ICreditQueryService>(sp => sp.GetRequiredService<NavigationService>());
+        services.AddSingleton<ITransactionService, TransactionService>();
+        services.AddSingleton<ICreditService, CreditService>();
+        services.AddSingleton<IDividendService, DividendService>();
+
+        return services;
+    }
+}

--- a/Financial.Application/Financial.Application.csproj
+++ b/Financial.Application/Financial.Application.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Financial.Domain\Financial.Domain.csproj" />
   </ItemGroup>
 

--- a/Financial.Application/Interfaces/INavigationService.cs
+++ b/Financial.Application/Interfaces/INavigationService.cs
@@ -8,4 +8,5 @@ public interface INavigationService
     TreeNodeDTO GetNavigationTree();
     AssetDetailsDTO? GetAssetDetails(string brokerName, string portfolioName, string assetName);
     IEnumerable<BrokerNodeDTO> GetBrokers();
+    IEnumerable<AssetNodeDTO> GetAssetsByBrokerPortfolio(string brokerName, string portfolioName);
 }

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -154,7 +154,7 @@ internal static class NavigationMapper
         };
     }
 
-    private static AssetNodeDTO MapAsset(Asset asset)
+    internal static AssetNodeDTO MapAsset(Asset asset)
     {
         return new AssetNodeDTO
         {

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -91,6 +91,13 @@ public sealed class NavigationService : INavigationService, ICreditQueryService
         return brokers.Select(NavigationMapper.MapBroker).ToList();
     }
 
+    public IEnumerable<AssetNodeDTO> GetAssetsByBrokerPortfolio(string brokerName, string portfolioName)
+    {
+        return _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName)
+            .Select(NavigationMapper.MapAsset)
+            .ToList();
+    }
+
     public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName)
     {
         if (string.IsNullOrWhiteSpace(brokerName))

--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using Financial.Application.Interfaces;
-using Financial.Application.Services;
 using Financial.Infrastructure.Configuration;
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
@@ -22,13 +21,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IRepository>(sp =>
             new RepositoryFactory(sp.GetRequiredService<IInvestmentsSerializer>())
                 .CreateFromConfiguration(configuration));
-        services.AddSingleton<NavigationService>();
-        services.AddSingleton<INavigationService>(sp => sp.GetRequiredService<NavigationService>());
-        services.AddSingleton<ICreditQueryService>(sp => sp.GetRequiredService<NavigationService>());
-        services.AddSingleton<ITransactionService, TransactionService>();
-        services.AddSingleton<ICreditService, CreditService>();
         services.AddSingleton<IAssetPriceService, AssetPriceService>();
-        services.AddSingleton<IDividendService, DividendService>();
 
         return services;
     }


### PR DESCRIPTION
## Summary

- **R-01**: Extracts Application-layer service registrations out of `InfrastructureServiceCollectionExtensions` into a new `ApplicationServiceCollectionExtensions.AddFinancialApplication()` method in `Financial.Application`. Infrastructure now only registers infrastructure concerns (repository, serializer, data sources, asset price service). Both `Program.cs` (API) and `App.xaml.cs` (WPF) now call `AddFinancialApplication()` before `AddFinancialInfrastructure()`.
- **R-10**: Adds `GetAssetsByBrokerPortfolio(brokerName, portfolioName)` to `INavigationService` and implements it in `NavigationService`. `MainWindow` now injects `INavigationService` instead of `IRepository`, removing the Presentation→Domain infrastructure bypass.

## Architecture compliance
- `Financial.Application` depends on `Microsoft.Extensions.DependencyInjection.Abstractions` (interface only, not implementation) — acceptable for Application self-registration.
- Dependency direction restored: Presentation → Application → Domain; Infrastructure → Application.
- Infrastructure no longer references Application service implementations.

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 164 passed, 3 pre-existing skips, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)