### PR TITLE
feat(F04): Portfolio Navigator - Summary Tab - Broker/Portfolio Aggregated View

### DIFF
--- a/Financial.Api/Controllers/SummaryController.cs
+++ b/Financial.Api/Controllers/SummaryController.cs
@@ -1,0 +1,37 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Financial.Api.Controllers;
+
+[ApiController]
+[Route("summary")]
+public sealed class SummaryController : ControllerBase
+{
+    private readonly ISummaryQueryService _summaryQueryService;
+
+    public SummaryController(ISummaryQueryService summaryQueryService)
+    {
+        _summaryQueryService = summaryQueryService ?? throw new ArgumentNullException(nameof(summaryQueryService));
+    }
+
+    [HttpGet("broker/{brokerName}")]
+    [ProducesResponseType(typeof(AggregatedSummaryDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult<AggregatedSummaryDTO> GetBrokerSummary(string brokerName)
+    {
+        var dto = _summaryQueryService.GetBrokerSummary(brokerName);
+        return Ok(dto);
+    }
+
+    [HttpGet("portfolio/{brokerName}/{portfolioName}")]
+    [ProducesResponseType(typeof(AggregatedSummaryDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult<AggregatedSummaryDTO> GetPortfolioSummary(
+        string brokerName,
+        string portfolioName)
+    {
+        var dto = _summaryQueryService.GetPortfolioSummary(brokerName, portfolioName);
+        return Ok(dto);
+    }
+}

--- a/Financial.Application/DTOs/AggregatedSummaryDTO.cs
+++ b/Financial.Application/DTOs/AggregatedSummaryDTO.cs
@@ -1,0 +1,8 @@
+namespace Financial.Application.DTOs;
+
+public sealed class AggregatedSummaryDTO
+{
+    public decimal TotalBought { get; init; }
+    public decimal TotalSold { get; init; }
+    public decimal TotalCredits { get; init; }
+}

--- a/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ public static class ApplicationServiceCollectionExtensions
     {
         services.AddSingleton<INavigationService, NavigationService>();
         services.AddSingleton<ICreditQueryService, CreditQueryService>();
+        services.AddSingleton<ISummaryQueryService, SummaryQueryService>();
         services.AddSingleton<ITransactionService, TransactionService>();
         services.AddSingleton<ICreditService, CreditService>();
         services.AddSingleton<IDividendService, DividendService>();

--- a/Financial.Application/Interfaces/ISummaryQueryService.cs
+++ b/Financial.Application/Interfaces/ISummaryQueryService.cs
@@ -1,0 +1,9 @@
+using Financial.Application.DTOs;
+
+namespace Financial.Application.Interfaces;
+
+public interface ISummaryQueryService
+{
+    AggregatedSummaryDTO GetBrokerSummary(string brokerName);
+    AggregatedSummaryDTO GetPortfolioSummary(string brokerName, string portfolioName);
+}

--- a/Financial.Application/Services/SummaryQueryService.cs
+++ b/Financial.Application/Services/SummaryQueryService.cs
@@ -1,0 +1,61 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Domain.Entities;
+
+namespace Financial.Application.Services;
+
+public sealed class SummaryQueryService : ISummaryQueryService
+{
+    private readonly IRepository _repository;
+
+    public SummaryQueryService(IRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public AggregatedSummaryDTO GetBrokerSummary(string brokerName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName))
+            return new AggregatedSummaryDTO();
+
+        var assets = _repository.GetAssetsByBroker(brokerName).Where(a => a.Active);
+        return Aggregate(assets);
+    }
+
+    public AggregatedSummaryDTO GetPortfolioSummary(string brokerName, string portfolioName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
+            return new AggregatedSummaryDTO();
+
+        var assets = _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName).Where(a => a.Active);
+        return Aggregate(assets);
+    }
+
+    private static AggregatedSummaryDTO Aggregate(IEnumerable<Asset> assets)
+    {
+        decimal totalBought = 0;
+        decimal totalSold = 0;
+        decimal totalCredits = 0;
+
+        foreach (var asset in assets)
+        {
+            foreach (var transaction in asset.Transactions)
+            {
+                if (transaction.Type == Transaction.TransactionType.Buy)
+                    totalBought += transaction.TotalPrice;
+                else
+                    totalSold += transaction.TotalPrice;
+            }
+
+            foreach (var credit in asset.Credits)
+                totalCredits += credit.Value;
+        }
+
+        return new AggregatedSummaryDTO
+        {
+            TotalBought = totalBought,
+            TotalSold = totalSold,
+            TotalCredits = totalCredits,
+        };
+    }
+}

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL } from './config'
 import type {
+  AggregatedSummaryDto,
   AssetDetailsDto,
   AssetPriceDto,
   BrokerNodeDto,
@@ -21,6 +22,8 @@ export interface FinancialApiClient {
   getAssetDetails: (brokerName: string, portfolioName: string, assetName: string) => Promise<AssetDetailsDto>
   getCreditsByBroker: (brokerName: string) => Promise<CreditDto[]>
   getCreditsByPortfolio: (brokerName: string, portfolioName: string) => Promise<CreditDto[]>
+  getSummaryByBroker: (brokerName: string) => Promise<AggregatedSummaryDto>
+  getSummaryByPortfolio: (brokerName: string, portfolioName: string) => Promise<AggregatedSummaryDto>
   addTransaction: (request: TransactionCreateDto) => Promise<AssetDetailsDto>
   updateTransaction: (request: TransactionUpdateDto) => Promise<AssetDetailsDto>
   deleteTransaction: (request: TransactionDeleteDto) => Promise<AssetDetailsDto>
@@ -92,6 +95,12 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
     getCreditsByPortfolio: (brokerName, portfolioName) =>
       request<CreditDto[]>(
         `/credits/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}`,
+      ),
+    getSummaryByBroker: (brokerName) =>
+      request<AggregatedSummaryDto>(`/summary/broker/${encodeURIComponent(brokerName)}`),
+    getSummaryByPortfolio: (brokerName, portfolioName) =>
+      request<AggregatedSummaryDto>(
+        `/summary/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}`,
       ),
     addTransaction: (requestBody) =>
       request<AssetDetailsDto>('/transactions', {

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -176,3 +176,9 @@ export interface AssetPriceDto {
   price: number
   asOf: string | null
 }
+
+export interface AggregatedSummaryDto {
+  totalBought: number
+  totalSold: number
+  totalCredits: number
+}

--- a/Financial.Web/src/components/AggregatedSummaryTab.css
+++ b/Financial.Web/src/components/AggregatedSummaryTab.css
@@ -1,0 +1,47 @@
+.aggregated-summary {
+  padding: 16px;
+  overflow-y: auto;
+  height: 100%;
+}
+
+.aggregated-summary__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px 24px;
+}
+
+.aggregated-summary__field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.aggregated-summary__field--full {
+  grid-column: 1 / -1;
+}
+
+.aggregated-summary__label {
+  font-size: 11px;
+  color: var(--text-muted, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.aggregated-summary__value {
+  font-size: 13px;
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.aggregated-summary__value--green {
+  color: #2e7d32;
+}
+
+.aggregated-summary__value--red {
+  color: #c62828;
+}
+
+.aggregated-summary__value--blue {
+  color: #1565c0;
+}

--- a/Financial.Web/src/components/AggregatedSummaryTab.tsx
+++ b/Financial.Web/src/components/AggregatedSummaryTab.tsx
@@ -1,0 +1,52 @@
+import ErrorState from './ErrorState'
+import LoadingState from './LoadingState'
+import { useAggregatedSummary } from '../hooks/useAggregatedSummary'
+import './AggregatedSummaryTab.css'
+
+function formatN2(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+export default function AggregatedSummaryTab() {
+  const { summary, isLoading, error, retry } = useAggregatedSummary()
+
+  if (isLoading) {
+    return <LoadingState />
+  }
+
+  if (error) {
+    return <ErrorState message={error} onRetry={retry} />
+  }
+
+  if (!summary) {
+    return null
+  }
+
+  return (
+    <div className="aggregated-summary">
+      <div className="aggregated-summary__grid">
+        <div className="aggregated-summary__field">
+          <span className="aggregated-summary__label">Total Bought</span>
+          <span className="aggregated-summary__value aggregated-summary__value--green">
+            {formatN2(summary.totalBought)}
+          </span>
+        </div>
+        <div className="aggregated-summary__field">
+          <span className="aggregated-summary__label">Total Sold</span>
+          <span className="aggregated-summary__value aggregated-summary__value--red">
+            {formatN2(summary.totalSold)}
+          </span>
+        </div>
+        <div className="aggregated-summary__field aggregated-summary__field--full">
+          <span className="aggregated-summary__label">Total Credits</span>
+          <span className="aggregated-summary__value aggregated-summary__value--blue">
+            {formatN2(summary.totalCredits)}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/Financial.Web/src/components/DetailPanel.tsx
+++ b/Financial.Web/src/components/DetailPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
 import { useSelectedNode } from '../context/SelectedNodeContext'
+import AggregatedSummaryTab from './AggregatedSummaryTab'
 import AssetSummaryTab from './AssetSummaryTab'
 import './DetailPanel.css'
 
@@ -98,11 +99,12 @@ export default function DetailPanel() {
 
       <div className="detail-panel__content">
         {activeTab === 'summary' && isAsset && <AssetSummaryTab />}
-        {activeTab === 'summary' && !isAsset && (
-          <p className="detail-panel__placeholder">Summary — coming in F04</p>
-        )}
-        {activeTab === 'transactions' && (
+        {activeTab === 'summary' && !isAsset && <AggregatedSummaryTab />}
+        {activeTab === 'transactions' && isAsset && (
           <p className="detail-panel__placeholder">Transactions — coming in F05</p>
+        )}
+        {activeTab === 'transactions' && !isAsset && (
+          <p className="detail-panel__placeholder">Transactions are only available for individual assets</p>
         )}
         {activeTab === 'credits' && (
           <p className="detail-panel__placeholder">Credits — coming in F06</p>

--- a/Financial.Web/src/components/__tests__/AggregatedSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/AggregatedSummaryTab.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AggregatedSummaryData } from '../../hooks/useAggregatedSummary'
+import type { AggregatedSummaryDto } from '../../api/types'
+import AggregatedSummaryTab from '../AggregatedSummaryTab'
+
+const mockRetry = vi.fn()
+
+const mockHookValue: AggregatedSummaryData = {
+  summary: null,
+  isLoading: false,
+  error: null,
+  retry: mockRetry,
+}
+
+vi.mock('../../hooks/useAggregatedSummary', () => ({
+  useAggregatedSummary: () => mockHookValue,
+}))
+
+const SUMMARY: AggregatedSummaryDto = {
+  totalBought: 15420.5,
+  totalSold: 3200.0,
+  totalCredits: 842.3,
+}
+
+function setMock(overrides: Partial<AggregatedSummaryData>) {
+  Object.assign(mockHookValue, overrides)
+}
+
+describe('AggregatedSummaryTab', () => {
+  beforeEach(() => {
+    mockRetry.mockReset()
+    Object.assign(mockHookValue, {
+      summary: null,
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it('renders_loading_indicator_while_data_loads', () => {
+    setMock({ isLoading: true })
+    render(<AggregatedSummaryTab />)
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('renders_error_state_with_retry_on_failure', () => {
+    setMock({ error: 'Unable to load summary' })
+    render(<AggregatedSummaryTab />)
+    expect(screen.getByText('Unable to load summary')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('renders_total_bought_in_green', () => {
+    setMock({ summary: SUMMARY })
+    render(<AggregatedSummaryTab />)
+    const label = screen.getByText('Total Bought')
+    const valueEl = label.nextElementSibling
+    expect(valueEl).toHaveClass('aggregated-summary__value--green')
+  })
+
+  it('renders_total_sold_in_red', () => {
+    setMock({ summary: SUMMARY })
+    render(<AggregatedSummaryTab />)
+    const label = screen.getByText('Total Sold')
+    const valueEl = label.nextElementSibling
+    expect(valueEl).toHaveClass('aggregated-summary__value--red')
+  })
+
+  it('renders_total_credits_in_blue', () => {
+    setMock({ summary: SUMMARY })
+    render(<AggregatedSummaryTab />)
+    const label = screen.getByText('Total Credits')
+    const valueEl = label.nextElementSibling
+    expect(valueEl).toHaveClass('aggregated-summary__value--blue')
+  })
+
+  it('renders_values_formatted_to_two_decimal_places', () => {
+    setMock({ summary: { totalBought: 15420.5678, totalSold: 3200.1234, totalCredits: 842.9999 } })
+    render(<AggregatedSummaryTab />)
+    const label = screen.getByText('Total Bought')
+    expect(label.nextElementSibling?.textContent).toMatch(/\d+[.,]\d{2}$/)
+  })
+
+  it('renders_zero_values_without_error', () => {
+    setMock({ summary: { totalBought: 0, totalSold: 0, totalCredits: 0 } })
+    render(<AggregatedSummaryTab />)
+    expect(screen.getByText('Total Bought')).toBeInTheDocument()
+    expect(screen.getByText('Total Sold')).toBeInTheDocument()
+    expect(screen.getByText('Total Credits')).toBeInTheDocument()
+  })
+})

--- a/Financial.Web/src/components/__tests__/DetailPanel.test.tsx
+++ b/Financial.Web/src/components/__tests__/DetailPanel.test.tsx
@@ -7,11 +7,15 @@ import type { SelectedNode } from '../../api/types'
 
 const getAssetDetailsMock = vi.fn()
 const getCurrentPriceMock = vi.fn()
+const getSummaryByBrokerMock = vi.fn()
+const getSummaryByPortfolioMock = vi.fn()
 
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
     getAssetDetails: getAssetDetailsMock,
     getCurrentPrice: getCurrentPriceMock,
+    getSummaryByBroker: getSummaryByBrokerMock,
+    getSummaryByPortfolio: getSummaryByPortfolioMock,
   }),
 }))
 
@@ -59,6 +63,8 @@ describe('DetailPanel', () => {
     vi.stubGlobal('confirm', vi.fn())
     getAssetDetailsMock.mockReturnValue(new Promise(() => {}))
     getCurrentPriceMock.mockReturnValue(new Promise(() => {}))
+    getSummaryByBrokerMock.mockReturnValue(new Promise(() => {}))
+    getSummaryByPortfolioMock.mockReturnValue(new Promise(() => {}))
   })
 
   it('shows empty state when selectedNode is null', () => {
@@ -155,16 +161,37 @@ describe('DetailPanel', () => {
     expect(screen.getByText('Loading...')).toBeInTheDocument()
   })
 
-  it('renders_summary_placeholder_for_broker_node', () => {
+  it('renders_aggregated_summary_tab_for_broker_node', () => {
     renderPanel(brokerNode)
     act(() => screen.getByTestId('setter').click())
-    expect(screen.getByText('Summary — coming in F04')).toBeInTheDocument()
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
   })
 
-  it('renders_summary_placeholder_for_portfolio_node', () => {
+  it('renders_aggregated_summary_tab_for_portfolio_node', () => {
     renderPanel(portfolioNode)
     act(() => screen.getByTestId('setter').click())
-    expect(screen.getByText('Summary — coming in F04')).toBeInTheDocument()
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('renders_asset_summary_tab_for_asset_node_regression', () => {
+    renderPanel(activeAssetNode)
+    act(() => screen.getByTestId('setter').click())
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(screen.queryByText('Transactions are only available for individual assets')).not.toBeInTheDocument()
+  })
+
+  it('renders_transactions_message_for_broker_node', () => {
+    renderPanel(brokerNode)
+    act(() => screen.getByTestId('setter').click())
+    fireEvent.click(screen.getByRole('button', { name: 'Transactions' }))
+    expect(screen.getByText('Transactions are only available for individual assets')).toBeInTheDocument()
+  })
+
+  it('renders_transactions_message_for_portfolio_node', () => {
+    renderPanel(portfolioNode)
+    act(() => screen.getByTestId('setter').click())
+    fireEvent.click(screen.getByRole('button', { name: 'Transactions' }))
+    expect(screen.getByText('Transactions are only available for individual assets')).toBeInTheDocument()
   })
 
   it('active tab resets to Summary on selectedNode change', () => {

--- a/Financial.Web/src/hooks/useAggregatedSummary.test.ts
+++ b/Financial.Web/src/hooks/useAggregatedSummary.test.ts
@@ -1,0 +1,165 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { createElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FinancialApiClient } from '../api/financialApiClient'
+import type { AggregatedSummaryDto, SelectedNode } from '../api/types'
+import { SelectedNodeProvider, useSelectedNode } from '../context/SelectedNodeContext'
+import { useAggregatedSummary } from './useAggregatedSummary'
+
+const getSummaryByBrokerMock = vi.fn<FinancialApiClient['getSummaryByBroker']>()
+const getSummaryByPortfolioMock = vi.fn<FinancialApiClient['getSummaryByPortfolio']>()
+
+vi.mock('../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getSummaryByBroker: getSummaryByBrokerMock,
+    getSummaryByPortfolio: getSummaryByPortfolioMock,
+  }),
+}))
+
+const BROKER_NODE: SelectedNode = {
+  nodeType: 'Broker',
+  brokerName: 'XPI',
+  currency: 'BRL',
+}
+
+const PORTFOLIO_NODE: SelectedNode = {
+  nodeType: 'Portfolio',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+}
+
+const ASSET_NODE: SelectedNode = {
+  nodeType: 'Asset',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+  assetName: 'KLBN4',
+  ticker: 'KLBN4',
+  exchange: 'BVMF',
+}
+
+const SUMMARY_DTO: AggregatedSummaryDto = {
+  totalBought: 15420.5,
+  totalSold: 3200.0,
+  totalCredits: 842.3,
+}
+
+function createWrapper() {
+  let setNodeRef: ((node: SelectedNode | null) => void) | undefined
+
+  function NodeControl() {
+    const { setSelectedNode } = useSelectedNode()
+    setNodeRef = setSelectedNode
+    return null
+  }
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(SelectedNodeProvider, null, createElement(NodeControl), children)
+  }
+
+  return {
+    wrapper: Wrapper,
+    setNode: (node: SelectedNode | null) => act(() => { setNodeRef?.(node) }),
+  }
+}
+
+describe('useAggregatedSummary', () => {
+  beforeEach(() => {
+    getSummaryByBrokerMock.mockReset()
+    getSummaryByPortfolioMock.mockReset()
+  })
+
+  it('calls_getSummaryByBroker_on_broker_node_selection', async () => {
+    getSummaryByBrokerMock.mockResolvedValue(SUMMARY_DTO)
+    const { wrapper, setNode } = createWrapper()
+    renderHook(() => useAggregatedSummary(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => {
+      expect(getSummaryByBrokerMock).toHaveBeenCalledWith('XPI')
+    })
+    expect(getSummaryByPortfolioMock).not.toHaveBeenCalled()
+  })
+
+  it('calls_getSummaryByPortfolio_on_portfolio_node_selection', async () => {
+    getSummaryByPortfolioMock.mockResolvedValue(SUMMARY_DTO)
+    const { wrapper, setNode } = createWrapper()
+    renderHook(() => useAggregatedSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => {
+      expect(getSummaryByPortfolioMock).toHaveBeenCalledWith('XPI', 'Acoes')
+    })
+    expect(getSummaryByBrokerMock).not.toHaveBeenCalled()
+  })
+
+  it('sets_isLoading_true_while_fetch_is_in_progress', async () => {
+    getSummaryByBrokerMock.mockReturnValue(new Promise(() => {}))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useAggregatedSummary(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.isLoading).toBe(true))
+  })
+
+  it('populates_summary_on_successful_fetch', async () => {
+    getSummaryByBrokerMock.mockResolvedValue(SUMMARY_DTO)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useAggregatedSummary(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.summary).not.toBeNull())
+    expect(result.current.summary?.totalBought).toBe(15420.5)
+    expect(result.current.summary?.totalSold).toBe(3200.0)
+    expect(result.current.summary?.totalCredits).toBe(842.3)
+  })
+
+  it('sets_error_on_fetch_failure', async () => {
+    getSummaryByBrokerMock.mockRejectedValue(new Error('Network error'))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useAggregatedSummary(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.error).toBe('Network error'))
+    expect(result.current.summary).toBeNull()
+  })
+
+  it('resets_state_on_node_change', async () => {
+    getSummaryByBrokerMock.mockResolvedValue(SUMMARY_DTO)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useAggregatedSummary(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.summary).not.toBeNull())
+
+    getSummaryByPortfolioMock.mockReturnValue(new Promise(() => {}))
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(result.current.isLoading).toBe(true))
+    expect(result.current.summary).toBeNull()
+  })
+
+  it('retry_re_triggers_fetch', async () => {
+    getSummaryByBrokerMock.mockRejectedValueOnce(new Error('Fail'))
+    getSummaryByBrokerMock.mockResolvedValue(SUMMARY_DTO)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useAggregatedSummary(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.error).toBe('Fail'))
+
+    act(() => result.current.retry())
+    await waitFor(() => expect(result.current.summary).not.toBeNull())
+    expect(getSummaryByBrokerMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does_not_fetch_when_asset_node_selected', async () => {
+    const { wrapper, setNode } = createWrapper()
+    renderHook(() => useAggregatedSummary(), { wrapper })
+    setNode(ASSET_NODE)
+    await act(async () => {})
+    expect(getSummaryByBrokerMock).not.toHaveBeenCalled()
+    expect(getSummaryByPortfolioMock).not.toHaveBeenCalled()
+  })
+
+  it('does_not_fetch_when_no_node_selected', async () => {
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useAggregatedSummary(), { wrapper })
+    setNode(null)
+    await act(async () => {})
+    expect(getSummaryByBrokerMock).not.toHaveBeenCalled()
+    expect(result.current.summary).toBeNull()
+  })
+})

--- a/Financial.Web/src/hooks/useAggregatedSummary.ts
+++ b/Financial.Web/src/hooks/useAggregatedSummary.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react'
+import { createFinancialApiClient } from '../api/financialApiClient'
+import type { AggregatedSummaryDto } from '../api/types'
+import { useSelectedNode } from '../context/SelectedNodeContext'
+
+interface AggregatedSummaryState {
+  summary: AggregatedSummaryDto | null
+  isLoading: boolean
+  error: string | null
+  retryCount: number
+}
+
+type AggregatedSummaryAction =
+  | { type: 'RESET' }
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; payload: AggregatedSummaryDto }
+  | { type: 'FETCH_ERROR'; payload: string }
+  | { type: 'RETRY' }
+
+const INITIAL_STATE: AggregatedSummaryState = {
+  summary: null,
+  isLoading: false,
+  error: null,
+  retryCount: 0,
+}
+
+function reducer(state: AggregatedSummaryState, action: AggregatedSummaryAction): AggregatedSummaryState {
+  switch (action.type) {
+    case 'RESET':
+      return INITIAL_STATE
+    case 'FETCH_START':
+      return { ...state, isLoading: true, error: null, summary: null }
+    case 'FETCH_SUCCESS':
+      return { ...state, isLoading: false, summary: action.payload }
+    case 'FETCH_ERROR':
+      return { ...state, isLoading: false, error: action.payload }
+    case 'RETRY':
+      return { ...state, retryCount: state.retryCount + 1 }
+    default:
+      return state
+  }
+}
+
+export interface AggregatedSummaryData {
+  summary: AggregatedSummaryDto | null
+  isLoading: boolean
+  error: string | null
+  retry: () => void
+}
+
+export function useAggregatedSummary(): AggregatedSummaryData {
+  const { selectedNode } = useSelectedNode()
+  const apiClient = useMemo(() => createFinancialApiClient(), [])
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  const isBroker = selectedNode?.nodeType === 'Broker'
+  const isPortfolio = selectedNode?.nodeType === 'Portfolio'
+  const shouldFetch = isBroker || isPortfolio
+
+  useEffect(() => {
+    if (!shouldFetch || !selectedNode) {
+      dispatch({ type: 'RESET' })
+      return
+    }
+
+    dispatch({ type: 'FETCH_START' })
+
+    const fetchPromise = isBroker
+      ? apiClient.getSummaryByBroker(selectedNode.brokerName)
+      : apiClient.getSummaryByPortfolio(selectedNode.brokerName, selectedNode.portfolioName!)
+
+    void fetchPromise
+      .then((result) => dispatch({ type: 'FETCH_SUCCESS', payload: result }))
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'FETCH_ERROR',
+          payload: err instanceof Error ? err.message : 'Unable to load summary',
+        })
+      })
+  }, [selectedNode, shouldFetch, isBroker, apiClient, state.retryCount])
+
+  const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
+
+  return {
+    summary: state.summary,
+    isLoading: state.isLoading,
+    error: state.error,
+    retry,
+  }
+}

--- a/Financial.Web/src/pages/__tests__/PortfolioNavigatorPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/PortfolioNavigatorPage.test.tsx
@@ -8,12 +8,16 @@ import type { TreeNodeDto } from '../../api/types'
 const getNavigationTreeMock = vi.fn()
 const getAssetDetailsMock = vi.fn()
 const getCurrentPriceMock = vi.fn()
+const getSummaryByBrokerMock = vi.fn()
+const getSummaryByPortfolioMock = vi.fn()
 
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
     getNavigationTree: getNavigationTreeMock,
     getAssetDetails: getAssetDetailsMock,
     getCurrentPrice: getCurrentPriceMock,
+    getSummaryByBroker: getSummaryByBrokerMock,
+    getSummaryByPortfolio: getSummaryByPortfolioMock,
   }),
 }))
 
@@ -64,6 +68,8 @@ describe('PortfolioNavigatorPage', () => {
     getNavigationTreeMock.mockReset()
     getAssetDetailsMock.mockReturnValue(new Promise(() => {}))
     getCurrentPriceMock.mockReturnValue(new Promise(() => {}))
+    getSummaryByBrokerMock.mockReturnValue(new Promise(() => {}))
+    getSummaryByPortfolioMock.mockReturnValue(new Promise(() => {}))
   })
 
   it('renders tree and empty detail state on load', async () => {

--- a/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
@@ -1,0 +1,43 @@
+using Financial.Application.DTOs;
+using FluentAssertions;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace Financial.Api.Tests;
+
+public class SummaryEndpointsTests
+{
+    [Fact]
+    public async Task GetBrokerSummary_Returns200WithDto()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/broker/XPI");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var dto = await response.Content.ReadFromJsonAsync<AggregatedSummaryDTO>();
+        dto.Should().NotBeNull();
+        dto!.TotalBought.Should().BeGreaterThanOrEqualTo(0m);
+        dto.TotalSold.Should().BeGreaterThanOrEqualTo(0m);
+        dto.TotalCredits.Should().BeGreaterThanOrEqualTo(0m);
+    }
+
+    [Fact]
+    public async Task GetPortfolioSummary_Returns200WithDto()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/portfolio/XPI/Default");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var dto = await response.Content.ReadFromJsonAsync<AggregatedSummaryDTO>();
+        dto.Should().NotBeNull();
+        dto!.TotalBought.Should().BeGreaterThanOrEqualTo(0m);
+        dto.TotalSold.Should().BeGreaterThanOrEqualTo(0m);
+        dto.TotalCredits.Should().BeGreaterThanOrEqualTo(0m);
+    }
+}

--- a/Tests/Financial.Application.Tests/Services/SummaryQueryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/SummaryQueryServiceTests.cs
@@ -1,0 +1,219 @@
+using Financial.Application.Interfaces;
+using Financial.Application.Services;
+using Financial.Domain.Entities;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace Financial.Application.Tests.Services;
+
+public class SummaryQueryServiceTests
+{
+    private readonly StubRepository _repository = new();
+
+    [Fact]
+    public void Constructor_WithNullRepository_Throws()
+    {
+        Action act = () => new SummaryQueryService(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public void GetBrokerSummary_ReturnsSumOfBuyTransactions()
+    {
+        var asset = MakeAsset();
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 15m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 20m, 0m));
+        _repository.AssetsByBroker = [asset];
+
+        var result = CreateService().GetBrokerSummary("XPI");
+
+        result.TotalBought.Should().Be(250m);
+    }
+
+    [Fact]
+    public void GetBrokerSummary_ReturnsSumOfSellTransactions()
+    {
+        var asset = MakeAsset();
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 20m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 12m, 0m));
+        _repository.AssetsByBroker = [asset];
+
+        var result = CreateService().GetBrokerSummary("XPI");
+
+        result.TotalSold.Should().Be(60m);
+    }
+
+    [Fact]
+    public void GetBrokerSummary_ReturnsSumOfCredits()
+    {
+        var asset = MakeAsset();
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        asset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 30m));
+        asset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Rent, 15m));
+        _repository.AssetsByBroker = [asset];
+
+        var result = CreateService().GetBrokerSummary("XPI");
+
+        result.TotalCredits.Should().Be(45m);
+    }
+
+    [Fact]
+    public void GetBrokerSummary_ExcludesInactiveAssets()
+    {
+        var activeAsset = MakeAsset();
+        activeAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 5m, 0m));
+        activeAsset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 20m));
+
+        var inactiveAsset = MakeZeroQuantityAsset();
+        inactiveAsset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 100m));
+
+        _repository.AssetsByBroker = [activeAsset, inactiveAsset];
+
+        var result = CreateService().GetBrokerSummary("XPI");
+
+        using var _ = new AssertionScope();
+        result.TotalBought.Should().Be(50m);
+        result.TotalCredits.Should().Be(20m);
+    }
+
+    [Fact]
+    public void GetBrokerSummary_ReturnsZerosForBrokerWithNoActiveAssets()
+    {
+        _repository.AssetsByBroker = [MakeZeroQuantityAsset()];
+
+        var result = CreateService().GetBrokerSummary("XPI");
+
+        using var _ = new AssertionScope();
+        result.TotalBought.Should().Be(0m);
+        result.TotalSold.Should().Be(0m);
+        result.TotalCredits.Should().Be(0m);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetBrokerSummary_ReturnsZerosOnNullOrWhitespaceBrokerName(string? brokerName)
+    {
+        var result = CreateService().GetBrokerSummary(brokerName!);
+
+        using var _ = new AssertionScope();
+        result.TotalBought.Should().Be(0m);
+        result.TotalSold.Should().Be(0m);
+        result.TotalCredits.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetPortfolioSummary_ReturnsSumOfBuyTransactions()
+    {
+        var asset = MakeAsset();
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 8m, 25m, 0m));
+        _repository.AssetsByBrokerPortfolio = [asset];
+
+        var result = CreateService().GetPortfolioSummary("XPI", "Default");
+
+        result.TotalBought.Should().Be(200m);
+    }
+
+    [Fact]
+    public void GetPortfolioSummary_ReturnsSumOfSellTransactions()
+    {
+        var asset = MakeAsset();
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 20m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 3m, 15m, 0m));
+        _repository.AssetsByBrokerPortfolio = [asset];
+
+        var result = CreateService().GetPortfolioSummary("XPI", "Default");
+
+        result.TotalSold.Should().Be(45m);
+    }
+
+    [Fact]
+    public void GetPortfolioSummary_ReturnsSumOfCredits()
+    {
+        var asset = MakeAsset();
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        asset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 50m));
+        _repository.AssetsByBrokerPortfolio = [asset];
+
+        var result = CreateService().GetPortfolioSummary("XPI", "Default");
+
+        result.TotalCredits.Should().Be(50m);
+    }
+
+    [Fact]
+    public void GetPortfolioSummary_ExcludesInactiveAssets()
+    {
+        var activeAsset = MakeAsset();
+        activeAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
+
+        var inactiveAsset = MakeZeroQuantityAsset();
+        inactiveAsset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 999m));
+
+        _repository.AssetsByBrokerPortfolio = [activeAsset, inactiveAsset];
+
+        var result = CreateService().GetPortfolioSummary("XPI", "Default");
+
+        using var _ = new AssertionScope();
+        result.TotalBought.Should().Be(50m);
+        result.TotalCredits.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetPortfolioSummary_ReturnsZerosForPortfolioWithNoActiveAssets()
+    {
+        _repository.AssetsByBrokerPortfolio = [MakeZeroQuantityAsset()];
+
+        var result = CreateService().GetPortfolioSummary("XPI", "Default");
+
+        using var _ = new AssertionScope();
+        result.TotalBought.Should().Be(0m);
+        result.TotalSold.Should().Be(0m);
+        result.TotalCredits.Should().Be(0m);
+    }
+
+    [Theory]
+    [InlineData(null, "Default")]
+    [InlineData("", "Default")]
+    [InlineData("   ", "Default")]
+    [InlineData("XPI", null)]
+    [InlineData("XPI", "")]
+    [InlineData("XPI", "   ")]
+    public void GetPortfolioSummary_ReturnsZerosOnNullOrWhitespaceInput(string? brokerName, string? portfolioName)
+    {
+        var result = CreateService().GetPortfolioSummary(brokerName!, portfolioName!);
+
+        using var _ = new AssertionScope();
+        result.TotalBought.Should().Be(0m);
+        result.TotalSold.Should().Be(0m);
+        result.TotalCredits.Should().Be(0m);
+    }
+
+    private SummaryQueryService CreateService() => new(_repository);
+
+    private static Asset MakeAsset(string name = "TEST", string ticker = "TEST") =>
+        Asset.Create(name, "ISIN", "BVMF", ticker);
+
+    private static Asset MakeZeroQuantityAsset()
+    {
+        var asset = Asset.Create("INACTIVE", "ISIN2", "BVMF", "INACT");
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 10m, 0m));
+        return asset;
+    }
+
+    private sealed class StubRepository : IRepository
+    {
+        public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
+        public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
+
+        public IReadOnlyList<string> GetAllAssetsFullName() => [];
+        public IEnumerable<Asset> GetAssetsByBroker(string name) => AssetsByBroker;
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => AssetsByBrokerPortfolio;
+        public IEnumerable<Asset> GetAssetsByPortfolio(string name) => [];
+        public IEnumerable<Asset> GetAssetsByAssetName(string name) => [];
+        public IEnumerable<Broker> GetBrokerList() => [];
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => null;
+        public Task SaveChangesAsync() => Task.CompletedTask;
+    }
+}

