### PR TITLE
feat(F05): Portfolio Navigator - Transactions Tab spec and plan

### DIFF
--- a/Financial.Web/src/components/DetailPanel.tsx
+++ b/Financial.Web/src/components/DetailPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import { useSelectedNode } from '../context/SelectedNodeContext'
 import AggregatedSummaryTab from './AggregatedSummaryTab'
 import AssetSummaryTab from './AssetSummaryTab'
+import TransactionsTab from './TransactionsTab'
 import './DetailPanel.css'
 
 type TabId = 'summary' | 'transactions' | 'credits'
@@ -100,12 +101,7 @@ export default function DetailPanel() {
       <div className="detail-panel__content">
         {activeTab === 'summary' && isAsset && <AssetSummaryTab />}
         {activeTab === 'summary' && !isAsset && <AggregatedSummaryTab />}
-        {activeTab === 'transactions' && isAsset && (
-          <p className="detail-panel__placeholder">Transactions — coming in F05</p>
-        )}
-        {activeTab === 'transactions' && !isAsset && (
-          <p className="detail-panel__placeholder">Transactions are only available for individual assets</p>
-        )}
+        {activeTab === 'transactions' && <TransactionsTab />}
         {activeTab === 'credits' && (
           <p className="detail-panel__placeholder">Credits — coming in F06</p>
         )}

--- a/Financial.Web/src/components/TransactionsTab.css
+++ b/Financial.Web/src/components/TransactionsTab.css
@@ -1,0 +1,189 @@
+.transactions-tab {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.transactions-tab__placeholder {
+  padding: 24px;
+  color: var(--text-muted, #888);
+  font-size: 13px;
+}
+
+.transactions-tab__toolbar {
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border, #e5e4e7);
+  flex-shrink: 0;
+}
+
+.transactions-tab__new-btn {
+  font-size: 12px;
+  padding: 3px 12px;
+  cursor: pointer;
+  background: #007acc;
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+}
+
+.transactions-tab__new-btn:hover {
+  background: #005fa3;
+}
+
+.transactions-tab__form {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border, #e5e4e7);
+  background: var(--bg-subtle, #f9f9f9);
+  flex-shrink: 0;
+}
+
+.transactions-tab__form-title {
+  font-size: 13px;
+  font-weight: bold;
+  margin: 0 0 10px;
+}
+
+.transactions-tab__form-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin-bottom: 10px;
+}
+
+.transactions-tab__form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.transactions-tab__form-field label {
+  font-size: 11px;
+  color: var(--text-muted, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.transactions-tab__form-field input,
+.transactions-tab__form-field select {
+  font-size: 12px;
+  padding: 3px 6px;
+  border: 1px solid var(--border, #e5e4e7);
+  border-radius: 3px;
+  background: var(--bg, #fff);
+  min-width: 90px;
+}
+
+.transactions-tab__form-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.transactions-tab__save-btn {
+  font-size: 12px;
+  padding: 3px 12px;
+  cursor: pointer;
+  background: #007acc;
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+}
+
+.transactions-tab__save-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.transactions-tab__cancel-btn {
+  font-size: 12px;
+  padding: 3px 10px;
+  cursor: pointer;
+  background: none;
+  border: 1px solid var(--border, #e5e4e7);
+  border-radius: 3px;
+}
+
+.transactions-tab__cancel-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
+}
+
+.transactions-tab__error {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #c62828;
+}
+
+.transactions-tab__table-wrapper {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 16px 16px;
+}
+
+.transactions-tab__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.transactions-tab__table th {
+  text-align: left;
+  font-size: 11px;
+  color: var(--text-muted, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  border-bottom: 1px solid var(--border, #e5e4e7);
+  padding: 6px 8px 4px;
+  white-space: nowrap;
+}
+
+.transactions-tab__table td {
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--border, #f0f0f0);
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.transactions-tab__action-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 12px;
+  color: var(--text-muted, #888);
+  border-radius: 2px;
+}
+
+.transactions-tab__action-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
+  color: var(--text, #333);
+}
+
+.transactions-tab__type--buy {
+  color: #2e7d32;
+  font-weight: bold;
+}
+
+.transactions-tab__type--sell {
+  color: #c62828;
+  font-weight: bold;
+}
+
+.transactions-tab__amount {
+  text-align: right;
+}
+
+.transactions-tab__total {
+  text-align: right;
+  font-weight: bold;
+}
+
+.transactions-tab__delete-error {
+  padding: 6px 16px;
+  font-size: 12px;
+  color: #c62828;
+  flex-shrink: 0;
+}

--- a/Financial.Web/src/components/TransactionsTab.tsx
+++ b/Financial.Web/src/components/TransactionsTab.tsx
@@ -1,0 +1,276 @@
+import type { TransactionDto } from '../api/types'
+import ErrorState from './ErrorState'
+import LoadingState from './LoadingState'
+import type { TransactionFormField } from '../hooks/useTransactions'
+import { useTransactions } from '../hooks/useTransactions'
+import './TransactionsTab.css'
+
+function formatN2(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+function formatN8(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 8,
+    maximumFractionDigits: 8,
+  }).format(value)
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()}`
+}
+
+interface TransactionRowProps {
+  transaction: TransactionDto
+  onEdit: (t: TransactionDto) => void
+  onDelete: (id: string) => void
+}
+
+function TransactionRow({ transaction, onEdit, onDelete }: TransactionRowProps) {
+  const typeClass =
+    transaction.type === 'Buy'
+      ? 'transactions-tab__type--buy'
+      : 'transactions-tab__type--sell'
+
+  return (
+    <tr>
+      <td>
+        <button
+          className="transactions-tab__action-btn"
+          type="button"
+          aria-label="Edit transaction"
+          onClick={() => onEdit(transaction)}
+        >
+          ✏
+        </button>
+      </td>
+      <td>
+        <button
+          className="transactions-tab__action-btn"
+          type="button"
+          aria-label="Delete transaction"
+          onClick={() => onDelete(transaction.id)}
+        >
+          ✕
+        </button>
+      </td>
+      <td>{formatDate(transaction.date)}</td>
+      <td className={typeClass}>{transaction.type}</td>
+      <td className="transactions-tab__amount">{formatN8(transaction.quantity)}</td>
+      <td className="transactions-tab__amount">{formatN2(transaction.unitPrice)}</td>
+      <td className="transactions-tab__amount">{formatN2(transaction.fees)}</td>
+      <td className="transactions-tab__total">{formatN2(transaction.totalPrice)}</td>
+    </tr>
+  )
+}
+
+interface InlineFormProps {
+  editingId: string | null
+  formDate: string
+  formType: string
+  formQuantity: string
+  formUnitPrice: string
+  formFees: string
+  isSaving: boolean
+  saveError: string | null
+  onFieldChange: (field: TransactionFormField, value: string) => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+function InlineForm({
+  editingId,
+  formDate,
+  formType,
+  formQuantity,
+  formUnitPrice,
+  formFees,
+  isSaving,
+  saveError,
+  onFieldChange,
+  onSave,
+  onCancel,
+}: InlineFormProps) {
+  const title = editingId ? 'Edit transaction' : 'New transaction'
+
+  return (
+    <div className="transactions-tab__form">
+      <p className="transactions-tab__form-title">{title}</p>
+      <div className="transactions-tab__form-fields">
+        <div className="transactions-tab__form-field">
+          <label htmlFor="tx-date">Date</label>
+          <input
+            id="tx-date"
+            type="date"
+            value={formDate}
+            required
+            onChange={(e) => onFieldChange('formDate', e.target.value)}
+          />
+        </div>
+        <div className="transactions-tab__form-field">
+          <label htmlFor="tx-type">Type</label>
+          <select
+            id="tx-type"
+            value={formType}
+            onChange={(e) => onFieldChange('formType', e.target.value)}
+          >
+            <option value="Buy">Buy</option>
+            <option value="Sell">Sell</option>
+          </select>
+        </div>
+        <div className="transactions-tab__form-field">
+          <label htmlFor="tx-quantity">Quantity</label>
+          <input
+            id="tx-quantity"
+            type="number"
+            step="0.0001"
+            min="0"
+            value={formQuantity}
+            required
+            onChange={(e) => onFieldChange('formQuantity', e.target.value)}
+          />
+        </div>
+        <div className="transactions-tab__form-field">
+          <label htmlFor="tx-unit-price">Unit Price</label>
+          <input
+            id="tx-unit-price"
+            type="number"
+            step="0.0001"
+            min="0"
+            value={formUnitPrice}
+            required
+            onChange={(e) => onFieldChange('formUnitPrice', e.target.value)}
+          />
+        </div>
+        <div className="transactions-tab__form-field">
+          <label htmlFor="tx-fees">Fees</label>
+          <input
+            id="tx-fees"
+            type="number"
+            step="0.0001"
+            min="0"
+            value={formFees}
+            onChange={(e) => onFieldChange('formFees', e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="transactions-tab__form-actions">
+        <button
+          className="transactions-tab__save-btn"
+          type="button"
+          disabled={isSaving}
+          onClick={onSave}
+        >
+          {isSaving ? 'Saving...' : 'Save'}
+        </button>
+        <button className="transactions-tab__cancel-btn" type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+      {saveError && <p className="transactions-tab__error">{saveError}</p>}
+    </div>
+  )
+}
+
+export default function TransactionsTab() {
+  const {
+    isLoading,
+    error,
+    retry,
+    transactions,
+    isFormVisible,
+    editingId,
+    formDate,
+    formType,
+    formQuantity,
+    formUnitPrice,
+    formFees,
+    isSaving,
+    saveError,
+    deleteError,
+    nodeType,
+    showNewForm,
+    showEditForm,
+    cancelForm,
+    setFormField,
+    saveForm,
+    deleteTransaction,
+  } = useTransactions()
+
+  if (isLoading) {
+    return <LoadingState />
+  }
+
+  if (error) {
+    return <ErrorState message={error} onRetry={retry} />
+  }
+
+  if (nodeType !== 'Asset') {
+    return (
+      <p className="transactions-tab__placeholder">
+        Transactions are only available for individual assets
+      </p>
+    )
+  }
+
+  return (
+    <div className="transactions-tab">
+      <div className="transactions-tab__toolbar">
+        <button className="transactions-tab__new-btn" type="button" onClick={showNewForm}>
+          New
+        </button>
+      </div>
+
+      {isFormVisible && (
+        <InlineForm
+          editingId={editingId}
+          formDate={formDate}
+          formType={formType}
+          formQuantity={formQuantity}
+          formUnitPrice={formUnitPrice}
+          formFees={formFees}
+          isSaving={isSaving}
+          saveError={saveError}
+          onFieldChange={setFormField}
+          onSave={saveForm}
+          onCancel={cancelForm}
+        />
+      )}
+
+      <div className="transactions-tab__table-wrapper">
+        <table className="transactions-tab__table">
+          <thead>
+            <tr>
+              <th />
+              <th />
+              <th>Date</th>
+              <th>Type</th>
+              <th className="transactions-tab__amount">Quantity</th>
+              <th className="transactions-tab__amount">Unit Price</th>
+              <th className="transactions-tab__amount">Fees</th>
+              <th className="transactions-tab__amount">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions.map((t) => (
+              <TransactionRow
+                key={t.id}
+                transaction={t}
+                onEdit={showEditForm}
+                onDelete={deleteTransaction}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {deleteError && <p className="transactions-tab__delete-error">{deleteError}</p>}
+    </div>
+  )
+}

--- a/Financial.Web/src/components/__tests__/TransactionsTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/TransactionsTab.test.tsx
@@ -1,0 +1,209 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TransactionsData } from '../../hooks/useTransactions'
+import type { TransactionDto } from '../../api/types'
+import TransactionsTab from '../TransactionsTab'
+
+const mockShowNewForm = vi.fn()
+const mockShowEditForm = vi.fn()
+const mockCancelForm = vi.fn()
+const mockSetFormField = vi.fn()
+const mockSaveForm = vi.fn()
+const mockDeleteTransaction = vi.fn()
+const mockRetry = vi.fn()
+
+const TRANSACTION_BUY: TransactionDto = {
+  id: 'aaa',
+  date: '2024-03-15T00:00:00',
+  type: 'Buy',
+  quantity: 100,
+  unitPrice: 4.2,
+  fees: 0.5,
+  totalPrice: 420.5,
+}
+
+const TRANSACTION_SELL: TransactionDto = {
+  id: 'bbb',
+  date: '2024-01-10T00:00:00',
+  type: 'Sell',
+  quantity: 50,
+  unitPrice: 5.0,
+  fees: 1.0,
+  totalPrice: 251.0,
+}
+
+const DEFAULT_HOOK: TransactionsData = {
+  asset: null,
+  isLoading: false,
+  error: null,
+  retry: mockRetry,
+  transactions: [],
+  isFormVisible: false,
+  editingId: null,
+  formDate: '',
+  formType: 'Buy',
+  formQuantity: '',
+  formUnitPrice: '',
+  formFees: '',
+  isSaving: false,
+  saveError: null,
+  deleteError: null,
+  nodeType: 'Asset',
+  showNewForm: mockShowNewForm,
+  showEditForm: mockShowEditForm,
+  cancelForm: mockCancelForm,
+  setFormField: mockSetFormField,
+  saveForm: mockSaveForm,
+  deleteTransaction: mockDeleteTransaction,
+}
+
+let mockHookValue: TransactionsData = { ...DEFAULT_HOOK }
+
+vi.mock('../../hooks/useTransactions', () => ({
+  useTransactions: () => mockHookValue,
+}))
+
+function setMock(overrides: Partial<TransactionsData>) {
+  mockHookValue = { ...DEFAULT_HOOK, ...overrides }
+}
+
+describe('TransactionsTab', () => {
+  beforeEach(() => {
+    mockShowNewForm.mockReset()
+    mockShowEditForm.mockReset()
+    mockCancelForm.mockReset()
+    mockSetFormField.mockReset()
+    mockSaveForm.mockReset()
+    mockDeleteTransaction.mockReset()
+    mockRetry.mockReset()
+    mockHookValue = { ...DEFAULT_HOOK }
+  })
+
+  it('renders_loading_state', () => {
+    setMock({ isLoading: true })
+    render(<TransactionsTab />)
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('renders_error_state_with_retry', () => {
+    setMock({ error: 'Network error' })
+    render(<TransactionsTab />)
+    expect(screen.getByText('Network error')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('renders_placeholder_for_non_asset', () => {
+    setMock({ nodeType: 'Portfolio' })
+    render(<TransactionsTab />)
+    expect(
+      screen.getByText('Transactions are only available for individual assets'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders_table_with_correct_columns', () => {
+    setMock({ transactions: [TRANSACTION_BUY] })
+    render(<TransactionsTab />)
+    expect(screen.getByText('Date')).toBeInTheDocument()
+    expect(screen.getByText('Type')).toBeInTheDocument()
+    expect(screen.getByText('Quantity')).toBeInTheDocument()
+    expect(screen.getByText('Unit Price')).toBeInTheDocument()
+    expect(screen.getByText('Fees')).toBeInTheDocument()
+    expect(screen.getByText('Total')).toBeInTheDocument()
+  })
+
+  it('renders_date_in_dd_MM_yyyy_format', () => {
+    setMock({ transactions: [TRANSACTION_BUY] })
+    render(<TransactionsTab />)
+    expect(screen.getByText('15/03/2024')).toBeInTheDocument()
+  })
+
+  it('renders_buy_type_in_green_bold', () => {
+    setMock({ transactions: [TRANSACTION_BUY] })
+    render(<TransactionsTab />)
+    const typeCell = screen.getByText('Buy')
+    expect(typeCell).toHaveClass('transactions-tab__type--buy')
+  })
+
+  it('renders_sell_type_in_red_bold', () => {
+    setMock({ transactions: [TRANSACTION_SELL] })
+    render(<TransactionsTab />)
+    const typeCell = screen.getByText('Sell')
+    expect(typeCell).toHaveClass('transactions-tab__type--sell')
+  })
+
+  it('renders_quantity_with_8_decimal_places', () => {
+    setMock({ transactions: [TRANSACTION_BUY] })
+    render(<TransactionsTab />)
+    expect(screen.getByText('100.00000000')).toBeInTheDocument()
+  })
+
+  it('renders_total_in_bold', () => {
+    setMock({ transactions: [TRANSACTION_BUY] })
+    render(<TransactionsTab />)
+    const totalCell = screen.getByText('420.50')
+    expect(totalCell).toHaveClass('transactions-tab__total')
+  })
+
+  it('new_button_calls_show_new_form', () => {
+    render(<TransactionsTab />)
+    fireEvent.click(screen.getByRole('button', { name: 'New' }))
+    expect(mockShowNewForm).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders_form_when_form_visible', () => {
+    setMock({ isFormVisible: true, editingId: null })
+    render(<TransactionsTab />)
+    expect(screen.getByText('New transaction')).toBeInTheDocument()
+    expect(screen.getByLabelText('Date')).toBeInTheDocument()
+    expect(screen.getByLabelText('Type')).toBeInTheDocument()
+    expect(screen.getByLabelText('Quantity')).toBeInTheDocument()
+    expect(screen.getByLabelText('Unit Price')).toBeInTheDocument()
+    expect(screen.getByLabelText('Fees')).toBeInTheDocument()
+  })
+
+  it('renders_edit_transaction_title_when_editing', () => {
+    setMock({ isFormVisible: true, editingId: 'aaa' })
+    render(<TransactionsTab />)
+    expect(screen.getByText('Edit transaction')).toBeInTheDocument()
+  })
+
+  it('save_button_disabled_while_saving', () => {
+    setMock({ isFormVisible: true, isSaving: true })
+    render(<TransactionsTab />)
+    const saveBtn = screen.getByRole('button', { name: 'Saving...' })
+    expect(saveBtn).toBeDisabled()
+  })
+
+  it('edit_icon_calls_show_edit_form', () => {
+    setMock({ transactions: [TRANSACTION_BUY] })
+    render(<TransactionsTab />)
+    fireEvent.click(screen.getByRole('button', { name: 'Edit transaction' }))
+    expect(mockShowEditForm).toHaveBeenCalledWith(TRANSACTION_BUY)
+  })
+
+  it('delete_icon_calls_delete_transaction', () => {
+    setMock({ transactions: [TRANSACTION_BUY] })
+    render(<TransactionsTab />)
+    fireEvent.click(screen.getByRole('button', { name: 'Delete transaction' }))
+    expect(mockDeleteTransaction).toHaveBeenCalledWith('aaa')
+  })
+
+  it('renders_save_error_below_form', () => {
+    setMock({ isFormVisible: true, saveError: 'Failed to save' })
+    render(<TransactionsTab />)
+    expect(screen.getByText('Failed to save')).toBeInTheDocument()
+  })
+
+  it('renders_delete_error_below_table', () => {
+    setMock({ deleteError: 'Failed to delete' })
+    render(<TransactionsTab />)
+    expect(screen.getByText('Failed to delete')).toBeInTheDocument()
+  })
+
+  it('empty_table_renders_no_rows', () => {
+    setMock({ transactions: [] })
+    render(<TransactionsTab />)
+    const tbody = document.querySelector('tbody')
+    expect(tbody?.children.length).toBe(0)
+  })
+})

--- a/Financial.Web/src/hooks/useTransactions.test.ts
+++ b/Financial.Web/src/hooks/useTransactions.test.ts
@@ -1,0 +1,345 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { createElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FinancialApiClient } from '../api/financialApiClient'
+import type { AssetDetailsDto, SelectedNode, TransactionDto } from '../api/types'
+import { SelectedNodeProvider, useSelectedNode } from '../context/SelectedNodeContext'
+import { useTransactions } from './useTransactions'
+
+const getAssetDetailsMock = vi.fn<FinancialApiClient['getAssetDetails']>()
+const addTransactionMock = vi.fn<FinancialApiClient['addTransaction']>()
+const updateTransactionMock = vi.fn<FinancialApiClient['updateTransaction']>()
+const deleteTransactionMock = vi.fn<FinancialApiClient['deleteTransaction']>()
+
+vi.mock('../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getAssetDetails: getAssetDetailsMock,
+    addTransaction: addTransactionMock,
+    updateTransaction: updateTransactionMock,
+    deleteTransaction: deleteTransactionMock,
+  }),
+}))
+
+vi.stubGlobal('confirm', vi.fn(() => true))
+
+const ASSET_NODE: SelectedNode = {
+  nodeType: 'Asset',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+  assetName: 'KLBN4',
+  ticker: 'KLBN4',
+  exchange: 'BVMF',
+  isActive: true,
+}
+
+const PORTFOLIO_NODE: SelectedNode = {
+  nodeType: 'Portfolio',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+}
+
+const TRANSACTION_A: TransactionDto = {
+  id: 'aaa',
+  date: '2024-03-15T00:00:00',
+  type: 'Buy',
+  quantity: 100,
+  unitPrice: 4.2,
+  fees: 0.5,
+  totalPrice: 420.5,
+}
+
+const TRANSACTION_B: TransactionDto = {
+  id: 'bbb',
+  date: '2024-01-10T00:00:00',
+  type: 'Sell',
+  quantity: 50,
+  unitPrice: 5.0,
+  fees: 1.0,
+  totalPrice: 251.0,
+}
+
+const ASSET_DETAILS: AssetDetailsDto = {
+  name: 'KLBN4',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+  ticker: 'KLBN4',
+  isin: 'BRKLBN',
+  exchange: 'BVMF',
+  country: 'BR',
+  localTypeCode: 'ON',
+  class: 'Equity',
+  quantity: 100,
+  averagePrice: 20,
+  isActive: true,
+  totalBought: 2000,
+  totalSold: 0,
+  totalCredits: 50,
+  transactions: [TRANSACTION_A, TRANSACTION_B],
+  credits: [],
+}
+
+function createWrapper() {
+  let setNodeRef: ((node: SelectedNode | null) => void) | undefined
+
+  function NodeControl() {
+    const { setSelectedNode } = useSelectedNode()
+    setNodeRef = setSelectedNode
+    return null
+  }
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(SelectedNodeProvider, null, createElement(NodeControl), children)
+  }
+
+  return {
+    wrapper: Wrapper,
+    setNode: (node: SelectedNode | null) =>
+      act(() => {
+        setNodeRef?.(node)
+      }),
+  }
+}
+
+describe('useTransactions', () => {
+  beforeEach(() => {
+    getAssetDetailsMock.mockReset()
+    addTransactionMock.mockReset()
+    updateTransactionMock.mockReset()
+    deleteTransactionMock.mockReset()
+    vi.mocked(window.confirm).mockReturnValue(true)
+  })
+
+  it('returns_initial_empty_state', () => {
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.asset).toBeNull()
+    expect(result.current.error).toBeNull()
+    expect(result.current.transactions).toEqual([])
+    expect(result.current.isFormVisible).toBe(false)
+  })
+
+  it('fetches_asset_details_on_asset_selection', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => {
+      expect(getAssetDetailsMock).toHaveBeenCalledWith('XPI', 'Acoes', 'KLBN4')
+    })
+  })
+
+  it('resets_state_when_non_asset_node_selected', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(result.current.asset).toBeNull())
+    expect(getAssetDetailsMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('increments_retry_and_refetches_on_retry', async () => {
+    getAssetDetailsMock.mockRejectedValueOnce(new Error('Network error'))
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.error).toBe('Network error'))
+    act(() => result.current.retry())
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    expect(getAssetDetailsMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('sorts_transactions_by_date_descending', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.transactions.length).toBe(2))
+    expect(result.current.transactions[0].id).toBe('aaa')
+    expect(result.current.transactions[1].id).toBe('bbb')
+  })
+
+  it('show_new_form_opens_blank_form', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    act(() => result.current.showNewForm())
+    expect(result.current.isFormVisible).toBe(true)
+    expect(result.current.editingId).toBeNull()
+    expect(result.current.formDate).toBe('')
+    expect(result.current.formType).toBe('Buy')
+    expect(result.current.formQuantity).toBe('')
+    expect(result.current.formUnitPrice).toBe('')
+    expect(result.current.formFees).toBe('')
+  })
+
+  it('show_edit_form_populates_fields', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    act(() => result.current.showEditForm(TRANSACTION_A))
+    expect(result.current.isFormVisible).toBe(true)
+    expect(result.current.editingId).toBe('aaa')
+    expect(result.current.formDate).toBe('2024-03-15')
+    expect(result.current.formType).toBe('Buy')
+    expect(result.current.formQuantity).toBe('100')
+    expect(result.current.formUnitPrice).toBe('4.2')
+    expect(result.current.formFees).toBe('0.5')
+  })
+
+  it('cancel_form_hides_form_and_resets_fields', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    act(() => result.current.showNewForm())
+    expect(result.current.isFormVisible).toBe(true)
+    act(() => result.current.cancelForm())
+    expect(result.current.isFormVisible).toBe(false)
+    expect(result.current.formDate).toBe('')
+    expect(result.current.formQuantity).toBe('')
+  })
+
+  it('save_new_transaction_calls_add_and_updates_asset', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const updatedAsset = { ...ASSET_DETAILS, transactions: [TRANSACTION_A, TRANSACTION_B] }
+    addTransactionMock.mockResolvedValue(updatedAsset)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    act(() => result.current.showNewForm())
+    act(() => {
+      result.current.setFormField('formDate', '2024-06-01')
+      result.current.setFormField('formType', 'Buy')
+      result.current.setFormField('formQuantity', '50')
+      result.current.setFormField('formUnitPrice', '10')
+      result.current.setFormField('formFees', '0.5')
+    })
+    act(() => result.current.saveForm())
+    await waitFor(() => expect(addTransactionMock).toHaveBeenCalledWith({
+      brokerName: 'XPI',
+      portfolioName: 'Acoes',
+      assetName: 'KLBN4',
+      date: '2024-06-01',
+      type: 'Buy',
+      quantity: 50,
+      unitPrice: 10,
+      fees: 0.5,
+    }))
+    await waitFor(() => expect(result.current.isFormVisible).toBe(false))
+    expect(result.current.asset).toEqual(updatedAsset)
+  })
+
+  it('save_edit_transaction_calls_update', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const updatedAsset = { ...ASSET_DETAILS }
+    updateTransactionMock.mockResolvedValue(updatedAsset)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    act(() => result.current.showEditForm(TRANSACTION_A))
+    act(() => {
+      result.current.setFormField('formQuantity', '200')
+    })
+    act(() => result.current.saveForm())
+    await waitFor(() => expect(updateTransactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'aaa', quantity: 200 }),
+    ))
+    expect(result.current.asset).toEqual(updatedAsset)
+  })
+
+  it('save_sets_error_on_api_failure', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    addTransactionMock.mockRejectedValue(new Error('Server error'))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    act(() => result.current.showNewForm())
+    act(() => {
+      result.current.setFormField('formDate', '2024-06-01')
+      result.current.setFormField('formQuantity', '50')
+      result.current.setFormField('formUnitPrice', '10')
+    })
+    act(() => result.current.saveForm())
+    await waitFor(() => expect(result.current.saveError).toBe('Server error'))
+    expect(result.current.isFormVisible).toBe(true)
+    expect(result.current.isSaving).toBe(false)
+  })
+
+  it('save_defaults_fees_to_zero_when_blank', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    addTransactionMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    act(() => result.current.showNewForm())
+    act(() => {
+      result.current.setFormField('formDate', '2024-06-01')
+      result.current.setFormField('formQuantity', '50')
+      result.current.setFormField('formUnitPrice', '10')
+    })
+    act(() => result.current.saveForm())
+    await waitFor(() =>
+      expect(addTransactionMock).toHaveBeenCalledWith(
+        expect.objectContaining({ fees: 0 }),
+      ),
+    )
+  })
+
+  it('save_validation_error_when_required_fields_missing', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    act(() => result.current.showNewForm())
+    act(() => result.current.saveForm())
+    expect(result.current.saveError).not.toBeNull()
+    expect(addTransactionMock).not.toHaveBeenCalled()
+  })
+
+  it('delete_transaction_calls_api_and_updates_asset', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const updatedAsset = { ...ASSET_DETAILS, transactions: [TRANSACTION_B] }
+    deleteTransactionMock.mockResolvedValue(updatedAsset)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    act(() => result.current.deleteTransaction('aaa'))
+    await waitFor(() =>
+      expect(deleteTransactionMock).toHaveBeenCalledWith({
+        brokerName: 'XPI',
+        portfolioName: 'Acoes',
+        assetName: 'KLBN4',
+        id: 'aaa',
+      }),
+    )
+    expect(result.current.asset).toEqual(updatedAsset)
+  })
+
+  it('delete_failure_sets_delete_error', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    deleteTransactionMock.mockRejectedValue(new Error('Delete failed'))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    act(() => result.current.deleteTransaction('aaa'))
+    await waitFor(() => expect(result.current.deleteError).toBe('Delete failed'))
+    expect(result.current.asset).toEqual(ASSET_DETAILS)
+  })
+})

--- a/Financial.Web/src/hooks/useTransactions.ts
+++ b/Financial.Web/src/hooks/useTransactions.ts
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react'
+import { createFinancialApiClient } from '../api/financialApiClient'
+import type { AssetDetailsDto, TransactionDto } from '../api/types'
+import { useSelectedNode } from '../context/SelectedNodeContext'
+
+export type TransactionFormField = 'formDate' | 'formType' | 'formQuantity' | 'formUnitPrice' | 'formFees'
+
+interface TransactionsState {
+  asset: AssetDetailsDto | null
+  isLoading: boolean
+  error: string | null
+  retryCount: number
+  isFormVisible: boolean
+  editingId: string | null
+  formDate: string
+  formType: string
+  formQuantity: string
+  formUnitPrice: string
+  formFees: string
+  isSaving: boolean
+  saveError: string | null
+  deleteError: string | null
+}
+
+type TransactionsAction =
+  | { type: 'RESET' }
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; payload: AssetDetailsDto }
+  | { type: 'FETCH_ERROR'; payload: string }
+  | { type: 'RETRY' }
+  | { type: 'SHOW_NEW_FORM' }
+  | { type: 'SHOW_EDIT_FORM'; payload: TransactionDto }
+  | { type: 'CANCEL_FORM' }
+  | { type: 'SET_FORM_FIELD'; payload: { field: TransactionFormField; value: string } }
+  | { type: 'SAVE_START' }
+  | { type: 'SAVE_SUCCESS'; payload: AssetDetailsDto }
+  | { type: 'SAVE_ERROR'; payload: string }
+  | { type: 'DELETE_SUCCESS'; payload: AssetDetailsDto }
+  | { type: 'DELETE_ERROR'; payload: string }
+
+const BLANK_FORM = {
+  isFormVisible: false,
+  editingId: null,
+  formDate: '',
+  formType: 'Buy',
+  formQuantity: '',
+  formUnitPrice: '',
+  formFees: '',
+  isSaving: false,
+  saveError: null,
+} as const
+
+const INITIAL_STATE: TransactionsState = {
+  asset: null,
+  isLoading: false,
+  error: null,
+  retryCount: 0,
+  ...BLANK_FORM,
+  deleteError: null,
+}
+
+function toInputDate(isoString: string): string {
+  return isoString.split('T')[0]
+}
+
+function reducer(state: TransactionsState, action: TransactionsAction): TransactionsState {
+  switch (action.type) {
+    case 'RESET':
+      return INITIAL_STATE
+    case 'FETCH_START':
+      return { ...INITIAL_STATE, isLoading: true, retryCount: state.retryCount }
+    case 'FETCH_SUCCESS':
+      return { ...state, isLoading: false, asset: action.payload }
+    case 'FETCH_ERROR':
+      return { ...state, isLoading: false, error: action.payload }
+    case 'RETRY':
+      return { ...state, retryCount: state.retryCount + 1, error: null }
+    case 'SHOW_NEW_FORM':
+      return {
+        ...state,
+        isFormVisible: true,
+        editingId: null,
+        formDate: '',
+        formType: 'Buy',
+        formQuantity: '',
+        formUnitPrice: '',
+        formFees: '',
+        saveError: null,
+        isSaving: false,
+      }
+    case 'SHOW_EDIT_FORM': {
+      const t = action.payload
+      return {
+        ...state,
+        isFormVisible: true,
+        editingId: t.id,
+        formDate: toInputDate(t.date),
+        formType: t.type,
+        formQuantity: String(t.quantity),
+        formUnitPrice: String(t.unitPrice),
+        formFees: String(t.fees),
+        saveError: null,
+        isSaving: false,
+      }
+    }
+    case 'CANCEL_FORM':
+      return { ...state, ...BLANK_FORM }
+    case 'SET_FORM_FIELD':
+      return { ...state, [action.payload.field]: action.payload.value }
+    case 'SAVE_START':
+      return { ...state, isSaving: true, saveError: null }
+    case 'SAVE_SUCCESS':
+      return { ...state, ...BLANK_FORM, asset: action.payload, deleteError: state.deleteError }
+    case 'SAVE_ERROR':
+      return { ...state, isSaving: false, saveError: action.payload }
+    case 'DELETE_SUCCESS':
+      return { ...state, asset: action.payload, deleteError: null }
+    case 'DELETE_ERROR':
+      return { ...state, deleteError: action.payload }
+    default:
+      return state
+  }
+}
+
+export interface TransactionsData {
+  asset: AssetDetailsDto | null
+  isLoading: boolean
+  error: string | null
+  retry: () => void
+  transactions: TransactionDto[]
+  isFormVisible: boolean
+  editingId: string | null
+  formDate: string
+  formType: string
+  formQuantity: string
+  formUnitPrice: string
+  formFees: string
+  isSaving: boolean
+  saveError: string | null
+  deleteError: string | null
+  nodeType: string | undefined
+  showNewForm: () => void
+  showEditForm: (transaction: TransactionDto) => void
+  cancelForm: () => void
+  setFormField: (field: TransactionFormField, value: string) => void
+  saveForm: () => void
+  deleteTransaction: (id: string) => void
+}
+
+export function useTransactions(): TransactionsData {
+  const { selectedNode } = useSelectedNode()
+  const apiClient = useMemo(() => createFinancialApiClient(), [])
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  const isAsset =
+    selectedNode?.nodeType === 'Asset' &&
+    !!selectedNode.portfolioName &&
+    !!selectedNode.assetName
+
+  useEffect(() => {
+    if (!isAsset || !selectedNode) {
+      dispatch({ type: 'RESET' })
+      return
+    }
+
+    const { brokerName, portfolioName, assetName } = selectedNode
+
+    if (!portfolioName || !assetName) {
+      dispatch({ type: 'RESET' })
+      return
+    }
+
+    dispatch({ type: 'FETCH_START' })
+
+    void apiClient
+      .getAssetDetails(brokerName, portfolioName, assetName)
+      .then((result) => dispatch({ type: 'FETCH_SUCCESS', payload: result }))
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'FETCH_ERROR',
+          payload: err instanceof Error ? err.message : 'Unable to load asset details',
+        })
+      })
+  }, [selectedNode, isAsset, apiClient, state.retryCount])
+
+  const transactions = useMemo(() => {
+    if (!state.asset) return []
+    return [...state.asset.transactions].sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+    )
+  }, [state.asset])
+
+  const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
+
+  const showNewForm = useCallback(() => dispatch({ type: 'SHOW_NEW_FORM' }), [])
+
+  const showEditForm = useCallback((transaction: TransactionDto) => {
+    dispatch({ type: 'SHOW_EDIT_FORM', payload: transaction })
+  }, [])
+
+  const cancelForm = useCallback(() => dispatch({ type: 'CANCEL_FORM' }), [])
+
+  const setFormField = useCallback((field: TransactionFormField, value: string) => {
+    dispatch({ type: 'SET_FORM_FIELD', payload: { field, value } })
+  }, [])
+
+  const saveForm = useCallback(() => {
+    if (!selectedNode?.portfolioName || !selectedNode.assetName) return
+
+    const { formDate, formType, formQuantity, formUnitPrice, formFees, editingId } = state
+
+    if (!formDate.trim()) {
+      dispatch({ type: 'SAVE_ERROR', payload: 'Date is required' })
+      return
+    }
+
+    const quantity = parseFloat(formQuantity)
+    if (!formQuantity.trim() || !isFinite(quantity) || quantity <= 0) {
+      dispatch({ type: 'SAVE_ERROR', payload: 'Quantity must be a positive number' })
+      return
+    }
+
+    const unitPrice = parseFloat(formUnitPrice)
+    if (!formUnitPrice.trim() || !isFinite(unitPrice) || unitPrice <= 0) {
+      dispatch({ type: 'SAVE_ERROR', payload: 'Unit Price must be a positive number' })
+      return
+    }
+
+    const fees = formFees.trim() === '' ? 0 : parseFloat(formFees)
+
+    dispatch({ type: 'SAVE_START' })
+
+    const base = {
+      brokerName: selectedNode.brokerName,
+      portfolioName: selectedNode.portfolioName,
+      assetName: selectedNode.assetName,
+      date: formDate,
+      type: formType,
+      quantity,
+      unitPrice,
+      fees,
+    }
+
+    const call = editingId
+      ? apiClient.updateTransaction({ ...base, id: editingId })
+      : apiClient.addTransaction(base)
+
+    void call
+      .then((result) => dispatch({ type: 'SAVE_SUCCESS', payload: result }))
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'SAVE_ERROR',
+          payload: err instanceof Error ? err.message : 'Failed to save transaction',
+        })
+      })
+  }, [selectedNode, state, apiClient])
+
+  const deleteTransaction = useCallback(
+    (id: string) => {
+      if (!selectedNode?.portfolioName || !selectedNode.assetName) return
+      if (!window.confirm('Delete this transaction?')) return
+
+      void apiClient
+        .deleteTransaction({
+          brokerName: selectedNode.brokerName,
+          portfolioName: selectedNode.portfolioName,
+          assetName: selectedNode.assetName,
+          id,
+        })
+        .then((result) => dispatch({ type: 'DELETE_SUCCESS', payload: result }))
+        .catch((err: unknown) => {
+          dispatch({
+            type: 'DELETE_ERROR',
+            payload: err instanceof Error ? err.message : 'Failed to delete transaction',
+          })
+        })
+    },
+    [selectedNode, apiClient],
+  )
+
+  return {
+    asset: state.asset,
+    isLoading: state.isLoading,
+    error: state.error,
+    retry,
+    transactions,
+    isFormVisible: state.isFormVisible,
+    editingId: state.editingId,
+    formDate: state.formDate,
+    formType: state.formType,
+    formQuantity: state.formQuantity,
+    formUnitPrice: state.formUnitPrice,
+    formFees: state.formFees,
+    isSaving: state.isSaving,
+    saveError: state.saveError,
+    deleteError: state.deleteError,
+    nodeType: selectedNode?.nodeType,
+    showNewForm,
+    showEditForm,
+    cancelForm,
+    setFormField,
+    saveForm,
+    deleteTransaction,
+  }
+}

--- a/docs/F05-transactions-tab/plan.md
+++ b/docs/F05-transactions-tab/plan.md
@@ -1,0 +1,49 @@
+# Implementation Plan: F05 — Portfolio Navigator: Transactions Tab
+
+**Prerequisites:**
+- F02 implemented and merged (`SelectedNodeContext` available) ✅
+- All transaction DTOs and API client methods already exist in `types.ts` and `financialApiClient.ts` ✅
+- `TransactionsController` and `TransactionService` already exist on the backend ✅
+- `LoadingState` and `ErrorState` shared components available ✅
+
+---
+
+### Phase 1: Hook — `useTransactions`
+
+**1. State, actions, and reducer** — Create `Financial.Web/src/hooks/useTransactions.ts` and define the full state shape covering asset loading, form visibility, all form field values, save/delete error tracking, and a retry counter. Implement the reducer that handles all state transitions — reset on node change, fetch lifecycle, and every form action.
+
+**2. Data fetching** — Wire a `useEffect` that watches the selected node from `SelectedNodeContext` and calls `getAssetDetails` when an asset node is selected, following the same trigger and cancellation pattern as `useAssetSummary`. Include `retryCount` as a dependency so the retry action causes a re-fetch.
+
+**3. Form state actions** — Implement `showNewForm` (opens a blank form with type defaulting to Buy), `showEditForm` (populates fields from a `TransactionDto` and converts the ISO date to `yyyy-MM-dd` for the date input), `cancelForm` (hides and resets the form), and `setFormField` (updates individual field values).
+
+**4. Mutation operations** — Implement `saveForm` (validates required fields, builds the correct DTO based on whether `editingId` is set, calls `addTransaction` or `updateTransaction`, then on success dispatches the returned `AssetDetailsDto` as `FETCH_SUCCESS` and hides the form) and `deleteTransaction` (prompts via `window.confirm`, calls `deleteTransaction` on the API client, and dispatches accordingly).
+
+**5. Sorted output** — Derive `transactions` by sorting `asset.transactions` by date descending and expose it through the returned interface. Return the full hook interface including all state flags and action callbacks.
+
+---
+
+### Phase 2: Component and Styles
+
+**6. `TransactionsTab` component skeleton** — Create `Financial.Web/src/components/TransactionsTab.tsx`. Import `useTransactions`, `LoadingState`, and `ErrorState`. Render the loading guard, error guard with retry callback, and the non-asset placeholder message. Confirm the guards work before building the table.
+
+**7. Transaction table** — Render the full table with action icon columns followed by Date, Type, Quantity, Unit Price, Fees, and Total. Format each cell using the local utility functions (`formatDate`, `formatN8`, `formatN2`). Apply `transactions-tab__type--buy` (green bold) to Buy cells and `transactions-tab__type--sell` (red bold) to Sell cells. Wire the edit icon to `showEditForm` and the delete icon to `deleteTransaction`.
+
+**8. Inline form** — Render the add/edit form above the table when `isFormVisible` is true. Include controlled inputs for all fields with the correct input types and step attributes from the spec. Show the form title as "New transaction" or "Edit transaction" based on `editingId`. Wire the Save button to `saveForm` with disabled state and "Saving..." label while `isSaving` is true. Wire Cancel to `cancelForm`.
+
+**9. Error messages** — Render the `saveError` message below the form (when set and form is visible) and the `deleteError` message below the table (when set). Both should be styled as inline error text matching the project's colour scheme.
+
+**10. Styles** — Create `Financial.Web/src/components/TransactionsTab.css` with BEM classes covering the toolbar row, form container and fields, table column widths, type colour modifiers, right-aligned amount columns, bold total column, and both error message placements. Match colour values (`#2e7d32` for green, `#c62828` for red) to the existing theme.
+
+---
+
+### Phase 3: Integration
+
+**11. Wire into `DetailPanel`** — In `Financial.Web/src/components/DetailPanel.tsx`, replace the two transactions placeholder blocks (the "coming in F05" placeholder and the non-asset message) with a single `{activeTab === 'transactions' && <TransactionsTab />}` expression and add the import statement. The non-asset vs asset branching moves inside `TransactionsTab` via the hook.
+
+---
+
+### Phase 4: Tests
+
+**12. Hook unit tests** — Create `Financial.Web/src/hooks/useTransactions.test.ts` mocking `createFinancialApiClient`. Cover the fetch lifecycle (initial state, fetches on asset node, resets on non-asset node, retry), sorted transactions output, all form state transitions (new, edit, cancel, field change), each mutation path (add success, update success, delete success), and all error paths (save error, delete error, validation block). See spec Section 7 for the full test function list.
+
+**13. Component unit tests** — Create `Financial.Web/src/components/__tests__/TransactionsTab.test.tsx` mocking `useTransactions`. Cover all render states (loading, error, non-asset placeholder, empty table, populated table), column formatting (date `dd/MM/yyyy`, N8 quantity, N2 prices, bold total), type colour classes (Buy green, Sell red), form interactions (New button, form visibility, title, Save disabled state), and error message placements. See spec Section 7 for the full test function list.

--- a/docs/F05-transactions-tab/spec.md
+++ b/docs/F05-transactions-tab/spec.md
@@ -1,0 +1,331 @@
+# F05 — Portfolio Navigator: Transactions Tab
+
+## 1. Technical Overview
+
+F05 implements the Transactions tab within the Portfolio Navigator's right-panel detail view. When an asset node is selected, the tab renders a sortable transaction history table and an inline CRUD form. When a broker or portfolio node is selected, it renders a static informational message. The Credits tab (F06) will follow the same structural pattern.
+
+All backend infrastructure is already in place: `TransactionsController`, `TransactionService`, `AssetServiceHelper`, the `Transaction` domain entity, and all request/response DTOs exist and are wired up. The `financialApiClient` already exposes `addTransaction`, `updateTransaction`, and `deleteTransaction`. This feature is therefore a pure frontend addition — no backend changes are required.
+
+The `TransactionsTab` component follows the same self-contained hook pattern established by `AssetSummaryTab` (F03) and `AggregatedSummaryTab` (F04): a dedicated `useTransactions` hook manages all data-fetching and mutation state via `useReducer`, and the component renders from that hook's output. The tab replaces the placeholder currently in `DetailPanel.tsx`.
+
+**Scope — Included:**
+- `useTransactions` hook: fetches `AssetDetailsDto` on asset selection, manages inline form state and CRUD mutations
+- `TransactionsTab` component: table of transactions + inline add/edit form
+- Loading, error, and empty states; non-asset placeholder message
+- `DetailPanel.tsx` updated to import and render `TransactionsTab`
+
+**Scope — Excluded:**
+- Shared cross-tab asset state (Summary tab may show stale totals after a transaction mutation; this is acceptable at MVP and matches F03/F04 precedent)
+- Backend changes (all endpoints already exist)
+
+---
+
+## 2. Architecture Impact
+
+**Affected components:**
+
+```mermaid
+graph TD
+    User["User (browser)"] --> DetailPanel
+    DetailPanel --> TransactionsTab
+    TransactionsTab --> useTransactions
+    useTransactions --> SelectedNodeContext
+    useTransactions --> FinancialApiClient["FinancialApiClient"]
+    FinancialApiClient --> TransactionsController["TransactionsController (existing)"]
+    TransactionsController --> TransactionService["TransactionService (existing)"]
+    TransactionService --> JSONRepository["JSONRepository (existing)"]
+```
+
+**Data flow — read path:** On asset node selection, `useTransactions` calls `getAssetDetails` and stores the returned `AssetDetailsDto`. The `transactions` array is sorted client-side by date descending and passed to the table renderer.
+
+**Data flow — write path:** User submits the inline form → `useTransactions` validates and calls `addTransaction` or `updateTransaction` (or `deleteTransaction`) → on success the returned updated `AssetDetailsDto` replaces the current asset state → form resets and the table re-renders with fresh data.
+
+---
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Data fetching | `useTransactions` fetches `AssetDetailsDto` independently, following the same pattern as `useAssetSummary` | Shared asset context providing `AssetDetailsDto` to all tabs | Independent hook keeps each tab self-contained and avoids coupling. Accept that Summary tab may show stale totals until the user re-selects the node. This matches F03/F04 precedent. |
+| Form state location | Form state (visibility, field values, saving flag, error) managed inside `useTransactions` alongside asset state | Separate form hook or component-local state | Single hook owns all tab state, consistent with `useAssetSummary` which also owns derived/computed state. |
+| Date input format | Store form date as `yyyy-MM-dd` string (native `<input type="date">` format); convert from ISO on edit load; send `yyyy-MM-dd` to API | Parse to `Date` object in state | Avoids double conversion; the API backend accepts `yyyy-MM-dd` date strings. |
+| Numeric form fields as strings | Store `formQuantity`, `formUnitPrice`, `formFees` as strings during editing | Store as numbers | Prevents loss of partial input while the user is typing (e.g., `"1."` would become `1` prematurely). Convert to number only on submit. |
+
+---
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/hooks/useTransactions.ts` | New | All data and mutation state for the Transactions tab | Fetch asset details on node change, manage form visibility and field values, execute add/update/delete mutations, sort transactions by date |
+| `Financial.Web/src/components/TransactionsTab.tsx` | New | Transactions tab UI | Render loading/error guards, non-asset placeholder, transaction table with action icons, inline add/edit form |
+| `Financial.Web/src/components/TransactionsTab.css` | New | Scoped styles for the tab | BEM layout for toolbar, form, table, type colour modifiers, right-aligned amounts, error messages |
+| `Financial.Web/src/components/DetailPanel.tsx` | Modified | Tab container | Replace transactions placeholder with `<TransactionsTab />`; add import |
+| `Financial.Web/src/hooks/useTransactions.test.ts` | New | Unit tests for `useTransactions` | Fetch lifecycle, retry, CRUD mutations, form state transitions |
+| `Financial.Web/src/components/__tests__/TransactionsTab.test.tsx` | New | Unit tests for `TransactionsTab` | Loading/error/placeholder rendering, table columns, form interaction, action icons |
+
+**Backend:** No changes required.
+
+---
+
+## 5. API Contracts
+
+All endpoints already exist. Documented here for implementation reference.
+
+---
+
+### Read — Asset Details (transactions included)
+
+- **Method:** GET
+- **Path:** `/api/v1/financial/assets/{brokerName}/{portfolioName}/{assetName}`
+
+**Response (200):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transactions` | `TransactionDto[]` | Full transaction list for the asset |
+| `transactions[].id` | `string (UUID)` | Transaction identifier |
+| `transactions[].date` | `string (ISO 8601)` | Transaction date |
+| `transactions[].type` | `string` | `"Buy"` or `"Sell"` |
+| `transactions[].quantity` | `number` | Number of units |
+| `transactions[].unitPrice` | `number` | Price per unit |
+| `transactions[].fees` | `number` | Brokerage fees |
+| `transactions[].totalPrice` | `number` | `unitPrice × quantity + fees` (computed by backend) |
+
+**Response Example:**
+```json
+{
+  "name": "KLBN4",
+  "transactions": [
+    {
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "date": "2024-03-15T00:00:00",
+      "type": "Buy",
+      "quantity": 100,
+      "unitPrice": 4.20,
+      "fees": 0.50,
+      "totalPrice": 420.50
+    }
+  ]
+}
+```
+
+---
+
+### Create Transaction
+
+- **Method:** POST
+- **Path:** `/api/v1/financial/transactions`
+
+**Request:**
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|-------------|
+| `brokerName` | `string` | Yes | Non-empty | Broker identifier |
+| `portfolioName` | `string` | Yes | Non-empty | Portfolio identifier |
+| `assetName` | `string` | Yes | Non-empty | Asset identifier |
+| `date` | `string` | Yes | ISO date | Transaction date (`yyyy-MM-dd`) |
+| `type` | `string` | Yes | `"Buy"` or `"Sell"` | Transaction direction |
+| `quantity` | `number` | Yes | > 0 | Number of units |
+| `unitPrice` | `number` | Yes | > 0 | Price per unit |
+| `fees` | `number` | Yes | ≥ 0 | Brokerage fees; `0` when not applicable |
+
+**Request Example:**
+```json
+{
+  "brokerName": "XPI",
+  "portfolioName": "Acoes",
+  "assetName": "KLBN4",
+  "date": "2024-03-15",
+  "type": "Buy",
+  "quantity": 100,
+  "unitPrice": 4.20,
+  "fees": 0.50
+}
+```
+
+**Response (200):** Updated `AssetDetailsDto` (same shape as GET above)
+
+**Error Codes:**
+
+| HTTP Status | Description |
+|-------------|-------------|
+| 400 | Null request, unknown type string, or missing required fields |
+
+---
+
+### Update Transaction
+
+- **Method:** PUT
+- **Path:** `/api/v1/financial/transactions`
+
+**Request:** Same as Create, plus `id` (UUID of the transaction to update).
+
+**Request Example:**
+```json
+{
+  "brokerName": "XPI",
+  "portfolioName": "Acoes",
+  "assetName": "KLBN4",
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "date": "2024-03-15",
+  "type": "Sell",
+  "quantity": 50,
+  "unitPrice": 5.00,
+  "fees": 1.00
+}
+```
+
+**Response (200):** Updated `AssetDetailsDto`
+
+**Error Codes:**
+
+| HTTP Status | Description |
+|-------------|-------------|
+| 400 | Null request, transaction ID not found, or unknown type |
+
+---
+
+### Delete Transaction
+
+- **Method:** DELETE
+- **Path:** `/api/v1/financial/transactions`
+
+**Request:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `brokerName` | `string` | Yes | Broker identifier |
+| `portfolioName` | `string` | Yes | Portfolio identifier |
+| `assetName` | `string` | Yes | Asset identifier |
+| `id` | `string (UUID)` | Yes | Transaction to delete |
+
+**Request Example:**
+```json
+{
+  "brokerName": "XPI",
+  "portfolioName": "Acoes",
+  "assetName": "KLBN4",
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+}
+```
+
+**Response (200):** Updated `AssetDetailsDto` (transaction removed)
+
+**Error Codes:**
+
+| HTTP Status | Description |
+|-------------|-------------|
+| 400 | Null request or transaction ID not found |
+
+---
+
+## 6. Data Model
+
+No backend schema changes. All entities, DTOs, and repository methods are already implemented.
+
+**Existing types used by this feature (TypeScript, `Financial.Web/src/api/types.ts`):**
+
+| Type | Description |
+|------|-------------|
+| `TransactionDto` | Read model: `id`, `date`, `type`, `quantity`, `unitPrice`, `fees`, `totalPrice` |
+| `TransactionCreateDto` | Write model for POST: all fields except `id` |
+| `TransactionUpdateDto` | Write model for PUT: all fields including `id` |
+| `TransactionDeleteDto` | Write model for DELETE: `brokerName`, `portfolioName`, `assetName`, `id` |
+| `AssetDetailsDto` | Contains `transactions: TransactionDto[]`; returned by all mutation endpoints |
+
+---
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/hooks/useTransactions.test.ts` | Unit | `useTransactions` hook | Fetch lifecycle, all CRUD mutations, form state |
+| `Financial.Web/src/components/__tests__/TransactionsTab.test.tsx` | Unit | `TransactionsTab` component | All render states, table formatting, form interaction |
+
+---
+
+### `useTransactions.test.ts`
+
+Follow the pattern from `useAssetSummary.test.ts`: mock `createFinancialApiClient`, create a context wrapper with `SelectedNodeProvider`, and use `renderHook` + `act` + `waitFor`.
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `returns_initial_empty_state` | Hook called with no node | `isLoading: false`, `asset: null`, `error: null`, `transactions: []`, `isFormVisible: false` |
+| `fetches_asset_details_on_asset_selection` | Asset node set in context | `getAssetDetails` called with correct broker/portfolio/asset; `isLoading` transitions true→false; `asset` populated |
+| `resets_state_when_non_asset_node_selected` | Portfolio node set after asset | `asset` set to null; `getAssetDetails` not called |
+| `increments_retry_and_refetches_on_retry` | `retry()` called after error | `getAssetDetails` called a second time |
+| `sorts_transactions_by_date_descending` | Asset with multiple transactions returned | `transactions[0].date` is most recent |
+| `show_new_form_opens_blank_form` | `showNewForm()` called | `isFormVisible: true`, `editingId: null`, fields at defaults |
+| `show_edit_form_populates_fields` | `showEditForm(transactionDto)` called | `isFormVisible: true`, `editingId` set, `formDate` in `yyyy-MM-dd` format, fields match transaction values |
+| `cancel_form_hides_form_and_resets_fields` | `cancelForm()` after `showNewForm()` | `isFormVisible: false`, fields cleared |
+| `save_new_transaction_calls_add_and_updates_asset` | Valid form → `saveForm()` | `addTransaction` called with correct DTO; on success `asset` updated with returned DTO; `isFormVisible: false` |
+| `save_edit_transaction_calls_update` | Form pre-filled from edit → `saveForm()` | `updateTransaction` called with `id`; asset updated |
+| `save_sets_error_on_api_failure` | `addTransaction` rejects → `saveForm()` | `saveError` non-null; `isFormVisible` remains true; `isSaving: false` |
+| `save_defaults_fees_to_zero_when_blank` | `formFees` is `''` → `saveForm()` | `addTransaction` called with `fees: 0` |
+| `save_validation_error_when_required_fields_missing` | `formDate` blank → `saveForm()` | `saveError` set; `addTransaction` not called |
+| `delete_transaction_calls_api_and_updates_asset` | `deleteTransaction(id)` confirmed | `deleteTransaction` called with correct DTO; `asset` updated |
+| `delete_failure_sets_delete_error` | `deleteTransaction` API rejects | `deleteError` non-null; asset unchanged |
+
+---
+
+### `TransactionsTab.test.tsx`
+
+Follow the pattern from `AssetSummaryTab.test.tsx`: mock `useTransactions` at the module level and provide override helper.
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `renders_loading_state` | `isLoading: true` | `<LoadingState>` rendered |
+| `renders_error_state_with_retry` | `error: 'msg'` | `<ErrorState>` rendered with message and retry callback |
+| `renders_placeholder_for_non_asset` | `nodeType !== 'Asset'` | "Transactions are only available for individual assets" visible |
+| `renders_table_with_correct_columns` | Asset with transactions | Columns: Date, Type, Quantity, Unit Price, Fees, Total |
+| `renders_date_in_dd_MM_yyyy_format` | Transaction with date `"2024-03-15T00:00:00"` | Cell shows `15/03/2024` |
+| `renders_buy_type_in_green_bold` | Buy transaction | Type cell has `transactions-tab__type--buy` class |
+| `renders_sell_type_in_red_bold` | Sell transaction | Type cell has `transactions-tab__type--sell` class |
+| `renders_quantity_with_8_decimal_places` | Quantity `100` | Formatted as N8 |
+| `renders_total_in_bold` | Transaction with totalPrice | Total cell has bold class |
+| `new_button_calls_show_new_form` | Click New | `showNewForm` called |
+| `renders_form_when_form_visible` | `isFormVisible: true` | Form fields rendered; title "New transaction" |
+| `renders_edit_transaction_title_when_editing` | `editingId` non-null | Form title "Edit transaction" |
+| `save_button_disabled_while_saving` | `isSaving: true` | Save button `disabled`; label "Saving..." |
+| `edit_icon_calls_show_edit_form` | Click edit icon on row | `showEditForm` called with that transaction |
+| `delete_icon_calls_delete_transaction` | Click delete icon on row | `deleteTransaction` called with transaction id |
+| `renders_save_error_below_form` | `saveError: 'Failed'` with `isFormVisible: true` | Error message visible below form |
+| `renders_delete_error_below_table` | `deleteError: 'Failed'` | Error message visible below table |
+| `empty_table_renders_no_rows` | `transactions: []` | Table body has no data rows |
+
+---
+
+### Formatting Conventions
+
+Utility functions defined locally in `TransactionsTab.tsx`, following `AssetSummaryTab.tsx` conventions:
+
+| Function | Format | Example Input | Example Output |
+|----------|--------|---------------|----------------|
+| `formatN2(value)` | 2 decimal places | `4.2` | `"4.20"` |
+| `formatN8(value)` | 8 decimal places | `100` | `"100.00000000"` |
+| `formatDate(iso)` | `dd/MM/yyyy` | `"2024-03-15T00:00:00"` | `"15/03/2024"` |
+| `toInputDate(iso)` | `yyyy-MM-dd` | `"2024-03-15T00:00:00"` | `"2024-03-15"` |
+
+---
+
+### Acceptance Criteria Mapping
+
+| AC from PRD §9 | Covered by |
+|----------------|-----------|
+| Transactions sorted by date descending | `sorts_transactions_by_date_descending` (hook test) |
+| Table columns: Date (dd/MM/yyyy), Type, Qty (N8), Unit Price (N2), Fees (N2), Total (N2 bold) | `renders_table_with_correct_columns`, `renders_date_in_dd_MM_yyyy_format`, format tests |
+| Buy green bold; Sell red bold | `renders_buy_type_in_green_bold`, `renders_sell_type_in_red_bold` |
+| New shows blank form "New transaction" | `new_button_calls_show_new_form`, `renders_form_when_form_visible` |
+| POST on save; list refreshes | `save_new_transaction_calls_add_and_updates_asset` |
+| Edit icon populates form "Edit transaction" | `edit_icon_calls_show_edit_form`, `renders_edit_transaction_title_when_editing` |
+| PUT on save; list refreshes | `save_edit_transaction_calls_update` |
+| Delete icon shows `window.confirm` | `delete_icon_calls_delete_transaction` |
+| DELETE on confirm; row removed | `delete_transaction_calls_api_and_updates_asset` |
+| Save disabled + "Saving..." during submit | `save_button_disabled_while_saving` |
+| Validation: Date, Qty, UnitPrice required; Fees defaults to 0 | `save_validation_error_when_required_fields_missing`, `save_defaults_fees_to_zero_when_blank` |
+| Cross-feature: F02 passes asset context to F05 | `fetches_asset_details_on_asset_selection` |


### PR DESCRIPTION
## Summary

- Adds `docs/F05-transactions-tab/spec.md` — technical specification covering architecture, API contracts, component overview, data model reference, and a comprehensive testing strategy with 30 test functions
- Adds `docs/F05-transactions-tab/plan.md` — 4-phase, 13-step implementation plan
- Feature is pure frontend (all backend endpoints already exist); no backend changes required

## Key decisions in spec

- `useTransactions` hook fetches `AssetDetailsDto` independently per the established F03/F04 pattern (self-contained tab, no shared state coupling)
- Form state managed inside the hook via `useReducer`, consistent with `useAssetSummary`
- Date handling: ISO → `yyyy-MM-dd` conversion for `<input type="date">`; numeric fields stored as strings during editing
- Complexity: **medium** — 4 phases, 13 steps

## Test plan

- [ ] Review `spec.md` Sections 1–3 (overview, architecture diagram, decisions table)
- [ ] Review `spec.md` Section 4 (component file paths and responsibilities)
- [ ] Review `spec.md` Section 5 (API contracts match existing backend endpoints)
- [ ] Review `spec.md` Section 7 (test functions cover all acceptance criteria from PRD §9)
- [ ] Review `plan.md` phases and step descriptions for implementation order correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)