### PR TITLE
fix(R-03,R-06,R-07,R-12,R-13,R-14): low-priority architecture violations

### DIFF
--- a/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
+++ b/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
@@ -1,4 +1,5 @@
 using Financial.Application.Interfaces;
+using Financial.Infrastructure.Configuration;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using System;
 using System.Threading.Tasks;
@@ -7,9 +8,6 @@ namespace Financial.Infrastructure.Persistence;
 
 public sealed class GoogleDriveJsonStorage : IJsonStorage
 {
-    public const string CredentialsPathConfigurationKey = "GoogleDrive:CredentialsPath";
-    public const string FilePathConfigurationKey = "GoogleDrive:FilePath";
-
     private readonly GoogleService _service;
     private readonly string _driveFilePath;
 
@@ -28,7 +26,7 @@ public sealed class GoogleDriveJsonStorage : IJsonStorage
     private static string ResolveDriveFilePath(string? driveFilePath)
     {
         if (string.IsNullOrWhiteSpace(driveFilePath))
-            throw new ArgumentException($"Drive file path must be configured via '{FilePathConfigurationKey}'.", nameof(driveFilePath));
+            throw new ArgumentException($"Drive file path must be configured via '{RepositoryConfigurationKeys.GoogleDriveFilePath}'.", nameof(driveFilePath));
         return driveFilePath;
     }
 }

--- a/Financial.Infrastructure/Persistence/InvestmentsJsonSerializer.cs
+++ b/Financial.Infrastructure/Persistence/InvestmentsJsonSerializer.cs
@@ -10,7 +10,7 @@ public static class InvestmentsJsonSerializer
 
     public static Investments Deserialize(string json)
     {
-        var investments = JsonSerializer.Deserialize<Investments>(json, InvestmentsSerializerOptions.Default);
-        return investments!;
+        return JsonSerializer.Deserialize<Investments>(json, InvestmentsSerializerOptions.Default)
+            ?? throw new InvalidOperationException("Failed to deserialize investments data: JSON produced a null result.");
     }
 }

--- a/Financial.Infrastructure/Repositories/JSONRepository.cs
+++ b/Financial.Infrastructure/Repositories/JSONRepository.cs
@@ -12,18 +12,18 @@ public sealed class JSONRepository : IRepository
 {
     private readonly IJsonStorage _storage;
     private readonly IInvestmentsSerializer _serializer;
-    private readonly Investments _investiments;
+    private readonly Investments _investments;
 
     public JSONRepository(Investments investments, IJsonStorage storage, IInvestmentsSerializer serializer)
     {
-        _investiments = investments ?? throw new ArgumentNullException(nameof(investments));
+        _investments = investments ?? throw new ArgumentNullException(nameof(investments));
         _storage = storage ?? throw new ArgumentNullException(nameof(storage));
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
     }
 
     public IReadOnlyList<string> GetAllAssetsFullName()
     {
-        return _investiments.Brokers
+        return _investments.Brokers
             .SelectMany(b => b.Portfolios.SelectMany(p => p.Assets.Select(a => $"{b.Name}/{p.Name}/{a.Name}")))
             .ToList();
     }
@@ -60,17 +60,17 @@ public sealed class JSONRepository : IRepository
 
     public IEnumerable<Broker> GetBrokerList()
     {
-        return _investiments.Brokers;
+        return _investments.Brokers;
     }
 
     public async Task SaveChangesAsync()
     {
-        var json = _serializer.Serialize(_investiments);
+        var json = _serializer.Serialize(_investments);
         await _storage.WriteAsync(json).ConfigureAwait(false);
     }
 
     private IEnumerable<Broker> GetBrokersByName(string brokerName) =>
-        _investiments.Brokers.Where(b => b.Name == brokerName);
+        _investments.Brokers.Where(b => b.Name == brokerName);
 
     private IEnumerable<Portfolio> GetPortfoliosByBroker(string brokerName) =>
         GetBrokersByName(brokerName).SelectMany(b => b.Portfolios);
@@ -79,8 +79,8 @@ public sealed class JSONRepository : IRepository
         GetPortfoliosByBroker(brokerName).SelectMany(p => p.Assets);
 
     private IEnumerable<Portfolio> GetPortfoliosByName(string portfolioName) =>
-        _investiments.Brokers.SelectMany(b => b.Portfolios.Where(p => p.Name == portfolioName));
+        _investments.Brokers.SelectMany(b => b.Portfolios.Where(p => p.Name == portfolioName));
 
     private IEnumerable<Asset> GetAllAssetsInternal() =>
-        _investiments.Brokers.SelectMany(b => b.Portfolios.SelectMany(p => p.Assets));
+        _investments.Brokers.SelectMany(b => b.Portfolios.SelectMany(p => p.Assets));
 }