--- a/docs/F04-summary-tab-broker-portfolio-aggregated-view/plan.md
+++ b/docs/F04-summary-tab-broker-portfolio-aggregated-view/plan.md
@@ -1,0 +1,33 @@
+# Implementation Plan: F04 — Summary Tab — Broker/Portfolio Aggregated View
+
+**Prerequisites:**
+- F02 fully implemented — `SelectedNodeContext` must expose `nodeType`, `brokerName`, and `portfolioName`
+- F03 fully implemented — `LoadingState`, `ErrorState`, `AssetSummaryTab.css` colour classes, and the `useReducer` hook pattern are all in place as reference
+
+---
+
+### Phase 1: Backend — Application Layer
+
+**1. AggregatedSummaryDTO** - Create the DTO class in `Financial.Application/DTOs/` with `TotalBought`, `TotalSold`, and `TotalCredits` decimal properties. This is the single response contract shared by both the broker and portfolio endpoints.
+
+**2. ISummaryQueryService** - Define the service interface in `Financial.Application/Interfaces/` declaring the broker summary and portfolio summary methods, following the same structure as `ICreditQueryService`.
+
+**3. SummaryQueryService and DI registration** - Implement the service in `Financial.Application/Services/` using `IRepository` to fetch active assets for the given scope, then LINQ-aggregate Buy transaction totals, Sell transaction totals, and credit value totals into the DTO. Register the service as a singleton in `ApplicationServiceCollectionExtensions`, following the existing registration pattern for `ICreditQueryService`.
+
+---
+
+### Phase 2: Backend — API Layer
+
+**4. SummaryController** - Create `Financial.Api/Controllers/SummaryController.cs` with the `[Route("summary")]` prefix. Expose one GET action for `broker/{brokerName}` and one for `portfolio/{brokerName}/{portfolioName}`, each delegating to `ISummaryQueryService` and returning `Ok(dto)`. Follow the structure of `CreditsController` for attribute routing and `ProducesResponseType` declarations.
+
+---
+
+### Phase 3: Frontend
+
+**5. API types and client methods** - Add the `AggregatedSummaryDto` TypeScript interface to `Financial.Web/src/api/types.ts`, then add `getSummaryByBroker` and `getSummaryByPortfolio` to the `FinancialApiClient` interface and `createFinancialApiClient` factory in `financialApiClient.ts`, using the existing `request<T>()` helper.
+
+**6. useAggregatedSummary hook** - Create `Financial.Web/src/hooks/useAggregatedSummary.ts` using `useReducer` for state (summary, isLoading, error, retryCount) and `useEffect` to fire the correct API method based on `selectedNode.nodeType`. The hook should reset state on node change and expose a `retry` callback, mirroring the structure of `useAssetSummary`.
+
+**7. AggregatedSummaryTab component** - Create `Financial.Web/src/components/AggregatedSummaryTab.tsx` and co-located `AggregatedSummaryTab.css`. The component consumes `useAggregatedSummary` and renders `LoadingState` or `ErrorState` for non-data states, and three labelled N2 value rows with the established green/red/blue colour classes for data states.
+
+**8. DetailPanel integration** - Update `Financial.Web/src/components/DetailPanel.tsx` to import `AggregatedSummaryTab` and render it in the `summary` tab branch for `Broker` and `Portfolio` node types (replacing the current placeholder). Also update the `transactions` tab branch to display the static message "Transactions are only available for individual assets" when the selected node is not an asset.

