### PR TITLE
fix(arch): resolve architecture violations O-01 to O-17

### DIFF
--- a/Financial.App/App.xaml.cs
+++ b/Financial.App/App.xaml.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Configuration;
 using Financial.Application.DependencyInjection;
 using Financial.Infrastructure.DependencyInjection;
 using Financial.Presentation.App.Options;
@@ -5,6 +6,7 @@ using Financial.Presentation.App.ViewModels;
 using Financial.Presentation.App.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using System;
 using System.IO;
 using System.Windows;
@@ -24,9 +26,14 @@ namespace Financial.Presentation.App
                     services.AddFinancialInfrastructure(context.Configuration);
                     services.Configure<WatchlistOptions>(context.Configuration.GetSection(WatchlistOptions.SectionName));
                     services.Configure<AssetPriceFetchOptions>(context.Configuration.GetSection(AssetPriceFetchOptions.SectionName));
+                    services.Configure<DividendOptions>(context.Configuration.GetSection(DividendOptions.SectionName));
                     services.AddTransient<MainNavigationViewModel>();
                     services.AddTransient<DividendCheckViewModel>();
-                    services.AddTransient<AssetPriceFetchViewModel>();
+                    services.AddTransient<AssetPriceFetchViewModel>(sp => new AssetPriceFetchViewModel(
+                        sp.GetRequiredService<Financial.Application.Interfaces.INavigationService>(),
+                        sp.GetRequiredService<Financial.Application.Interfaces.IAssetPriceService>(),
+                        sp.GetRequiredService<IOptions<AssetPriceFetchOptions>>(),
+                        msg => MessageBox.Show(msg, "Error", MessageBoxButton.OK, MessageBoxImage.Error)));
                     services.AddTransient<DividendCheckView>();
                     services.AddTransient<AssetPriceView>();
                     services.AddTransient<MainWindow>();

--- a/Financial.App/ViewModels/AssetActionsBase.cs
+++ b/Financial.App/ViewModels/AssetActionsBase.cs
@@ -10,7 +10,7 @@ public abstract class AssetActionsBase
     private readonly Func<string> _brokerName;
     private readonly Func<string> _portfolioName;
     private readonly Func<string> _assetName;
-    protected readonly Action<AssetDetailsDTO> _applyDetails;
+    private readonly Action<AssetDetailsDTO> _applyDetails;
     private readonly Action<string, string, MessageBoxImage> _showMessage;
     private readonly string _title;
 
@@ -36,6 +36,7 @@ public abstract class AssetActionsBase
     protected string GetBrokerName() => _brokerName();
     protected string GetPortfolioName() => _portfolioName();
     protected string GetAssetName() => _assetName();
+    protected void ApplyDetails(AssetDetailsDTO details) => _applyDetails(details);
 
     protected void ShowInfo(string message) =>
         _showMessage(message, _title, MessageBoxImage.Information);

--- a/Financial.App/ViewModels/AssetClassFilterOptionViewModel.cs
+++ b/Financial.App/ViewModels/AssetClassFilterOptionViewModel.cs
@@ -1,0 +1,15 @@
+using Financial.Domain.Entities;
+
+namespace Financial.Presentation.App.ViewModels;
+
+public sealed class AssetClassFilterOptionViewModel : ViewModelBase
+{
+    public AssetClassFilterOptionViewModel(string label, GlobalAssetClass? filter)
+    {
+        Label = label;
+        Filter = filter;
+    }
+
+    public string Label { get; }
+    public GlobalAssetClass? Filter { get; }
+}

--- a/Financial.App/ViewModels/AssetPriceFetchViewModel.cs
+++ b/Financial.App/ViewModels/AssetPriceFetchViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.ObjectModel;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
@@ -11,6 +12,7 @@ public class AssetPriceFetchViewModel : ViewModelBase
     private readonly INavigationService _navigationService;
     private readonly IAssetPriceService _assetPriceService;
     private readonly IReadOnlyList<PortfolioReference> _portfolios;
+    private readonly Action<string> _showError;
     private bool _isFetching;
     private string _progressMessage = string.Empty;
     private double _progressPercent;
@@ -41,10 +43,12 @@ public class AssetPriceFetchViewModel : ViewModelBase
     public AssetPriceFetchViewModel(
         INavigationService navigationService,
         IAssetPriceService assetPriceService,
-        IOptions<AssetPriceFetchOptions> options)
+        IOptions<AssetPriceFetchOptions> options,
+        Action<string> showError)
     {
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
         _assetPriceService = assetPriceService ?? throw new ArgumentNullException(nameof(assetPriceService));
+        _showError = showError ?? throw new ArgumentNullException(nameof(showError));
         _portfolios = (options?.Value.Portfolios ?? new List<PortfolioReference>()).AsReadOnly();
         FetchCommand = new RelayCommand(async () => await FetchAsync(), () => !IsFetching);
     }
@@ -81,11 +85,7 @@ public class AssetPriceFetchViewModel : ViewModelBase
         catch (Exception ex)
         {
             ProgressMessage = $"Error: {ex.Message}";
-            System.Windows.MessageBox.Show(
-                $"An error occurred while fetching prices:\n{ex.Message}",
-                "Error",
-                System.Windows.MessageBoxButton.OK,
-                System.Windows.MessageBoxImage.Error);
+            _showError($"An error occurred while fetching prices:\n{ex.Message}");
         }
         finally
         {

--- a/Financial.App/ViewModels/CreditActions.cs
+++ b/Financial.App/ViewModels/CreditActions.cs
@@ -65,7 +65,7 @@ public sealed class CreditActions : AssetActionsBase
             return;
         }
 
-        _applyDetails(updatedDetails);
+        ApplyDetails(updatedDetails);
     }
 
     public async Task Update(CreditDTO? selectedCredit, Func<CreditDialogData?> showDialog)
@@ -110,7 +110,7 @@ public sealed class CreditActions : AssetActionsBase
             return;
         }
 
-        _applyDetails(updatedDetails);
+        ApplyDetails(updatedDetails);
     }
 
     public async Task Delete(CreditDTO? selectedCredit, Func<bool> confirmDialog)
@@ -150,7 +150,7 @@ public sealed class CreditActions : AssetActionsBase
             return;
         }
 
-        _applyDetails(updatedDetails);
+        ApplyDetails(updatedDetails);
     }
 
 }

--- a/Financial.App/ViewModels/DividendCheckViewModel.cs
+++ b/Financial.App/ViewModels/DividendCheckViewModel.cs
@@ -1,21 +1,22 @@
 using System.Collections.ObjectModel;
+using Financial.Application.Configuration;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Rules;
+using Microsoft.Extensions.Options;
 
 namespace Financial.Presentation.App.ViewModels;
 
 public class DividendCheckViewModel : ViewModelBase
 {
     private readonly IDividendService _dividendService;
+    private readonly string _defaultExchange;
     private string _ticker = string.Empty;
     private string _summaryName = string.Empty;
     private string _summaryPrice = string.Empty;
     private string _summaryAverageDividend = string.Empty;
     private string _summaryPriceMaxBuy = string.Empty;
     private bool _isPriceGood;
-
-    private const string BvmfExchange = "BVMF";
 
     public string Ticker
     {
@@ -57,15 +58,17 @@ public class DividendCheckViewModel : ViewModelBase
     public ObservableCollection<DividendYearTotalDTO> YearTotals { get; } = new();
     public RelayCommand CheckCommand { get; }
 
-    public DividendCheckViewModel(IDividendService dividendService)
+    public DividendCheckViewModel(IDividendService dividendService, IOptions<DividendOptions> dividendOptions)
     {
         _dividendService = dividendService ?? throw new ArgumentNullException(nameof(dividendService));
+        _defaultExchange = dividendOptions?.Value.DefaultExchange
+            ?? throw new ArgumentNullException(nameof(dividendOptions));
         CheckCommand = new RelayCommand(Check);
     }
 
     private void Check()
     {
-        var request = new DividendLookupRequestDTO { Exchange = BvmfExchange, Ticker = Ticker.ToUpperInvariant() };
+        var request = new DividendLookupRequestDTO { Exchange = _defaultExchange, Ticker = Ticker.ToUpperInvariant() };
         var summary = _dividendService.GetDividendSummary(request);
 
         History.Clear();

--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -186,18 +186,6 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
         };
     }
 
-    public sealed class AssetClassFilterOptionViewModel : ViewModelBase
-    {
-        public AssetClassFilterOptionViewModel(string label, GlobalAssetClass? filter)
-        {
-            Label = label;
-            Filter = filter;
-        }
-
-        public string Label { get; }
-        public GlobalAssetClass? Filter { get; }
-    }
-
     private void OnTreeNodeSelected(object? sender, TreeNodeViewModel selectedNode)
     {
         LoadSelectionDetails(selectedNode);

--- a/Financial.App/ViewModels/TransactionActions.cs
+++ b/Financial.App/ViewModels/TransactionActions.cs
@@ -67,7 +67,7 @@ public sealed class TransactionActions : AssetActionsBase
             return;
         }
 
-        _applyDetails(updatedDetails);
+        ApplyDetails(updatedDetails);
     }
 
     public async Task Update(TransactionDTO? selectedTransaction, Func<TransactionDialogData?> showDialog)