--- a/Integrations/FinancialToolSupport/IGenerator.cs
+++ b/Integrations/FinancialToolSupport/IGenerator.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -6,6 +7,6 @@ namespace Financial.Infrastructure.Integrations.FinancialToolSupport;
 
 public interface IGenerator
 {
-    Task GenerateAsync(List<string> fileName, IProgress<string> progress = null);
+    Task GenerateAsync(List<string> fileNames, IProgress<string>? progress = null);
 }
 

--- a/Integrations/WebPageParser/GoogleFinance.cs
+++ b/Integrations/WebPageParser/GoogleFinance.cs
@@ -13,6 +13,10 @@ namespace Financial.Infrastructure.Integrations.WebPageParser;
 /// </summary>
 public static class GoogleFinance
 {
+    private const int MinAssetNameLength = 5;
+    private const int MaxAssetNameLength = 100;
+    private const int MaxContainerTraversalDepth = 8;
+
     public static AssetValue GetFinancialInfo(string exchange, string ticker)
     {
         var snapshot = GetFinancialInfoSnapshot(exchange, ticker);
@@ -75,7 +79,7 @@ public static class GoogleFinance
     {
         // Traverse up to find a suitable container (typically 5-6 levels up)
         var container = priceNode.ParentNode;
-        for (int i = 0; i < 8 && container != null; i++)
+        for (int i = 0; i < MaxContainerTraversalDepth && container != null; i++)
         {
             var xpath = $".//div[contains(@class, '{GoogleFinanceSelectors.AssetName.PrimaryClass}')]";
             var nameNode = container.SelectSingleNode(xpath);
@@ -116,7 +120,7 @@ public static class GoogleFinance
         foreach (var div in divNodes.Take(10))
         {
             var text = div.InnerText.Trim();
-            if (!string.IsNullOrWhiteSpace(text) && text.Length > 5 && text.Length < 100)
+            if (!string.IsNullOrWhiteSpace(text) && text.Length > MinAssetNameLength && text.Length < MaxAssetNameLength)
                 return text;
         }
 


### PR DESCRIPTION
## Summary

- **R-03**: Removed `CredentialsPathConfigurationKey` and `FilePathConfigurationKey` constants from `GoogleDriveJsonStorage` — they duplicate `RepositoryConfigurationKeys`; error message now references `RepositoryConfigurationKeys.GoogleDriveFilePath`.
- **R-06**: Replaced magic numbers `5` and `100` in `GoogleFinance.TryReadAssetNameByText` with `MinAssetNameLength` and `MaxAssetNameLength` private constants.
- **R-07**: Replaced magic number `8` in `GoogleFinance.TraverseUpToFindContainer` with `MaxContainerTraversalDepth` constant.
- **R-12**: Renamed typo `_investiments` → `_investments` throughout `JSONRepository`.
- **R-13**: Replaced null-forgiving operator (`investments!`) in `InvestmentsJsonSerializer.Deserialize` with a null-guard that throws `InvalidOperationException` with a descriptive message.
- **R-14**: Renamed `IGenerator.GenerateAsync` parameter `fileName` → `fileNames`; added nullable annotation `IProgress<string>?`; added `#nullable enable` to the file since the project does not enable it globally.

> **Depends on**: #71 (fix/R-02-04-05-08-09-11-medium must merge first, which depends on #70)

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 164 passed, 3 pre-existing skips, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)