### PR TITLE
fix(R-02,R-04,R-05,R-08,R-09): medium-priority architecture violations

### DIFF
--- a/Financial.App/Helpers/DateFormatHelper.cs
+++ b/Financial.App/Helpers/DateFormatHelper.cs
@@ -1,0 +1,59 @@
+using System.Globalization;
+using System.Text;
+
+namespace Financial.Presentation.App.Helpers;
+
+internal static class DateFormatHelper
+{
+    internal static string GetPaddedShortDatePattern()
+    {
+        var pattern = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
+        return PadDayMonthTokens(pattern);
+    }
+
+    private static string PadDayMonthTokens(string pattern)
+    {
+        var sb = new StringBuilder();
+        bool inQuote = false;
+
+        for (int i = 0; i < pattern.Length; i++)
+        {
+            var ch = pattern[i];
+            if (ch == '\'')
+            {
+                i = HandleQuoteChar(pattern, i, sb, ref inQuote);
+                continue;
+            }
+            if (inQuote) { sb.Append(ch); continue; }
+            if (ch == 'd' || ch == 'M')
+            {
+                i = HandleFormatToken(pattern, i, ch, sb);
+                continue;
+            }
+            sb.Append(ch);
+        }
+
+        return sb.ToString();
+    }
+
+    private static int HandleQuoteChar(string pattern, int i, StringBuilder sb, ref bool inQuote)
+    {
+        sb.Append('\'');
+        if (i + 1 < pattern.Length && pattern[i + 1] == '\'')
+        {
+            sb.Append(pattern[i + 1]);
+            return i + 1;
+        }
+        inQuote = !inQuote;
+        return i;
+    }
+
+    private static int HandleFormatToken(string pattern, int i, char ch, StringBuilder sb)
+    {
+        int count = 1;
+        while (i + count < pattern.Length && pattern[i + count] == ch)
+            count++;
+        sb.Append(ch, count < 2 ? 2 : count);
+        return i + count - 1;
+    }
+}

--- a/Financial.App/MainWindow.xaml.cs
+++ b/Financial.App/MainWindow.xaml.cs
@@ -2,11 +2,11 @@ using Financial.Application.DTOs;
 using Financial.Domain.Rules;
 using Financial.Application.Interfaces;
 using Financial.Presentation.App.Components;
+using Financial.Presentation.App.Helpers;
+using Financial.Presentation.App.Options;
 using Financial.Presentation.App.ViewModels;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -28,18 +28,6 @@ namespace Financial.Presentation.App
         private const string AcoesPortfolioName = "Acoes";
         private const int ProgressHideDelayMs = 2000;
 
-        private static readonly IReadOnlyList<Option> DefaultDividendWatchlist = new[]
-        {
-            new Option { Group = "Ja possuidas", Name = "KLBN4" },
-            new Option { Group = "Ja possuidas", Name = "TASA4" },
-            new Option { Group = "Ja possuidas", Name = "TAEE3" },
-            new Option { Group = "Outras Barse", Name = "UNIP6" },
-            new Option { Group = "Outras Barse", Name = "CMIG4" },
-            new Option { Group = "Outras Barse", Name = "TRPL4" },
-            new Option { Group = "Outras Barse", Name = "BBAS3" },
-            new Option { Group = "Outras",        Name = "CSAN3" },
-        };
-
         public MainNavigationViewModel NavigationViewModel => _navigationViewModel;
 
         public MainWindow(
@@ -55,7 +43,7 @@ namespace Financial.Presentation.App
 
             InitializeComponent();
 
-            var groupedOptions = new ListCollectionView(new List<Option>(DefaultDividendWatchlist));
+            var groupedOptions = new ListCollectionView(new List<WatchlistItem>(WatchlistOptions.DefaultDividendWatchlist));
             groupedOptions.GroupDescriptions.Add(new PropertyGroupDescription("Group"));
             txtTicker.ItemsSource = groupedOptions;
 
@@ -84,12 +72,6 @@ namespace Financial.Presentation.App
                     return result;
             }
             return null;
-        }
-
-        public class Option
-        {
-            public required string Group { get; set; }
-            public required string Name { get; set; }
         }
 
         public class AssetValue
@@ -124,7 +106,7 @@ namespace Financial.Presentation.App
                 var dataGridColumn = e.Column as DataGridTextColumn;
                 if (dataGridColumn != null)
                 {
-                    dataGridColumn.Binding.StringFormat = GetPaddedShortDatePattern();
+                    dataGridColumn.Binding.StringFormat = DateFormatHelper.GetPaddedShortDatePattern();
                 }
             }
 