@@ -114,7 +114,7 @@ public sealed class TransactionActions : AssetActionsBase
             return;
         }
 
-        _applyDetails(updatedDetails);
+        ApplyDetails(updatedDetails);
     }
 
     public async Task Delete(TransactionDTO? selectedTransaction, Func<bool> confirmDialog)
@@ -154,7 +154,7 @@ public sealed class TransactionActions : AssetActionsBase
             return;
         }
 
-        _applyDetails(updatedDetails);
+        ApplyDetails(updatedDetails);
     }
 
 }

--- a/Financial.App/Views/AssetPriceView.xaml
+++ b/Financial.App/Views/AssetPriceView.xaml
@@ -54,7 +54,7 @@
                 <StackPanel Visibility="{Binding IsFetching, Converter={StaticResource BoolToVisibilityConverter}}"
                             Margin="0,15,0,0">
                     <ProgressBar Height="8" Minimum="0" Maximum="100"
-                                 Value="{Binding ProgressPercent}" Foreground="#007ACC"/>
+                                 Value="{Binding ProgressPercent, Mode=OneWay}" Foreground="#007ACC"/>
                     <TextBlock Text="{Binding ProgressMessage}" FontSize="13"
                                Foreground="#666666" Margin="0,8,0,0"/>
                 </StackPanel>

--- a/Financial.App/Views/DividendCheckView.xaml.cs
+++ b/Financial.App/Views/DividendCheckView.xaml.cs
@@ -1,6 +1,7 @@
 using Financial.Presentation.App.Helpers;
 using Financial.Presentation.App.Options;
 using Financial.Presentation.App.ViewModels;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Windows;
@@ -11,7 +12,7 @@ namespace Financial.Presentation.App.Views;
 
 public partial class DividendCheckView : UserControl
 {
-    public DividendCheckView(DividendCheckViewModel viewModel, WatchlistOptions watchlistOptions)
+    public DividendCheckView(DividendCheckViewModel viewModel, IOptions<WatchlistOptions> watchlistOptions)
     {
         ArgumentNullException.ThrowIfNull(viewModel);
         ArgumentNullException.ThrowIfNull(watchlistOptions);
@@ -19,7 +20,7 @@ public partial class DividendCheckView : UserControl
         InitializeComponent();
         DataContext = viewModel;
 
-        var groupedOptions = new ListCollectionView(new List<WatchlistItem>(watchlistOptions.Items));
+        var groupedOptions = new ListCollectionView(new List<WatchlistItem>(watchlistOptions.Value.Items));
         groupedOptions.GroupDescriptions.Add(new PropertyGroupDescription("Group"));
         txtTicker.ItemsSource = groupedOptions;
     }

--- a/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -8,9 +8,8 @@ public static class ApplicationServiceCollectionExtensions
 {
     public static IServiceCollection AddFinancialApplication(this IServiceCollection services)
     {
-        services.AddSingleton<NavigationService>();
-        services.AddSingleton<INavigationService>(sp => sp.GetRequiredService<NavigationService>());
-        services.AddSingleton<ICreditQueryService>(sp => sp.GetRequiredService<NavigationService>());
+        services.AddSingleton<INavigationService, NavigationService>();
+        services.AddSingleton<ICreditQueryService, CreditQueryService>();
         services.AddSingleton<ITransactionService, TransactionService>();
         services.AddSingleton<ICreditService, CreditService>();
         services.AddSingleton<IDividendService, DividendService>();

--- a/Financial.Application/Interfaces/IDividendDataSource.cs
+++ b/Financial.Application/Interfaces/IDividendDataSource.cs
@@ -5,5 +5,5 @@ namespace Financial.Application.Interfaces;
 
 public interface IDividendDataSource
 {
-    IReadOnlyList<DividendValue> GetDividends(string ticker);
+    IReadOnlyList<DividendValue> GetDividends(string exchange, string ticker);
 }

--- a/Financial.Application/Services/CreditQueryService.cs
+++ b/Financial.Application/Services/CreditQueryService.cs
@@ -1,0 +1,43 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Financial.Application.Services;
+
+public sealed class CreditQueryService : ICreditQueryService
+{
+    private readonly IRepository _repository;
+
+    public CreditQueryService(IRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName))
+            return Array.Empty<CreditDTO>();
+
+        return _repository.GetAssetsByBroker(brokerName)
+            .Where(asset => asset.Active)
+            .SelectMany(asset => asset.Credits)
+            .Select(NavigationMapper.MapCredit)
+            .OrderByDescending(credit => credit.Date)
+            .ToList();
+    }
+
+    public IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
+            return Array.Empty<CreditDTO>();
+
+        return _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName)
+            .Where(asset => asset.Active)
+            .SelectMany(asset => asset.Credits)
+            .Select(NavigationMapper.MapCredit)
+            .OrderByDescending(credit => credit.Date)
+            .ToList();
+    }
+}

--- a/Financial.Application/Services/DividendService.cs
+++ b/Financial.Application/Services/DividendService.cs
@@ -80,7 +80,7 @@ public sealed class DividendService : IDividendService
             throw new ArgumentException("Exchange and ticker are required.", nameof(request));
         }
 
-        return _dividendDataSource.GetDividends(request.Ticker);
+        return _dividendDataSource.GetDividends(request.Exchange, request.Ticker);
     }
 
     private static List<DividendHistoryItemDTO> MapToHistory(IReadOnlyList<DividendValue> values)

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -1,13 +1,12 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Financial.Application.Services;
 
-public sealed class NavigationService : INavigationService, ICreditQueryService
+public sealed class NavigationService : INavigationService
 {
     private readonly IRepository _repository;
 
@@ -98,33 +97,4 @@ public sealed class NavigationService : INavigationService, ICreditQueryService
             .ToList();
     }
 
-    public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName)
-    {
-        if (string.IsNullOrWhiteSpace(brokerName))
-        {
-            return Array.Empty<CreditDTO>();
-        }
-
-        return _repository.GetAssetsByBroker(brokerName)
-            .Where(asset => asset.Active)
-            .SelectMany(asset => asset.Credits)
-            .Select(NavigationMapper.MapCredit)
-            .OrderByDescending(credit => credit.Date)
-            .ToList();
-    }
-
-    public IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName)
-    {
-        if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
-        {
-            return Array.Empty<CreditDTO>();
-        }
-
-        return _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName)
-            .Where(asset => asset.Active)
-            .SelectMany(asset => asset.Credits)
-            .Select(NavigationMapper.MapCredit)
-            .OrderByDescending(credit => credit.Date)
-            .ToList();
-    }
 }

--- a/Financial.Domain/Entities/Asset.cs
+++ b/Financial.Domain/Entities/Asset.cs
@@ -26,7 +26,7 @@ public class Asset
     public bool Active => Quantity > 0;
 
     private List<Transaction> _transactions = new List<Transaction>();
-    public IReadOnlyCollection<Transaction> Transactions { get => _transactions.AsReadOnly(); set => SetTransactions(value); }
+    public IReadOnlyCollection<Transaction> Transactions { get => _transactions.AsReadOnly(); private set => SetTransactions(value); }
     private void SetTransactions(IReadOnlyCollection<Transaction> data)
     {
         RebuildTransactions(data);
@@ -45,7 +45,7 @@ public class Asset
     }
 
     private List<Credit> _credits = new List<Credit>();
-    public IReadOnlyCollection<Credit> Credits { get => _credits.AsReadOnly(); set => SetCredits(value); }
+    public IReadOnlyCollection<Credit> Credits { get => _credits.AsReadOnly(); private set => SetCredits(value); }
     private void SetCredits(IReadOnlyCollection<Credit> data)
     {
         _credits.Clear();
@@ -98,7 +98,6 @@ public class Asset
             throw new ArgumentNullException(nameof(transaction));
         }
 
