### PR TITLE
fix: correct API base path for Docker and dev proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Financial.Web/package*.json .
 RUN npm install
 COPY Financial.Web/ .
-RUN echo "API_BASE_URL=" > .env
+RUN echo "API_BASE_URL=/api/v1/financial" > .env
 RUN npm run build
 
 # Stage 2: Build .NET API

--- a/Financial.Web/.env.example
+++ b/Financial.Web/.env.example
@@ -1,2 +1,4 @@
-# API base URL — copy this file to .env and adjust as needed
-API_BASE_URL=http://localhost:5190/api/v1/financial
+# API base path. Keep as a relative path so the Vite dev proxy forwards requests
+# to the .NET API (http://localhost:5190) without needing CORS configuration.
+# In Docker this same value is embedded in the production bundle.
+API_BASE_URL=/api/v1/financial

--- a/Financial.Web/vite.config.ts
+++ b/Financial.Web/vite.config.ts
@@ -4,10 +4,16 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), 'API_')
+  const apiTarget = env.API_BASE_URL || 'http://localhost:5190'
   return {
     plugins: [react()],
     define: {
-      'import.meta.env.API_BASE_URL': JSON.stringify(env.API_BASE_URL ?? ''),
+      'import.meta.env.API_BASE_URL': JSON.stringify(''),
+    },
+    server: {
+      proxy: {
+        '/api': { target: apiTarget, changeOrigin: true },
+      },
     },
     test: {
       environment: 'jsdom',

--- a/Financial.Web/vite.config.ts
+++ b/Financial.Web/vite.config.ts
@@ -1,18 +1,17 @@
-import { defineConfig } from 'vitest/config'
-import { loadEnv } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), 'API_')
-  const apiTarget = env.API_BASE_URL || 'http://localhost:5190'
+  const apiBaseUrl = env.API_BASE_URL ?? '/api/v1/financial'
   return {
     plugins: [react()],
     define: {
-      'import.meta.env.API_BASE_URL': JSON.stringify(''),
+      'import.meta.env.API_BASE_URL': JSON.stringify(apiBaseUrl),
     },
     server: {
       proxy: {
-        '/api': { target: apiTarget, changeOrigin: true },
+        '/api': { target: 'http://localhost:5190', changeOrigin: true },
       },
     },
     test: {


### PR DESCRIPTION
## Root cause

The React bundle was calling `/navigation/brokers` but the .NET controller group registers routes at `/api/v1/financial/navigation/brokers`. .NET found no match and returned `index.html` (SPA fallback), causing the **"Unexpected token '<'"** JSON parse error on the *Read Assets Current Values* page.

## Changes

### `Dockerfile`
- `API_BASE_URL=` → `API_BASE_URL=/api/v1/financial` so the production bundle embeds the correct base path.

### `Financial.Web/vite.config.ts`
- Read `API_BASE_URL` from the env file instead of hardcoding `''`.
- Dev server proxy target is fixed at `http://localhost:5190` (the .NET dev port) — no longer incorrectly derived from `API_BASE_URL`.

### `Financial.Web/.env.example`
- Use a relative path (`/api/v1/financial`) instead of an absolute URL. This works in both Docker (same-origin) and local dev (Vite proxy forwards `/api/…` to `http://localhost:5190`), without requiring CORS configuration on the backend.

## How it works now

| Context | `API_BASE_URL` | Request path | Handled by |
|---|---|---|---|
| Docker (`docker compose up`) | `/api/v1/financial` (built in) | `/api/v1/financial/navigation/brokers` | .NET controller |
| Local dev (`npm run dev`) | `/api/v1/financial` (from `.env`) | `/api/v1/financial/navigation/brokers` | Vite proxy → .NET on 5190 |

## Test plan

- [ ] `docker compose up --build` → open `http://localhost:8080` → navigate to *Read Assets Current Values* → no JSON parse error
- [ ] `npm run dev` (with `dotnet run --project Financial.Api` running) → same page works
- [ ] `npm test` — 28 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)