### PR TITLE
test: add unit test coverage for C# and React stacks

### DIFF
--- a/.claude/skills/testing-guide-Financial/SKILL.md
+++ b/.claude/skills/testing-guide-Financial/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: testing-guide-Financial
+description: >
+  Testing guide for Financial. Reference this skill when planning features,
+  implementing code, creating tests, or reviewing changes in Financial.
+  Covers what to test, at which layer, and how to set up unit tests —
+  organized by artifact type for both C# (.NET) and TypeScript (React) stacks.
+  Triggers on: planning Financial features, implementing Financial features,
+  writing tests for Financial, reviewing Financial code, reviewing Financial tests,
+  what should I test in Financial, how to test Financial, Financial test guide.
+---
+
+## §0. Purpose
+
+This guide helps you decide **what to test** and **how to set up tests** for each artifact type in `Financial`. The project has two stacks — C# (.NET) and TypeScript (React) — each with dedicated artifact guides in `artifacts/`. Supporting references live in `references/`.
+
+**This iteration covers unit tests only.** Integration tests (WebApplicationFactory, multi-service) are out of scope.
+
+---
+
+## §1. Testability Foundations
+
+### C# (.NET)
+
+In Clean Architecture the dependency direction (Presentation → Application → Domain) means the Domain layer has **zero external dependencies** — domain entity tests need no mocks, no file I/O, no database. They are pure logic tests.
+
+The project has **no mocking framework** (no Moq/NSubstitute). This is intentional: since persistence is local JSON files, real implementations with temporary copies of `data.test.json` provide better confidence than fakes without adding infrastructure complexity. All Infrastructure-layer tests use this pattern.
+
+Application-layer tests (parsers, validators) also need no mocks — they are pure transformation logic with no system boundary.
+
+**When a C# test requires a mocking framework, it signals a layer violation** — business logic has leaked into Infrastructure, or a Domain type has an inappropriate external dependency.
+
+### TypeScript (React)
+
+The API client (`financialApiClient.ts`) is the single system boundary in the frontend. All component tests mock it via `vi.mock('../../api/financialApiClient')`. This is the correct boundary: mock where code crosses from your code into external HTTP.
+
+React Testing Library tests are the TypeScript equivalent of unit tests — they test user-visible component behavior without coupling to implementation details (internal state, CSS class names, component structure).
+
+**The mock boundary rule**: mock the API client factory once at the module level, not individual fetch calls. Utility functions and config helpers should be tested with real implementations.
+
+---
+
+## §2. Testing Criteria
+
+### Worth Testing
+
+**C#**
+- Domain entity state changes after operations (e.g., `AddTransaction` updates `AveragePrice`)
+- Domain entity guard clauses and validation (e.g., `ArgumentException` on empty Id)
+- Value object equality, immutability, and construction validation
+- Parser/validator branching: canonical normalization, null/empty handling, invalid input rejection
+- Infrastructure service CRUD operations via real temp file
+- Serialization round-trips (serialize → deserialize → structural equality)
+
+**TypeScript**
+- Page components: data displayed after mock API resolves, loading/error states, user interactions (form submit, navigation links)
+- Shared components: render with different props (error message shown, loading spinner visible)
+- Config/utility: pure functions with branching or transformation logic
+
+### NOT Worth Testing
+
+- C#: trivial getters/setters with no logic, xUnit framework behavior, FluentAssertions library itself
+- C#: serializer property mapping with no custom transformation logic
+- TypeScript: React rendering mechanics, Recharts chart rendering internals, CSS class names
+- TypeScript: API client method signatures (TypeScript's type checker covers that)
+- Either: mirror tests that duplicate the return value as the assertion
+
+---
+
+## §3. Feature Implementation Checklist
+
+When implementing a new feature, walk through each row and check the required tests exist.
+
+**C# (.NET)**
+
+| Artifact created/modified | Required tests | Guide |
+|---|---|---|
+| Domain entity with new method | `[Fact]`: state change + guard clause | `artifacts/domain-entities.md` |
+| Value object | `[Fact]`: equality, immutability, construction | `artifacts/value-objects.md` |
+| Application parser/validator | `[Theory]` + `[InlineData]`: all branches, null/empty | `artifacts/application-parsers.md` |
+| Infrastructure service (CRUD) | Real temp file + factory method | `artifacts/infrastructure-services.md` |
+| Serialization change | Round-trip test | `artifacts/serialization.md` |
+
+**TypeScript (React)**
+
+| Artifact created/modified | Required tests | Guide |
+|---|---|---|
+| New page (`*Page.tsx`) | Render + API mock + user interactions | `artifacts/react-pages.md` |
+| Shared component (`*.tsx`) | Render with variant props | `artifacts/react-components.md` |
+| Utility / config function | Pure function test | `artifacts/api-client.md` |
+
+---
+
+## §4. Artifact Quick Reference
+
+### C# (.NET)
+
+| Artifact Type | Identification | Guide |
+|---|---|---|
+| Domain Entities | Classes in `Financial.Domain/` with factory methods | `artifacts/domain-entities.md` |
+| Value Objects | Immutable types in `Financial.Domain/` | `artifacts/value-objects.md` |
+| Application Parsers/Validators | `*Parser.cs`, `*Validator.cs` in `Financial.Application/` | `artifacts/application-parsers.md` |
+| Infrastructure Services | `*Service.cs` in `Financial.Infrastructure/` | `artifacts/infrastructure-services.md` |
+| Serialization | `*Serializer.cs`, `*Adapter.cs` in `Financial.Infrastructure/` | `artifacts/serialization.md` |
+
+### TypeScript (React)
+
+| Artifact Type | Identification | Guide |
+|---|---|---|
+| React Pages | `*Page.tsx` in `Financial.Web/src/pages/` | `artifacts/react-pages.md` |
+| Shared Components | `*.tsx` in `Financial.Web/src/components/` | `artifacts/react-components.md` |
+| API Client / Config / Utilities | `*.ts` in `Financial.Web/src/api/` | `artifacts/api-client.md` |
+| Future types (Commands, Queries, Hooks) | — | `artifacts/future-types.md` |
+
+---
+
+## §5. Anti-patterns — Do NOT Do This
+
+**C# (.NET)**
+- ❌ **Mock domain entities or value objects** — they have no external dependencies; use real objects
+- ❌ **Skip guard clause tests** — an unchecked invariant is an untested business rule
+- ❌ **Share mutable objects across `[Theory]` data sets** — xUnit collects data before running; shared state causes cross-contamination (see `references/gotchas.md`)
+- ❌ **Use `[MemberData]` with magic strings** — use `[MemberData(nameof(DataProperty))]` for rename safety
+- ❌ **Put `File.Delete(tempFile)` in an Assert block** — a failing assertion skips cleanup; always use `finally` (see `references/gotchas.md`)
+- ❌ **Check multiple properties without `AssertionScope`** — one failure hides all others
+
+**TypeScript (React)**
+- ❌ **Mock individual `fetch` calls** — mock the factory at the module boundary (`vi.mock('../../api/financialApiClient')`)
+- ❌ **Test internal state or CSS class names** — test user-visible behavior via `screen` queries; implementation-detail tests break on refactor
+- ❌ **Use `container` instead of `screen`** — `container` couples tests to DOM structure
+- ❌ **Forget `mockReset()` in `beforeEach`** — mock call counts and implementations leak between tests (see `references/gotchas.md`)
+- ❌ **Use `getBy*` for async content** — use `screen.findBy*` or `waitFor` for content that appears after an API call resolves
+
+---
+
+## §6. Scope Note
+
+This guide covers **unit tests**: tests that run in-process with no network, no real HTTP server, and no browser. For C# Infrastructure tests, "unit" includes real JSON file I/O via temp files — this project's persistence layer has no complexity that warrants a fake.
+
+API endpoint tests (WebApplicationFactory) and browser-level E2E tests are out of scope for this iteration.
+
+---
+
+## §7. References
+
+| Topic | File |
+|---|---|
+| Local JSON file test strategy | `references/external-systems.md` |
+| Mock boundary rules (C# and TypeScript) | `references/mock-health-rules.md` |
+| File naming, directory structure, conventions | `references/file-conventions.md` |
+| Stack-specific gotchas and pitfalls | `references/gotchas.md` |
+
+---
+
+## §8. How to Use This Guide
+
+- **This file (SKILL.md)** — always loaded. Contains core rules, quick reference, and anti-patterns.
+- **`artifacts/`** — one file per artifact type. Read when creating or modifying that artifact.
+- **`references/`** — supporting content. Read for mock strategies, conventions, or gotchas.
+
+When working on a feature:
+1. Check §3 to identify which artifacts need tests
+2. Read the corresponding `artifacts/*.md` file for the full recipe
+3. Consult `references/` as needed for setup details, conventions, or pitfalls

--- a/.claude/skills/testing-guide-Financial/artifacts/api-client.md
+++ b/.claude/skills/testing-guide-Financial/artifacts/api-client.md
@@ -1,0 +1,76 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# API Client / Config / Utilities (`*.ts` in `Financial.Web/src/api/`)
+
+## What to test
+
+- **`config.ts`**: the exported URL is read from `import.meta.env.API_BASE_URL` — use `vi.stubEnv` to inject the env var and verify the value
+- **`financialApiClient.ts`**: the client itself is tested indirectly through page component tests via `vi.mock`. Add direct tests only if there is pure transformation logic (e.g., mapping a raw response shape to an internal DTO) that is separate from the HTTP call
+- **Pure utility functions**: any `.ts` function with branching or transformation logic
+
+## Layer assignment
+
+**Unit** — pure functions, no DOM, no HTTP calls. Config tests use `vi.stubEnv` to inject environment variables.
+
+## Setup pattern
+
+```typescript
+// Config test — must reset modules so env var change is re-evaluated at import time
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+describe('config', () => {
+  beforeEach(() => {
+    vi.resetModules()     // force re-import so stubbed env is picked up
+    vi.unstubAllEnvs()
+  })
+
+  it('reads API_BASE_URL from environment', async () => {
+    vi.stubEnv('API_BASE_URL', 'http://test-api.example.com')
+
+    const { apiBaseUrl } = await import('./config')
+
+    expect(apiBaseUrl).toBe('http://test-api.example.com')
+  })
+
+  it('returns empty string when API_BASE_URL is not set', async () => {
+    // env var not stubbed — falls back to undefined / empty
+
+    const { apiBaseUrl } = await import('./config')
+
+    expect(apiBaseUrl).toBe('')
+  })
+})
+
+// Pure utility function test
+import { describe, it, expect } from 'vitest'
+import { transformResponseData } from './utils'
+
+describe('transformResponseData', () => {
+  it('maps raw response fields to internal shape', () => {
+    const raw = { raw_field: 'value', amount: 100 }
+
+    const result = transformResponseData(raw)
+
+    expect(result.mappedField).toBe('value')
+    expect(result.amount).toBe(100)
+  })
+
+  it('handles empty response', () => {
+    const result = transformResponseData({})
+
+    expect(result).toBeDefined()
+  })
+})
+```
+
+**`vi.resetModules()`**: required when testing config values because `import.meta.env.*` is evaluated at module load time. Without resetting, a cached module is returned and the stubbed env is never read.
+
+## When to skip
+
+- HTTP fetch calls inside `financialApiClient.ts` — these are tested implicitly through page component tests that mock the client factory
+- TypeScript type definitions in `types.ts` — the compiler verifies these; no runtime test needed
+- The `createFinancialApiClient` factory function itself — it's a constructor wrapper; its behavior is covered by page tests
+
+## Examples from project
+
+`config.ts` reads `API_BASE_URL` from `import.meta.env`. A test that stubs this env var, resets modules, re-imports config, and asserts the exported value covers the environment variable wiring without making any HTTP call.

--- a/.claude/skills/testing-guide-Financial/artifacts/application-parsers.md
+++ b/.claude/skills/testing-guide-Financial/artifacts/application-parsers.md
@@ -1,0 +1,80 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# Application Parsers / Validators (`*Parser.cs`, `*Validator.cs` in `Financial.Application/`)
+
+## What to test
+
+- **Normalization**: valid inputs map to their canonical form (case-insensitive matching, trimming, etc.)
+- **Rejection**: invalid or unknown inputs return `false` / throw, with no output value
+- **Null and empty**: explicit cases for `null`, `""`, `"   "` (whitespace-only)
+- **All known branches**: each recognized value in a `switch`/`if` chain has at least one passing test
+
+## Layer assignment
+
+**Unit only** — parsers and validators are pure logic with no external dependencies or I/O. No setup beyond constructing the input string.
+
+## Setup pattern
+
+```csharp
+// Parameterized happy path — one [InlineData] row per canonical value + case variant
+[Theory]
+[InlineData("Dividend", "Dividend")]
+[InlineData("DIVIDEND", "Dividend")]
+[InlineData("dividend", "Dividend")]
+[InlineData("Rent", "Rent")]
+[InlineData("rENT", "Rent")]
+public void TryNormalize_WhenValueMatches_ReturnsCanonicalValue(string input, string expected)
+{
+    var result = Parser.TryNormalize(input, out var normalized);
+
+    result.Should().BeTrue();
+    normalized.Should().Be(expected);
+}
+
+// Null — cannot use [InlineData] for null; use [MemberData] with nameof
+public static IEnumerable<object?[]> NullValues => new[] { new object?[] { null } };
+
+[Theory]
+[MemberData(nameof(NullValues))]
+public void TryNormalize_WhenNull_ReturnsFalseAndEmpty(string? input)
+{
+    var result = Parser.TryNormalize(input, out var normalized);
+
+    result.Should().BeFalse();
+    normalized.Should().BeEmpty();
+}
+
+// Empty and whitespace
+[Theory]
+[InlineData("")]
+[InlineData("   ")]
+public void TryNormalize_WhenEmptyOrWhitespace_ReturnsFalse(string input)
+{
+    var result = Parser.TryNormalize(input, out _);
+
+    result.Should().BeFalse();
+}
+
+// Unknown value
+[Fact]
+public void TryNormalize_WhenUnknownValue_ReturnsFalse()
+{
+    var result = Parser.TryNormalize("NotAKnownType", out _);
+
+    result.Should().BeFalse();
+}
+```
+
+**`[MemberData]` rule**: always use `nameof()` — `[MemberData(nameof(NullValues))]` not `[MemberData("NullValues")]`.
+
+## When to skip
+
+- Validation that simply delegates to a .NET framework attribute (`[Required]`, `[Range]`) — the framework tests its own behavior
+
+## Examples from project
+
+| Instance | Test focus |
+|---|---|
+| `CreditTypeParser.TryNormalize` | All known types (Dividend, Rent, ...) in multiple casing variants; null; empty string; whitespace; unknown string |
+
+When adding new parsers, use `CreditTypeParser` and its test file (`CreditTypeParserTests.cs`) as the reference implementation.

--- a/.claude/skills/testing-guide-Financial/artifacts/domain-entities.md
+++ b/.claude/skills/testing-guide-Financial/artifacts/domain-entities.md
@@ -1,0 +1,82 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# Domain Entities (Classes in `Financial.Domain/`)
+
+## What to test
+
+- State changes after operations (e.g., `AddTransaction` recalculates `AveragePrice` and `Quantity`)
+- Guard clauses that throw on invalid input (empty Id, null arguments, business rule violations)
+- Factory method validation (correct initial state after `Create(...)`)
+- State after multiple sequential operations (ordering matters for aggregate invariants)
+- Boolean flags that change with lifecycle (e.g., `Active` becomes false after a full sell)
+
+## Layer assignment
+
+**Unit only** — domain entities have zero external dependencies (no I/O, no framework). Instantiate → call method → assert observable state. No mocks, no temp files, no async setup.
+
+## Setup pattern
+
+```csharp
+// Basic state change
+[Fact]
+public void MethodName_Condition_ExpectedResult()
+{
+    // Arrange — use factory methods, not constructors directly
+    var entity = Entity.Create("Name", "Param");
+    var dependency = DependentEntity.Create(/* params */);
+
+    // Act
+    entity.DoOperation(dependency);
+
+    // Assert
+    entity.Property.Should().Be(expectedValue);
+    entity.Collection.Should().HaveCount(1);
+}
+
+// Guard clause
+[Fact]
+public void MethodName_WhenInputInvalid_Throws()
+{
+    var entity = Entity.Create("Name", "Param");
+    var invalid = CreateInvalidInput();
+
+    Action act = () => entity.DoOperation(invalid);
+
+    act.Should().Throw<ArgumentException>();
+}
+
+// Multiple properties — use AssertionScope so all failures are reported
+[Fact]
+public void MethodName_AllPropertiesUpdated()
+{
+    var entity = Entity.Create(/* params */);
+
+    entity.DoOperation(/* params */);
+
+    using (new AssertionScope())
+    {
+        entity.Property1.Should().Be(expected1);
+        entity.Property2.Should().Be(expected2);
+        entity.Property3.Should().Be(expected3);
+    }
+}
+```
+
+## When to skip
+
+- Properties that are simple auto-properties with no logic
+- Factory methods that assign fields with no validation (covered implicitly by behavior tests)
+- Framework-managed lifecycle (EF Core tracking, etc.)
+
+## Examples from project
+
+| Instance | What to test |
+|---|---|
+| `Asset.AddTransaction(Buy)` | `Quantity` and `AveragePrice` recalculate correctly; `Active` = true |
+| `Asset.AddTransaction(Sell all)` | `Quantity` reaches 0; `Active` = false |
+| `Asset.UpdateTransaction(empty Id)` | `ArgumentException` thrown |
+| `Asset.AddTransaction` × 2 | Weighted average price across two buys |
+| `Broker.Create(...)` | Initial state: name and currency set correctly |
+| `Portfolio.AddAsset(...)` | Asset appears in `Assets` collection |
+| `Transaction.Create(...)` | Type, quantity, price, fees set correctly |
+| `Credit.Create(...)` | Date, type, value set correctly |

--- a/.claude/skills/testing-guide-Financial/artifacts/future-types.md
+++ b/.claude/skills/testing-guide-Financial/artifacts/future-types.md
@@ -1,0 +1,107 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# Future Artifact Types
+
+Proactive guidance for types not yet present but likely to be added.
+
+---
+
+## C# — Application Commands / Queries (CQRS handlers)
+
+If the Application layer introduces Commands and Queries (e.g., handled by MediatR or a custom dispatcher):
+
+- **Unit test the handler**: if the handler contains branching, use a manual inline stub for `IRepository` — no mocking framework needed.
+- **Integration test** (if warranted): use the same temp-file pattern as Infrastructure services.
+
+```csharp
+// Inline repository stub — define inside the test file
+private sealed class StubRepository : IRepository
+{
+    public Investments Data { get; set; } = Investments.Create();
+    public Task<Investments> GetAsync() => Task.FromResult(Data);
+    public Task SaveAsync(Investments investments) { Data = investments; return Task.CompletedTask; }
+}
+
+[Fact]
+public async Task Handler_WhenCondition_ExpectedResult()
+{
+    var repo = new StubRepository();
+    repo.Data = BuildTestData();
+    var handler = new SomeCommandHandler(repo);
+
+    var result = await handler.Handle(new SomeCommand { /* params */ }, CancellationToken.None);
+
+    result.Should().NotBeNull();
+}
+```
+
+---
+
+## C# — Domain Services
+
+Test like domain entities: pure unit tests with no I/O, no mocks. Instantiate the service with its real dependencies (domain objects, value objects), call the method, assert the result.
+
+---
+
+## TypeScript — Custom React Hooks (`use*.ts`)
+
+If pages extract data-fetching or state logic into custom hooks, test them with `renderHook` from `@testing-library/react` (included in the project's `@testing-library/react` 16.x).
+
+```typescript
+import { renderHook, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import { useMyHook } from '../hooks/useMyHook'
+
+const fetchMock = vi.fn()
+
+describe('useMyHook', () => {
+  beforeEach(() => fetchMock.mockReset())
+
+  it('fetches data on mount and returns it', async () => {
+    fetchMock.mockResolvedValue({ id: '1', name: 'Test' })
+
+    const { result } = renderHook(() => useMyHook(fetchMock))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.data).toEqual({ id: '1', name: 'Test' })
+  })
+
+  it('sets error when fetch rejects', async () => {
+    fetchMock.mockRejectedValue(new Error('network error'))
+
+    const { result } = renderHook(() => useMyHook(fetchMock))
+
+    await waitFor(() => expect(result.current.error).toBeTruthy())
+  })
+})
+```
+
+---
+
+## TypeScript — Pure Utility Functions
+
+Any pure TypeScript function added to the codebase:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { myUtility } from '../utils/myUtility'
+
+describe('myUtility', () => {
+  it('transforms input correctly', () => {
+    expect(myUtility('input')).toBe('expected output')
+  })
+
+  it('handles edge case', () => {
+    expect(myUtility('')).toBe('')
+  })
+})
+```
+
+Place test files in a `__tests__/` directory next to the source file being tested.
+
+---
+
+## C# — Application DTOs with Validation Attributes
+
+If DTOs gain validation attributes (e.g., `[Required]`, `[Range]`), test them through the API endpoint tests (WebApplicationFactory), not as unit tests. Validation attribute behavior is a framework concern.

--- a/.claude/skills/testing-guide-Financial/artifacts/infrastructure-services.md
+++ b/.claude/skills/testing-guide-Financial/artifacts/infrastructure-services.md
@@ -1,0 +1,101 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# Infrastructure Services (`*Service.cs` in `Financial.Infrastructure/`)
+
+## What to test
+
+- **Add**: created entity appears in subsequent read result with correct field values
+- **Update**: mutated fields are reflected in subsequent read; non-mutated fields are unchanged
+- **Delete**: removed entity is absent from subsequent read; other entities are unaffected
+- **Query**: reads return the expected subset of data given known test data
+- **Error conditions**: operations on non-existent entities behave as specified (return null, throw, etc.)
+
+## Layer assignment
+
+**Integration via real temp file** — Infrastructure services coordinate the repository and domain layer. Use real implementations with a temporary copy of `TestData/data.test.json`. No mocking framework.
+
+This is still considered "unit" for this project because the persistence layer is a local file with no external complexity.
+
+## Setup pattern
+
+```csharp
+[Fact]
+public async Task OperationName_Condition_ExpectedOutcome()
+{
+    var (service, tempFile) = CreateService();
+    try
+    {
+        var request = new OperationCreateDTO
+        {
+            BrokerName = "XPI",
+            PortfolioName = "Default",
+            AssetName = "BCIA11",
+            // ... other fields matching the seed data
+        };
+
+        var result = await service.DoOperationAsync(request);
+
+        result.Should().NotBeNull();
+        result!.SomeCollection.Should().ContainSingle(item =>
+            item.Field == request.Field &&
+            item.Id != Guid.Empty);
+    }
+    finally
+    {
+        File.Delete(tempFile);  // ALWAYS in finally — never in Assert block
+    }
+}
+
+// Delete scenario — assert absence
+[Fact]
+public async Task RemoveItem_ItemIsAbsentAfterDeletion()
+{
+    var (service, tempFile) = CreateService();
+    try
+    {
+        // Get a known ID from the seed data first
+        var existing = await service.GetAsync(/* known broker/portfolio/asset */);
+        var idToDelete = existing!.Items.First().Id;
+
+        await service.RemoveAsync(new RemoveDTO { Id = idToDelete, /* locators */ });
+
+        var updated = await service.GetAsync(/* same locators */);
+        updated!.Items.Should().NotContain(item => item.Id == idToDelete);
+    }
+    finally
+    {
+        File.Delete(tempFile);
+    }
+}
+
+// Factory method — copy this pattern for each service under test
+private static (SomeService Service, string TempFile) CreateService()
+{
+    var tempFile = Path.Combine(Path.GetTempPath(), $"data.test.{Guid.NewGuid():N}.json");
+    File.Copy(TestDataPaths.DataJsonFile, tempFile, true);
+
+    var storage = new LocalJsonStorage(tempFile);
+    var serializer = new InvestmentsSerializerAdapter();
+    var repository = new JSONRepository(
+        InvestmentsLoader.LoadSync(storage, serializer),
+        storage,
+        serializer);
+    var navigationService = new NavigationService(repository);
+    var service = new SomeService(repository, navigationService);
+
+    return (service, tempFile);
+}
+```
+
+**Why `finally`**: if the assertion throws, code after the assertion is skipped. `finally` runs regardless, preventing temp file accumulation. See `references/gotchas.md`.
+
+## When to skip
+
+- Service methods that are pure delegation to a single repository call with no branching or domain logic (tested by the repository tests)
+
+## Examples from project
+
+| Service | Operations to test |
+|---|---|
+| `CreditService` | AddCredit (appears in result, Id not empty), UpdateCredit (fields updated), RemoveCredit (absent after delete) |
+| `NavigationService` | GetNavigationTree returns hierarchy with expected brokers/portfolios/assets |

--- a/.claude/skills/testing-guide-Financial/artifacts/react-components.md
+++ b/.claude/skills/testing-guide-Financial/artifacts/react-components.md
@@ -1,0 +1,66 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# Shared Components (`*.tsx` in `Financial.Web/src/components/`)
+
+## What to test
+
+- **Prop-driven rendering**: component renders the correct content for each prop variant
+- **Conditional output**: elements that appear only under certain prop combinations (e.g., a retry button that appears only when `onRetry` is provided)
+- **Callback props**: interactive components invoke the provided callback when triggered
+- **ARIA semantics**: if the component has accessibility-critical attributes, verify them
+
+## Layer assignment
+
+**Component test (unit)** — render in isolation with `render()` from Testing Library, no router needed unless the component uses `Link`. No API mocking needed — shared components receive all data via props.
+
+## Setup pattern
+
+```typescript
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ComponentName } from '../ComponentName'
+
+describe('ComponentName', () => {
+  it('renders the provided message', () => {
+    render(<ComponentName message="Something went wrong" />)
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+  })
+
+  it('renders retry button when onRetry is provided', () => {
+    render(<ComponentName message="Error" onRetry={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+  })
+
+  it('does not render retry button when onRetry is not provided', () => {
+    render(<ComponentName message="Error" />)
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('calls onRetry when retry button is clicked', () => {
+    const onRetry = vi.fn()
+    render(<ComponentName message="Error" onRetry={onRetry} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+})
+```
+
+**`queryByRole` vs `getByRole`**: use `queryBy*` when asserting absence (it returns `null` instead of throwing). Use `getBy*` when the element is expected to be present.
+
+## When to skip
+
+- Components with no props and no conditional logic (static markup wrappers with no behavior)
+- Purely visual components (spinners, dividers) with no interactive behavior or prop-driven content
+
+## Examples from project
+
+| Component | Key test scenarios |
+|---|---|
+| `ErrorState` | Error message displayed; retry button shown when `onRetry` provided, hidden otherwise; callback invoked on click |
+| `LoadingState` | Loading indicator rendered (verify by role or text, not CSS class) |
+| `NavigationTreePanel` | Tree nodes rendered from `items` prop; selection callback called with correct node when clicked |

--- a/.claude/skills/testing-guide-Financial/artifacts/react-pages.md
+++ b/.claude/skills/testing-guide-Financial/artifacts/react-pages.md
@@ -1,0 +1,120 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# React Pages (`*Page.tsx` in `Financial.Web/src/pages/`)
+
+## What to test
+
+- **Data display**: after mock API resolves, expected labels and values appear in the DOM
+- **Loading state**: if a loading indicator is rendered before the API resolves, verify its presence
+- **Error state**: when the mock API rejects, the error message appears
+- **User interactions**: form submission calls the API mock with the correct arguments
+- **Navigation links**: links have the correct `href` attribute
+- **State changes after mutation**: after add/update/delete, the updated content is visible
+
+## Layer assignment
+
+**Component test (unit-level for TypeScript)** — render the page in a `MemoryRouter`, mock the API client factory at the module boundary, assert user-visible output via `screen` queries.
+
+## Setup pattern
+
+```typescript
+// Declare mocks BEFORE vi.mock() call (vi.mock is hoisted — see references/gotchas.md)
+const getDataMock = vi.fn()
+const submitMock = vi.fn()
+
+vi.mock('../../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getRelevantData: getDataMock,
+    submitData: submitMock,
+    // include only methods this page actually calls
+  }),
+}))
+
+describe('SomePage', () => {
+  beforeEach(() => {
+    getDataMock.mockReset()   // resets call count AND implementation
+    submitMock.mockReset()
+  })
+
+  it('displays data after API resolves', async () => {
+    getDataMock.mockResolvedValue(mockData satisfies SomeDto)
+
+    render(
+      <MemoryRouter initialEntries={['/path/to/page']}>
+        <Routes>
+          <Route path="/path/to/page" element={<SomePage />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    // Use findBy* (async) for content that appears after API resolves
+    expect(await screen.findByText('Expected Label')).toBeInTheDocument()
+    expect(screen.getByText('Expected Value')).toBeInTheDocument()
+  })
+
+  it('displays error when API rejects', async () => {
+    getDataMock.mockRejectedValue(new Error('network error'))
+
+    render(/* same MemoryRouter setup */)
+
+    expect(await screen.findByText(/error/i)).toBeInTheDocument()
+  })
+
+  it('submits form with correct arguments', async () => {
+    getDataMock.mockResolvedValue(mockData)
+    submitMock.mockResolvedValue(updatedData)
+
+    render(/* MemoryRouter */)
+
+    await screen.findByText('Expected Label') // wait for page to load
+
+    fireEvent.change(screen.getByRole('spinbutton', { name: /quantity/i }), {
+      target: { value: '5' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(submitMock).toHaveBeenCalledWith(
+        expect.objectContaining({ quantity: 5 })
+      )
+    })
+  })
+
+  it('navigation link points to correct route', async () => {
+    getDataMock.mockResolvedValue(mockData)
+    render(/* MemoryRouter */)
+
+    await screen.findByText('Expected Label')
+
+    const link = screen.getByRole('link', { name: /broker name/i })
+    expect(link).toHaveAttribute('href', '/expected/path')
+  })
+})
+```
+
+**Mock data pattern** — use `satisfies` for type safety:
+```typescript
+const mockData = {
+  name: 'BCIA11',
+  brokerName: 'XPI',
+  portfolioName: 'Default',
+  // ...
+} satisfies AssetDetailsDto
+```
+
+## When to skip
+
+- Recharts chart rendering details (SVG structure, axis label positions)
+- URL path matching behavior (router's responsibility — test the `href` attribute value instead)
+
+## Examples from project
+
+| Page | Key test scenarios |
+|---|---|
+| `AssetDetailPage` | Asset details displayed, transaction add/update/delete, credit add/remove, form field values |
+| `BrokersPage` | Broker list rendered, links to broker detail pages have correct href |
+| `BrokerDetailPage` | Broker info and portfolio list displayed |
+| `CreditsPage` | Credits list for broker/portfolio/asset displayed |
+| `CurrentValuesPage` | Asset value rows displayed with correct amounts |
+| `DividendCheckPage` | Dividend check results displayed |
+| `NavigationTreePage` | Tree nodes rendered, selection triggers navigation |

--- a/.claude/skills/testing-guide-Financial/artifacts/serialization.md
+++ b/.claude/skills/testing-guide-Financial/artifacts/serialization.md
@@ -1,0 +1,86 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# Serialization (`*Serializer.cs`, `*Adapter.cs` in `Financial.Infrastructure/`)
+
+## What to test
+
+- **Round-trip**: `Deserialize(Serialize(x))` returns a structurally equivalent object graph
+- **Object graph preservation**: nested collections (Brokers → Portfolios → Assets → Transactions/Credits) survive the round-trip
+- **Field correctness**: specific field values (name, currency, type, quantity) are preserved, not just that the result is non-null
+- **Non-empty output**: serialized output is a non-empty string
+
+## Layer assignment
+
+**Unit** — serialization is pure transformation: domain graph → JSON string → domain graph. No file I/O, no async, no external services in the serializer itself.
+
+Note: `InvestmentsLoader.LoadSync` reads from an `IStorage` implementation. That integration is tested in Infrastructure service tests. Serializer tests focus on the serialize/deserialize logic alone.
+
+## Setup pattern
+
+```csharp
+[Fact]
+public void SerializeDeserialize_RoundTripPreservesStructure()
+{
+    // Build a representative object graph using domain factory methods
+    var investments = Investments.Create();
+    var broker = Broker.Create("Broker A", "USD");
+    var portfolio = broker.AddPortfolio("Default");
+    portfolio.AddAsset(Asset.Create("Asset A", "ISIN123", "NYSE", "AAA"));
+    investments.AddBroker(broker);
+
+    // Serialize then deserialize
+    var json = InvestmentsJsonSerializer.Serialize(investments);
+    var result = InvestmentsJsonSerializer.Deserialize(json);
+
+    // Assert structure — use .Which to drill into single-element collections
+    result.Should().NotBeNull();
+    var brokerResult = result.Brokers.Should().ContainSingle().Which;
+    brokerResult.Name.Should().Be("Broker A");
+    var portfolioResult = brokerResult.Portfolios.Should().ContainSingle().Which;
+    portfolioResult.Assets.Should().ContainSingle()
+        .Which.Name.Should().Be("Asset A");
+}
+
+[Fact]
+public void Serialize_ProducesNonEmptyJson()
+{
+    var investments = Investments.Create();
+    investments.AddBroker(Broker.Create("Broker A", "USD"));
+
+    var json = InvestmentsJsonSerializer.Serialize(investments);
+
+    json.Should().NotBeNullOrWhiteSpace();
+}
+
+// Round-trip with transactions and credits
+[Fact]
+public void SerializeDeserialize_PreservesTransactionsAndCredits()
+{
+    var investments = Investments.Create();
+    var broker = Broker.Create("Broker A", "USD");
+    var portfolio = broker.AddPortfolio("Default");
+    var asset = Asset.Create("Asset A", "ISIN123", "NYSE", "AAA");
+    asset.AddTransaction(Transaction.Create(new DateTime(2024, 1, 1),
+        Transaction.TransactionType.Buy, 10m, 5m, 0m));
+    portfolio.AddAsset(asset);
+    investments.AddBroker(broker);
+
+    var json = InvestmentsJsonSerializer.Serialize(investments);
+    var result = InvestmentsJsonSerializer.Deserialize(json);
+
+    result.Brokers.Single().Portfolios.Single().Assets.Single()
+        .Transactions.Should().ContainSingle()
+        .Which.Quantity.Should().Be(10m);
+}
+```
+
+## When to skip
+
+- JSON property name mapping with no custom logic (System.Text.Json handles this)
+- Adapter classes that only delegate to the underlying serializer without transformation
+
+## Examples from project
+
+| Instance | Test focus |
+|---|---|
+| `InvestmentsJsonSerializer` | Full hierarchy round-trip: Investments → Broker → Portfolio → Asset → Transactions + Credits |

--- a/.claude/skills/testing-guide-Financial/artifacts/value-objects.md
+++ b/.claude/skills/testing-guide-Financial/artifacts/value-objects.md
@@ -1,0 +1,77 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# Value Objects (Immutable types in `Financial.Domain/`)
+
+## What to test
+
+- **Equality**: two instances with same data are equal; different data are not equal
+- **Immutability**: operations return new instances rather than mutating the original
+- **Construction validation**: invalid inputs are rejected at construction time (e.g., negative amounts, null strings)
+- **Canonical form**: if a VO normalizes or transforms input (e.g., trims whitespace, normalizes currency code), assert the stored form
+
+## Layer assignment
+
+**Unit only** — value objects are pure data types with no external dependencies.
+
+## Setup pattern
+
+```csharp
+// Equality
+[Fact]
+public void TwoInstances_WithSameData_AreEqual()
+{
+    var a = ValueObject.Create("same");
+    var b = ValueObject.Create("same");
+
+    a.Should().Be(b);
+}
+
+[Fact]
+public void TwoInstances_WithDifferentData_AreNotEqual()
+{
+    var a = ValueObject.Create("one");
+    var b = ValueObject.Create("two");
+
+    a.Should().NotBe(b);
+}
+
+// Invalid construction
+[Fact]
+public void Create_WithNullInput_Throws()
+{
+    Action act = () => ValueObject.Create(null!);
+
+    act.Should().Throw<ArgumentException>();
+}
+
+// Immutability — operation returns new instance
+[Fact]
+public void Operation_ReturnsNewInstance_OriginalUnchanged()
+{
+    var original = ValueObject.Create("value");
+
+    var result = original.DoOperation();
+
+    result.Should().NotBeSameAs(original);
+    original.Property.Should().Be("value"); // unchanged
+}
+
+// Canonical form
+[Theory]
+[InlineData("usd", "USD")]
+[InlineData(" USD ", "USD")]
+public void Create_NormalizesInput(string input, string expected)
+{
+    var vo = ValueObject.Create(input);
+
+    vo.Value.Should().Be(expected);
+}
+```
+
+## When to skip
+
+- C# `record` types where the compiler generates structural equality and there is no custom validation or normalization logic
+
+## Examples from project
+
+Document value object instances here as they are added to the domain. As of the current codebase, value objects are embedded within entity classes rather than as standalone types. If a value type is extracted into its own class, add it here with its specific test scenarios.

--- a/.claude/skills/testing-guide-Financial/references/external-systems.md
+++ b/.claude/skills/testing-guide-Financial/references/external-systems.md
@@ -1,0 +1,65 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# External Systems Test Strategy
+
+This project has **one external system**: the local JSON file that stores investment data. There are no databases, no Redis, no message queues, no external HTTP APIs in the backend.
+
+## Local JSON File Storage (C#)
+
+**Strategy: real temp file, real implementation.**
+
+| Consideration | Decision |
+|---|---|
+| Complexity | Low — JSON read/write, no schema migration |
+| Speed | Fast — file I/O < 10ms for test data size |
+| Isolation | Achieved via `Guid`-named temp file per test |
+| Cleanup | `File.Delete(tempFile)` in `finally` block |
+| Why not a fake? | No mocking framework in this project; file I/O is simple enough that faking it adds no benefit |
+
+### Setup
+
+```csharp
+var tempFile = Path.Combine(Path.GetTempPath(), $"data.test.{Guid.NewGuid():N}.json");
+File.Copy(TestDataPaths.DataJsonFile, tempFile, true);
+
+var storage = new LocalJsonStorage(tempFile);
+var serializer = new InvestmentsSerializerAdapter();
+var repository = new JSONRepository(
+    InvestmentsLoader.LoadSync(storage, serializer),
+    storage,
+    serializer);
+```
+
+### Test Data
+
+`TestData/data.test.json` is the seed file. It contains a minimal but representative dataset: at least one broker ("XPI"), one portfolio ("Default"), one asset ("BCIA11"), and existing transactions/credits.
+
+**Do not modify `data.test.json` directly in tests** — always write to the temp copy. The seed file must remain stable so all tests start from the same known state.
+
+### Cleanup
+
+```csharp
+try
+{
+    // act + assert
+}
+finally
+{
+    File.Delete(tempFile);  // runs whether the test passes or fails
+}
+```
+
+## HTTP API Client (TypeScript)
+
+The React frontend calls the .NET API. In tests, the API client is mocked at the module boundary:
+
+```typescript
+vi.mock('../../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getAssetDetails: getAssetDetailsMock,
+    // include only methods used by the component under test
+  }),
+}))
+```
+
+This eliminates all network dependency from frontend tests. There is no Docker setup or test server for frontend unit tests — the mock replaces the HTTP call entirely.

--- a/.claude/skills/testing-guide-Financial/references/file-conventions.md
+++ b/.claude/skills/testing-guide-Financial/references/file-conventions.md
@@ -1,0 +1,108 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# File Naming and Directory Conventions
+
+## C# (.NET)
+
+### Project structure
+
+Tests live in **separate projects** under `Tests/` — not colocated with source files:
+
+```
+Tests/
+├── Financial.Domain.Tests/        ← pure domain logic tests
+├── Financial.Application.Tests/   ← parsers, validators, use case handlers
+├── Financial.Infrastructure.Tests/ ← services, repositories, serialization
+└── Financial.Api.Tests/           ← WebApplicationFactory endpoint tests (out of scope for unit guide)
+```
+
+Each test project references only its counterpart source project.
+
+### Naming conventions
+
+| Element | Convention | Example |
+|---|---|---|
+| Test file | `{SubjectName}Tests.cs` | `AssetTests.cs`, `CreditTypeParserTests.cs` |
+| Test class | `{SubjectName}Tests` | `public class AssetTests` |
+| Test method | `{MethodName}_{Condition}_{ExpectedResult}` | `AddTransaction_Buy_UpdatesAveragePriceAndQuantity` |
+| Factory helper | `Create{SubjectName}()` | `private static (CreditService, string) CreateService()` |
+
+### Global usings
+
+xUnit is available globally via `.csproj` `<Using Include="Xunit" />`. Do **not** add `using Xunit;` in individual test files.
+
+FluentAssertions and other namespaces must still be explicitly imported unless added to `GlobalUsings.cs`.
+
+### Test data
+
+```
+Tests/Financial.Infrastructure.Tests/
+└── TestData/
+    └── data.test.json    (CopyToOutputDirectory: Always)
+
+Tests/Financial.Api.Tests/
+└── TestData/
+    └── data.test.json    (CopyToOutputDirectory: PreserveNewest)
+```
+
+Access via:
+```csharp
+internal static class TestDataPaths
+{
+    public static string DataJsonFile =>
+        Path.Combine(AppContext.BaseDirectory, "TestData", "data.test.json");
+}
+```
+
+---
+
+## TypeScript (React)
+
+### Directory structure
+
+Tests live in `__tests__/` subdirectories next to the files they test:
+
+```
+Financial.Web/src/
+├── pages/
+│   ├── BrokersPage.tsx
+│   └── __tests__/
+│       └── BrokersPage.test.tsx
+├── components/
+│   ├── ErrorState.tsx
+│   └── __tests__/               ← create when adding component tests
+│       └── ErrorState.test.tsx
+├── api/
+│   ├── config.ts
+│   └── __tests__/               ← create when adding utility tests
+│       └── config.test.ts
+├── App.tsx
+└── App.test.tsx                  ← colocated at src root
+```
+
+### Naming conventions
+
+| Element | Convention | Example |
+|---|---|---|
+| Test file | `{ComponentName}.test.tsx` or `{FileName}.test.ts` | `BrokersPage.test.tsx`, `config.test.ts` |
+| Describe block | Component name | `describe('BrokersPage', () => {` |
+| Test name | User-centric description | `it('displays broker list after API resolves')` |
+
+### Test runner commands
+
+```bash
+npm test           # single run (CI)
+npm run test:watch # watch mode (development)
+```
+
+### Configuration files
+
+| File | Purpose |
+|---|---|
+| `vite.config.ts` | Vitest config (test environment: jsdom, setup file) |
+| `src/setupTests.ts` | Global setup: jest-dom matchers + ResizeObserver mock |
+| `tsconfig.app.json` | Includes `@testing-library/jest-dom` types |
+
+### Coverage philosophy
+
+Pragmatic — test business-critical paths and user-visible behavior. No specific coverage % target. Focus test effort on pages with complex interactions and domain-logic-adjacent code.

--- a/.claude/skills/testing-guide-Financial/references/gotchas.md
+++ b/.claude/skills/testing-guide-Financial/references/gotchas.md
@@ -1,0 +1,164 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# Stack-Specific Gotchas and Pitfalls
+
+---
+
+## C# (.NET)
+
+### Temp file leak on test failure
+
+If `File.Delete(tempFile)` is after an assertion and the assertion fails, the file is never deleted.
+
+```csharp
+// ❌ File leaks if assertion throws
+var result = await service.AddAsync(request);
+result.Should().NotBeNull();
+File.Delete(tempFile);   // skipped on failure
+
+// ✅ Always in finally
+try
+{
+    var result = await service.AddAsync(request);
+    result.Should().NotBeNull();
+}
+finally
+{
+    File.Delete(tempFile);
+}
+```
+
+### xUnit Theory data sharing
+
+xUnit collects all `[Theory]` data before running any test. If data rows share a mutable object, state from one run leaks into another.
+
+```csharp
+// ❌ All rows share the same list instance
+private static readonly List<string> shared = new() { "a" };
+public static IEnumerable<object[]> Data => new[] { new object[] { shared } };
+
+// ✅ New instance per row
+public static IEnumerable<object[]> Data => new[]
+{
+    new object[] { new List<string> { "a" } }
+};
+```
+
+### null in [InlineData]
+
+`null` is not a valid C# attribute argument. Use `[MemberData]` for null test cases.
+
+```csharp
+// ❌ Does not compile
+[InlineData(null)]
+
+// ✅
+public static IEnumerable<object?[]> NullCases => new[] { new object?[] { null } };
+[Theory, MemberData(nameof(NullCases))]
+public void Method_WithNull_ReturnsFalse(string? input) { ... }
+```
+
+### Multiple assertion failures hidden
+
+FluentAssertions stops at the first failure by default. Wrap multiple assertions in `AssertionScope` to see all failures at once.
+
+```csharp
+// ❌ Only first failure reported
+asset.Quantity.Should().Be(10);
+asset.AveragePrice.Should().Be(5);
+
+// ✅ All failures reported in one test run
+using (new AssertionScope())
+{
+    asset.Quantity.Should().Be(10);
+    asset.AveragePrice.Should().Be(5);
+    asset.Active.Should().BeTrue();
+}
+```
+
+### [MemberData] magic strings
+
+```csharp
+[MemberData("NullValues")]        // ❌ silently passes after rename
+[MemberData(nameof(NullValues))]  // ✅ compile error after rename
+```
+
+---
+
+## TypeScript (React)
+
+### vi.mock hoisting
+
+`vi.mock(...)` is hoisted to the top of the file before all imports. Variables declared in module scope with `const`/`let` are NOT hoisted. The safe pattern is to declare `vi.fn()` at module scope and reference it inside the mock factory:
+
+```typescript
+// ✅ vi.fn() declared at module scope is initialized before the hoisted mock runs
+const getDataMock = vi.fn()
+
+vi.mock('../../api/financialApiClient', () => ({
+  createFinancialApiClient: () => ({ getData: getDataMock }),
+}))
+```
+
+### Mock pollution between tests
+
+`mockReset()` resets both call count and implementation. `mockClear()` resets only call count (keeps the implementation). Use `mockReset()` in `beforeEach` unless you set the implementation once for all tests in a `describe` block.
+
+```typescript
+beforeEach(() => {
+  getDataMock.mockReset()   // ✅ clean slate each test
+})
+```
+
+### screen vs container
+
+```typescript
+// ✅ Query by role/text/label — user-centric
+screen.getByRole('button', { name: /save/i })
+
+// ❌ Couples to DOM structure, breaks on refactor
+container.querySelector('button.save-btn')
+```
+
+### Async assertions — getBy vs findBy
+
+`getBy*` throws immediately if the element is not present. For content that appears after an API call resolves, always use `findBy*` (returns a Promise) or `waitFor`.
+
+```typescript
+// ❌ Fails immediately — component hasn't rendered async content yet
+const heading = screen.getByText('Asset Name')
+
+// ✅ Waits for the element to appear
+const heading = await screen.findByText('Asset Name')
+```
+
+### ResizeObserver not available in jsdom
+
+Recharts uses `ResizeObserver`, which jsdom does not implement. The project's `setupTests.ts` already provides a mock. Do **not** add a second mock in individual test files — it will conflict.
+
+### Re-importing modules after vi.stubEnv
+
+`import.meta.env.*` values are resolved at module load time. After calling `vi.stubEnv(...)`, you must reset and re-import the module to get the updated value:
+
+```typescript
+beforeEach(() => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+})
+
+it('reads env var', async () => {
+  vi.stubEnv('API_BASE_URL', 'http://test')
+  const { apiBaseUrl } = await import('./config')  // dynamic re-import
+  expect(apiBaseUrl).toBe('http://test')
+})
+```
+
+### mockReset vs mockClear vs mockRestore
+
+| Method | What it resets |
+|---|---|
+| `mockClear()` | Call count and call arguments only |
+| `mockReset()` | Call count + implementation (returns `undefined`) |
+| `mockRestore()` | Restores the original implementation (for `vi.spyOn` only) |
+
+Use `mockReset()` in `beforeEach` for standard test isolation. Use `mockRestore()` only when cleaning up a `vi.spyOn`.

--- a/.claude/skills/testing-guide-Financial/references/mock-health-rules.md
+++ b/.claude/skills/testing-guide-Financial/references/mock-health-rules.md
@@ -1,0 +1,66 @@
+> Part of the `testing-guide-Financial` skill (see `../SKILL.md`).
+
+# Mock Health Rules
+
+## The Boundary Rule
+
+**Mock across architecturally significant boundaries, not within.**
+
+A boundary is where your code hands off to something outside your control: a file system, an HTTP endpoint, a message broker. Within a single layer, use real objects.
+
+---
+
+## C# (.NET)
+
+This project has **no mocking framework** — and that is correct for the current architecture. The only external dependency is a local JSON file, which is simple enough to use real implementations with temp files.
+
+| Dependency | How to handle |
+|---|---|
+| Domain entities and value objects | Always real — these are the things being tested |
+| `JSONRepository` | Real instance with temp file (Infrastructure tests) |
+| `NavigationService` | Real instance — construct it with the same repository |
+| `LocalJsonStorage` | Real — it is just file I/O on the temp file |
+| `InvestmentsSerializerAdapter` | Real — serialization logic under test |
+| External HTTP API (if added in future) | Define a manual stub implementing the interface |
+
+### When a C# test needs many setup steps
+
+If constructing a service requires assembling many dependencies, the test is a signal — not a problem to solve with mocks. Consider:
+1. Does the factory method `CreateService()` cover reuse of this setup?
+2. Is the class doing too many things (SRP violation)?
+
+### Inline stubs for future Command/Query handlers
+
+If Application-layer handlers are added and need isolation from the real repository, use a minimal inline stub instead of a mocking framework:
+
+```csharp
+private sealed class StubRepository : IRepository
+{
+    public Investments Data { get; set; } = Investments.Create();
+    public Task<Investments> GetAsync() => Task.FromResult(Data);
+    public Task SaveAsync(Investments data) { Data = data; return Task.CompletedTask; }
+}
+```
+
+This is simpler than Moq for this project's scale and keeps the "no mocking framework" pattern.
+
+---
+
+## TypeScript (React)
+
+| Dependency | How to handle |
+|---|---|
+| `financialApiClient` factory | `vi.mock` the entire module once per test file |
+| `MemoryRouter` / `Routes` | Always real — pages require router context |
+| React context (if added) | Real test provider wrapping the component |
+| Individual `fetch` calls | Never — mock at the client factory, not lower |
+| Utility functions | Always real — they are pure functions being tested |
+| Child components | Real by default; only mock if a child has heavy side effects that are impossible to control in tests |
+
+### Mock scope
+
+One `vi.mock(...)` call per module per file. Do not add multiple partial mocks for the same module. If a page uses only 3 of 10 API methods, include only those 3 in the mock factory — missing methods are `undefined`, which will throw if accidentally called, making missing mocks visible.
+
+### Signal: too many vi.fn() calls in one test
+
+A test that creates many `vi.fn()` instances may be an integration test in disguise. Consider whether a real implementation with controlled input would be simpler and more meaningful.

--- a/Financial.Web/src/components/__tests__/ErrorState.test.tsx
+++ b/Financial.Web/src/components/__tests__/ErrorState.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import ErrorState from '../ErrorState'
+
+describe('ErrorState', () => {
+  it('renders the error message', () => {
+    render(<ErrorState message="Something went wrong" />)
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+  })
+
+  it('wraps content in an alert role', () => {
+    render(<ErrorState message="An error occurred" />)
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('does not render a retry button when onRetry is not provided', () => {
+    render(<ErrorState message="An error occurred" />)
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('renders a retry button when onRetry is provided', () => {
+    render(<ErrorState message="An error occurred" onRetry={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('calls onRetry when the retry button is clicked', () => {
+    const onRetry = vi.fn()
+    render(<ErrorState message="An error occurred" onRetry={onRetry} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+})

--- a/Financial.Web/src/components/__tests__/LoadingState.test.tsx
+++ b/Financial.Web/src/components/__tests__/LoadingState.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import LoadingState from '../LoadingState'
+
+describe('LoadingState', () => {
+  it('renders the default loading message', () => {
+    render(<LoadingState />)
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('renders a custom message when provided', () => {
+    render(<LoadingState message="Please wait..." />)
+
+    expect(screen.getByText('Please wait...')).toBeInTheDocument()
+  })
+})

--- a/Financial.Web/src/components/__tests__/NavigationTreePanel.test.tsx
+++ b/Financial.Web/src/components/__tests__/NavigationTreePanel.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import NavigationTreePanel from '../NavigationTreePanel'
+import type { FinancialApiClient } from '../../api/financialApiClient'
+import type { TreeNodeDto } from '../../api/types'
+
+const getNavigationTreeMock = vi.fn()
+
+vi.mock('../../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getNavigationTree: getNavigationTreeMock,
+  }),
+}))
+
+const stubTree: TreeNodeDto = {
+  nodeType: 'Investments',
+  displayName: 'All Investments',
+  metadata: {},
+  children: [
+    {
+      nodeType: 'Broker',
+      displayName: 'XPI (BRL)',
+      metadata: { BrokerName: 'XPI', Currency: 'BRL', PortfolioCount: 1, TotalAssets: 1 },
+      children: [],
+    },
+  ],
+}
+
+const renderPanel = (props?: { title?: string }) =>
+  render(
+    <MemoryRouter>
+      <NavigationTreePanel {...props} />
+    </MemoryRouter>,
+  )
+
+describe('NavigationTreePanel', () => {
+  beforeEach(() => {
+    getNavigationTreeMock.mockReset()
+  })
+
+  it('renders tree nodes after the API resolves', async () => {
+    getNavigationTreeMock.mockResolvedValue(stubTree)
+
+    renderPanel()
+
+    expect(await screen.findByText(/All Investments/)).toBeInTheDocument()
+    expect(screen.getByText(/XPI/)).toBeInTheDocument()
+  })
+
+  it('shows loading state while the API call is in flight', () => {
+    getNavigationTreeMock.mockReturnValue(new Promise(() => {}))
+
+    renderPanel()
+
+    expect(screen.getByText('Loading navigation tree...')).toBeInTheDocument()
+  })
+
+  it('shows error state when the API call fails', async () => {
+    getNavigationTreeMock.mockRejectedValue(new Error('Network error'))
+
+    renderPanel()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Network error')
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('renders the title prop as a heading', async () => {
+    getNavigationTreeMock.mockResolvedValue(stubTree)
+
+    renderPanel({ title: 'My Portfolio' })
+
+    expect(await screen.findByRole('heading', { name: 'My Portfolio' })).toBeInTheDocument()
+  })
+
+  it('renders broker link with correct href', async () => {
+    getNavigationTreeMock.mockResolvedValue(stubTree)
+
+    renderPanel()
+
+    await screen.findByText(/All Investments/)
+    expect(screen.getByRole('link', { name: /XPI/ })).toHaveAttribute('href', '/brokers/XPI')
+  })
+
+  it('retries the API call when the retry button is clicked', async () => {
+    getNavigationTreeMock
+      .mockRejectedValueOnce(new Error('First failure'))
+      .mockResolvedValueOnce(stubTree)
+
+    renderPanel()
+
+    await screen.findByRole('alert')
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText(/All Investments/)).toBeInTheDocument()
+    expect(getNavigationTreeMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/Tests/Financial.Application.Tests/Services/DividendServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/DividendServiceTests.cs
@@ -1,0 +1,245 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Application.Services;
+using Financial.Domain.Entities;
+using Financial.Domain.Rules;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace Financial.Application.Tests.Services;
+
+public class DividendServiceTests
+{
+    private readonly StubDividendDataSource _dataSource = new();
+    private readonly StubSnapshotSource _snapshotSource = new();
+
+    [Fact]
+    public void Constructor_WithNullDividendDataSource_Throws()
+    {
+        Action act = () => new DividendService(null!, _snapshotSource);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("dividendDataSource");
+    }
+
+    [Fact]
+    public void Constructor_WithNullSnapshotSource_Throws()
+    {
+        Action act = () => new DividendService(_dataSource, null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("snapshotSource");
+    }
+
+    [Fact]
+    public void GetDividendHistory_WithNullRequest_Throws()
+    {
+        var service = CreateService();
+
+        Action act = () => service.GetDividendHistory(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData("", "TICK")]
+    [InlineData("   ", "TICK")]
+    [InlineData("NYSE", "")]
+    [InlineData("NYSE", "  ")]
+    public void GetDividendHistory_WithMissingExchangeOrTicker_Throws(string exchange, string ticker)
+    {
+        var service = CreateService();
+
+        Action act = () => service.GetDividendHistory(new DividendLookupRequestDTO
+        {
+            Exchange = exchange,
+            Ticker = ticker
+        });
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void GetDividendHistory_WithNoDividends_ReturnsEmptyList()
+    {
+        _dataSource.Dividends = [];
+        var service = CreateService();
+
+        var result = service.GetDividendHistory(MakeRequest());
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetDividendHistory_OrdersByDateDescending()
+    {
+        _dataSource.Dividends =
+        [
+            new DividendValue(DividendType.Dividend, new DateTime(2020, 1, 1), 2.0m),
+            new DividendValue(DividendType.Dividend, new DateTime(2022, 1, 1), 4.0m),
+            new DividendValue(DividendType.Dividend, new DateTime(2021, 1, 1), 3.0m),
+        ];
+        var service = CreateService();
+
+        var result = service.GetDividendHistory(MakeRequest());
+
+        result[0].Date.Should().Be(new DateTime(2022, 1, 1));
+        result[1].Date.Should().Be(new DateTime(2021, 1, 1));
+        result[2].Date.Should().Be(new DateTime(2020, 1, 1));
+    }
+
+    [Fact]
+    public void GetDividendHistory_MapsTypeAndValue()
+    {
+        _dataSource.Dividends =
+        [
+            new DividendValue(DividendType.JCP, new DateTime(2021, 6, 1), 5.5m),
+        ];
+        var service = CreateService();
+
+        var item = service.GetDividendHistory(MakeRequest()).Should().ContainSingle().Which;
+
+        using (new AssertionScope())
+        {
+            item.Type.Should().Be("JCP");
+            item.Value.Should().Be(5.5m);
+            item.Date.Should().Be(new DateTime(2021, 6, 1));
+        }
+    }
+
+    [Fact]
+    public void GetDividendSummary_MapsSnapshotFields()
+    {
+        _dataSource.Dividends = [];
+        _snapshotSource.Snapshot = new AssetValueSnapshot("TICK", "Asset Name", 50m, DateTimeOffset.UtcNow);
+        var service = CreateService();
+
+        var result = service.GetDividendSummary(MakeRequest("NYSE", "TICK"));
+
+        using (new AssertionScope())
+        {
+            result.Exchange.Should().Be("NYSE");
+            result.Ticker.Should().Be("TICK");
+            result.Name.Should().Be("Asset Name");
+            result.CurrentPrice.Should().Be(50m);
+        }
+    }
+
+    [Fact]
+    public void GetDividendSummary_GroupsDividendsByYear()
+    {
+        _dataSource.Dividends =
+        [
+            new DividendValue(DividendType.Dividend, new DateTime(2020, 1, 1), 2.0m),
+            new DividendValue(DividendType.Dividend, new DateTime(2020, 6, 1), 3.0m),
+            new DividendValue(DividendType.Dividend, new DateTime(2019, 1, 1), 4.0m),
+        ];
+        var service = CreateService();
+
+        var result = service.GetDividendSummary(MakeRequest());
+
+        result.YearTotals.Should().HaveCount(2);
+        result.YearTotals.First(t => t.Year == 2020).Total.Should().Be(5.0m);
+        result.YearTotals.First(t => t.Year == 2019).Total.Should().Be(4.0m);
+    }
+
+    [Fact]
+    public void GetDividendSummary_CalculatesPriceMaxAndDiscount()
+    {
+        // One past year with total 6.0m → priceMax = 6.0 / 0.06 = 100m, price 80m → discount 20%
+        _dataSource.Dividends =
+        [
+            new DividendValue(DividendType.Dividend, new DateTime(2020, 1, 1), 6.0m),
+        ];
+        _snapshotSource.Snapshot = new AssetValueSnapshot("TICK", "Name", 80m, DateTimeOffset.UtcNow);
+        var service = CreateService();
+
+        var result = service.GetDividendSummary(MakeRequest());
+
+        using (new AssertionScope())
+        {
+            result.AverageDividendPerYear.Should().Be(6.0m);
+            result.PriceMaxBuy.Should().Be(6.0m / DividendValuationRules.RequiredYield);
+            result.DiscountPercent.Should().Be(20.0m);
+        }
+    }
+
+    [Fact]
+    public void GetDividendSummary_ExcludesCurrentYearFromAverage()
+    {
+        // Only current-year dividend — should be excluded → average and priceMax stay zero
+        _dataSource.Dividends =
+        [
+            new DividendValue(DividendType.Dividend, new DateTime(DateTime.Today.Year, 1, 1), 12.0m),
+        ];
+        var service = CreateService();
+
+        var result = service.GetDividendSummary(MakeRequest());
+
+        using (new AssertionScope())
+        {
+            result.AverageDividendPerYear.Should().Be(0m);
+            result.PriceMaxBuy.Should().Be(0m);
+        }
+    }
+
+    [Fact]
+    public void GetDividendSummary_LimitsAverageToLastFiveYears()
+    {
+        // 7 past years; latest 5 average to 5.0m, all 7 would average to ~3.86m
+        _dataSource.Dividends =
+        [
+            new DividendValue(DividendType.Dividend, new DateTime(2014, 1, 1), 1.0m),
+            new DividendValue(DividendType.Dividend, new DateTime(2015, 1, 1), 1.0m),
+            new DividendValue(DividendType.Dividend, new DateTime(2016, 1, 1), 1.0m),
+            new DividendValue(DividendType.Dividend, new DateTime(2017, 1, 1), 6.0m),
+            new DividendValue(DividendType.Dividend, new DateTime(2018, 1, 1), 6.0m),
+            new DividendValue(DividendType.Dividend, new DateTime(2019, 1, 1), 6.0m),
+            new DividendValue(DividendType.Dividend, new DateTime(2020, 1, 1), 6.0m),
+        ];
+        var service = CreateService();
+
+        var result = service.GetDividendSummary(MakeRequest());
+
+        // Latest 5 years (2020:6, 2019:6, 2018:6, 2017:6, 2016:1) → average = 25/5 = 5.0m
+        result.AverageDividendPerYear.Should().Be(5.0m);
+    }
+
+    [Fact]
+    public void GetDividendSummary_WithNoDividends_ReturnsZeroCalculations()
+    {
+        _dataSource.Dividends = [];
+        var service = CreateService();
+
+        var result = service.GetDividendSummary(MakeRequest());
+
+        using (new AssertionScope())
+        {
+            result.AverageDividendPerYear.Should().Be(0m);
+            result.PriceMaxBuy.Should().Be(0m);
+            result.DiscountPercent.Should().Be(0m);
+            result.YearTotals.Should().BeEmpty();
+            result.History.Should().BeEmpty();
+        }
+    }
+
+    private DividendService CreateService() => new(_dataSource, _snapshotSource);
+
+    private static DividendLookupRequestDTO MakeRequest(string exchange = "NYSE", string ticker = "TICK") =>
+        new() { Exchange = exchange, Ticker = ticker };
+
+    private sealed class StubDividendDataSource : IDividendDataSource
+    {
+        public IReadOnlyList<DividendValue> Dividends { get; set; } = [];
+
+        public IReadOnlyList<DividendValue> GetDividends(string exchange, string ticker) => Dividends;
+    }
+
+    private sealed class StubSnapshotSource : IAssetSnapshotSource
+    {
+        public AssetValueSnapshot Snapshot { get; set; } =
+            new AssetValueSnapshot("DEFAULT", "Default Asset", 0m, DateTimeOffset.UtcNow);
+
+        public AssetValueSnapshot GetSnapshot(string exchange, string ticker) => Snapshot;
+    }
+}

--- a/Tests/Financial.Domain.Tests/Domain/GlobalAssetClassMappingTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/GlobalAssetClassMappingTests.cs
@@ -8,14 +8,38 @@ public class GlobalAssetClassMappingTests
     [Theory]
     [InlineData(CountryCode.BR, "FII", GlobalAssetClass.RealEstate)]
     [InlineData(CountryCode.BR, "Acoes", GlobalAssetClass.Equity)]
-    [InlineData(CountryCode.US, "REIT", GlobalAssetClass.RealEstate)]
+    [InlineData(CountryCode.BR, "ETF", GlobalAssetClass.ETF)]
+    [InlineData(CountryCode.BR, "Fund", GlobalAssetClass.Fund)]
+    [InlineData(CountryCode.BR, "Bond", GlobalAssetClass.Bond)]
     [InlineData(CountryCode.BR, "TesouroDireto", GlobalAssetClass.Bond)]
-    [InlineData(CountryCode.US, "T-Bill", GlobalAssetClass.Bond)]
-    [InlineData(CountryCode.UK, "ConventionalGilt", GlobalAssetClass.Bond)]
-    [InlineData(CountryCode.US, "ETF", GlobalAssetClass.ETF)]
-    [InlineData(CountryCode.UK, "Fund", GlobalAssetClass.Fund)]
+    [InlineData(CountryCode.US, "REIT", GlobalAssetClass.RealEstate)]
     [InlineData(CountryCode.US, "Stock", GlobalAssetClass.Equity)]
+    [InlineData(CountryCode.US, "ETF", GlobalAssetClass.ETF)]
+    [InlineData(CountryCode.US, "Fund", GlobalAssetClass.Fund)]
+    [InlineData(CountryCode.US, "Bond", GlobalAssetClass.Bond)]
+    [InlineData(CountryCode.US, "T-Bill", GlobalAssetClass.Bond)]
+    [InlineData(CountryCode.US, "Cash", GlobalAssetClass.Cash)]
+    [InlineData(CountryCode.US, "Pension", GlobalAssetClass.Pension)]
+    [InlineData(CountryCode.UK, "REIT", GlobalAssetClass.RealEstate)]
+    [InlineData(CountryCode.UK, "Stock", GlobalAssetClass.Equity)]
+    [InlineData(CountryCode.UK, "ETF", GlobalAssetClass.ETF)]
+    [InlineData(CountryCode.UK, "Fund", GlobalAssetClass.Fund)]
+    [InlineData(CountryCode.UK, "Bond", GlobalAssetClass.Bond)]
+    [InlineData(CountryCode.UK, "ConventionalGilt", GlobalAssetClass.Bond)]
+    [InlineData(CountryCode.UK, "Cash", GlobalAssetClass.Cash)]
+    [InlineData(CountryCode.UK, "Pension", GlobalAssetClass.Pension)]
     public void Resolve_KnownMappings_ReturnExpected(CountryCode country, string localTypeCode, GlobalAssetClass expected)
+    {
+        var result = GlobalAssetClassMapping.Resolve(country, localTypeCode);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(CountryCode.BR, "fii", GlobalAssetClass.RealEstate)]
+    [InlineData(CountryCode.BR, "ACOES", GlobalAssetClass.Equity)]
+    [InlineData(CountryCode.UK, "conventionalgilt", GlobalAssetClass.Bond)]
+    public void Resolve_CaseInsensitive_ReturnsMappedClass(CountryCode country, string localTypeCode, GlobalAssetClass expected)
     {
         var result = GlobalAssetClassMapping.Resolve(country, localTypeCode);
 

--- a/Tests/Financial.Infrastructure.Tests/Persistence/LocalJsonStorageTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Persistence/LocalJsonStorageTests.cs
@@ -1,0 +1,95 @@
+using Financial.Infrastructure.Persistence;
+using FluentAssertions;
+using System.IO;
+
+namespace Financial.Infrastructure.Tests.Persistence;
+
+public class LocalJsonStorageTests
+{
+    [Fact]
+    public async Task ReadAsync_WhenFileExists_ReturnsContent()
+    {
+        var tempFile = CreateTempFile("{\"test\": true}");
+        try
+        {
+            var storage = new LocalJsonStorage(tempFile);
+
+            var result = await storage.ReadAsync();
+
+            result.Should().Be("{\"test\": true}");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenFileDoesNotExist_ThrowsFileNotFoundException()
+    {
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), $"nonexistent-{Guid.NewGuid():N}.json");
+        var storage = new LocalJsonStorage(nonExistentPath);
+
+        Func<Task> act = () => storage.ReadAsync();
+
+        await act.Should().ThrowAsync<FileNotFoundException>();
+    }
+
+    [Fact]
+    public async Task WriteAsync_WritesContentToFile()
+    {
+        var tempFile = CreateTempFile("initial");
+        try
+        {
+            var storage = new LocalJsonStorage(tempFile);
+
+            await storage.WriteAsync("{\"written\": true}");
+
+            var content = await File.ReadAllTextAsync(tempFile);
+            content.Should().Be("{\"written\": true}");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task WriteAsync_ThenReadAsync_ReturnsSameContent()
+    {
+        var tempFile = CreateTempFile(string.Empty);
+        try
+        {
+            var storage = new LocalJsonStorage(tempFile);
+            const string json = "{\"round-trip\": true}";
+
+            await storage.WriteAsync(json);
+            var result = await storage.ReadAsync();
+
+            result.Should().Be(json);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Constructor_WithNullPath_UsesDefaultFileName()
+    {
+        // Null path resolves to AppContext.BaseDirectory/data.json; file won't exist there in tests
+        var storage = new LocalJsonStorage(null);
+
+        Func<Task> act = () => storage.ReadAsync();
+
+        var ex = await act.Should().ThrowAsync<FileNotFoundException>();
+        ex.Which.FileName.Should().EndWith(LocalJsonStorage.DefaultDataFileName);
+    }
+
+    private static string CreateTempFile(string content)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"storage-test-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/context.md
+++ b/context.md
@@ -1,36 +1,36 @@
-I've revised the text for grammar, spelling, clarity, cohesion, and consistency while keeping the original meaning and intent.
-
 # Financial Project
 
 ## Purpose
 
-This document provides the context for my personal Financial Project.
+This document provides the context and requirements for my personal Financial Project.
 
-The application should allow users to record asset purchase and sale transactions, as well as register dividends and any other forms of investment income or profit.
+The application is a personal financial management tool that consolidates investment transactions across multiple brokers and portfolios.
 
-The system should also support the creation and management of brokers, portfolios, and assets.
+The system must allow users to:
+
+* Record asset purchase transactions.
+* Record asset sale transactions.
+* Register dividends and other forms of investment income.
+* Manage brokers.
+* Manage portfolios.
+* Manage assets.
 
 ---
 
 # Project Overview
 
-The project is a **personal financial management tool** designed to consolidate financial transactions across multiple Brokers.
-
-The current portfolio spans **two countries**:
+The current portfolio spans two countries:
 
 * United Kingdom
 * Brazil
 
-This introduces the need to manage:
+As a result, the system must support:
 
-* Multiple currencies
-* Different tax regulations
-
-The system must support:
-
-* **Annual tax reporting** for both jurisdictions
-* **Investment performance tracking**
-* **Portfolio analytics**
+* Multiple currencies.
+* Different tax regulations.
+* Annual tax reporting for both jurisdictions.
+* Investment performance tracking.
+* Portfolio analytics.
 
 Supported asset classes include:
 
@@ -41,24 +41,112 @@ Supported asset classes include:
 * Government bonds
 * ISAs
 
-The system must be designed with flexibility in mind, allowing **new asset classes to be added in the future**.
+The solution must be extensible so that new asset classes can be added in the future without significant architectural changes.
 
 ---
 
 # Technical Requirements
 
-As this is currently a personal project, a database is not required. A simple JSON file stored on the local hard drive is sufficient for persisting data.
+## Storage
 
-However, the design should also support storing data in Google Drive as an alternative to local storage. The storage mechanism should be abstracted so that future changes can be implemented with minimal impact on the rest of the application.
+This is currently a personal project. A traditional database is not required at this stage.
 
-For the initial version, all data can be loaded into memory when the application starts and saved either on user request or automatically when the application closes. Although this approach may evolve in the future, the codebase should be structured to make such changes as straightforward as possible.
+The initial implementation should use JSON files stored locally for persistence.
 
-The project must adhere to the following development principles:
+Future storage providers may include:
+
+* Local file system
+* Google Drive
+* Additional cloud storage providers
+
+The persistence layer must be abstracted so that storage implementations can be replaced with minimal impact on the rest of the application.
+
+For the initial version:
+
+* All data may be loaded into memory during application startup.
+* Data may be saved manually by the user.
+* Data should also be saved automatically during application shutdown.
+
+The codebase should be structured to allow migration to a more sophisticated persistence model in the future.
+
+---
+
+## User Interfaces
+
+The project will support two front ends:
+
+### WPF Application
+
+A desktop application built using WPF.
+
+### React Application
+
+A web application built using React.
+
+Because the React application requires server-side communication, the solution must include an API layer.
+
+The WPF application should use the same application services and business logic as the API, ensuring that business rules are implemented only once.
+
+Business logic must never reside in either UI project.
+
+---
+
+## Architecture
+
+The architecture should follow Domain-Driven Design (DDD) principles while remaining pragmatic and avoiding unnecessary complexity.
+
+The domain is relatively small and currently consists of concepts such as:
+
+* Broker
+* Portfolio
+* Asset
+* Transaction
+* Credit
+
+The primary architectural goal is separation of responsibilities, enabling the system to be:
+
+* Easy to maintain
+* Easy to test
+* Easy to extend
+* Easy to evolve
+
+A clean architecture approach is preferred, with clear boundaries between:
+
+* Domain
+* Application
+* Infrastructure
+* Presentation
+
+Dependencies should always point inward toward the domain.
+
+---
+
+## Code Quality
+
+The project must adhere to the following principles:
 
 * SOLID principles
 * Clean Code practices
-* Comprehensive unit test coverage
+* Separation of concerns
+* Dependency Injection
+* High unit test coverage
 
-The architecture should follow Domain-Driven Design (DDD) principles to provide a clear and maintainable structure. However, given the relatively simple domain model, consisting of concepts such as Brokers, Portfolios, Assets, Transactions, and Credits, the architecture should remain pragmatic and avoid unnecessary complexity.
+All business rules should be testable without requiring a UI, database, or external services.
 
-The primary goal of the architecture is to separate responsibilities effectively, making the system easier to maintain, extend, and evolve over time.
+Unit tests should focus on domain and application behavior rather than implementation details.
+
+---
+
+## Guidance for AI Coding Agents
+
+When generating code for this project:
+
+* Prioritize maintainability over premature optimization.
+* Prefer simple solutions over complex abstractions.
+* Avoid overengineering.
+* Follow established C# and .NET conventions.
+* Keep the domain model independent of infrastructure concerns.
+* Design interfaces around business needs rather than technical implementation details.
+* Ensure new features remain compatible with both the WPF and React front ends.
+* Remove unused dependencies and unnecessary abstractions.
+* Generate unit tests for all business-critical functionality.


### PR DESCRIPTION
## Summary

- **C# (.NET)**: Extended `GlobalAssetClassMappingTests` to cover all 22 mappings and case-insensitive resolution; added `DividendServiceTests` covering the business logic (year grouping, 5-year lookback average, `PriceMaxBuy` formula, discount %, current-year exclusion) using inline stubs; added `LocalJsonStorageTests` for read/write/round-trip/missing-file/null-path
- **TypeScript (React)**: Added component tests for `ErrorState`, `LoadingState`, and `NavigationTreePanel` (render, loading state, error state, retry flow, link hrefs)
- **Skill**: Added `.claude/skills/testing-guide-Financial/` — a project-specific testing guide (SKILL.md + 9 artifact guides + 4 reference files) documenting what to test, at which layer, and how to set up tests for both stacks

## Test plan

- [x] `dotnet test` — all 4 C# projects pass (199 passed, 3 skipped intentionally)
- [x] `npm test` in `Financial.Web` — all 39 TypeScript tests pass (12 test files)
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)