### PR TITLE
fix(ci): add lint step, fix npm install, and resolve pre-existing lint errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,11 @@ jobs:
 
     - name: Install dependencies
       working-directory: Financial.Web
-      run: npm ci
+      run: npm install
+
+    - name: Lint
+      working-directory: Financial.Web
+      run: npm run lint
 
     - name: Run tests
       working-directory: Financial.Web

--- a/Financial.Web/src/components/NavigationTreePanel.tsx
+++ b/Financial.Web/src/components/NavigationTreePanel.tsx
@@ -83,24 +83,27 @@ export default function NavigationTreePanel({ title = 'Navigation', className }:
   const [tree, setTree] = useState<TreeNodeDto | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-
-  const loadTree = useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
-    try {
-      const data = await apiClient.getNavigationTree()
-      setTree(data)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unable to load navigation tree.'
-      setError(message)
-    } finally {
-      setIsLoading(false)
-    }
-  }, [apiClient])
+  const [retryCount, setRetryCount] = useState(0)
 
   useEffect(() => {
-    void loadTree()
-  }, [loadTree])
+    apiClient
+      .getNavigationTree()
+      .then((data) => {
+        setTree(data)
+        setError(null)
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Unable to load navigation tree.'
+        setError(message)
+      })
+      .finally(() => setIsLoading(false))
+  }, [apiClient, retryCount])
+
+  const handleRetry = useCallback(() => {
+    setIsLoading(true)
+    setError(null)
+    setRetryCount((c) => c + 1)
+  }, [])
 
   return (
     <div className={['nav-tree', className].filter(Boolean).join(' ')}>
@@ -110,7 +113,7 @@ export default function NavigationTreePanel({ title = 'Navigation', className }:
       {isLoading ? (
         <LoadingState message="Loading navigation tree..." />
       ) : error ? (
-        <ErrorState message={error} onRetry={loadTree} />
+        <ErrorState message={error} onRetry={handleRetry} />
       ) : tree ? (
         <ul className="nav-tree__list">
           <TreeNode node={tree} context={{}} />

--- a/Financial.Web/src/pages/CurrentValuesPage.tsx
+++ b/Financial.Web/src/pages/CurrentValuesPage.tsx
@@ -34,23 +34,27 @@ export default function CurrentValuesPage() {
     [],
   )
 
-  const loadBrokers = useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
-    try {
-      const data = await apiClient.getBrokers()
-      setBrokers(data)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unable to load brokers.'
-      setError(message)
-    } finally {
-      setIsLoading(false)
-    }
-  }, [apiClient])
+  const [retryCount, setRetryCount] = useState(0)
 
   useEffect(() => {
-    void loadBrokers()
-  }, [loadBrokers])
+    apiClient
+      .getBrokers()
+      .then((data) => {
+        setBrokers(data)
+        setError(null)
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Unable to load brokers.'
+        setError(message)
+      })
+      .finally(() => setIsLoading(false))
+  }, [apiClient, retryCount])
+
+  const handleRetry = useCallback(() => {
+    setIsLoading(true)
+    setError(null)
+    setRetryCount((c) => c + 1)
+  }, [])
 
   const portfolios = useMemo(() => {
     const broker = brokers.find((item) => item.name === selectedBroker)
@@ -143,7 +147,7 @@ export default function CurrentValuesPage() {
   }
 
   if (error) {
-    return <ErrorState message={error} onRetry={loadBrokers} />
+    return <ErrorState message={error} onRetry={handleRetry} />
   }
 
   return (


### PR DESCRIPTION
## Summary

- **`npm ci` → `npm install`** in the web CI job — `npm ci` fails on Linux when the lock file was generated on Windows because Linux-specific optional dependencies (e.g. `@emnapi/runtime`) are never written to the lock file on Windows
- **Add `Lint` step** to the web CI job — `npm run lint` now runs before tests so ESLint errors block PRs
- **Fix two pre-existing `react-hooks/set-state-in-effect` lint errors** that would have immediately broken the new lint step

## Lint fixes

Both `NavigationTreePanel` and `CurrentValuesPage` used the same pattern that the rule flags — a `useCallback` that sets state synchronously at the top, called via `void fn()` inside `useEffect`:

**Before:**
```tsx
const loadX = useCallback(async () => {
  setIsLoading(true)  // ← synchronous setState flagged by the rule
  setError(null)
  ...
}, [apiClient])

useEffect(() => {
  void loadX()  // ← triggers the rule
}, [loadX])
```

**After:**
```tsx
useEffect(() => {
  apiClient.getX()
    .then(data => { setData(data); setError(null) })
    .catch(err => setError(...))
    .finally(() => setIsLoading(false))  // all setState calls are async
}, [apiClient, retryCount])

const handleRetry = useCallback(() => {
  setIsLoading(true)
  setError(null)
  setRetryCount(c => c + 1)  // triggers the effect — fine, called from click handler
}, [])
```

## Test plan

- [ ] CI web job passes lint, tests, and build on Ubuntu
- [ ] CI .NET job unchanged — still passes
- [ ] `npm run lint` passes locally with no errors
- [ ] `npm test` passes (28 tests)
- [ ] Retry button still works in `NavigationTreePanel` and `CurrentValuesPage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)