@@ -162,58 +144,6 @@ namespace Financial.Presentation.App
             style.Setters.Add(new Setter(TextBlock.FontWeightProperty, FontWeights.Bold));
             style.Setters.Add(new Setter(TextBlock.ForegroundProperty, Brushes.Black));
             dataGridColumn.ElementStyle = style;
-        }
-
-        private static string GetPaddedShortDatePattern()
-        {
-            var pattern = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
-            return PadDayMonthTokens(pattern);
-        }
-
-        private static string PadDayMonthTokens(string pattern)
-        {
-            var sb = new StringBuilder();
-            bool inQuote = false;
-
-            for (int i = 0; i < pattern.Length; i++)
-            {
-                var ch = pattern[i];
-                if (ch == '\'')
-                {
-                    i = HandleQuoteChar(pattern, i, sb, ref inQuote);
-                    continue;
-                }
-                if (inQuote) { sb.Append(ch); continue; }
-                if (ch == 'd' || ch == 'M')
-                {
-                    i = HandleFormatToken(pattern, i, ch, sb);
-                    continue;
-                }
-                sb.Append(ch);
-            }
-
-            return sb.ToString();
-        }
-
-        private static int HandleQuoteChar(string pattern, int i, StringBuilder sb, ref bool inQuote)
-        {
-            sb.Append('\'');
-            if (i + 1 < pattern.Length && pattern[i + 1] == '\'')
-            {
-                sb.Append(pattern[i + 1]);
-                return i + 1;
-            }
-            inQuote = !inQuote;
-            return i;
-        }
-
-        private static int HandleFormatToken(string pattern, int i, char ch, StringBuilder sb)
-        {
-            int count = 1;
-            while (i + count < pattern.Length && pattern[i + count] == ch)
-                count++;
-            sb.Append(ch, count < 2 ? 2 : count);
-            return i + count - 1;
         }
 
         private async void btnCheckFIIS_Click(object sender, RoutedEventArgs e)

--- a/Financial.App/Options/WatchlistItem.cs
+++ b/Financial.App/Options/WatchlistItem.cs
@@ -1,0 +1,7 @@
+namespace Financial.Presentation.App.Options;
+
+public class WatchlistItem
+{
+    public required string Group { get; set; }
+    public required string Name { get; set; }
+}

--- a/Financial.App/Options/WatchlistOptions.cs
+++ b/Financial.App/Options/WatchlistOptions.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace Financial.Presentation.App.Options;
+
+internal static class WatchlistOptions
+{
+    internal static IReadOnlyList<WatchlistItem> DefaultDividendWatchlist { get; } = new[]
+    {
+        new WatchlistItem { Group = "Ja possuidas", Name = "KLBN4" },
+        new WatchlistItem { Group = "Ja possuidas", Name = "TASA4" },
+        new WatchlistItem { Group = "Ja possuidas", Name = "TAEE3" },
+        new WatchlistItem { Group = "Outras Barse", Name = "UNIP6" },
+        new WatchlistItem { Group = "Outras Barse", Name = "CMIG4" },
+        new WatchlistItem { Group = "Outras Barse", Name = "TRPL4" },
+        new WatchlistItem { Group = "Outras Barse", Name = "BBAS3" },
+        new WatchlistItem { Group = "Outras",       Name = "CSAN3" },
+    };
+}

--- a/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ public static class ApplicationServiceCollectionExtensions
     {
         services.AddSingleton<NavigationService>();
         services.AddSingleton<INavigationService>(sp => sp.GetRequiredService<NavigationService>());
-        services.AddSingleton<ICreditQueryService>(sp => sp.GetRequiredService<NavigationService>());
+        services.AddSingleton<ICreditQueryService, CreditQueryService>();
         services.AddSingleton<ITransactionService, TransactionService>();
         services.AddSingleton<ICreditService, CreditService>();
         services.AddSingleton<IDividendService, DividendService>();

--- a/Financial.Application/Services/CreditQueryService.cs
+++ b/Financial.Application/Services/CreditQueryService.cs
@@ -1,0 +1,47 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Financial.Application.Services;
+
+public sealed class CreditQueryService : ICreditQueryService
+{
+    private readonly IRepository _repository;
+
+    public CreditQueryService(IRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName))
+        {
+            return Array.Empty<CreditDTO>();
+        }
+
+        return _repository.GetAssetsByBroker(brokerName)
+            .Where(asset => asset.Active)
+            .SelectMany(asset => asset.Credits)
+            .Select(NavigationMapper.MapCredit)
+            .OrderByDescending(credit => credit.Date)
+            .ToList();
+    }
+
+    public IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
+        {
+            return Array.Empty<CreditDTO>();
+        }
+
+        return _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName)
+            .Where(asset => asset.Active)
+            .SelectMany(asset => asset.Credits)
+            .Select(NavigationMapper.MapCredit)
+            .OrderByDescending(credit => credit.Date)
+            .ToList();
+    }
+}

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Financial.Application.Services;
 