-        transaction.EnsureId();
         if (transaction.Type == Transaction.TransactionType.Buy)
         {
             AveragePrice = (AveragePrice * Quantity + transaction.TotalPrice) / (Quantity + transaction.Quantity);
@@ -159,7 +158,6 @@ public class Asset
             throw new ArgumentNullException(nameof(credit));
         }
 
-        credit.EnsureId();
         _credits.Add(credit);
     }
 

--- a/Financial.Domain/Entities/Broker.cs
+++ b/Financial.Domain/Entities/Broker.cs
@@ -9,7 +9,7 @@ public class Broker
     public string Currency { get; private set; }
 
     private List<Portfolio> _portfolios = new List<Portfolio>();
-    public IReadOnlyCollection<Portfolio> Portfolios { get => _portfolios.AsReadOnly(); set => SetPortfolios(value); }
+    public IReadOnlyCollection<Portfolio> Portfolios { get => _portfolios.AsReadOnly(); private set => SetPortfolios(value); }
     private void SetPortfolios(IReadOnlyCollection<Portfolio> data)
     {
         _portfolios.Clear();

--- a/Financial.Domain/Entities/Credit.cs
+++ b/Financial.Domain/Entities/Credit.cs
@@ -27,11 +27,4 @@ public class Credit
     public static Credit CreateWithId(Guid id, DateTime date, CreditType type, decimal value) =>
         new(id, date, type, value);
 
-    public void EnsureId()
-    {
-        if (Id == Guid.Empty)
-        {
-            Id = Guid.NewGuid();
-        }
-    }
 }

--- a/Financial.Domain/Entities/Investments.cs
+++ b/Financial.Domain/Entities/Investments.cs
@@ -5,7 +5,7 @@ namespace Financial.Domain.Entities;
 public class Investments
 {
     private List<Broker> _brokers = new List<Broker>();
-    public IReadOnlyCollection<Broker> Brokers { get => _brokers.AsReadOnly(); set => SetBrokers(value); }
+    public IReadOnlyCollection<Broker> Brokers { get => _brokers.AsReadOnly(); private set => SetBrokers(value); }
     private void SetBrokers(IReadOnlyCollection<Broker> data)
     {
         _brokers.Clear();

--- a/Financial.Domain/Entities/Portfolio.cs
+++ b/Financial.Domain/Entities/Portfolio.cs
@@ -7,7 +7,7 @@ public class Portfolio
     public string Name { get; private set; }
 
     private List<Asset> _assets = new List<Asset>();
-    public IReadOnlyCollection<Asset> Assets { get => _assets.AsReadOnly(); set => SetAssets(value); }
+    public IReadOnlyCollection<Asset> Assets { get => _assets.AsReadOnly(); private set => SetAssets(value); }
     private void SetAssets(IReadOnlyCollection<Asset> data)
     {
         _assets.Clear();

--- a/Financial.Domain/Entities/Transaction.cs
+++ b/Financial.Domain/Entities/Transaction.cs
@@ -33,12 +33,4 @@ public class Transaction
     public static Transaction CreateWithId(Guid id, DateTime date, TransactionType type, decimal quantity, decimal unitPrice, decimal fees) =>
         new(id, date, type, quantity, unitPrice, fees);
 
-    internal void EnsureId()
-    {
-        if (Id == Guid.Empty)
-        {
-            Id = Guid.NewGuid();
-        }
-    }
-
 }

--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Financial.Infrastructure.Repositories;
 using Financial.Infrastructure.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace Financial.Infrastructure.DependencyInjection;
 
@@ -19,10 +20,31 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IDividendDataSource, DividendDataSourceAdapter>();
         services.AddSingleton<IAssetSnapshotSource, AssetSnapshotSourceAdapter>();
         services.AddSingleton<IRepository>(sp =>
-            new RepositoryFactory(sp.GetRequiredService<IInvestmentsSerializer>())
-                .CreateFromConfiguration(configuration));
+        {
+            var options = BuildRepositoryOptions(configuration);
+            return new RepositoryFactory(sp.GetRequiredService<IInvestmentsSerializer>()).Create(options);
+        });
         services.AddSingleton<IAssetPriceService, AssetPriceService>();
 
         return services;
+    }
+
+    private static RepositorySelectionOptions BuildRepositoryOptions(IConfiguration configuration)
+    {
+        var providerValue = configuration[RepositoryConfigurationKeys.Provider]
+            ?? nameof(RepositoryProvider.LocalJson);
+
+        if (!Enum.TryParse(providerValue, ignoreCase: true, out RepositoryProvider provider))
+        {
+            throw new InvalidOperationException(
+                $"Repository provider '{providerValue}' is not supported. " +
+                $"Valid values: {string.Join(", ", Enum.GetNames<RepositoryProvider>())}.");
+        }
+
+        return new RepositorySelectionOptions(
+            provider,
+            configuration[RepositoryConfigurationKeys.LocalJsonDataFile],
+            configuration[RepositoryConfigurationKeys.GoogleDriveCredentialsPath],
+            configuration[RepositoryConfigurationKeys.GoogleDriveFilePath]);
     }
 }

--- a/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
+++ b/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
@@ -1,4 +1,5 @@
 using Financial.Application.Interfaces;
+using Financial.Infrastructure.Configuration;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using System;
 using System.Threading.Tasks;
@@ -7,9 +8,6 @@ namespace Financial.Infrastructure.Persistence;
 
 public sealed class GoogleDriveJsonStorage : IJsonStorage
 {
-    public const string CredentialsPathConfigurationKey = "GoogleDrive:CredentialsPath";
-    public const string FilePathConfigurationKey = "GoogleDrive:FilePath";
-
     private readonly GoogleService _service;
     private readonly string _driveFilePath;
 
@@ -28,7 +26,9 @@ public sealed class GoogleDriveJsonStorage : IJsonStorage
     private static string ResolveDriveFilePath(string? driveFilePath)
     {
         if (string.IsNullOrWhiteSpace(driveFilePath))
-            throw new ArgumentException($"Drive file path must be configured via '{FilePathConfigurationKey}'.", nameof(driveFilePath));
+            throw new ArgumentException(
+                $"Drive file path must be configured via '{RepositoryConfigurationKeys.GoogleDriveFilePath}'.",
+                nameof(driveFilePath));
         return driveFilePath;
     }
 }

--- a/Financial.Infrastructure/Persistence/InvestmentsLoader.cs
+++ b/Financial.Infrastructure/Persistence/InvestmentsLoader.cs
@@ -5,7 +5,9 @@ namespace Financial.Infrastructure.Persistence;
 
 public static class InvestmentsLoader
 {
-    public static Investments Load(IJsonStorage storage, IInvestmentsSerializer serializer)
+    // Intentionally synchronous: called from DI factory at startup before the app's async loop begins.
+    // ConfigureAwait(false) avoids SynchronizationContext deadlock in WPF startup context.
+    public static Investments LoadSync(IJsonStorage storage, IInvestmentsSerializer serializer)
     {
         var json = storage.ReadAsync()
             .ConfigureAwait(false)

--- a/Financial.Infrastructure/Repositories/RepositoryFactory.cs
+++ b/Financial.Infrastructure/Repositories/RepositoryFactory.cs
@@ -2,7 +2,6 @@ using Financial.Application.Interfaces;
 using Financial.Infrastructure.Configuration;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using Financial.Infrastructure.Persistence;
-using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -34,34 +33,8 @@ public sealed class RepositoryFactory
         }
 
         var storage = CreateStorage(options);
-        var investments = InvestmentsLoader.Load(storage, _serializer);
+        var investments = InvestmentsLoader.LoadSync(storage, _serializer);
         return new JSONRepository(investments, storage, _serializer);
-    }
-
-    public IRepository CreateFromConfiguration(IConfiguration configuration)
-    {
-        if (configuration is null)
-        {
-            throw new ArgumentNullException(nameof(configuration));
-        }
-
-        var providerValue = configuration[RepositoryConfigurationKeys.Provider]
-            ?? nameof(RepositoryProvider.LocalJson);
-
-        if (!Enum.TryParse(providerValue, true, out RepositoryProvider provider))
-        {
-            throw new InvalidOperationException(
-                $"Repository provider '{providerValue}' is not supported. " +
-                $"Valid values: {string.Join(", ", Enum.GetNames<RepositoryProvider>())}.");
-        }
-
-        var options = new RepositorySelectionOptions(
-            provider,
-            configuration[RepositoryConfigurationKeys.LocalJsonDataFile],
-            configuration[RepositoryConfigurationKeys.GoogleDriveCredentialsPath],
-            configuration[RepositoryConfigurationKeys.GoogleDriveFilePath]);
-
-        return Create(options);
     }
 
     private static IJsonStorage CreateStorage(RepositorySelectionOptions options)

