### PR TITLE
refactor: rename Diagnostics → Settings and remove unnecessary usings

### DIFF
--- a/Financial.Api/Controllers/AssetPricesController.cs
+++ b/Financial.Api/Controllers/AssetPricesController.cs
@@ -1,8 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using System;
 
 namespace Financial.Api.Controllers;
 

--- a/Financial.Api/Controllers/AssetsController.cs
+++ b/Financial.Api/Controllers/AssetsController.cs
@@ -1,8 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using System;
 
 namespace Financial.Api.Controllers;
 

--- a/Financial.Api/Controllers/CreditsController.cs
+++ b/Financial.Api/Controllers/CreditsController.cs
@@ -1,10 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Financial.Api.Controllers;
 

--- a/Financial.Api/Controllers/DiagnosticsController.cs
+++ b/Financial.Api/Controllers/DiagnosticsController.cs
@@ -7,12 +7,12 @@ namespace Financial.Api.Controllers;
 [Route("")]
 public sealed class DiagnosticsController : ControllerBase
 {
-    private readonly IRepositoryDiagnostics _repositoryDiagnostics;
+    private readonly IRepositorySettings _repositorySettings;
     private readonly IHostEnvironment _environment;
 
-    public DiagnosticsController(IRepositoryDiagnostics repositoryDiagnostics, IHostEnvironment environment)
+    public DiagnosticsController(IRepositorySettings repositorySettings, IHostEnvironment environment)
     {
-        _repositoryDiagnostics = repositoryDiagnostics ?? throw new ArgumentNullException(nameof(repositoryDiagnostics));
+        _repositorySettings = repositorySettings ?? throw new ArgumentNullException(nameof(repositorySettings));
         _environment = environment ?? throw new ArgumentNullException(nameof(environment));
     }
 
@@ -37,11 +37,11 @@ public sealed class DiagnosticsController : ControllerBase
         string? googleDriveCredentialsPath = null;
         string? googleDriveFilePath = null;
 
-        if (_repositoryDiagnostics is ILocalJsonRepositoryDiagnostics localJson)
+        if (_repositorySettings is ILocalJsonRepositorySettings localJson)
         {
             dataJsonFile = localJson.DataJsonFile;
         }
-        else if (_repositoryDiagnostics is IGoogleDriveRepositoryDiagnostics googleDrive)
+        else if (_repositorySettings is IGoogleDriveRepositorySettings googleDrive)
         {
             googleDriveCredentialsPath = googleDrive.GoogleDriveCredentialsPath;
             googleDriveFilePath = googleDrive.GoogleDriveFilePath;
@@ -49,7 +49,7 @@ public sealed class DiagnosticsController : ControllerBase
 
         return Ok(new
         {
-            provider = _repositoryDiagnostics.Provider,
+            provider = _repositorySettings.Provider,
             dataJsonFile,
             googleDriveCredentialsPath,
             googleDriveFilePath

--- a/Financial.Api/Controllers/DiagnosticsController.cs
+++ b/Financial.Api/Controllers/DiagnosticsController.cs
@@ -1,8 +1,5 @@
 using Financial.Application.Interfaces;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Hosting;
-using System;
 
 namespace Financial.Api.Controllers;
 

--- a/Financial.Api/Controllers/DividendsController.cs
+++ b/Financial.Api/Controllers/DividendsController.cs
@@ -1,11 +1,8 @@
 using Financial.Application.Configuration;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using System;
-using System.Collections.Generic;
 
 namespace Financial.Api.Controllers;
 

--- a/Financial.Api/Controllers/NavigationController.cs
+++ b/Financial.Api/Controllers/NavigationController.cs
@@ -1,8 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using System;
 
 namespace Financial.Api.Controllers;
 

--- a/Financial.Api/Controllers/TransactionsController.cs
+++ b/Financial.Api/Controllers/TransactionsController.cs
@@ -1,9 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Threading.Tasks;
 
 namespace Financial.Api.Controllers;
 

--- a/Financial.Api/Program.cs
+++ b/Financial.Api/Program.cs
@@ -1,7 +1,6 @@
 using Financial.Application.Configuration;
 using Financial.Application.DependencyInjection;
 using Financial.Infrastructure.DependencyInjection;
-using System;
 
 var builder = WebApplication.CreateBuilder(args);
 var configuration = builder.Configuration;

--- a/Financial.App/App.xaml.cs
+++ b/Financial.App/App.xaml.cs
@@ -2,12 +2,10 @@ using Financial.Application.Configuration;
 using Financial.Application.DependencyInjection;
 using Financial.Infrastructure.DependencyInjection;
 using Financial.Presentation.App.Options;
-using Financial.Presentation.App.ViewModels;
 using Financial.Presentation.App.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-using System;
 using System.IO;
 using System.Windows;
 

--- a/Financial.App/Components/NavigationView.xaml.cs
+++ b/Financial.App/Components/NavigationView.xaml.cs
@@ -1,6 +1,5 @@
 using System.Windows;
 using System.Windows.Controls;
-using Financial.Presentation.App.ViewModels;
 
 namespace Financial.Presentation.App.Components
 {

--- a/Financial.App/Components/Totals.xaml.cs
+++ b/Financial.App/Components/Totals.xaml.cs
@@ -1,17 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace Financial.Presentation.App.Components
 {

--- a/Financial.App/Converters/BetweenTextSeparatorConverter.cs
+++ b/Financial.App/Converters/BetweenTextSeparatorConverter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Globalization;
 using System.Windows.Data;
 

--- a/Financial.App/Converters/BoolToActiveStatusConverter.cs
+++ b/Financial.App/Converters/BoolToActiveStatusConverter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Globalization;
 using System.Windows.Data;
 

--- a/Financial.App/Converters/CurrencyFormatConverter.cs
+++ b/Financial.App/Converters/CurrencyFormatConverter.cs
@@ -14,12 +14,12 @@ public class CurrencyFormatConverter : IValueConverter
         {
             // Parameter can optionally specify currency symbol
             var currencySymbol = parameter as string ?? string.Empty;
-            
+
             if (string.IsNullOrEmpty(currencySymbol))
             {
                 return amount.ToString("N2", culture);
             }
-            
+
             return $"{currencySymbol} {amount:N2}";
         }
         return string.Empty;
@@ -27,7 +27,7 @@ public class CurrencyFormatConverter : IValueConverter
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is string str && decimal.TryParse(str.Replace(",", "").Replace(".", ""), 
+        if (value is string str && decimal.TryParse(str.Replace(",", "").Replace(".", ""),
             NumberStyles.Any, culture, out decimal result))
         {
             return result;

--- a/Financial.App/Converters/SignedValueToBrushConverter.cs
+++ b/Financial.App/Converters/SignedValueToBrushConverter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Media;

--- a/Financial.App/CreditDialog.xaml.cs
+++ b/Financial.App/CreditDialog.xaml.cs
@@ -1,9 +1,7 @@
-using System;
+using Financial.Presentation.App.Input;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Financial.Presentation.App.Input;
-using Financial.Presentation.App.ViewModels;
 
 namespace Financial.Presentation.App;
 

--- a/Financial.App/Extensions/DecimalExtensions.cs
+++ b/Financial.App/Extensions/DecimalExtensions.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Linq;
 
 namespace Financial.Presentation.App.Extensions;
 

--- a/Financial.App/Financial.App.csproj.user
+++ b/Financial.App/Financial.App.csproj.user
@@ -7,23 +7,11 @@
     </ApplicationDefinition>
   </ItemGroup>
   <ItemGroup>
-    <Compile Update="Components\AssetInfo.xaml.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Update="Components\BrokerInfo.xaml.cs">
-      <SubType>Code</SubType>
-    </Compile>
     <Compile Update="Components\Totals.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Page Update="Components\AssetInfo.xaml">
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Update="Components\BrokerInfo.xaml">
-      <SubType>Designer</SubType>
-    </Page>
     <Page Update="Components\Totals.xaml">
       <SubType>Designer</SubType>
     </Page>
@@ -32,4 +20,3 @@
     </Page>
   </ItemGroup>
 </Project>
-

--- a/Financial.App/MainWindow.xaml.cs
+++ b/Financial.App/MainWindow.xaml.cs
@@ -1,4 +1,3 @@
-using Financial.Presentation.App.ViewModels;
 using Financial.Presentation.App.Views;
 using System.Windows;
 

--- a/Financial.App/TransactionDialog.xaml.cs
+++ b/Financial.App/TransactionDialog.xaml.cs
@@ -1,9 +1,7 @@
-using System;
+using Financial.Presentation.App.Input;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Financial.Presentation.App.Input;
-using Financial.Presentation.App.ViewModels;
 
 namespace Financial.Presentation.App;
 

--- a/Financial.App/ViewModels/AssetActionsBase.cs
+++ b/Financial.App/ViewModels/AssetActionsBase.cs
@@ -1,6 +1,5 @@
-using System;
-using System.Windows;
 using Financial.Application.DTOs;
+using System.Windows;
 
 namespace Financial.Presentation.App.ViewModels;
 

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -1,14 +1,9 @@
-using System;
-using System.Collections.ObjectModel;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using OxyPlot;
-using OxyPlot.Axes;
+using System.Collections.ObjectModel;
+using System.Windows;
 
 namespace Financial.Presentation.App.ViewModels;
 

--- a/Financial.App/ViewModels/AssetPriceFetchViewModel.cs
+++ b/Financial.App/ViewModels/AssetPriceFetchViewModel.cs
@@ -1,9 +1,8 @@
-using System;
-using System.Collections.ObjectModel;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Presentation.App.Options;
 using Microsoft.Extensions.Options;
+using System.Collections.ObjectModel;
 
 namespace Financial.Presentation.App.ViewModels;
 

--- a/Financial.App/ViewModels/CreditActions.cs
+++ b/Financial.App/ViewModels/CreditActions.cs
@@ -1,9 +1,7 @@
-using System;
-using System.Threading.Tasks;
-using System.Windows;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Application.Validation;
+using System.Windows;
 
 namespace Financial.Presentation.App.ViewModels;
 

--- a/Financial.App/ViewModels/CreditDialogValidation.cs
+++ b/Financial.App/ViewModels/CreditDialogValidation.cs
@@ -1,6 +1,4 @@
 using Financial.Application.Validation;
-using System;
-using System.Collections.Generic;
 
 namespace Financial.Presentation.App.ViewModels;
 

--- a/Financial.App/ViewModels/CreditDialogViewModel.cs
+++ b/Financial.App/ViewModels/CreditDialogViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Financial.Presentation.App.ViewModels;
 
 public enum CreditDialogMode

--- a/Financial.App/ViewModels/DividendCheckViewModel.cs
+++ b/Financial.App/ViewModels/DividendCheckViewModel.cs
@@ -1,9 +1,9 @@
-using System.Collections.ObjectModel;
 using Financial.Application.Configuration;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Rules;
 using Microsoft.Extensions.Options;
+using System.Collections.ObjectModel;
 
 namespace Financial.Presentation.App.ViewModels;
 

--- a/Financial.App/ViewModels/IAssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/IAssetDetailsViewModel.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Financial.Application.DTOs;
 
 namespace Financial.Presentation.App.ViewModels;

--- a/Financial.App/ViewModels/MainNavigationViewModel.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModel.cs
@@ -1,6 +1,4 @@
-using System;
 using Financial.Application.Interfaces;
-using Financial.Presentation.App.ViewModels;
 
 namespace Financial.Presentation.App.ViewModels;
 

--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
+using System.Collections.ObjectModel;
 
 namespace Financial.Presentation.App.ViewModels;
 

--- a/Financial.App/ViewModels/TodayInfoTracker.cs
+++ b/Financial.App/ViewModels/TodayInfoTracker.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 

--- a/Financial.App/ViewModels/TransactionActions.cs
+++ b/Financial.App/ViewModels/TransactionActions.cs
@@ -1,9 +1,7 @@
-using System;
-using System.Threading.Tasks;
-using System.Windows;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Application.Validation;
+using System.Windows;
 
 namespace Financial.Presentation.App.ViewModels;
 

--- a/Financial.App/ViewModels/TransactionDialogValidation.cs
+++ b/Financial.App/ViewModels/TransactionDialogValidation.cs
@@ -1,6 +1,4 @@
 using Financial.Application.Validation;
-using System;
-using System.Collections.Generic;
 
 namespace Financial.Presentation.App.ViewModels;
 

--- a/Financial.App/ViewModels/TransactionDialogViewModel.cs
+++ b/Financial.App/ViewModels/TransactionDialogViewModel.cs
@@ -1,6 +1,3 @@
-using System;
-using Financial.Presentation.App.ViewModels;
-
 namespace Financial.Presentation.App.ViewModels;
 
 public enum TransactionDialogMode

--- a/Financial.App/ViewModels/TreeNodeViewModel.cs
+++ b/Financial.App/ViewModels/TreeNodeViewModel.cs
@@ -1,7 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using Financial.Application.DTOs;
+using System.Collections.ObjectModel;
 
 namespace Financial.Presentation.App.ViewModels;
 

--- a/Financial.App/Views/AssetPriceView.xaml.cs
+++ b/Financial.App/Views/AssetPriceView.xaml.cs
@@ -1,4 +1,3 @@
-using Financial.Presentation.App.ViewModels;
 using System.Windows.Controls;
 
 namespace Financial.Presentation.App.Views;

--- a/Financial.App/Views/DividendCheckView.xaml.cs
+++ b/Financial.App/Views/DividendCheckView.xaml.cs
@@ -1,9 +1,6 @@
 using Financial.Presentation.App.Helpers;
 using Financial.Presentation.App.Options;
-using Financial.Presentation.App.ViewModels;
 using Microsoft.Extensions.Options;
-using System;
-using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;

--- a/Financial.Application/DTOs/CreditDTO.cs
+++ b/Financial.Application/DTOs/CreditDTO.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Financial.Application.DTOs;
 
 /// <summary>

--- a/Financial.Application/Interfaces/ICreditQueryService.cs
+++ b/Financial.Application/Interfaces/ICreditQueryService.cs
@@ -1,5 +1,4 @@
 using Financial.Application.DTOs;
-using System.Collections.Generic;
 
 namespace Financial.Application.Interfaces;
 

--- a/Financial.Application/Interfaces/ICreditService.cs
+++ b/Financial.Application/Interfaces/ICreditService.cs
@@ -1,5 +1,4 @@
 using Financial.Application.DTOs;
-using System.Threading.Tasks;
 
 namespace Financial.Application.Interfaces;
 

--- a/Financial.Application/Interfaces/IDividendDataSource.cs
+++ b/Financial.Application/Interfaces/IDividendDataSource.cs
@@ -1,5 +1,4 @@
 using Financial.Domain.Entities;
-using System.Collections.Generic;
 
 namespace Financial.Application.Interfaces;
 

--- a/Financial.Application/Interfaces/IGoogleDriveRepositorySettings.cs
+++ b/Financial.Application/Interfaces/IGoogleDriveRepositorySettings.cs
@@ -1,6 +1,6 @@
 namespace Financial.Application.Interfaces;
 
-public interface IGoogleDriveRepositoryDiagnostics : IRepositoryDiagnostics
+public interface IGoogleDriveRepositorySettings : IRepositorySettings
 {
     string? GoogleDriveCredentialsPath { get; }
     string? GoogleDriveFilePath { get; }

--- a/Financial.Application/Interfaces/IJsonStorage.cs
+++ b/Financial.Application/Interfaces/IJsonStorage.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace Financial.Application.Interfaces;
 
 public interface IJsonStorage

--- a/Financial.Application/Interfaces/ILocalJsonRepositorySettings.cs
+++ b/Financial.Application/Interfaces/ILocalJsonRepositorySettings.cs
@@ -1,6 +1,6 @@
 namespace Financial.Application.Interfaces;
 
-public interface ILocalJsonRepositoryDiagnostics : IRepositoryDiagnostics
+public interface ILocalJsonRepositorySettings : IRepositorySettings
 {
     string? DataJsonFile { get; }
 }

--- a/Financial.Application/Interfaces/INavigationService.cs
+++ b/Financial.Application/Interfaces/INavigationService.cs
@@ -1,5 +1,4 @@
 using Financial.Application.DTOs;
-using System.Collections.Generic;
 
 namespace Financial.Application.Interfaces;
 

--- a/Financial.Application/Interfaces/IRepository.cs
+++ b/Financial.Application/Interfaces/IRepository.cs
@@ -1,5 +1,4 @@
 ﻿using Financial.Domain.Entities;
-using System.Threading.Tasks;
 
 namespace Financial.Application.Interfaces;
 

--- a/Financial.Application/Interfaces/IRepositorySettings.cs
+++ b/Financial.Application/Interfaces/IRepositorySettings.cs
@@ -1,6 +1,6 @@
 namespace Financial.Application.Interfaces;
 
-public interface IRepositoryDiagnostics
+public interface IRepositorySettings
 {
     string? Provider { get; }
 }

--- a/Financial.Application/Interfaces/ITransactionService.cs
+++ b/Financial.Application/Interfaces/ITransactionService.cs
@@ -1,5 +1,4 @@
 using Financial.Application.DTOs;
-using System.Threading.Tasks;
 
 namespace Financial.Application.Interfaces;
 

--- a/Financial.Application/Services/AssetServiceHelper.cs
+++ b/Financial.Application/Services/AssetServiceHelper.cs
@@ -1,8 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
-using System;
-using System.Threading.Tasks;
 
 namespace Financial.Application.Services;
 

--- a/Financial.Application/Services/CreditQueryService.cs
+++ b/Financial.Application/Services/CreditQueryService.cs
@@ -1,8 +1,5 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Financial.Application.Services;
 

--- a/Financial.Application/Services/CreditService.cs
+++ b/Financial.Application/Services/CreditService.cs
@@ -2,8 +2,6 @@ using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Application.Validation;
 using Financial.Domain.Entities;
-using System;
-using System.Threading.Tasks;
 
 namespace Financial.Application.Services;
 

--- a/Financial.Application/Services/DividendService.cs
+++ b/Financial.Application/Services/DividendService.cs
@@ -2,9 +2,6 @@ using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using Financial.Domain.Rules;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Financial.Application.Services;
 

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -1,8 +1,5 @@
 using Financial.Application.DTOs;
 using Financial.Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Financial.Application.Services;
 

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -1,8 +1,5 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
-using Financial.Domain.Entities;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Financial.Application.Services;
 

--- a/Financial.Application/Services/TransactionService.cs
+++ b/Financial.Application/Services/TransactionService.cs
@@ -2,8 +2,6 @@ using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Application.Validation;
 using Financial.Domain.Entities;
-using System;
-using System.Threading.Tasks;
 
 namespace Financial.Application.Services;
 

--- a/Financial.Application/Validation/EnumParser.cs
+++ b/Financial.Application/Validation/EnumParser.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace Financial.Application.Validation;
 
 internal static class EnumParser

--- a/Financial.Domain/Entities/Asset.cs
+++ b/Financial.Domain/Entities/Asset.cs
@@ -9,7 +9,7 @@ public class Asset
 
     public string ISIN { get; private set; }
 
-    public string Exchange{ get; private set; }
+    public string Exchange { get; private set; }
 
     public string Ticker { get; private set; }
 
@@ -55,7 +55,7 @@ public class Asset
         }
     }
 
-    private Asset() {}
+    private Asset() { }
 
     private Asset(string name, string isin, string exchange, string ticker, CountryCode country, string localTypeCode, GlobalAssetClass assetClass) : this()
     {

--- a/Financial.Domain/Entities/Broker.cs
+++ b/Financial.Domain/Entities/Broker.cs
@@ -16,7 +16,7 @@ public class Broker
         _portfolios.AddRange(data);
     }
 
-    private Broker() {}
+    private Broker() { }
 
     private Broker(string name, string currency) : this()
     {

--- a/Financial.Domain/Entities/Investments.cs
+++ b/Financial.Domain/Entities/Investments.cs
@@ -12,7 +12,7 @@ public class Investments
         _brokers.AddRange(data);
     }
 
-    private Investments() {}
+    private Investments() { }
 
     public static Investments Create() => new();
 

--- a/Financial.Infrastructure/Configuration/RepositoryDiagnosticsProvider.cs
+++ b/Financial.Infrastructure/Configuration/RepositoryDiagnosticsProvider.cs
@@ -1,6 +1,5 @@
 using Financial.Application.Interfaces;
 using Microsoft.Extensions.Configuration;
-using System;
 
 namespace Financial.Infrastructure.Configuration;
 

--- a/Financial.Infrastructure/Configuration/RepositorySettingsProvider.cs
+++ b/Financial.Infrastructure/Configuration/RepositorySettingsProvider.cs
@@ -3,11 +3,11 @@ using Microsoft.Extensions.Configuration;
 
 namespace Financial.Infrastructure.Configuration;
 
-public sealed class RepositoryDiagnosticsProvider : ILocalJsonRepositoryDiagnostics, IGoogleDriveRepositoryDiagnostics
+public sealed class RepositorySettingsProvider : ILocalJsonRepositorySettings, IGoogleDriveRepositorySettings
 {
     private readonly IConfiguration _configuration;
 
-    public RepositoryDiagnosticsProvider(IConfiguration configuration)
+    public RepositorySettingsProvider(IConfiguration configuration)
     {
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
     }

--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ public static class InfrastructureServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        services.AddSingleton<IRepositoryDiagnostics, RepositoryDiagnosticsProvider>();
+        services.AddSingleton<IRepositorySettings, RepositorySettingsProvider>();
         services.AddSingleton<IInvestmentsSerializer, InvestmentsSerializerAdapter>();
         services.AddSingleton<IDividendDataSource, DividendDataSourceAdapter>();
         services.AddSingleton<IAssetSnapshotSource, AssetSnapshotSourceAdapter>();

--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -5,7 +5,6 @@ using Financial.Infrastructure.Repositories;
 using Financial.Infrastructure.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 
 namespace Financial.Infrastructure.DependencyInjection;
 

--- a/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
+++ b/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
@@ -1,8 +1,6 @@
 using Financial.Application.Interfaces;
 using Financial.Infrastructure.Configuration;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
-using System;
-using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Persistence;
 

--- a/Financial.Infrastructure/Persistence/InvestmentsTypeInfoResolver.cs
+++ b/Financial.Infrastructure/Persistence/InvestmentsTypeInfoResolver.cs
@@ -1,6 +1,4 @@
 using Financial.Domain.Entities;
-using System;
-using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;

--- a/Financial.Infrastructure/Persistence/LocalJsonStorage.cs
+++ b/Financial.Infrastructure/Persistence/LocalJsonStorage.cs
@@ -1,8 +1,5 @@
 using Financial.Application.Interfaces;
 using Financial.Infrastructure.Configuration;
-using System;
-using System.IO;
-using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Persistence;
 

--- a/Financial.Infrastructure/Repositories/JSONRepository.cs
+++ b/Financial.Infrastructure/Repositories/JSONRepository.cs
@@ -1,10 +1,5 @@
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
-using Financial.Infrastructure.Persistence;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Repositories;
 

--- a/Financial.Infrastructure/Repositories/RepositoryFactory.cs
+++ b/Financial.Infrastructure/Repositories/RepositoryFactory.cs
@@ -2,9 +2,6 @@ using Financial.Application.Interfaces;
 using Financial.Infrastructure.Configuration;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using Financial.Infrastructure.Persistence;
-using System;
-using System.Collections.Generic;
-using System.IO;
 
 namespace Financial.Infrastructure.Repositories;
 

--- a/Financial.Infrastructure/Services/AssetPriceService.cs
+++ b/Financial.Infrastructure/Services/AssetPriceService.cs
@@ -1,4 +1,3 @@
-using System;
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Infrastructure.Integrations.WebPageParser;

--- a/Financial.Infrastructure/Services/DividendDataSourceAdapter.cs
+++ b/Financial.Infrastructure/Services/DividendDataSourceAdapter.cs
@@ -1,7 +1,6 @@
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using Financial.Infrastructure.Integrations.WebPageParser;
-using System.Collections.Generic;
 
 namespace Financial.Infrastructure.Services;
 

--- a/Integrations/FinancialToolSupport/DecimalExtension.cs
+++ b/Integrations/FinancialToolSupport/DecimalExtension.cs
@@ -9,7 +9,7 @@ namespace Financial.Infrastructure.Integrations.FinancialToolSupport
     {
         private static readonly Dictionary<string, CultureInfo> ISOCurrenciesToACultureMap =
             CultureInfo.GetCultures(CultureTypes.SpecificCultures)
-                .Select(c => new { c, ISOCurrencySymbol=GetRegionISOCurrencySymbol(c.LCID) })
+                .Select(c => new { c, ISOCurrencySymbol = GetRegionISOCurrencySymbol(c.LCID) })
                 .Where(o => o.ISOCurrencySymbol != null)
                 .GroupBy(x => x.ISOCurrencySymbol)
                 .ToDictionary(g => g.Key, g => g.First().c, StringComparer.OrdinalIgnoreCase);

--- a/Integrations/FinancialToolSupport/HTMLHelper.cs
+++ b/Integrations/FinancialToolSupport/HTMLHelper.cs
@@ -1,5 +1,5 @@
-using System.Net.Http;
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Integrations.FinancialToolSupport;

--- a/Integrations/GoogleFinancialSupport/AssetMetadataResolver.cs
+++ b/Integrations/GoogleFinancialSupport/AssetMetadataResolver.cs
@@ -1,6 +1,6 @@
 using Financial.Domain.Entities;
-using System;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport.DTO;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/Integrations/GoogleFinancialSupport/AssetTypeLookup.cs
+++ b/Integrations/GoogleFinancialSupport/AssetTypeLookup.cs
@@ -2,7 +2,6 @@ using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using Financial.Infrastructure.Integrations.WebPageParser;
-using HtmlAgilityPack;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Integrations/GoogleFinancialSupport/GoogleDriveClient.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleDriveClient.cs
@@ -1,6 +1,6 @@
+using Financial.Infrastructure.Integrations.GoogleFinancialSupport.DTO;
 using Google.Apis.Drive.v3;
 using Google.Apis.Upload;
-using Financial.Infrastructure.Integrations.GoogleFinancialSupport.DTO;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Integrations/GoogleFinancialSupport/GoogleSheetValueParser.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleSheetValueParser.cs
@@ -1,4 +1,3 @@
-using System;
 using Google.Apis.Sheets.v4.Data;
 
 namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;

--- a/Integrations/GoogleFinancialSupport/GoogleSheetsClient.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleSheetsClient.cs
@@ -1,5 +1,5 @@
-using Google.Apis.Sheets.v4;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport.DTO;
+using Google.Apis.Sheets.v4;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/Integrations/ImportGoogleSpreadSheets/App.xaml.cs
+++ b/Integrations/ImportGoogleSpreadSheets/App.xaml.cs
@@ -1,11 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
-
 namespace Financial.Infrastructure.Integrations.ImportGoogleSpreadSheets
 {
     /// <summary>

--- a/Integrations/ImportGoogleSpreadSheets/Properties/AssemblyInfo.cs
+++ b/Integrations/ImportGoogleSpreadSheets/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 ﻿using System.Reflection;
-using System.Resources;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 

--- a/Integrations/WebPageParser/DadosMercadoDividend.cs
+++ b/Integrations/WebPageParser/DadosMercadoDividend.cs
@@ -1,9 +1,6 @@
 using Financial.Domain.Entities;
 using HtmlAgilityPack;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 
 namespace Financial.Infrastructure.Integrations.WebPageParser;
 

--- a/Integrations/WebPageParser/GoogleFinance.cs
+++ b/Integrations/WebPageParser/GoogleFinance.cs
@@ -1,6 +1,5 @@
 using Financial.Domain.Entities;
 using HtmlAgilityPack;
-using System;
 using System.Text.RegularExpressions;
 
 namespace Financial.Infrastructure.Integrations.WebPageParser;

--- a/Integrations/WebPageParser/GoogleFinanceAssetTypeParser.cs
+++ b/Integrations/WebPageParser/GoogleFinanceAssetTypeParser.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Financial.Infrastructure.Integrations.WebPageParser;

--- a/Tests/Financial.Api.Tests/ApiTestFactory.cs
+++ b/Tests/Financial.Api.Tests/ApiTestFactory.cs
@@ -1,9 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
-using System;
-using System.Collections.Generic;
-using System.IO;
 
 namespace Financial.Api.Tests;
 

--- a/Tests/Financial.Api.Tests/AssetEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/AssetEndpointsTests.cs
@@ -2,8 +2,6 @@ using Financial.Application.DTOs;
 using FluentAssertions;
 using System.Net;
 using System.Net.Http.Json;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace Financial.Api.Tests;
 

--- a/Tests/Financial.Api.Tests/AssetPriceEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/AssetPriceEndpointsTests.cs
@@ -4,11 +4,8 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using System;
 using System.Net;
 using System.Net.Http.Json;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace Financial.Api.Tests;
 

--- a/Tests/Financial.Api.Tests/CreditEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/CreditEndpointsTests.cs
@@ -1,12 +1,7 @@
 using Financial.Application.DTOs;
 using FluentAssertions;
-using System;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Net.Http.Json;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace Financial.Api.Tests;
 

--- a/Tests/Financial.Api.Tests/DividendEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/DividendEndpointsTests.cs
@@ -4,11 +4,8 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using System;
 using System.Net;
 using System.Net.Http.Json;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace Financial.Api.Tests;
 

--- a/Tests/Financial.Api.Tests/NavigationEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/NavigationEndpointsTests.cs
@@ -2,8 +2,6 @@ using Financial.Application.DTOs;
 using FluentAssertions;
 using System.Net;
 using System.Net.Http.Json;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace Financial.Api.Tests;
 

--- a/Tests/Financial.Api.Tests/TestDataPaths.cs
+++ b/Tests/Financial.Api.Tests/TestDataPaths.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-
 namespace Financial.Api.Tests;
 
 internal static class TestDataPaths

--- a/Tests/Financial.Api.Tests/TransactionEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/TransactionEndpointsTests.cs
@@ -1,12 +1,7 @@
 using Financial.Application.DTOs;
 using FluentAssertions;
-using System;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Net.Http.Json;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace Financial.Api.Tests;
 

--- a/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
@@ -1,6 +1,5 @@
-using System;
-using FluentAssertions;
 using Financial.Domain.Entities;
+using FluentAssertions;
 
 namespace Financial.Domain.Tests;
 

--- a/Tests/Financial.Domain.Tests/Domain/BrokerTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/BrokerTests.cs
@@ -1,5 +1,5 @@
-using FluentAssertions;
 using Financial.Domain.Entities;
+using FluentAssertions;
 
 namespace Financial.Domain.Tests;
 

--- a/Tests/Financial.Domain.Tests/Domain/CreditTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/CreditTests.cs
@@ -1,6 +1,5 @@
-using System;
-using FluentAssertions;
 using Financial.Domain.Entities;
+using FluentAssertions;
 
 namespace Financial.Domain.Tests;
 

--- a/Tests/Financial.Domain.Tests/Domain/GlobalAssetClassMappingTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/GlobalAssetClassMappingTests.cs
@@ -1,5 +1,5 @@
-using FluentAssertions;
 using Financial.Domain.Entities;
+using FluentAssertions;
 
 namespace Financial.Domain.Tests;
 

--- a/Tests/Financial.Domain.Tests/Domain/InvestmentsTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/InvestmentsTests.cs
@@ -1,5 +1,5 @@
-using FluentAssertions;
 using Financial.Domain.Entities;
+using FluentAssertions;
 
 namespace Financial.Domain.Tests;
 

--- a/Tests/Financial.Domain.Tests/Domain/PortfolioTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/PortfolioTests.cs
@@ -1,5 +1,5 @@
-using FluentAssertions;
 using Financial.Domain.Entities;
+using FluentAssertions;
 
 namespace Financial.Domain.Tests;
 

--- a/Tests/Financial.Domain.Tests/Domain/TransactionTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/TransactionTests.cs
@@ -1,6 +1,5 @@
-using System;
-using FluentAssertions;
 using Financial.Domain.Entities;
+using FluentAssertions;
 
 namespace Financial.Domain.Tests;
 

--- a/Tests/Financial.Infrastructure.Tests/Integrations/DadosMercadoDividendTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Integrations/DadosMercadoDividendTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Financial.Domain.Entities;
 using Financial.Infrastructure.Integrations.WebPageParser;
 using FluentAssertions;

--- a/Tests/Financial.Infrastructure.Tests/Integrations/GoogleFinanceParsingTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Integrations/GoogleFinanceParsingTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Financial.Infrastructure.Integrations.WebPageParser;
 using FluentAssertions;
 

--- a/Tests/Financial.Infrastructure.Tests/Integrations/GoogleFinanceVerificationTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Integrations/GoogleFinanceVerificationTests.cs
@@ -1,6 +1,5 @@
 using Financial.Infrastructure.Integrations;
 using Financial.Infrastructure.Integrations.WebPageParser;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Financial.Infrastructure.Tests.Integrations;

--- a/Tests/Financial.Infrastructure.Tests/Repositories/JsonRepositoryTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Repositories/JsonRepositoryTests.cs
@@ -1,6 +1,5 @@
-using System;
-using Financial.Infrastructure.Repositories;
 using Financial.Infrastructure.Persistence;
+using Financial.Infrastructure.Repositories;
 using FluentAssertions;
 
 namespace Financial.Infrastructure.Tests.Repositories;

--- a/Tests/Financial.Infrastructure.Tests/Repositories/RepositoryFactoryTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Repositories/RepositoryFactoryTests.cs
@@ -1,7 +1,6 @@
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
 using FluentAssertions;
-using System;
 using System.IO;
 
 namespace Financial.Infrastructure.Tests.Repositories;

--- a/Tests/Financial.Infrastructure.Tests/Services/CreditServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/CreditServiceTests.cs
@@ -1,12 +1,9 @@
-using System;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Financial.Application.DTOs;
 using Financial.Application.Services;
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
 using FluentAssertions;
+using System.IO;
 
 namespace Financial.Infrastructure.Tests.Services;
 

--- a/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
@@ -1,9 +1,8 @@
-using System.Threading.Tasks;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
 using Financial.Domain.Entities;
-using Financial.Infrastructure.Repositories;
 using Financial.Infrastructure.Persistence;
+using Financial.Infrastructure.Repositories;
 using FluentAssertions;
 
 namespace Financial.Infrastructure.Tests.Services;

--- a/Tests/Financial.Infrastructure.Tests/Services/TransactionServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/TransactionServiceTests.cs
@@ -1,12 +1,9 @@
-using System;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Financial.Application.DTOs;
 using Financial.Application.Services;
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
 using FluentAssertions;
+using System.IO;
 
 namespace Financial.Infrastructure.Tests.Services;
 

--- a/Tests/Financial.Infrastructure.Tests/TestData/TestDataPaths.cs
+++ b/Tests/Financial.Infrastructure.Tests/TestData/TestDataPaths.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 
 namespace Financial.Infrastructure.Tests;

--- a/context.md
+++ b/context.md
@@ -1,21 +1,27 @@
+I've revised the text for grammar, spelling, clarity, cohesion, and consistency while keeping the original meaning and intent.
+
 # Financial Project
 
 ## Purpose
 
-This is the context for the Financial Project.
+This document provides the context for my personal Financial Project.
+
+The application should allow users to record asset purchase and sale transactions, as well as register dividends and any other forms of investment income or profit.
+
+The system should also support the creation and management of brokers, portfolios, and assets.
 
 ---
 
 # Project Overview
 
-The project is a **personal financial management tool** designed to consolidate financial transactions across multiple investment accounts.
+The project is a **personal financial management tool** designed to consolidate financial transactions across multiple Brokers.
 
 The current portfolio spans **two countries**:
 
 * United Kingdom
 * Brazil
 
-This introduces:
+This introduces the need to manage:
 
 * Multiple currencies
 * Different tax regulations
@@ -35,4 +41,24 @@ Supported asset classes include:
 * Government bonds
 * ISAs
 
-The system must be flexible so that **new asset classes can be added in the future**.
+The system must be designed with flexibility in mind, allowing **new asset classes to be added in the future**.
+
+---
+
+# Technical Requirements
+
+As this is currently a personal project, a database is not required. A simple JSON file stored on the local hard drive is sufficient for persisting data.
+
+However, the design should also support storing data in Google Drive as an alternative to local storage. The storage mechanism should be abstracted so that future changes can be implemented with minimal impact on the rest of the application.
+
+For the initial version, all data can be loaded into memory when the application starts and saved either on user request or automatically when the application closes. Although this approach may evolve in the future, the codebase should be structured to make such changes as straightforward as possible.
+
+The project must adhere to the following development principles:
+
+* SOLID principles
+* Clean Code practices
+* Comprehensive unit test coverage
+
+The architecture should follow Domain-Driven Design (DDD) principles to provide a clear and maintainable structure. However, given the relatively simple domain model, consisting of concepts such as Brokers, Portfolios, Assets, Transactions, and Credits, the architecture should remain pragmatic and avoid unnecessary complexity.
+
+The primary goal of the architecture is to separate responsibilities effectively, making the system easier to maintain, extend, and evolve over time.


### PR DESCRIPTION
# Description
This branch contains two small housekeeping changes:

1. Renamed *Diagnostics → *Settings — IRepositoryDiagnostics, ILocalJsonRepositoryDiagnostics, and IGoogleDriveRepositoryDiagnostics (Application) and RepositoryDiagnosticsProvider (Infrastructure) were renamed to IRepositorySettings, ILocalJsonRepositorySettings, IGoogleDriveRepositorySettings, and RepositorySettingsProvider. The old name implied runtime health-checking behaviour; the new name correctly reflects that these types expose static configuration values (provider type, file paths, credentials path).
2. Removed unnecessary using directives — Dead using statements removed across 105 files, reducing noise with no behavioural change.

# Risk

* Pure rename and dead code removal — no logic changed
* Both commits are clean and fully reversible


# ✅ Checklist
- [ ] Tests added/updated (if applicable)
- [ ] Manually tested