-public sealed class NavigationService : INavigationService, ICreditQueryService
+public sealed class NavigationService : INavigationService
 {
     private readonly IRepository _repository;
 
@@ -98,33 +98,4 @@ public sealed class NavigationService : INavigationService, ICreditQueryService
             .ToList();
     }
 
-    public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName)
-    {
-        if (string.IsNullOrWhiteSpace(brokerName))
-        {
-            return Array.Empty<CreditDTO>();
-        }
-
-        return _repository.GetAssetsByBroker(brokerName)
-            .Where(asset => asset.Active)
-            .SelectMany(asset => asset.Credits)
-            .Select(NavigationMapper.MapCredit)
-            .OrderByDescending(credit => credit.Date)
-            .ToList();
-    }
-
-    public IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName)
-    {
-        if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
-        {
-            return Array.Empty<CreditDTO>();
-        }
-
-        return _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName)
-            .Where(asset => asset.Active)
-            .SelectMany(asset => asset.Credits)
-            .Select(NavigationMapper.MapCredit)
-            .OrderByDescending(credit => credit.Date)
-            .ToList();
-    }
 }

--- a/Financial.Domain/AssemblyInfo.cs
+++ b/Financial.Domain/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Financial.Domain.Tests")]

--- a/Financial.Domain/Entities/Credit.cs
+++ b/Financial.Domain/Entities/Credit.cs
@@ -27,7 +27,7 @@ public class Credit
     public static Credit CreateWithId(Guid id, DateTime date, CreditType type, decimal value) =>
         new(id, date, type, value);
 
-    public void EnsureId()
+    internal void EnsureId()
     {
         if (Id == Guid.Empty)
         {

--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
 using Financial.Application.Interfaces;
 using Financial.Infrastructure.Configuration;
+using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
 using Financial.Infrastructure.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Net.Http;
 
 namespace Financial.Infrastructure.DependencyInjection;
 
@@ -22,6 +24,7 @@ public static class InfrastructureServiceCollectionExtensions
             new RepositoryFactory(sp.GetRequiredService<IInvestmentsSerializer>())
                 .CreateFromConfiguration(configuration));
         services.AddSingleton<IAssetPriceService, AssetPriceService>();
+        services.AddSingleton<IAssetTypeLookup>(_ => new AssetTypeLookup(new HttpClient()));
 
         return services;
     }