--- a/Financial.Infrastructure/Services/DividendDataSourceAdapter.cs
+++ b/Financial.Infrastructure/Services/DividendDataSourceAdapter.cs
@@ -7,6 +7,6 @@ namespace Financial.Infrastructure.Services;
 
 public sealed class DividendDataSourceAdapter : IDividendDataSource
 {
-    public IReadOnlyList<DividendValue> GetDividends(string ticker) =>
+    public IReadOnlyList<DividendValue> GetDividends(string exchange, string ticker) =>
         DadosMercadoDividend.GetDividendInfo(ticker);
 }

--- a/Integrations/GoogleFinancialSupport/AssetClassificationLookup.cs
+++ b/Integrations/GoogleFinancialSupport/AssetClassificationLookup.cs
@@ -38,7 +38,7 @@ internal static class AssetClassificationLookup
                 $"Embedded resource '{ResourceName}' was not found. " +
                 "Ensure AssetClassifications.json is marked as EmbeddedResource in the project file.");
 
-        var options = new JsonSerializerOptions { Converters = { new JsonStringEnumConverter() } };
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, Converters = { new JsonStringEnumConverter() } };
         var jsonEntries = JsonSerializer.Deserialize<AssetClassificationJson[]>(stream, options)!;
 
         return jsonEntries.ToDictionary(

--- a/Integrations/GoogleFinancialSupport/AssetMetadataResolver.cs
+++ b/Integrations/GoogleFinancialSupport/AssetMetadataResolver.cs
@@ -1,4 +1,5 @@
 using Financial.Domain.Entities;
+using System;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport.DTO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -23,8 +24,13 @@ internal sealed class AssetMetadataResolver
     internal bool IsIgnoredSheet(string sheetName) =>
         _options.IgnoreSheetNames.Contains(sheetName);
 
-    internal string ResolveBrokerCurrency(string brokerName) =>
-        _options.BrokerCurrencyMap[brokerName];
+    internal string ResolveBrokerCurrency(string brokerName)
+    {
+        if (_options.BrokerCurrencyMap.TryGetValue(brokerName, out var currency))
+            return currency;
+        throw new InvalidOperationException(
+            $"No currency mapping found for broker '{brokerName}'. Add it to BrokerCurrencyMap.");
+    }
 
     internal string ResolvePortfolioName(string brokerName, SheetDTO spreadsheet)
     {

--- a/Integrations/GoogleFinancialSupport/AssetTypeLookup.cs
+++ b/Integrations/GoogleFinancialSupport/AssetTypeLookup.cs
@@ -13,7 +13,7 @@ namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 
 public sealed class AssetTypeLookup : IAssetTypeLookup
 {
-    private static readonly HttpClient HttpClient = new HttpClient();
+    private readonly HttpClient _httpClient;
     private static readonly string[] BrazilFiiPaths =
     {
         "bolsa/fundos-imobiliarios",
@@ -21,6 +21,11 @@ public sealed class AssetTypeLookup : IAssetTypeLookup
         "fundos-imobiliarios",
         "fiis"
     };
+
+    public AssetTypeLookup(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
 
     public async Task<AssetTypeLookupResultDTO> LookupAsync(AssetTypeLookupRequestDTO request)
     {
@@ -56,7 +61,7 @@ public sealed class AssetTypeLookup : IAssetTypeLookup
         return new AssetTypeLookupResultDTO();
     }
 
-    private static async Task<string> TryResolveBrazilTypeAsync(string ticker)
+    private async Task<string> TryResolveBrazilTypeAsync(string ticker)
     {
         if (string.IsNullOrWhiteSpace(ticker))
         {
@@ -76,7 +81,7 @@ public sealed class AssetTypeLookup : IAssetTypeLookup
         return string.IsNullOrWhiteSpace(equityHtml) ? string.Empty : "Acoes";
     }
 
-    private static async Task<string> TryResolveGoogleFinanceTypeAsync(AssetTypeLookupRequestDTO request, string ticker)
+    private async Task<string> TryResolveGoogleFinanceTypeAsync(AssetTypeLookupRequestDTO request, string ticker)
     {
         foreach (var url in BuildGoogleFinanceUrls(request, ticker))
         {
@@ -127,18 +132,15 @@ public sealed class AssetTypeLookup : IAssetTypeLookup
         return $"https://www.google.com/finance/quote/{Uri.EscapeDataString(value)}";
     }
 
-    private static async Task<string> TryLoadPageAsync(string url)
+    private async Task<string> TryLoadPageAsync(string url)
     {
         if (string.IsNullOrWhiteSpace(url))
-        {
             throw new ArgumentException("Url must be provided.", nameof(url));
-        }
 
-        using var response = await HttpClient.GetAsync(url);
+        using var response = await _httpClient.GetAsync(url);
         if (!response.IsSuccessStatusCode)
-        {
             return string.Empty;
-        }
+
         return await response.Content.ReadAsStringAsync();
     }
 

--- a/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
@@ -35,63 +35,69 @@ public sealed class GoogleGenerator : IGenerator
         var data = Investments.Create();
         var files = await _service.GetFilesNameAsync();
 
-        int brokerIndex = 0;
-        foreach (var fileName in fileNames)
+        for (var brokerIndex = 0; brokerIndex < fileNames.Count; brokerIndex++)
         {
-            brokerIndex++;
-            progress?.Report($"Processing broker {brokerIndex}/{fileNames.Count}: {fileName}");
+            var fileName = fileNames[brokerIndex];
+            progress?.Report($"Processing broker {brokerIndex + 1}/{fileNames.Count}: {fileName}");
 
-            if (brokerIndex > 1)
+            if (brokerIndex > 0)
             {
                 progress?.Report($"Waiting {DelayBetweenBrokersMs / 1000} seconds before next broker...");
                 await Task.Delay(DelayBetweenBrokersMs);
             }
 
-            var broker = Broker.Create(fileName, _metadataResolver.ResolveBrokerCurrency(fileName));
-            data.AddBroker(broker);
             var file = files.FirstOrDefault(f => f.Name == fileName);
-
-            progress?.Report($"Getting spreadsheets for: {fileName}");
-            var spreadSheets = await _service.GetSpreadSheetAsync(file.Id);
-            var activeSheets = spreadSheets.Where(s => !_metadataResolver.IsIgnoredSheet(s.Name)).ToList();
-
-            int sheetCount = 0;
-            foreach (var spreadsheet in activeSheets)
-            {
-                sheetCount++;
-                progress?.Report($"[{fileName}] Processing sheet {sheetCount}/{activeSheets.Count}: {spreadsheet.Name}");
-
-                var portfolioName = _metadataResolver.ResolvePortfolioName(fileName, spreadsheet);
-                var portfolio = broker.AddPortfolio(portfolioName);
-
-                var assetData = await _metadataResolver.ResolveAssetMetadataAsync(fileName, file!.Id, spreadsheet.Name);
-                var asset = Asset.Create(
-                    spreadsheet.Name,
-                    assetData.isin,
-                    assetData.exchangeId,
-                    assetData.ticker,
-                    assetData.country,
-                    assetData.localTypeCode,
-                    assetData.assetClass);
-                portfolio.AddAsset(asset);
-
-                asset.AddTransactions(await _sheetsReader.ReadTransactionsAsync(file.Id, spreadsheet.Name));
-
-                await Task.Delay(DelayBetweenOperationsMs);
-
-                asset.AddCredits(await _sheetsReader.ReadCreditsAsync(file.Id, spreadsheet.Name));
-
-                if (sheetCount < activeSheets.Count)
-                {
-                    progress?.Report($"[{fileName}] Waiting {DelayBetweenSheetsMs / 1000} seconds before next sheet...");
-                    await Task.Delay(DelayBetweenSheetsMs);
-                }
-            }
+            await ProcessBrokerAsync(data, fileName, file?.Id, progress);
         }
 
         progress?.Report("Saving data...");
         var json = _serializer.Serialize(data);
         await _storage.WriteAsync(json);
         progress?.Report("Complete!");
+    }
+
+    private async Task ProcessBrokerAsync(Investments data, string fileName, string fileId, IProgress<string> progress)
+    {
+        var broker = Broker.Create(fileName, _metadataResolver.ResolveBrokerCurrency(fileName));
+        data.AddBroker(broker);
+
+        progress?.Report($"Getting spreadsheets for: {fileName}");
+        var spreadSheets = await _service.GetSpreadSheetAsync(fileId);
+        var activeSheets = spreadSheets.Where(s => !_metadataResolver.IsIgnoredSheet(s.Name)).ToList();
+
+        for (var sheetIndex = 0; sheetIndex < activeSheets.Count; sheetIndex++)
+        {
+            var spreadsheet = activeSheets[sheetIndex];
+            progress?.Report($"[{fileName}] Processing sheet {sheetIndex + 1}/{activeSheets.Count}: {spreadsheet.Name}");
+
+            await ProcessSheetAsync(broker, fileName, fileId, spreadsheet, progress);
+
+            if (sheetIndex < activeSheets.Count - 1)
+            {
+                progress?.Report($"[{fileName}] Waiting {DelayBetweenSheetsMs / 1000} seconds before next sheet...");
+                await Task.Delay(DelayBetweenSheetsMs);
+            }
+        }
+    }
+
+    private async Task ProcessSheetAsync(Broker broker, string fileName, string fileId, DTO.SheetDTO spreadsheet, IProgress<string> progress)
+    {
+        var portfolioName = _metadataResolver.ResolvePortfolioName(fileName, spreadsheet);
+        var portfolio = broker.AddPortfolio(portfolioName);
+
+        var assetData = await _metadataResolver.ResolveAssetMetadataAsync(fileName, fileId, spreadsheet.Name);
+        var asset = Asset.Create(
+            spreadsheet.Name,
+            assetData.isin,
+            assetData.exchangeId,
+            assetData.ticker,
+            assetData.country,
+            assetData.localTypeCode,
+            assetData.assetClass);
+        portfolio.AddAsset(asset);
+
+        asset.AddTransactions(await _sheetsReader.ReadTransactionsAsync(fileId, spreadsheet.Name));
+        await Task.Delay(DelayBetweenOperationsMs);
+        asset.AddCredits(await _sheetsReader.ReadCreditsAsync(fileId, spreadsheet.Name));
     }
 }

--- a/Integrations/ImportGoogleSpreadSheets/App.xaml
+++ b/Integrations/ImportGoogleSpreadSheets/App.xaml
@@ -4,6 +4,7 @@
              xmlns:local="clr-namespace:Financial.Infrastructure.Integrations.ImportGoogleSpreadSheets"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
         <DrawingImage x:Key="AppIcon">
             <DrawingImage.Drawing>
                 <DrawingGroup>

--- a/Integrations/ImportGoogleSpreadSheets/FilesInfo.cs
+++ b/Integrations/ImportGoogleSpreadSheets/FilesInfo.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+
+namespace Financial.Infrastructure.Integrations.ImportGoogleSpreadSheets;
+
+public class FilesInfo : INotifyPropertyChanged
+{
+    public string Id { get; set; }
+    public string Name { get; set; }
+
+    private bool _isSelected;
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            _isSelected = value;
+            OnPropertyChanged(nameof(IsSelected));
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void OnPropertyChanged(string propertyName) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/Integrations/ImportGoogleSpreadSheets/GoogleGeneratorConfiguration.cs
+++ b/Integrations/ImportGoogleSpreadSheets/GoogleGeneratorConfiguration.cs
@@ -1,10 +1,11 @@
+using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using System.Collections.Generic;
 
 namespace Financial.Infrastructure.Integrations.ImportGoogleSpreadSheets;
 
 internal static class GoogleGeneratorConfiguration
 {
-    internal static readonly IReadOnlyList<string> IgnoreSheetNames = new[]
+    private static readonly IReadOnlyList<string> IgnoreSheetNames = new[]
     {
         "Totais",
         "Totais com cotacao",
@@ -13,7 +14,7 @@ internal static class GoogleGeneratorConfiguration
         "Opcoes"
     };
 
-    internal static readonly IReadOnlyDictionary<string, string> PortfolioNameMap =
+    private static readonly IReadOnlyDictionary<string, string> PortfolioNameMap =
         new Dictionary<string, string>
         {
             { "Trading 212_76a5af", "Fantastic Five Divid" },
@@ -26,7 +27,7 @@ internal static class GoogleGeneratorConfiguration
             { "Trading 212_222222", "Encerradas" },
         };
 
-    internal static readonly IReadOnlyDictionary<string, string> BrokerCurrencyMap =
+    private static readonly IReadOnlyDictionary<string, string> BrokerCurrencyMap =
         new Dictionary<string, string>
         {
             { "Trading 212", "GBP" },
@@ -34,4 +35,7 @@ internal static class GoogleGeneratorConfiguration
             { "FreeTrade",   "GBP" },
             { "Coinbase",    "GBP" },
         };
+
+    internal static GoogleGeneratorOptions BuildOptions() =>
+        new(IgnoreSheetNames, PortfolioNameMap, BrokerCurrencyMap);
 }

--- a/Integrations/ImportGoogleSpreadSheets/MainViewModel.cs
+++ b/Integrations/ImportGoogleSpreadSheets/MainViewModel.cs
@@ -1,0 +1,170 @@
+using Financial.Application.Interfaces;
+using Financial.Infrastructure.Integrations.FinancialToolSupport;
+using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+using Financial.Infrastructure.Persistence;
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+
+namespace Financial.Infrastructure.Integrations.ImportGoogleSpreadSheets;
+
+public sealed class MainViewModel : INotifyPropertyChanged
+{
+    private const string DefaultOutputPath = @"E:\dev\Projetos\Financial\data";
+
+    private readonly GoogleService? _service;
+    private readonly IInvestmentsSerializer _serializer;
+    private readonly RelayCommand _connectCommand;
+    private readonly RelayCommand _generateCommand;
+    private bool _isBusy;
+    private string _status = "Ready";
+    private string _statusBar = "Ready to import";
+    private string _outputPath = DefaultOutputPath;
+
+    public ObservableCollection<FilesInfo> Files { get; } = new();
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set
+        {
+            _isBusy = value;
+            OnPropertyChanged(nameof(IsBusy));
+            OnPropertyChanged(nameof(IsNotBusy));
+            _connectCommand.RaiseCanExecuteChanged();
+            _generateCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    public bool IsNotBusy => !_isBusy;
+
+    public string Status
+    {
+        get => _status;
+        private set { _status = value; OnPropertyChanged(nameof(Status)); }
+    }
+
+    public string StatusBar
+    {
+        get => _statusBar;
+        private set { _statusBar = value; OnPropertyChanged(nameof(StatusBar)); }
+    }
+
+    public string OutputPath
+    {
+        get => _outputPath;
+        set { _outputPath = value; OnPropertyChanged(nameof(OutputPath)); }
+    }
+
+    public ICommand ConnectCommand { get; }
+    public ICommand GenerateCommand { get; }
+
+    public MainViewModel(GoogleService? service, IInvestmentsSerializer serializer)
+    {
+        _service = service;
+        _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+        _connectCommand = new RelayCommand(async () => await ConnectAsync(), () => _service != null && !IsBusy);
+        _generateCommand = new RelayCommand(async () => await GenerateAsync(), () => _service != null && !IsBusy);
+        ConnectCommand = _connectCommand;
+        GenerateCommand = _generateCommand;
+    }
+
+    private async Task ConnectAsync()
+    {
+        if (_service == null) return;
+        try
+        {
+            IsBusy = true;
+            Status = "Connecting to Google Drive...";
+
+            var files = await _service.GetFilesNameAsync();
+            var filtered = files
+                .Where(f => !string.Equals(f.Name, "data.json", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            Files.Clear();
+            filtered.ForEach(f => Files.Add(new FilesInfo { Id = f.Id, Name = f.Name }));
+
+            UpdateStatus($"Connected! Found {filtered.Count} files.", "Ready to generate data");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error connecting to Google Drive:\n{ex.Message}", "Connection Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+            UpdateStatus("Connection failed", "Error - check credentials");
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private async Task GenerateAsync()
+    {
+        if (_service == null) return;
+
+        var selectedFiles = Files.Where(f => f.IsSelected).ToList();
+        if (selectedFiles.Count == 0)
+        {
+            MessageBox.Show("Please select at least one file to import.", "No Files Selected",
+                MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            Status = "Starting data generation...";
+
+            IGenerator generator = new GoogleGenerator(
+                _service,
+                new LocalJsonStorage(OutputPath),
+                GoogleGeneratorConfiguration.BuildOptions(),
+                _serializer);
+
+            var fileNames = selectedFiles.Select(f => f.Name).ToList();
+            var progress = new Progress<string>(msg => UpdateStatus(msg, $"Processing {fileNames.Count} file(s)..."));
+
+            await generator.GenerateAsync(fileNames, progress);
+
+            MessageBox.Show("Data generation completed successfully!", "Success",
+                MessageBoxButton.OK, MessageBoxImage.Information);
+            UpdateStatus("Data generation complete!", "Ready for next operation");
+        }
+        catch (Exception ex) when (ex.Message.Contains("rate limit") || ex.Message.Contains("quota"))
+        {
+            MessageBox.Show(
+                $"Google API Rate Limit Exceeded:\n\n{ex.Message}\n\n" +
+                "Tips to avoid this:\n" +
+                "• Process fewer files at once\n" +
+                "• Wait a few minutes before retrying\n" +
+                "• The app now uses automatic retry with delays",
+                "Rate Limit Error", MessageBoxButton.OK, MessageBoxImage.Warning);
+            UpdateStatus("Rate limit exceeded", "Wait before retrying");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error generating data:\n{ex.Message}", "Generation Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+            UpdateStatus("Generation failed", "Error occurred");
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private void UpdateStatus(string status, string statusBar)
+    {
+        Status = status;
+        StatusBar = statusBar;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged(string propertyName) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/Integrations/ImportGoogleSpreadSheets/MainWindow.xaml
+++ b/Integrations/ImportGoogleSpreadSheets/MainWindow.xaml
@@ -3,7 +3,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:Financial.Infrastructure.Integrations.ImportGoogleSpreadSheets"
         mc:Ignorable="d"
         Title="Import Google" Height="500" Width="850" Icon="{StaticResource AppIcon}">
     <Grid Margin="10">
@@ -21,10 +20,11 @@
 
         <!-- Left Section -->
         <StackPanel Grid.Row="0" Grid.Column="0" Grid.RowSpan="3">
-            <Button x:Name="btnConnect" Content="Connect to Google Drive" Height="35" Click="btnConnect_Click" Margin="0,0,0,10"/>
+            <Button Content="Connect to Google Drive" Height="35" Command="{Binding ConnectCommand}"
+                    IsEnabled="{Binding IsNotBusy}" Margin="0,0,0,10"/>
             <Label Content="Files to import:" FontWeight="Bold"/>
-            <ListBox Name="cblFiles" Height="280" SelectionMode="Multiple" Margin="0,5,10,0"
-                     ItemsSource="{Binding Files}">
+            <ListBox Height="280" SelectionMode="Multiple" Margin="0,5,10,0"
+                     ItemsSource="{Binding Files}" IsEnabled="{Binding IsNotBusy}">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <CheckBox Content="{Binding Name}" IsChecked="{Binding IsSelected}" />
@@ -35,23 +35,26 @@
 
         <!-- Right Section -->
         <StackPanel Grid.Row="0" Grid.Column="1" Margin="10,0,0,0">
-            <Button x:Name="btnGenerateData" Content="Generate Data" Height="35" Click="btnGenerateData_Click" Margin="0,0,0,10"/>
+            <Button Content="Generate Data" Height="35" Command="{Binding GenerateCommand}"
+                    IsEnabled="{Binding IsNotBusy}" Margin="0,0,0,10"/>
             <Label Content="Output Path:" FontWeight="Bold"/>
-            <TextBox x:Name="edtPath" Height="25" Margin="0,5,0,10" 
-                     Text="E:\dev\Projetos\Financial\data" VerticalContentAlignment="Center"/>
+            <TextBox Height="25" Margin="0,5,0,10" IsEnabled="{Binding IsNotBusy}"
+                     Text="{Binding OutputPath, UpdateSourceTrigger=PropertyChanged}"
+                     VerticalContentAlignment="Center"/>
         </StackPanel>
 
         <!-- Progress Section -->
         <StackPanel Grid.Row="1" Grid.Column="1" Margin="10,20,0,0">
             <Label Content="Status:" FontWeight="Bold"/>
-            <TextBlock x:Name="txtStatus" Text="Ready" Margin="0,5,0,10" TextWrapping="Wrap"/>
-            <ProgressBar x:Name="progressBar" Height="20" Minimum="0" Maximum="100" Visibility="Collapsed"/>
+            <TextBlock Text="{Binding Status}" Margin="0,5,0,10" TextWrapping="Wrap"/>
+            <ProgressBar Height="20" Minimum="0" Maximum="100" IsIndeterminate="True"
+                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibilityConverter}}"/>
         </StackPanel>
 
         <!-- Status Bar -->
         <StatusBar Grid.Row="4" Grid.ColumnSpan="2" Height="30">
             <StatusBarItem>
-                <TextBlock x:Name="txtStatusBar" Text="Ready to import"/>
+                <TextBlock Text="{Binding StatusBar}"/>
             </StatusBarItem>
         </StatusBar>
     </Grid>

--- a/Integrations/ImportGoogleSpreadSheets/MainWindow.xaml.cs
+++ b/Integrations/ImportGoogleSpreadSheets/MainWindow.xaml.cs
@@ -1,230 +1,66 @@
-using Financial.Infrastructure.Integrations.FinancialToolSupport;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using Financial.Infrastructure.Persistence;
 using System;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace Financial.Infrastructure.Integrations.ImportGoogleSpreadSheets;
 
-/// <summary>
-/// Interaction logic for MainWindow.xaml
-/// </summary>
 public partial class MainWindow : Window
 {
-    public class FilesInfo : INotifyPropertyChanged
-    {
-        public string Id { get; set; }
-        public string Name { get; set; }
-
-        private bool isSelected;
-        public bool IsSelected
-        {
-            get { return isSelected; }
-            set
-            {
-                isSelected = value;
-                OnPropertyChanged(nameof(IsSelected));
-            }
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected virtual void OnPropertyChanged(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-    }
-
-    public ObservableCollection<FilesInfo> Files { get; set; } = new ObservableCollection<FilesInfo>();
-
-    private GoogleService _service;
     private const string AppSettingsFileName = "appsettings.json";
     private const string CredentialsPathConfigurationKey = "GoogleDrive:CredentialsPath";
 
     public MainWindow()
     {
         InitializeComponent();
-        DataContext = this;
-        
-        // Validate credentials file exists
-        var credentialsPath = GetCredentialsPathFromConfig();
+
+        var credentialsPath = ResolveCredentialsPath();
+        var service = TryCreateService(credentialsPath);
+        DataContext = new MainViewModel(service, new InvestmentsSerializerAdapter());
+    }
+
+    private GoogleService? TryCreateService(string? credentialsPath)
+    {
         if (string.IsNullOrWhiteSpace(credentialsPath) || !File.Exists(credentialsPath))
         {
-            MessageBox.Show($"Google API credentials file not found!\n\n" +
-                           $"Configure '{CredentialsPathConfigurationKey}' in {AppSettingsFileName}.\n\n" +
-                           $"Resolved location:\n{credentialsPath ?? "(not set)"}\n\n" +
-                           "Please ensure the credentials file exists before using this application.",
-                           "Credentials File Missing",
-                           MessageBoxButton.OK,
-                           MessageBoxImage.Error);
-            btnConnect.IsEnabled = false;
-            btnGenerateData.IsEnabled = false;
-            UpdateStatus("Credentials file not found", "Configure credentials to continue");
-            return;
+            MessageBox.Show(
+                $"Google API credentials file not found!\n\n" +
+                $"Configure '{CredentialsPathConfigurationKey}' in {AppSettingsFileName}.\n\n" +
+                $"Resolved location:\n{credentialsPath ?? "(not set)"}\n\n" +
+                "Please ensure the credentials file exists before using this application.",
+                "Credentials File Missing", MessageBoxButton.OK, MessageBoxImage.Error);
+            return null;
         }
-        
+
         try
         {
-            _service = new GoogleService(credentialsPath);
+            return new GoogleService(credentialsPath);
         }
         catch (Exception ex)
         {
             MessageBox.Show($"Error initializing Google service:\n{ex.Message}",
-                           "Initialization Error",
-                           MessageBoxButton.OK,
-                           MessageBoxImage.Error);
-            btnConnect.IsEnabled = false;
-            btnGenerateData.IsEnabled = false;
-            UpdateStatus("Service initialization failed", "Check credentials file");
+                "Initialization Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            return null;
         }
     }
 
-    private async void btnConnect_Click(object sender, RoutedEventArgs e)
-    {
-        if (_service == null)
-        {
-            MessageBox.Show("Service is not initialized. Please restart the application.",
-                           "Service Error",
-                           MessageBoxButton.OK,
-                           MessageBoxImage.Error);
-            return;
-        }
-
-        try
-        {
-            SetUIBusy(true, "Connecting to Google Drive...");
-            
-            var files = await _service.GetFilesNameAsync();
-            var filteredFiles = files
-                .Where(f => !string.Equals(f.Name, "data.json", StringComparison.OrdinalIgnoreCase))
-                .ToList();
-
-            Files.Clear();
-            filteredFiles.ForEach(f => { Files.Add(new FilesInfo { Id = f.Id, Name = f.Name, IsSelected = false}); });
-            
-            UpdateStatus($"Connected! Found {filteredFiles.Count} files.", "Ready to generate data");
-        }
-        catch (Exception ex)
-        {
-            MessageBox.Show($"Error connecting to Google Drive:\n{ex.Message}", "Connection Error", 
-                MessageBoxButton.OK, MessageBoxImage.Error);
-            UpdateStatus("Connection failed", "Error - check credentials");
-        }
-        finally
-        {
-            SetUIBusy(false);
-        }
-    }
-
-    private async void btnGenerateData_Click(object sender, RoutedEventArgs e)
-    {
-        var selectedFiles = Files.Where(f => f.IsSelected).ToList();
-        
-        if (selectedFiles.Count == 0)
-        {
-            MessageBox.Show("Please select at least one file to import.", "No Files Selected", 
-                MessageBoxButton.OK, MessageBoxImage.Warning);
-            return;
-        }
-
-        try
-        {
-            SetUIBusy(true, "Starting data generation...");
-            
-            var options = new GoogleGeneratorOptions(
-                IgnoreSheetNames: GoogleGeneratorConfiguration.IgnoreSheetNames,
-                PortfolioNameMap: GoogleGeneratorConfiguration.PortfolioNameMap,
-                BrokerCurrencyMap: GoogleGeneratorConfiguration.BrokerCurrencyMap);
-            IGenerator generator = new GoogleGenerator(_service, new LocalJsonStorage(edtPath.Text), options, new InvestmentsSerializerAdapter());
-            var fileNames = selectedFiles.Select(f => f.Name).ToList();
-
-            var progress = new Progress<string>(status =>
-            {
-                UpdateStatus(status, $"Processing {fileNames.Count} file(s)...");
-            });
-
-            await generator.GenerateAsync(fileNames, progress);
-            
-            MessageBox.Show("Data generation completed successfully!", "Success", 
-                MessageBoxButton.OK, MessageBoxImage.Information);
-            UpdateStatus("Data generation complete!", "Ready for next operation");
-        }
-        catch (Exception ex) when (ex.Message.Contains("rate limit") || ex.Message.Contains("quota"))
-        {
-            MessageBox.Show($"Google API Rate Limit Exceeded:\n\n{ex.Message}\n\n" +
-                           "Tips to avoid this:\n" +
-                           "? Process fewer files at once\n" +
-                           "? Wait a few minutes before retrying\n" +
-                           "? The app now uses automatic retry with delays", 
-                           "Rate Limit Error", 
-                           MessageBoxButton.OK, MessageBoxImage.Warning);
-            UpdateStatus("Rate limit exceeded", "Wait before retrying");
-        }
-        catch (Exception ex)
-        {
-            MessageBox.Show($"Error generating data:\n{ex.Message}", "Generation Error", 
-                MessageBoxButton.OK, MessageBoxImage.Error);
-            UpdateStatus("Generation failed", "Error occurred");
-        }
-        finally
-        {
-            SetUIBusy(false);
-        }
-    }
-
-    private void SetUIBusy(bool isBusy, string statusMessage = "")
-    {
-        btnConnect.IsEnabled = !isBusy;
-        btnGenerateData.IsEnabled = !isBusy;
-        cblFiles.IsEnabled = !isBusy;
-        edtPath.IsEnabled = !isBusy;
-        
-        if (isBusy)
-        {
-            progressBar.Visibility = Visibility.Visible;
-            progressBar.IsIndeterminate = true;
-            if (!string.IsNullOrEmpty(statusMessage))
-                txtStatus.Text = statusMessage;
-        }
-        else
-        {
-            progressBar.Visibility = Visibility.Collapsed;
-            progressBar.IsIndeterminate = false;
-        }
-    }
-
-    private void UpdateStatus(string mainStatus, string statusBarText)
-    {
-        txtStatus.Text = mainStatus;
-        txtStatusBar.Text = statusBarText;
-    }
-
-    private static string GetCredentialsPathFromConfig()
+    private static string? ResolveCredentialsPath()
     {
         var settingsPath = Path.Combine(AppContext.BaseDirectory, AppSettingsFileName);
         if (!File.Exists(settingsPath))
-        {
             return null;
-        }
 
         using var stream = File.OpenRead(settingsPath);
         using var document = JsonDocument.Parse(stream);
-        if (!TryGetConfigValue(document.RootElement, CredentialsPathConfigurationKey, out var value) || value.ValueKind != JsonValueKind.String)
-        {
+        if (!TryGetConfigValue(document.RootElement, CredentialsPathConfigurationKey, out var value)
+            || value.ValueKind != JsonValueKind.String)
             return null;
-        }
 
         var rawPath = value.GetString();
         if (string.IsNullOrWhiteSpace(rawPath))
-        {
             return null;
-        }
 
         return Path.IsPathRooted(rawPath)
             ? rawPath
@@ -237,11 +73,8 @@ public partial class MainWindow : Window
         foreach (var segment in key.Split(':', StringSplitOptions.RemoveEmptyEntries))
         {
             if (value.ValueKind != JsonValueKind.Object || !value.TryGetProperty(segment, out value))
-            {
                 return false;
-            }
         }
         return true;
     }
 }
-

--- a/Integrations/ImportGoogleSpreadSheets/RelayCommand.cs
+++ b/Integrations/ImportGoogleSpreadSheets/RelayCommand.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Windows.Input;
+
+namespace Financial.Infrastructure.Integrations.ImportGoogleSpreadSheets;
+
+internal sealed class RelayCommand : ICommand
+{
+    private readonly Func<bool>? _canExecute;
+    private readonly Action _execute;
+
+    internal RelayCommand(Action execute, Func<bool>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+    public void Execute(object? parameter) => _execute();
+
+    internal void RaiseCanExecuteChanged() =>
+        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
@@ -108,15 +108,15 @@ public class AssetTests
     }
 
     [Fact]
-    public void AddCredit_AssignsIdWhenEmpty()
+    public void AddCredit_AddsToCollection()
     {
         var asset = Asset.Create("Asset A", "ISIN123", "NYSE", "AAA");
         var credit = Credit.CreateWithId(Guid.Empty, new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 10m);
 
         asset.AddCredit(credit);
 
-        credit.Id.Should().NotBe(Guid.Empty);
-        asset.Credits.Should().ContainSingle();
+        asset.Credits.Should().ContainSingle()
+            .Which.Should().Be(credit);
     }
 
     [Fact]

--- a/Tests/Financial.Domain.Tests/Domain/CreditTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/CreditTests.cs
@@ -25,12 +25,10 @@ public class CreditTests
     }
 
     [Fact]
-    public void EnsureId_SetsWhenEmpty()
+    public void CreateWithId_EmptyGuid_StoresEmptyId()
     {
         var credit = Credit.CreateWithId(Guid.Empty, new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 10m);
 
-        credit.EnsureId();
-
-        credit.Id.Should().NotBe(Guid.Empty);
+        credit.Id.Should().Be(Guid.Empty);
     }
 }

--- a/Tests/Financial.Infrastructure.Tests/Repositories/JsonRepositoryTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Repositories/JsonRepositoryTests.cs
@@ -13,7 +13,7 @@ public class JsonRepositoryTests
     {
         var storage = new LocalJsonStorage(dataFile);
         var serializer = new InvestmentsSerializerAdapter();
-        return new JSONRepository(InvestmentsLoader.Load(storage, serializer), storage, serializer);
+        return new JSONRepository(InvestmentsLoader.LoadSync(storage, serializer), storage, serializer);
     }
 
     [Fact]

--- a/Tests/Financial.Infrastructure.Tests/Repositories/RepositoryFactoryTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Repositories/RepositoryFactoryTests.cs
@@ -1,9 +1,7 @@
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
 using FluentAssertions;
-using Microsoft.Extensions.Configuration;
 using System;
-using System.Collections.Generic;
 using System.IO;
 
 namespace Financial.Infrastructure.Tests.Repositories;
@@ -56,47 +54,4 @@ public class RepositoryFactoryTests
             .WithParameterName("Provider");
     }
 
-    [Fact]
-    public void CreateFromConfiguration_WithLocalJsonProvider_ReturnsJsonRepository()
-    {
-        var configuration = BuildConfiguration(new Dictionary<string, string?>
-        {
-            ["Repository:Provider"] = "LocalJson",
-            ["DataJsonFile"] = TestDataPaths.DataJsonFile
-        });
-
-        var result = Factory.CreateFromConfiguration(configuration);
-
-        result.Should().BeOfType<JSONRepository>();
-    }
-
-    [Fact]
-    public void CreateFromConfiguration_WithNoProvider_DefaultsToLocalJson()
-    {
-        var configuration = BuildConfiguration(new Dictionary<string, string?>
-        {
-            ["DataJsonFile"] = TestDataPaths.DataJsonFile
-        });
-
-        var result = Factory.CreateFromConfiguration(configuration);
-
-        result.Should().BeOfType<JSONRepository>();
-    }
-
-    [Fact]
-    public void CreateFromConfiguration_WithUnsupportedProvider_ThrowsInvalidOperationException()
-    {
-        var configuration = BuildConfiguration(new Dictionary<string, string?>
-        {
-            ["Repository:Provider"] = "Unknown"
-        });
-
-        Action act = () => Factory.CreateFromConfiguration(configuration);
-
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage("*Repository provider 'Unknown' is not supported*");
-    }
-
-    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values) =>
-        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
 }

--- a/Tests/Financial.Infrastructure.Tests/Services/CreditServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/CreditServiceTests.cs
@@ -125,7 +125,7 @@ public class CreditServiceTests
 
         var storage = new LocalJsonStorage(tempFile);
         var serializer = new InvestmentsSerializerAdapter();
-        var repository = new JSONRepository(InvestmentsLoader.Load(storage, serializer), storage, serializer);
+        var repository = new JSONRepository(InvestmentsLoader.LoadSync(storage, serializer), storage, serializer);
         var navigationService = new NavigationService(repository);
         var service = new CreditService(repository, navigationService);
 

--- a/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
@@ -16,13 +16,15 @@ public class NavigationServiceTests
     {
         var storage = new LocalJsonStorage(TestDataPaths.DataJsonFile);
         var serializer = new InvestmentsSerializerAdapter();
-        return new JSONRepository(InvestmentsLoader.Load(storage, serializer), storage, serializer);
+        return new JSONRepository(InvestmentsLoader.LoadSync(storage, serializer), storage, serializer);
     }
     private readonly NavigationService _sut;
+    private readonly CreditQueryService _creditSut;
 
     public NavigationServiceTests()
     {
         _sut = new NavigationService(_repository);
+        _creditSut = new CreditQueryService(_repository);
     }
 
     [Fact]
@@ -297,7 +299,7 @@ public class NavigationServiceTests
     public void GetCreditsByBroker_WithInvalidParameters_ReturnsEmpty(string? brokerName)
     {
         // Act
-        var result = _sut.GetCreditsByBroker(brokerName!);
+        var result = _creditSut.GetCreditsByBroker(brokerName!);
 
         // Assert
         result.Should().BeEmpty();
@@ -311,7 +313,7 @@ public class NavigationServiceTests
     public void GetCreditsByPortfolio_WithInvalidParameters_ReturnsEmpty(string? brokerName, string? portfolioName)
     {
         // Act
-        var result = _sut.GetCreditsByPortfolio(brokerName!, portfolioName!);
+        var result = _creditSut.GetCreditsByPortfolio(brokerName!, portfolioName!);
 
         // Assert
         result.Should().BeEmpty();
@@ -324,7 +326,7 @@ public class NavigationServiceTests
         const string brokerName = "XPI";
 
         // Act
-        var result = _sut.GetCreditsByBroker(brokerName);
+        var result = _creditSut.GetCreditsByBroker(brokerName);
 
         // Assert
         result.Should().NotBeEmpty();
@@ -344,7 +346,7 @@ public class NavigationServiceTests
         const string portfolioName = "Default";
 
         // Act
-        var result = _sut.GetCreditsByPortfolio(brokerName, portfolioName);
+        var result = _creditSut.GetCreditsByPortfolio(brokerName, portfolioName);
 
         // Assert
         result.Should().NotBeEmpty();
@@ -363,7 +365,7 @@ public class NavigationServiceTests
         const string brokerName = "XPI";
 
         // Act
-        var result = _sut.GetCreditsByBroker(brokerName);
+        var result = _creditSut.GetCreditsByBroker(brokerName);
 
         // Assert
         if (result.Count > 1)

--- a/Tests/Financial.Infrastructure.Tests/Services/TransactionServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/TransactionServiceTests.cs
@@ -136,7 +136,7 @@ public class TransactionServiceTests
 
         var storage = new LocalJsonStorage(tempFile);
         var serializer = new InvestmentsSerializerAdapter();
-        var repository = new JSONRepository(InvestmentsLoader.Load(storage, serializer), storage, serializer);
+        var repository = new JSONRepository(InvestmentsLoader.LoadSync(storage, serializer), storage, serializer);
         var navigationService = new NavigationService(repository);
         var service = new TransactionService(repository, navigationService);
 


### PR DESCRIPTION
## Summary

- **O-01**: Extracted `CreditQueryService : ICreditQueryService` from `NavigationService` — two unrelated concerns now in separate classes; `ApplicationServiceCollectionExtensions` updated
- **O-02**: Moved raw `IConfiguration` parsing out of `RepositoryFactory` into `InfrastructureServiceCollectionExtensions`; `RepositoryFactory.CreateFromConfiguration` deleted
- **O-03**: Removed duplicate config key constants from `GoogleDriveJsonStorage`; now references `RepositoryConfigurationKeys`
- **O-04**: Renamed `InvestmentsLoader.Load` → `LoadSync` with comment explaining the deliberate synchronous blocking
- **O-05**: Made `_applyDetails` private in `AssetActionsBase`; exposed as `protected void ApplyDetails()`; updated `TransactionActions` and `CreditActions`
- **O-06**: Injected `Action<string> showError` delegate into `AssetPriceFetchViewModel`; wired in `App.xaml.cs`
- **O-07**: Replaced magic string `BvmfExchange = "BVMF"` with `IOptions<DividendOptions>.DefaultExchange`; registered `DividendOptions` in WPF DI
- **O-08**: Promoted `AssetClassFilterOptionViewModel` from nested class in generic base to top-level file
- **O-09 / O-17**: Extracted `MainViewModel` (Connect/Generate commands, Files, Status, IsBusy) from `ImportGoogleSpreadSheets` code-behind; extracted `FilesInfo` and `RelayCommand` to own files; `MainWindow.xaml.cs` is now a thin composition root; `MainWindow.xaml` uses MVVM bindings throughout
- **O-10**: Extracted `ProcessBrokerAsync` and `ProcessSheetAsync` from 64-line `GoogleGenerator.GenerateAsync`
- **O-11**: `AssetMetadataResolver.ResolveBrokerCurrency` now uses `TryGetValue` and throws `InvalidOperationException` with a clear message for unknown brokers
- **O-12**: Replaced `private static readonly HttpClient` with injected instance in `AssetTypeLookup`
- **O-13**: Added `exchange` parameter to `IDividendDataSource.GetDividends`; `DividendService` now passes the request exchange through; `DividendDataSourceAdapter` accepts the parameter
- **O-14**: Removed `EnsureId()` from `Transaction` and `Credit`; removed calls in `Asset.AddTransaction/AddCredit`; updated dead-code test
- **O-15**: Made all aggregate collection setters `private` on `Asset`, `Broker`, `Portfolio`, `Investments` — `InvestmentsTypeInfoResolver` accesses them via reflection unchanged

O-16 (integration lib depends on Application) skipped — low severity, pragmatic trade-off for personal tool.

## Test plan

- [x] Build `Financial.App` — 0 errors, 0 warnings
- [x] Build `ImportGoogleSpreadSheets` — 0 errors, 0 warnings
- [x] All 164 tests pass (161 passed, 3 pre-existing skips)
- [x] WPF app loads: Portfolio Navigator, Dividend Check tab, Asset Price tab all work
- [x] ImportGoogleSpreadSheets: Connect and Generate buttons work via MVVM commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)