--- a/docs/F04-summary-tab-broker-portfolio-aggregated-view/spec.md
+++ b/docs/F04-summary-tab-broker-portfolio-aggregated-view/spec.md
@@ -1,0 +1,265 @@
+# Spec: F04 — Summary Tab — Broker/Portfolio Aggregated View
+
+## 1. Technical Overview
+
+**What:** Replace the `"Summary — coming in F04"` placeholder in `DetailPanel.tsx` with an aggregated financial summary for broker and portfolio nodes in the Portfolio Navigator. Introduces two new backend GET endpoints, a new Application-layer query service and DTO, a new frontend hook, a new component, and updates `DetailPanel.tsx` to render the correct content per node type.
+
+**Why:** F02 provides selected node context (broker or portfolio), but `DetailPanel.tsx` currently renders a static placeholder for non-asset selections. F04 closes this gap by adding two aggregated summary endpoints that sum transactions and credits across all active assets within scope, and renders the three colour-coded totals (Total Bought, Total Sold, Total Credits) matching the WPF reference application's summary view at broker and portfolio level. The Transactions tab also requires its own static message for non-asset selections; this message is defined in F04 Capabilities and is included here so the tab is never blank.
+
+**Scope:**
+
+Included:
+- `AggregatedSummaryDTO` in the Application layer
+- `ISummaryQueryService` interface with `GetBrokerSummary` and `GetPortfolioSummary` methods
+- `SummaryQueryService` implementation that aggregates totals from active assets only
+- `SummaryController` with two GET endpoints under the `/summary` route prefix
+- DI singleton registration in `ApplicationServiceCollectionExtensions`
+- `AggregatedSummaryDto` TypeScript interface in `types.ts`
+- `getSummaryByBroker` and `getSummaryByPortfolio` methods in `financialApiClient.ts`
+- `useAggregatedSummary` hook managing fetch, loading, error, and retry state
+- `AggregatedSummaryTab` component and co-located CSS
+- `DetailPanel.tsx` updated to render `AggregatedSummaryTab` in the Summary tab for Broker and Portfolio nodes, and to show the static Transactions message for non-asset selections
+
+Excluded:
+- Current Value section at aggregate level (requires fetching all asset prices — not applicable per PRD)
+- Full Transactions tab functionality for assets (F05)
+
+---
+
+## 2. Architecture Impact
+
+**Affected components:**
+
+```mermaid
+graph TD
+    A["User — selects broker/portfolio node"] --> B[InvestmentTree]
+    B --> C[SelectedNodeContext]
+    C --> D["AggregatedSummaryTab (src/components/AggregatedSummaryTab.tsx)"]
+    D --> E["useAggregatedSummary (src/hooks/useAggregatedSummary.ts)"]
+    E --> F["financialApiClient.getSummaryByBroker()"]
+    E --> G["financialApiClient.getSummaryByPortfolio()"]
+    F --> H["GET /summary/broker/{brokerName}"]
+    G --> I["GET /summary/portfolio/{brokerName}/{portfolioName}"]
+    H --> J["SummaryController (Financial.Api)"]
+    I --> J
+    J --> K["ISummaryQueryService (Financial.Application)"]
+    K --> L["SummaryQueryService (Financial.Application)"]
+    L --> M["IRepository.GetAssetsByBroker()"]
+    L --> N["IRepository.GetAssetsByBrokerPortfolio()"]
+    M --> O["JSONRepository (Financial.Infrastructure)"]
+    N --> O
+```
+
+---
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| New service interface vs. extending `ICreditQueryService` | New `ISummaryQueryService` | Add summary methods to `ICreditQueryService` | Follows ISP and SRP; `ICreditQueryService` returns credit lists, not aggregate totals — mixing the two would muddy both interfaces |
+| Active-asset filtering | Filter to `asset.Active` only, consistent with `CreditQueryService` | Include inactive assets | Acceptance criterion requires `totalCredits` to match `GET /credits/broker/{brokerName}`, which already filters by `Active`; applying the same filter to Buy and Sell sums yields internally consistent totals |
+| Single shared DTO for both endpoints | `AggregatedSummaryDTO` used by both broker and portfolio responses | Separate `BrokerSummaryDTO` / `PortfolioSummaryDTO` | The response shape is identical (`totalBought`, `totalSold`, `totalCredits`); a shared DTO eliminates duplication without loss of clarity |
+| Dedicated `SummaryController` vs. adding to an existing controller | New `SummaryController` under `/summary` route prefix | Extend `NavigationController` or `CreditsController` | These endpoints have no operational overlap with navigation tree construction or credit mutations; a dedicated controller mirrors the existing single-responsibility pattern of `CreditsController` |
+
+---
+
+## 4. Component Overview
+
+### Frontend
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/api/types.ts` | Modified | New response type | Add `AggregatedSummaryDto` interface with `totalBought`, `totalSold`, `totalCredits` as `number` |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | Add summary fetch methods | Add `getSummaryByBroker(brokerName: string)` and `getSummaryByPortfolio(brokerName: string, portfolioName: string)` both returning `Promise<AggregatedSummaryDto>`; follow existing `request<T>()` pattern |
+| `Financial.Web/src/hooks/useAggregatedSummary.ts` | New | Aggregated summary data loading hook | Read `selectedNode` from `SelectedNodeContext`; route to `getSummaryByBroker` or `getSummaryByPortfolio` based on `nodeType`; manage `summary`, `isLoading`, `error`, and `retryCount` state via `useReducer`; reset on node change; skip fetch when `nodeType === 'Asset'` or no node selected |
+| `Financial.Web/src/components/AggregatedSummaryTab.tsx` | New | Summary tab renderer for broker and portfolio nodes | Consume `useAggregatedSummary`; show `LoadingState` while loading; show `ErrorState` with Retry on error; render Total Bought (green), Total Sold (red), Total Credits (blue) as N2 formatted values |
+| `Financial.Web/src/components/AggregatedSummaryTab.css` | New | Component styles | Field label/value layout matching `AssetSummaryTab.css`; reuse `.value--green`, `.value--red`, `.value--blue` CSS class semantics |
+| `Financial.Web/src/components/DetailPanel.tsx` | Modified | Route Summary and Transactions tabs per node type | Import `AggregatedSummaryTab`; render it in the `summary` branch when `nodeType` is `Broker` or `Portfolio`; update the `transactions` branch to show `"Transactions are only available for individual assets"` for non-asset nodes (retaining the coming-in-F05 placeholder for asset nodes) |
+
+### Backend
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Application/DTOs/AggregatedSummaryDTO.cs` | New | Response DTO | Expose `TotalBought`, `TotalSold`, `TotalCredits` as `decimal` properties |
+| `Financial.Application/Interfaces/ISummaryQueryService.cs` | New | Service abstraction | Declare `GetBrokerSummary(string brokerName)` and `GetPortfolioSummary(string brokerName, string portfolioName)` returning `AggregatedSummaryDTO` |
+| `Financial.Application/Services/SummaryQueryService.cs` | New | Aggregation logic | Accept `IRepository` via constructor; guard against null/whitespace inputs and return zero-filled DTO; call `GetAssetsByBroker` or `GetAssetsByBrokerPortfolio`; filter to `asset.Active`; sum Buy `TotalPrice`, Sell `TotalPrice`, and credit `Value`; return `AggregatedSummaryDTO` |
+| `Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs` | Modified | Register new service | Add `services.AddSingleton<ISummaryQueryService, SummaryQueryService>()` |
+| `Financial.Api/Controllers/SummaryController.cs` | New | REST endpoints | Inject `ISummaryQueryService`; expose `GET broker/{brokerName}` and `GET portfolio/{brokerName}/{portfolioName}` under `[Route("summary")]`; return `Ok(dto)` for both (zeros are a valid response when broker/portfolio is empty) |
+
+---
+
+## 5. API Contracts
+
+### GET Broker Aggregated Summary
+
+- **Method:** GET
+- **Path:** `/api/v1/financial/summary/broker/{brokerName}`
+- **Authentication:** None
+
+**Path Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `brokerName` | `string` | Yes | Exact broker name |
+
+**Response (200 OK):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalBought` | `decimal` | Sum of `TotalPrice` for all Buy transactions across active assets in the broker |
+| `totalSold` | `decimal` | Sum of `TotalPrice` for all Sell transactions across active assets in the broker |
+| `totalCredits` | `decimal` | Sum of `Value` for all credits across active assets in the broker |
+
+**Response Example:**
+```json
+{
+  "totalBought": 15420.50,
+  "totalSold": 3200.00,
+  "totalCredits": 842.30
+}
+```
+
+**Error Codes:**
+
+| HTTP Status | Condition |
+|-------------|-----------|
+| 200 | Always returned, including when broker has no active assets (all fields return `0.00`) |
+| 400 | `brokerName` is null or whitespace |
+
+---
+
+### GET Portfolio Aggregated Summary
+
+- **Method:** GET
+- **Path:** `/api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}`
+- **Authentication:** None
+
+**Path Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `brokerName` | `string` | Yes | Exact broker name |
+| `portfolioName` | `string` | Yes | Exact portfolio name within the broker |
+
+**Response (200 OK):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalBought` | `decimal` | Sum of `TotalPrice` for all Buy transactions across active assets in the portfolio |
+| `totalSold` | `decimal` | Sum of `TotalPrice` for all Sell transactions across active assets in the portfolio |
+| `totalCredits` | `decimal` | Sum of `Value` for all credits across active assets in the portfolio |
+
+**Response Example:**
+```json
+{
+  "totalBought": 8750.25,
+  "totalSold": 1100.00,
+  "totalCredits": 415.60
+}
+```
+
+**Error Codes:**
+
+| HTTP Status | Condition |
+|-------------|-----------|
+| 200 | Always returned, including when portfolio has no active assets (all fields return `0.00`) |
+| 400 | Either path parameter is null or whitespace |
+
+---
+
+## 6. Data Model
+
+Not applicable — no database or persistence schema changes. Totals are computed on-the-fly from the in-memory JSON-backed repository via existing `IRepository` methods.
+
+---
+
+## 7. Testing Strategy
+
+### Test file structure
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Application.Tests/Services/SummaryQueryServiceTests.cs` | Unit | `SummaryQueryService` | Aggregation logic, empty collections, active-only filtering |
+| `Financial.Api.Tests/Controllers/SummaryControllerTests.cs` | Unit | `SummaryController` | HTTP response codes and DTO passthrough |
+| `Financial.Web/src/hooks/useAggregatedSummary.test.ts` | Unit | `useAggregatedSummary` | Fetch dispatch, node-type routing, error and retry states |
+| `Financial.Web/src/components/AggregatedSummaryTab.test.tsx` | Unit | `AggregatedSummaryTab` | Rendering, colour classes, loading/error states |
+| `Financial.Web/src/components/DetailPanel.test.tsx` | Integration | `DetailPanel` + `AggregatedSummaryTab` | Summary and Transactions tab routing per node type |
+
+### SummaryQueryServiceTests.cs
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `GetBrokerSummary_ReturnsSumOfBuyTransactions` | Broker with multiple assets with Buy transactions | `TotalBought` equals sum of Buy `TotalPrice` values across active assets |
+| `GetBrokerSummary_ReturnsSumOfSellTransactions` | Broker with Sell transactions | `TotalSold` equals sum of Sell `TotalPrice` values |
+| `GetBrokerSummary_ReturnsSumOfCredits` | Broker with credits | `TotalCredits` equals sum of all credit `Value` values |
+| `GetBrokerSummary_ExcludesInactiveAssets` | Broker with one active and one inactive asset | Totals exclude transactions and credits of the inactive asset |
+| `GetBrokerSummary_ReturnsZerosForBrokerWithNoActiveAssets` | Broker exists but has no active assets | All three fields are `0.00` |
+| `GetBrokerSummary_ReturnsZerosOnNullOrWhitespaceBrokerName` | Null or whitespace input | Returns DTO with all zeros without throwing |
+| `GetPortfolioSummary_ReturnsSumOfBuyTransactions` | Portfolio with Buy transactions | `TotalBought` correct |
+| `GetPortfolioSummary_ReturnsSumOfSellTransactions` | Portfolio with Sell transactions | `TotalSold` correct |
+| `GetPortfolioSummary_ReturnsSumOfCredits` | Portfolio with credits | `TotalCredits` correct |
+| `GetPortfolioSummary_ExcludesInactiveAssets` | Portfolio with mixed active/inactive assets | Inactive asset excluded from all three totals |
+| `GetPortfolioSummary_ReturnsZerosForPortfolioWithNoActiveAssets` | Portfolio has no active assets | All fields are `0.00` |
+| `GetPortfolioSummary_ReturnsZerosOnNullOrWhitespaceInput` | Null or whitespace broker/portfolio name | Returns zeros without throwing |
+
+### SummaryControllerTests.cs
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `GetBrokerSummary_Returns200WithDto` | Service returns a valid DTO | HTTP 200; response body matches the DTO returned by the service |
+| `GetPortfolioSummary_Returns200WithDto` | Service returns a valid DTO | HTTP 200; response body matches the DTO returned by the service |
+
+### useAggregatedSummary.test.ts
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `calls_getSummaryByBroker_on_broker_node_selection` | Broker node set in context | `getSummaryByBroker` called with the correct `brokerName` |
+| `calls_getSummaryByPortfolio_on_portfolio_node_selection` | Portfolio node set in context | `getSummaryByPortfolio` called with the correct `brokerName` and `portfolioName` |
+| `sets_isLoading_true_while_fetch_is_in_progress` | Fetch not yet resolved | `isLoading` is `true` before the promise settles |
+| `populates_summary_on_successful_fetch` | API resolves with a DTO | `summary` contains correct `totalBought`, `totalSold`, `totalCredits` |
+| `sets_error_on_fetch_failure` | API rejects | `error` is populated; `summary` is `null` |
+| `resets_state_on_node_change` | Node changed while fetch is pending | Previous summary cleared; new fetch initiated |
+| `retry_re_triggers_fetch` | Calling `retry()` after an error | The API method is called a second time |
+| `does_not_fetch_when_asset_node_selected` | Asset node in context | Neither `getSummaryByBroker` nor `getSummaryByPortfolio` is called |
+| `does_not_fetch_when_no_node_selected` | `selectedNode` is `null` | No API call made; `summary` remains `null` |
+
+### AggregatedSummaryTab.test.tsx
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `renders_loading_indicator_while_data_loads` | `isLoading` is `true` | `LoadingState` component is visible |
+| `renders_error_state_with_retry_on_failure` | `error` is populated | Error message and Retry button are rendered |
+| `renders_total_bought_in_green` | `summary.totalBought` provided | TotalBought element carries the green colour class |
+| `renders_total_sold_in_red` | `summary.totalSold` provided | TotalSold element carries the red colour class |
+| `renders_total_credits_in_blue` | `summary.totalCredits` provided | TotalCredits element carries the blue colour class |
+| `renders_values_formatted_to_two_decimal_places` | Values with more than two decimal places | All three fields display N2 formatted text |
+| `renders_zero_values_without_error` | All three values are `0.00` | Fields render without exception or omission |
+
+### DetailPanel.test.tsx (additions)
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `renders_aggregated_summary_tab_for_broker_node` | Broker node in context, Summary tab active | `AggregatedSummaryTab` output is visible |
+| `renders_aggregated_summary_tab_for_portfolio_node` | Portfolio node in context, Summary tab active | `AggregatedSummaryTab` output is visible |
+| `renders_asset_summary_tab_for_asset_node_regression` | Asset node in context | `AssetSummaryTab` rendered; `AggregatedSummaryTab` absent |
+| `renders_transactions_message_for_broker_node` | Broker node, Transactions tab active | Static message "Transactions are only available for individual assets" visible |
+| `renders_transactions_message_for_portfolio_node` | Portfolio node, Transactions tab active | Same static message visible |
+
+### Acceptance test mapping (PRD Section 9 — F04)
+
+| Acceptance Criterion | Covered By |
+|----------------------|------------|
+| `GET /summary/broker/{brokerName}` returns `totalBought`, `totalSold`, `totalCredits` as decimals | `SummaryControllerTests: GetBrokerSummary_Returns200WithDto` |
+| `GET /summary/portfolio/{brokerName}/{portfolioName}` returns same three fields | `SummaryControllerTests: GetPortfolioSummary_Returns200WithDto` |
+| Selecting broker populates Summary tab with three colour-coded totals | `AggregatedSummaryTab: renders_total_bought_in_green / _sold_in_red / _credits_in_blue` + `DetailPanel: renders_aggregated_summary_tab_for_broker_node` |
+| Selecting portfolio populates Summary tab with three colour-coded totals | Same component tests + `DetailPanel: renders_aggregated_summary_tab_for_portfolio_node` |
+| `totalCredits` matches sum from `GET /credits/broker/{brokerName}` | `SummaryQueryServiceTests: GetBrokerSummary_ExcludesInactiveAssets` + `GetBrokerSummary_ReturnsSumOfCredits` (active-only filter aligns both endpoints) |
+| Transactions tab shows static message for broker/portfolio | `DetailPanel: renders_transactions_message_for_broker_node / _portfolio_node` |
+| No Current Value section in Summary tab for broker/portfolio | `AggregatedSummaryTab` renders only three total fields — no current-value output |
+
+### Cross-feature integration tests (PRD Section 9)
+
+| Integration Criterion | Covered By |
+|-----------------------|------------|
+| Selecting broker node in F02 passes `brokerName` to F04; summary uses the exact broker name | `useAggregatedSummary: calls_getSummaryByBroker_on_broker_node_selection` |
+| Selecting portfolio node in F02 passes `brokerName` and `portfolioName` to F04; summary uses both | `useAggregatedSummary: calls_getSummaryByPortfolio_on_portfolio_node_selection` |

--- a/docs/prd/prd-web-frontend-parity/prd-web-frontend-parity.md
+++ b/docs/prd/prd-web-frontend-parity/prd-web-frontend-parity.md
@@ -456,7 +456,7 @@ Chart capabilities (all selection types):
 | F07 | Shares Dividend Check Redesign | 1 | F01 | ⬜ Pending |
 | F08 | Read Assets Current Values Redesign | 1 | F01 | ⬜ Pending |
 | F03 | Summary Tab — Asset View | 1 | F02 | ✅ Done |
-| F04 | Summary Tab — Broker/Portfolio Aggregated View | 2 | F02 | ⬜ Pending |
+| F04 | Summary Tab — Broker/Portfolio Aggregated View | 2 | F02 | ✅ Done |
 | F05 | Transactions Tab | 1 | F02 | ⬜ Pending |
 | F06 | Credits Tab | 1 | F02 | ⬜ Pending |
 
@@ -532,13 +532,13 @@ graph TD
 - [ ] Status field shows error text when the price fetch fails
 
 ### F04. Portfolio Navigator - Summary Tab - Broker/Portfolio Aggregated View
-- [ ] `GET /api/v1/financial/summary/broker/{brokerName}` returns a JSON object with `totalBought`, `totalSold`, and `totalCredits` as decimal values
-- [ ] `GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}` returns a JSON object with `totalBought`, `totalSold`, and `totalCredits` as decimal values
-- [ ] Selecting a broker populates the Summary tab with aggregated Total Bought (green), Total Sold (red), Total Credits (blue)
-- [ ] Selecting a portfolio populates the Summary tab with aggregated Total Bought (green), Total Sold (red), Total Credits (blue)
-- [ ] `totalCredits` from the summary endpoint matches the sum of all credit values returned by `GET /credits/broker/{brokerName}` for the same broker
-- [ ] Transactions tab shows "Transactions are only available for individual assets" when a broker or portfolio is selected
-- [ ] No Current Value section appears in the Summary tab for broker or portfolio selections
+- [x] `GET /api/v1/financial/summary/broker/{brokerName}` returns a JSON object with `totalBought`, `totalSold`, and `totalCredits` as decimal values
+- [x] `GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}` returns a JSON object with `totalBought`, `totalSold`, and `totalCredits` as decimal values
+- [x] Selecting a broker populates the Summary tab with aggregated Total Bought (green), Total Sold (red), Total Credits (blue)
+- [x] Selecting a portfolio populates the Summary tab with aggregated Total Bought (green), Total Sold (red), Total Credits (blue)
+- [x] `totalCredits` from the summary endpoint matches the sum of all credit values returned by `GET /credits/broker/{brokerName}` for the same broker
+- [x] Transactions tab shows "Transactions are only available for individual assets" when a broker or portfolio is selected
+- [x] No Current Value section appears in the Summary tab for broker or portfolio selections
 
 ### F05. Portfolio Navigator - Transactions Tab
 - [ ] Transactions tab shows all transactions for the selected asset, sorted by date descending (most recent first)
@@ -596,8 +596,8 @@ graph TD
 
 ### Cross-Feature Integration
 - [ ] Selecting an asset node in F02 correctly passes brokerName, portfolioName, and assetName to F03; the asset details loaded match the selected node
-- [ ] Selecting a broker node in F02 correctly passes brokerName to F04; the aggregated summary fetched uses the broker's exact name
-- [ ] Selecting a portfolio node in F02 correctly passes brokerName and portfolioName to F04; the aggregated summary fetched uses both identifiers
+- [x] Selecting a broker node in F02 correctly passes brokerName to F04; the aggregated summary fetched uses the broker's exact name
+- [x] Selecting a portfolio node in F02 correctly passes brokerName and portfolioName to F04; the aggregated summary fetched uses both identifiers
 - [ ] Selecting an asset node in F02 correctly passes brokerName, portfolioName, and assetName to F05; transactions displayed belong to the selected asset
 - [ ] Selecting an asset node in F02 correctly passes the asset context to F06; credits list and chart display data for that asset only
 - [ ] Selecting a broker node in F02 correctly passes brokerName to F06; credits chart data matches `GET /credits/broker/{brokerName}`


### PR DESCRIPTION
## Summary

- Adds two new backend GET endpoints (`/summary/broker/{brokerName}` and `/summary/portfolio/{brokerName}/{portfolioName}`) that return `totalBought`, `totalSold`, and `totalCredits` aggregated across all active assets in scope
- Implements `AggregatedSummaryTab` component that renders the three colour-coded totals (green/red/blue) in the Summary tab when a broker or portfolio node is selected
- Updates `DetailPanel` to show the aggregated summary for broker/portfolio nodes and a static message in the Transactions tab ("Transactions are only available for individual assets")

## Architecture

- **Domain**: no changes
- **Application**: `AggregatedSummaryDTO`, `ISummaryQueryService`, `SummaryQueryService` (aggregates via existing `IRepository`)
- **Infrastructure**: no changes (reuses `GetAssetsByBroker` / `GetAssetsByBrokerPortfolio`)
- **API**: `SummaryController` under `[Route("summary")]`
- **Frontend**: `AggregatedSummaryDto` type, `getSummaryByBroker`/`getSummaryByPortfolio` client methods, `useAggregatedSummary` hook, `AggregatedSummaryTab` component

## Test plan

- [ ] `Tests/Financial.Application.Tests` — 20 new `SummaryQueryServiceTests` covering aggregation, active-only filtering, zero/null guards (72 total, all passing)
- [ ] `Tests/Financial.Api.Tests` — 2 new `SummaryEndpointsTests` verifying HTTP 200 + DTO shape (17 total, all passing)
- [ ] `Financial.Web` — 9 new `useAggregatedSummary` hook tests, 7 new `AggregatedSummaryTab` component tests, 5 updated/new `DetailPanel` tests (115 total, all passing)
- [ ] TypeScript type-check (`tsc -b --noEmit`) passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)