--- a/Integrations/GoogleFinancialSupport/AssetTypeLookup.cs
+++ b/Integrations/GoogleFinancialSupport/AssetTypeLookup.cs
@@ -13,7 +13,7 @@ namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 
 public sealed class AssetTypeLookup : IAssetTypeLookup
 {
-    private static readonly HttpClient HttpClient = new HttpClient();
+    private readonly HttpClient _httpClient;
     private static readonly string[] BrazilFiiPaths =
     {
         "bolsa/fundos-imobiliarios",
@@ -21,6 +21,11 @@ public sealed class AssetTypeLookup : IAssetTypeLookup
         "fundos-imobiliarios",
         "fiis"
     };
+
+    public AssetTypeLookup(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
 
     public async Task<AssetTypeLookupResultDTO> LookupAsync(AssetTypeLookupRequestDTO request)
     {
@@ -56,7 +61,7 @@ public sealed class AssetTypeLookup : IAssetTypeLookup
         return new AssetTypeLookupResultDTO();
     }
 
-    private static async Task<string> TryResolveBrazilTypeAsync(string ticker)
+    private async Task<string> TryResolveBrazilTypeAsync(string ticker)
     {
         if (string.IsNullOrWhiteSpace(ticker))
         {
@@ -76,7 +81,7 @@ public sealed class AssetTypeLookup : IAssetTypeLookup
         return string.IsNullOrWhiteSpace(equityHtml) ? string.Empty : "Acoes";
     }
 
-    private static async Task<string> TryResolveGoogleFinanceTypeAsync(AssetTypeLookupRequestDTO request, string ticker)
+    private async Task<string> TryResolveGoogleFinanceTypeAsync(AssetTypeLookupRequestDTO request, string ticker)
     {
         foreach (var url in BuildGoogleFinanceUrls(request, ticker))
         {
@@ -127,14 +132,14 @@ public sealed class AssetTypeLookup : IAssetTypeLookup
         return $"https://www.google.com/finance/quote/{Uri.EscapeDataString(value)}";
     }
 
-    private static async Task<string> TryLoadPageAsync(string url)
+    private async Task<string> TryLoadPageAsync(string url)
     {
         if (string.IsNullOrWhiteSpace(url))
         {
             throw new ArgumentException("Url must be provided.", nameof(url));
         }
 
-        using var response = await HttpClient.GetAsync(url);
+        using var response = await _httpClient.GetAsync(url);
         if (!response.IsSuccessStatusCode)
         {
             return string.Empty;

--- a/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
@@ -19,10 +19,12 @@ public class NavigationServiceTests
         return new JSONRepository(InvestmentsLoader.Load(storage, serializer), storage, serializer);
     }
     private readonly NavigationService _sut;
+    private readonly CreditQueryService _creditSut;
 
     public NavigationServiceTests()
     {
         _sut = new NavigationService(_repository);
+        _creditSut = new CreditQueryService(_repository);
     }
 
     [Fact]
@@ -297,7 +299,7 @@ public class NavigationServiceTests
     public void GetCreditsByBroker_WithInvalidParameters_ReturnsEmpty(string? brokerName)
     {
         // Act
-        var result = _sut.GetCreditsByBroker(brokerName!);
+        var result = _creditSut.GetCreditsByBroker(brokerName!);
 
         // Assert
         result.Should().BeEmpty();
@@ -311,7 +313,7 @@ public class NavigationServiceTests
     public void GetCreditsByPortfolio_WithInvalidParameters_ReturnsEmpty(string? brokerName, string? portfolioName)
     {
         // Act
-        var result = _sut.GetCreditsByPortfolio(brokerName!, portfolioName!);
+        var result = _creditSut.GetCreditsByPortfolio(brokerName!, portfolioName!);
 
         // Assert
         result.Should().BeEmpty();
@@ -324,7 +326,7 @@ public class NavigationServiceTests
         const string brokerName = "XPI";
 
         // Act
-        var result = _sut.GetCreditsByBroker(brokerName);
+        var result = _creditSut.GetCreditsByBroker(brokerName);
 
         // Assert
         result.Should().NotBeEmpty();
@@ -344,7 +346,7 @@ public class NavigationServiceTests
         const string portfolioName = "Default";
 
         // Act
-        var result = _sut.GetCreditsByPortfolio(brokerName, portfolioName);
+        var result = _creditSut.GetCreditsByPortfolio(brokerName, portfolioName);
 
         // Assert
         result.Should().NotBeEmpty();
@@ -363,7 +365,7 @@ public class NavigationServiceTests
         const string brokerName = "XPI";
 
         // Act
-        var result = _sut.GetCreditsByBroker(brokerName);
+        var result = _creditSut.GetCreditsByBroker(brokerName);
 
         // Assert
         if (result.Count > 1)


### PR DESCRIPTION
## Summary

- **R-02**: Extracted `GetCreditsByBroker` and `GetCreditsByPortfolio` from `NavigationService` into a new `CreditQueryService : ICreditQueryService`. `NavigationService` now implements only `INavigationService` (SRP). DI updated to bind `ICreditQueryService` → `CreditQueryService`. `NavigationServiceTests` updated to use `CreditQueryService` for credit assertions.
- **R-04**: Changed `Credit.EnsureId()` from `public` to `internal`, matching `Transaction.EnsureId()`. Added `[assembly: InternalsVisibleTo("Financial.Domain.Tests")]` so the domain test can still call it.
- **R-05**: Removed static `HttpClient` field from `AssetTypeLookup`; constructor now accepts `HttpClient`. Registered `IAssetTypeLookup` in `InfrastructureServiceCollectionExtensions` via singleton factory (previously unregistered).
- **R-08**: Moved `DefaultDividendWatchlist` from `MainWindow` static field to `WatchlistOptions`; extracted nested `Option` class to `WatchlistItem` in its own file.
- **R-09**: Extracted `GetPaddedShortDatePattern`, `PadDayMonthTokens`, `HandleQuoteChar`, `HandleFormatToken` from `MainWindow` to `DateFormatHelper` static class. `MainWindow` now delegates to `DateFormatHelper.GetPaddedShortDatePattern()`.
- **R-11**: Skipped — MainWindow feature extraction to UserControls requires XAML restructuring that cannot be safely validated from the CLI without a running WPF environment.

> **Depends on**: #70 (fix/R-01-10-high must merge first)

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 164 passed, 3 pre-existing skips, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)