### PR TITLE
feat(F06): Portfolio Navigator - Credits Tab

### DIFF
--- a/Financial.Web/src/components/CreditsTab.css
+++ b/Financial.Web/src/components/CreditsTab.css
@@ -1,0 +1,307 @@
+.credits-tab {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* Controls: filter + mode toolbar */
+.credits-tab__controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 6px 16px;
+  border-bottom: 1px solid var(--border, #e5e4e7);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.credits-tab__filters {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.credits-tab__filter-btn {
+  font-size: 12px;
+  padding: 2px 8px;
+  cursor: pointer;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  color: #007acc;
+  text-decoration: underline;
+}
+
+.credits-tab__filter-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
+}
+
+.credits-tab__filter-btn--active {
+  color: var(--text-h, #08060d);
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.credits-tab__modes {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.credits-tab__mode-label {
+  font-size: 12px;
+  color: var(--text-muted, #888);
+  margin-right: 4px;
+}
+
+.credits-tab__mode-btn {
+  font-size: 12px;
+  padding: 2px 8px;
+  cursor: pointer;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  color: #007acc;
+  text-decoration: underline;
+}
+
+.credits-tab__mode-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
+}
+
+.credits-tab__mode-btn--active {
+  color: var(--text-h, #08060d);
+  font-weight: bold;
+  text-decoration: none;
+}
+
+/* Inner resizable split (asset only) */
+.credits-tab__split {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.credits-tab__left {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  overflow: hidden;
+  min-width: 200px;
+}
+
+.credits-tab__handle {
+  width: 4px;
+  cursor: col-resize;
+  background: var(--border, #e5e4e7);
+  flex-shrink: 0;
+}
+
+.credits-tab__handle:hover {
+  background: #007acc;
+}
+
+.credits-tab__right {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* Table toolbar */
+.credits-tab__table-toolbar {
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border, #e5e4e7);
+  flex-shrink: 0;
+}
+
+.credits-tab__new-btn {
+  font-size: 12px;
+  padding: 3px 12px;
+  cursor: pointer;
+  background: #007acc;
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+}
+
+.credits-tab__new-btn:hover {
+  background: #005fa3;
+}
+
+/* Inline form */
+.credits-tab__form {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border, #e5e4e7);
+  background: var(--bg-subtle, #f9f9f9);
+  flex-shrink: 0;
+}
+
+.credits-tab__form-title {
+  font-size: 13px;
+  font-weight: bold;
+  margin: 0 0 10px;
+}
+
+.credits-tab__form-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin-bottom: 10px;
+}
+
+.credits-tab__form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.credits-tab__form-field label {
+  font-size: 11px;
+  color: var(--text-muted, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.credits-tab__form-field input,
+.credits-tab__form-field select {
+  font-size: 12px;
+  padding: 3px 6px;
+  border: 1px solid var(--border, #e5e4e7);
+  border-radius: 3px;
+  background: var(--bg, #fff);
+  min-width: 90px;
+}
+
+.credits-tab__form-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.credits-tab__save-btn {
+  font-size: 12px;
+  padding: 3px 12px;
+  cursor: pointer;
+  background: #007acc;
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+}
+
+.credits-tab__save-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.credits-tab__cancel-btn {
+  font-size: 12px;
+  padding: 3px 10px;
+  cursor: pointer;
+  background: none;
+  border: 1px solid var(--border, #e5e4e7);
+  border-radius: 3px;
+}
+
+.credits-tab__cancel-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
+}
+
+.credits-tab__error {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #c62828;
+}
+
+/* Credits table */
+.credits-tab__table-wrapper {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 16px 16px;
+}
+
+.credits-tab__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.credits-tab__table th {
+  text-align: left;
+  font-size: 11px;
+  color: var(--text-muted, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  border-bottom: 1px solid var(--border, #e5e4e7);
+  padding: 6px 8px 4px;
+  white-space: nowrap;
+}
+
+.credits-tab__table td {
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--border, #f0f0f0);
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.credits-tab__action-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 12px;
+  color: var(--text-muted, #888);
+  border-radius: 2px;
+}
+
+.credits-tab__action-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
+  color: var(--text, #333);
+}
+
+/* Type colour modifiers */
+.credits-tab__type--dividend {
+  color: #1565c0;
+}
+
+.credits-tab__type--rent {
+  color: #0277bd;
+}
+
+/* Value column */
+.credits-tab__value {
+  text-align: right;
+  font-weight: bold;
+}
+
+.credits-tab__delete-error {
+  padding: 6px 16px;
+  font-size: 12px;
+  color: #c62828;
+  flex-shrink: 0;
+}
+
+/* Chart */
+.credits-tab__chart-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 8px 0;
+}
+
+.credits-tab__chart-title {
+  font-size: 13px;
+  font-weight: bold;
+  text-align: center;
+  margin: 0 0 8px;
+  color: var(--text-h, #08060d);
+}
+
+.credits-tab__chart-container {
+  flex: 1;
+  min-height: 0;
+}

--- a/Financial.Web/src/components/CreditsTab.tsx
+++ b/Financial.Web/src/components/CreditsTab.tsx
@@ -1,0 +1,391 @@
+import { useCallback, useRef, useState } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  LabelList,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import type { CreditDto } from '../api/types'
+import ErrorState from './ErrorState'
+import LoadingState from './LoadingState'
+import type { CreditFormField, FilterOption, ViewMode } from '../hooks/useCredits'
+import { useCredits } from '../hooks/useCredits'
+import './CreditsTab.css'
+
+const DEFAULT_LEFT_WIDTH = 400
+const MIN_LEFT_WIDTH = 200
+
+function formatN2(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()}`
+}
+
+function toInputDate(iso: string): string {
+  return iso.split('T')[0]
+}
+
+function buildMonthKey(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${pad(date.getMonth() + 1)}/${date.getFullYear()}`
+}
+
+const FILTER_OPTIONS: { value: FilterOption; label: string }[] = [
+  { value: 'this-month', label: 'This month' },
+  { value: 'last-3-months', label: 'Last 3 months' },
+  { value: 'last-6-months', label: 'Last 6 months' },
+  { value: 'last-year', label: 'Last year' },
+  { value: 'all', label: 'All' },
+]
+
+const DIVIDEND_COLOR = '#4682b4'
+const RENT_COLOR = '#6aabdb'
+
+interface CreditRowProps {
+  credit: CreditDto
+  onEdit: (c: CreditDto) => void
+  onDelete: (id: string) => void
+}
+
+function CreditRow({ credit, onEdit, onDelete }: CreditRowProps) {
+  const typeClass =
+    credit.type === 'Dividend'
+      ? 'credits-tab__type--dividend'
+      : 'credits-tab__type--rent'
+
+  return (
+    <tr>
+      <td>
+        <button
+          className="credits-tab__action-btn"
+          type="button"
+          aria-label="Edit credit"
+          onClick={() => onEdit(credit)}
+        >
+          ✏
+        </button>
+      </td>
+      <td>
+        <button
+          className="credits-tab__action-btn"
+          type="button"
+          aria-label="Delete credit"
+          onClick={() => onDelete(credit.id)}
+        >
+          ✕
+        </button>
+      </td>
+      <td>{formatDate(credit.date)}</td>
+      <td className={typeClass}>{credit.type}</td>
+      <td className="credits-tab__value">{formatN2(credit.value)}</td>
+    </tr>
+  )
+}
+
+interface InlineFormProps {
+  editingId: string | null
+  formDate: string
+  formType: string
+  formValue: string
+  isSaving: boolean
+  saveError: string | null
+  onFieldChange: (field: CreditFormField, value: string) => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+function InlineForm({
+  editingId,
+  formDate,
+  formType,
+  formValue,
+  isSaving,
+  saveError,
+  onFieldChange,
+  onSave,
+  onCancel,
+}: InlineFormProps) {
+  const title = editingId ? 'Edit credit' : 'New credit'
+
+  return (
+    <div className="credits-tab__form">
+      <p className="credits-tab__form-title">{title}</p>
+      <div className="credits-tab__form-fields">
+        <div className="credits-tab__form-field">
+          <label htmlFor="cr-date">Date</label>
+          <input
+            id="cr-date"
+            type="date"
+            value={formDate}
+            required
+            onChange={(e) => onFieldChange('formDate', e.target.value)}
+          />
+        </div>
+        <div className="credits-tab__form-field">
+          <label htmlFor="cr-type">Type</label>
+          <select
+            id="cr-type"
+            value={formType}
+            onChange={(e) => onFieldChange('formType', e.target.value)}
+          >
+            <option value="Dividend">Dividend</option>
+            <option value="Rent">Rent</option>
+          </select>
+        </div>
+        <div className="credits-tab__form-field">
+          <label htmlFor="cr-value">Value</label>
+          <input
+            id="cr-value"
+            type="number"
+            step="0.01"
+            min="0"
+            value={formValue}
+            required
+            onChange={(e) => onFieldChange('formValue', e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="credits-tab__form-actions">
+        <button
+          className="credits-tab__save-btn"
+          type="button"
+          disabled={isSaving}
+          onClick={onSave}
+        >
+          {isSaving ? 'Saving...' : 'Save'}
+        </button>
+        <button className="credits-tab__cancel-btn" type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+      {saveError && <p className="credits-tab__error">{saveError}</p>}
+    </div>
+  )
+}
+
+interface ChartPanelProps {
+  chartData: ReturnType<typeof useCredits>['chartData']
+  selectedMode: ViewMode
+}
+
+function ChartPanel({ chartData, selectedMode }: ChartPanelProps) {
+  const isStacked = selectedMode === 'Stacked'
+  return (
+    <div className="credits-tab__chart-panel">
+      <p className="credits-tab__chart-title">Credits by Month</p>
+      <div className="credits-tab__chart-container">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={{ top: 8, right: 16, left: 8, bottom: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+            <YAxis tickFormatter={formatN2} tick={{ fontSize: 11 }} width={70} />
+            <Tooltip formatter={(v) => (typeof v === 'number' ? formatN2(v) : v)} />
+            <Legend />
+            <Bar
+              dataKey="Dividend"
+              fill={DIVIDEND_COLOR}
+              stackId={isStacked ? 'credits' : undefined}
+            >
+              <LabelList dataKey="Dividend" position="inside" formatter={(v: unknown) => typeof v === 'number' && v > 0 ? formatN2(v) : ''} style={{ fontSize: 10 }} />
+            </Bar>
+            <Bar
+              dataKey="Rent"
+              fill={RENT_COLOR}
+              stackId={isStacked ? 'credits' : undefined}
+            >
+              <LabelList dataKey="Rent" position="inside" formatter={(v: unknown) => typeof v === 'number' && v > 0 ? formatN2(v) : ''} style={{ fontSize: 10 }} />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}
+
+export default function CreditsTab() {
+  const {
+    credits,
+    chartData,
+    isLoading,
+    error,
+    retry,
+    selectedFilter,
+    selectedMode,
+    setFilter,
+    setMode,
+    isFormVisible,
+    editingId,
+    formDate,
+    formType,
+    formValue,
+    isSaving,
+    saveError,
+    deleteError,
+    nodeType,
+    showNewForm,
+    showEditForm,
+    cancelForm,
+    setFormField,
+    saveForm,
+    deleteCredit,
+  } = useCredits()
+
+  const [leftWidth, setLeftWidth] = useState(DEFAULT_LEFT_WIDTH)
+  const startX = useRef(0)
+  const startWidth = useRef(0)
+
+  const onHandleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      startX.current = e.clientX
+      startWidth.current = leftWidth
+      document.body.style.cursor = 'col-resize'
+      document.body.style.userSelect = 'none'
+
+      const handleMouseMove = (ev: MouseEvent) => {
+        const delta = ev.clientX - startX.current
+        const maxWidth = window.innerWidth / 2
+        setLeftWidth(Math.max(MIN_LEFT_WIDTH, Math.min(startWidth.current + delta, maxWidth)))
+      }
+
+      const handleMouseUp = () => {
+        document.removeEventListener('mousemove', handleMouseMove)
+        document.removeEventListener('mouseup', handleMouseUp)
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+      }
+
+      document.addEventListener('mousemove', handleMouseMove)
+      document.addEventListener('mouseup', handleMouseUp)
+    },
+    [leftWidth],
+  )
+
+  if (isLoading) {
+    return <LoadingState />
+  }
+
+  if (error) {
+    return <ErrorState message={error} onRetry={retry} />
+  }
+
+  const isAsset = nodeType === 'Asset'
+
+  const toolbar = (
+    <div className="credits-tab__controls">
+      <div className="credits-tab__filters">
+        {FILTER_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            className={`credits-tab__filter-btn${selectedFilter === opt.value ? ' credits-tab__filter-btn--active' : ''}`}
+            onClick={() => setFilter(opt.value)}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+      <div className="credits-tab__modes">
+        <span className="credits-tab__mode-label">View:</span>
+        {(['Stacked', 'Grouped'] as ViewMode[]).map((mode) => (
+          <button
+            key={mode}
+            type="button"
+            className={`credits-tab__mode-btn${selectedMode === mode ? ' credits-tab__mode-btn--active' : ''}`}
+            onClick={() => setMode(mode)}
+          >
+            {mode}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+
+  if (!isAsset) {
+    return (
+      <div className="credits-tab">
+        {toolbar}
+        <ChartPanel chartData={chartData} selectedMode={selectedMode} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="credits-tab">
+      {toolbar}
+      <div className="credits-tab__split">
+        <div className="credits-tab__left" style={{ width: leftWidth }}>
+          <div className="credits-tab__table-toolbar">
+            <button className="credits-tab__new-btn" type="button" onClick={showNewForm}>
+              New
+            </button>
+          </div>
+
+          {isFormVisible && (
+            <InlineForm
+              editingId={editingId}
+              formDate={formDate}
+              formType={formType}
+              formValue={formValue}
+              isSaving={isSaving}
+              saveError={saveError}
+              onFieldChange={setFormField}
+              onSave={saveForm}
+              onCancel={cancelForm}
+            />
+          )}
+
+          <div className="credits-tab__table-wrapper">
+            <table className="credits-tab__table">
+              <thead>
+                <tr>
+                  <th />
+                  <th />
+                  <th>Date</th>
+                  <th>Type</th>
+                  <th className="credits-tab__value">Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {credits.map((c) => (
+                  <CreditRow
+                    key={c.id}
+                    credit={c}
+                    onEdit={showEditForm}
+                    onDelete={deleteCredit}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {deleteError && <p className="credits-tab__delete-error">{deleteError}</p>}
+        </div>
+
+        <div
+          className="credits-tab__handle"
+          onMouseDown={onHandleMouseDown}
+          aria-label="Resize panel"
+        />
+
+        <div className="credits-tab__right">
+          <ChartPanel chartData={chartData} selectedMode={selectedMode} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export { formatN2, formatDate, toInputDate, buildMonthKey }

--- a/Financial.Web/src/components/CreditsTab.tsx
+++ b/Financial.Web/src/components/CreditsTab.tsx
@@ -34,15 +34,6 @@ function formatDate(iso: string): string {
   return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()}`
 }
 
-function toInputDate(iso: string): string {
-  return iso.split('T')[0]
-}
-
-function buildMonthKey(date: Date): string {
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return `${pad(date.getMonth() + 1)}/${date.getFullYear()}`
-}
-
 const FILTER_OPTIONS: { value: FilterOption; label: string }[] = [
   { value: 'this-month', label: 'This month' },
   { value: 'last-3-months', label: 'Last 3 months' },
@@ -387,5 +378,3 @@ export default function CreditsTab() {
     </div>
   )
 }
-
-export { formatN2, formatDate, toInputDate, buildMonthKey }

--- a/Financial.Web/src/components/DetailPanel.tsx
+++ b/Financial.Web/src/components/DetailPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import { useSelectedNode } from '../context/SelectedNodeContext'
 import AggregatedSummaryTab from './AggregatedSummaryTab'
 import AssetSummaryTab from './AssetSummaryTab'
+import CreditsTab from './CreditsTab'
 import TransactionsTab from './TransactionsTab'
 import './DetailPanel.css'
 
@@ -102,9 +103,7 @@ export default function DetailPanel() {
         {activeTab === 'summary' && isAsset && <AssetSummaryTab />}
         {activeTab === 'summary' && !isAsset && <AggregatedSummaryTab />}
         {activeTab === 'transactions' && <TransactionsTab />}
-        {activeTab === 'credits' && (
-          <p className="detail-panel__placeholder">Credits — coming in F06</p>
-        )}
+        {activeTab === 'credits' && <CreditsTab />}
       </div>
     </div>
   )

--- a/Financial.Web/src/components/__tests__/CreditsTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/CreditsTab.test.tsx
@@ -1,0 +1,293 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CreditsData } from '../../hooks/useCredits'
+import type { CreditDto } from '../../api/types'
+import CreditsTab from '../CreditsTab'
+
+const mockShowNewForm = vi.fn()
+const mockShowEditForm = vi.fn()
+const mockCancelForm = vi.fn()
+const mockSetFormField = vi.fn()
+const mockSaveForm = vi.fn()
+const mockDeleteCredit = vi.fn()
+const mockRetry = vi.fn()
+const mockSetFilter = vi.fn()
+const mockSetMode = vi.fn()
+
+vi.mock('recharts', () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  LabelList: () => null,
+}))
+
+const CREDIT_DIVIDEND: CreditDto = {
+  id: 'aaa',
+  date: '2024-03-15T00:00:00',
+  type: 'Dividend',
+  value: 120.5,
+}
+
+const CREDIT_RENT: CreditDto = {
+  id: 'bbb',
+  date: '2024-01-10T00:00:00',
+  type: 'Rent',
+  value: 350.0,
+}
+
+const DEFAULT_HOOK: CreditsData = {
+  credits: [],
+  filteredCredits: [],
+  chartData: [],
+  isLoading: false,
+  error: null,
+  retry: mockRetry,
+  selectedFilter: 'last-year',
+  selectedMode: 'Stacked',
+  setFilter: mockSetFilter,
+  setMode: mockSetMode,
+  isFormVisible: false,
+  editingId: null,
+  formDate: '',
+  formType: 'Dividend',
+  formValue: '',
+  isSaving: false,
+  saveError: null,
+  deleteError: null,
+  nodeType: 'Asset',
+  showNewForm: mockShowNewForm,
+  showEditForm: mockShowEditForm,
+  cancelForm: mockCancelForm,
+  setFormField: mockSetFormField,
+  saveForm: mockSaveForm,
+  deleteCredit: mockDeleteCredit,
+}
+
+let mockHookValue: CreditsData = { ...DEFAULT_HOOK }
+
+vi.mock('../../hooks/useCredits', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useCredits')>()
+  return {
+    ...actual,
+    useCredits: () => mockHookValue,
+  }
+})
+
+function setMock(overrides: Partial<CreditsData>) {
+  mockHookValue = { ...DEFAULT_HOOK, ...overrides }
+}
+
+describe('CreditsTab', () => {
+  beforeEach(() => {
+    mockShowNewForm.mockReset()
+    mockShowEditForm.mockReset()
+    mockCancelForm.mockReset()
+    mockSetFormField.mockReset()
+    mockSaveForm.mockReset()
+    mockDeleteCredit.mockReset()
+    mockRetry.mockReset()
+    mockSetFilter.mockReset()
+    mockSetMode.mockReset()
+    mockHookValue = { ...DEFAULT_HOOK }
+  })
+
+  it('renders_loading_state', () => {
+    setMock({ isLoading: true })
+    render(<CreditsTab />)
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('renders_error_state_with_retry', () => {
+    setMock({ error: 'Network error' })
+    render(<CreditsTab />)
+    expect(screen.getByText('Network error')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('renders_chart_only_for_broker_node', () => {
+    setMock({ nodeType: 'Broker' })
+    render(<CreditsTab />)
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()
+  })
+
+  it('renders_chart_only_for_portfolio_node', () => {
+    setMock({ nodeType: 'Portfolio' })
+    render(<CreditsTab />)
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()
+  })
+
+  it('renders_table_and_chart_for_asset_node', () => {
+    setMock({ nodeType: 'Asset', credits: [CREDIT_DIVIDEND] })
+    render(<CreditsTab />)
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument()
+  })
+
+  it('renders_table_columns_date_type_value', () => {
+    setMock({ credits: [CREDIT_DIVIDEND] })
+    render(<CreditsTab />)
+    expect(screen.getByText('Date')).toBeInTheDocument()
+    expect(screen.getByText('Type')).toBeInTheDocument()
+    expect(screen.getByText('Value')).toBeInTheDocument()
+  })
+
+  it('renders_date_in_dd_MM_yyyy_format', () => {
+    setMock({ credits: [CREDIT_DIVIDEND] })
+    render(<CreditsTab />)
+    expect(screen.getByText('15/03/2024')).toBeInTheDocument()
+  })
+
+  it('renders_dividend_type_with_dividend_class', () => {
+    setMock({ credits: [CREDIT_DIVIDEND] })
+    render(<CreditsTab />)
+    const typeCell = screen.getByText('Dividend')
+    expect(typeCell).toHaveClass('credits-tab__type--dividend')
+  })
+
+  it('renders_rent_type_with_rent_class', () => {
+    setMock({ credits: [CREDIT_RENT] })
+    render(<CreditsTab />)
+    const typeCell = screen.getByText('Rent')
+    expect(typeCell).toHaveClass('credits-tab__type--rent')
+  })
+
+  it('renders_value_in_n2_bold', () => {
+    setMock({ credits: [CREDIT_DIVIDEND] })
+    render(<CreditsTab />)
+    const valueCell = screen.getByText('120.50')
+    expect(valueCell).toHaveClass('credits-tab__value')
+  })
+
+  it('new_button_present_for_asset_only', () => {
+    setMock({ nodeType: 'Asset' })
+    render(<CreditsTab />)
+    expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument()
+  })
+
+  it('new_button_not_present_for_broker', () => {
+    setMock({ nodeType: 'Broker' })
+    render(<CreditsTab />)
+    expect(screen.queryByRole('button', { name: 'New' })).not.toBeInTheDocument()
+  })
+
+  it('new_button_calls_show_new_form', () => {
+    render(<CreditsTab />)
+    fireEvent.click(screen.getByRole('button', { name: 'New' }))
+    expect(mockShowNewForm).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders_form_when_form_visible', () => {
+    setMock({ isFormVisible: true, editingId: null })
+    render(<CreditsTab />)
+    expect(screen.getByLabelText('Date')).toBeInTheDocument()
+    expect(screen.getByLabelText('Type')).toBeInTheDocument()
+    expect(screen.getByLabelText('Value')).toBeInTheDocument()
+  })
+
+  it('form_title_is_new_credit_when_no_editing_id', () => {
+    setMock({ isFormVisible: true, editingId: null })
+    render(<CreditsTab />)
+    expect(screen.getByText('New credit')).toBeInTheDocument()
+  })
+
+  it('form_title_is_edit_credit_when_editing_id_set', () => {
+    setMock({ isFormVisible: true, editingId: 'some-id' })
+    render(<CreditsTab />)
+    expect(screen.getByText('Edit credit')).toBeInTheDocument()
+  })
+
+  it('save_button_disabled_while_saving', () => {
+    setMock({ isFormVisible: true, isSaving: true })
+    render(<CreditsTab />)
+    const saveBtn = screen.getByRole('button', { name: 'Saving...' })
+    expect(saveBtn).toBeDisabled()
+  })
+
+  it('edit_icon_calls_show_edit_form', () => {
+    setMock({ credits: [CREDIT_DIVIDEND] })
+    render(<CreditsTab />)
+    fireEvent.click(screen.getByRole('button', { name: 'Edit credit' }))
+    expect(mockShowEditForm).toHaveBeenCalledWith(CREDIT_DIVIDEND)
+  })
+
+  it('delete_icon_calls_delete_credit', () => {
+    setMock({ credits: [CREDIT_DIVIDEND] })
+    render(<CreditsTab />)
+    fireEvent.click(screen.getByRole('button', { name: 'Delete credit' }))
+    expect(mockDeleteCredit).toHaveBeenCalledWith('aaa')
+  })
+
+  it('renders_save_error_below_form', () => {
+    setMock({ isFormVisible: true, saveError: 'Failed' })
+    render(<CreditsTab />)
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+  })
+
+  it('renders_delete_error_below_table', () => {
+    setMock({ deleteError: 'Failed to delete' })
+    render(<CreditsTab />)
+    expect(screen.getByText('Failed to delete')).toBeInTheDocument()
+  })
+
+  it('renders_five_filter_buttons', () => {
+    render(<CreditsTab />)
+    expect(screen.getByRole('button', { name: 'This month' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Last 3 months' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Last 6 months' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Last year' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument()
+  })
+
+  it('active_filter_has_active_class', () => {
+    setMock({ selectedFilter: 'last-year' })
+    render(<CreditsTab />)
+    const btn = screen.getByRole('button', { name: 'Last year' })
+    expect(btn).toHaveClass('credits-tab__filter-btn--active')
+  })
+
+  it('clicking_filter_calls_set_filter', () => {
+    render(<CreditsTab />)
+    fireEvent.click(screen.getByRole('button', { name: 'Last 3 months' }))
+    expect(mockSetFilter).toHaveBeenCalledWith('last-3-months')
+  })
+
+  it('renders_mode_toggles', () => {
+    render(<CreditsTab />)
+    expect(screen.getByRole('button', { name: 'Stacked' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Grouped' })).toBeInTheDocument()
+  })
+
+  it('active_mode_has_active_class', () => {
+    setMock({ selectedMode: 'Stacked' })
+    render(<CreditsTab />)
+    const btn = screen.getByRole('button', { name: 'Stacked' })
+    expect(btn).toHaveClass('credits-tab__mode-btn--active')
+  })
+
+  it('clicking_mode_calls_set_mode', () => {
+    render(<CreditsTab />)
+    fireEvent.click(screen.getByRole('button', { name: 'Grouped' }))
+    expect(mockSetMode).toHaveBeenCalledWith('Grouped')
+  })
+
+  it('empty_table_renders_no_rows', () => {
+    setMock({ credits: [] })
+    render(<CreditsTab />)
+    const tbody = document.querySelector('tbody')
+    expect(tbody?.children.length).toBe(0)
+  })
+})

--- a/Financial.Web/src/hooks/useCredits.test.ts
+++ b/Financial.Web/src/hooks/useCredits.test.ts
@@ -1,0 +1,426 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { createElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FinancialApiClient } from '../api/financialApiClient'
+import type { AssetDetailsDto, CreditDto, SelectedNode } from '../api/types'
+import { SelectedNodeProvider, useSelectedNode } from '../context/SelectedNodeContext'
+import { useCredits } from './useCredits'
+
+const getAssetDetailsMock = vi.fn<FinancialApiClient['getAssetDetails']>()
+const getCreditsByBrokerMock = vi.fn<FinancialApiClient['getCreditsByBroker']>()
+const getCreditsByPortfolioMock = vi.fn<FinancialApiClient['getCreditsByPortfolio']>()
+const addCreditMock = vi.fn<FinancialApiClient['addCredit']>()
+const updateCreditMock = vi.fn<FinancialApiClient['updateCredit']>()
+const deleteCreditMock = vi.fn<FinancialApiClient['deleteCredit']>()
+
+vi.mock('../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getAssetDetails: getAssetDetailsMock,
+    getCreditsByBroker: getCreditsByBrokerMock,
+    getCreditsByPortfolio: getCreditsByPortfolioMock,
+    addCredit: addCreditMock,
+    updateCredit: updateCreditMock,
+    deleteCredit: deleteCreditMock,
+  }),
+}))
+
+vi.stubGlobal('confirm', vi.fn(() => true))
+
+const ASSET_NODE: SelectedNode = {
+  nodeType: 'Asset',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+  assetName: 'KLBN4',
+  ticker: 'KLBN4',
+  exchange: 'BVMF',
+  isActive: true,
+}
+
+const BROKER_NODE: SelectedNode = {
+  nodeType: 'Broker',
+  brokerName: 'XPI',
+}
+
+const PORTFOLIO_NODE: SelectedNode = {
+  nodeType: 'Portfolio',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+}
+
+const ASSET_NODE_B: SelectedNode = {
+  nodeType: 'Asset',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+  assetName: 'TASA4',
+  ticker: 'TASA4',
+  exchange: 'BVMF',
+  isActive: true,
+}
+
+const CREDIT_A: CreditDto = {
+  id: 'aaa',
+  date: '2024-03-15T00:00:00',
+  type: 'Dividend',
+  value: 120.5,
+}
+
+const CREDIT_B: CreditDto = {
+  id: 'bbb',
+  date: '2024-01-10T00:00:00',
+  type: 'Rent',
+  value: 350.0,
+}
+
+const ASSET_DETAILS: AssetDetailsDto = {
+  name: 'KLBN4',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+  ticker: 'KLBN4',
+  isin: 'BRKLBN',
+  exchange: 'BVMF',
+  country: 'BR',
+  localTypeCode: 'ON',
+  class: 'Equity',
+  quantity: 100,
+  averagePrice: 20,
+  isActive: true,
+  totalBought: 2000,
+  totalSold: 0,
+  totalCredits: 470.5,
+  transactions: [],
+  credits: [CREDIT_A, CREDIT_B],
+}
+
+function createWrapper() {
+  let setNodeRef: ((node: SelectedNode | null) => void) | undefined
+
+  function NodeControl() {
+    const { setSelectedNode } = useSelectedNode()
+    setNodeRef = setSelectedNode
+    return null
+  }
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(SelectedNodeProvider, null, createElement(NodeControl), children)
+  }
+
+  return {
+    wrapper: Wrapper,
+    setNode: (node: SelectedNode | null) =>
+      act(() => {
+        setNodeRef?.(node)
+      }),
+  }
+}
+
+describe('useCredits', () => {
+  beforeEach(() => {
+    getAssetDetailsMock.mockReset()
+    getCreditsByBrokerMock.mockReset()
+    getCreditsByPortfolioMock.mockReset()
+    addCreditMock.mockReset()
+    updateCreditMock.mockReset()
+    deleteCreditMock.mockReset()
+    vi.mocked(window.confirm).mockReturnValue(true)
+  })
+
+  it('returns_initial_empty_state', () => {
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.credits).toEqual([])
+    expect(result.current.error).toBeNull()
+    expect(result.current.selectedFilter).toBe('last-year')
+    expect(result.current.selectedMode).toBe('Stacked')
+  })
+
+  it('fetches_asset_credits_on_asset_selection', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(getAssetDetailsMock).toHaveBeenCalledWith('XPI', 'Acoes', 'KLBN4'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.credits).toHaveLength(2)
+  })
+
+  it('fetches_broker_credits_on_broker_selection', async () => {
+    getCreditsByBrokerMock.mockResolvedValue([CREDIT_A])
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() =>
+      expect(getCreditsByBrokerMock).toHaveBeenCalledWith('XPI'),
+    )
+    await waitFor(() => expect(result.current.credits).toHaveLength(1))
+  })
+
+  it('fetches_portfolio_credits_on_portfolio_selection', async () => {
+    getCreditsByPortfolioMock.mockResolvedValue([CREDIT_B])
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() =>
+      expect(getCreditsByPortfolioMock).toHaveBeenCalledWith('XPI', 'Acoes'),
+    )
+    await waitFor(() => expect(result.current.credits).toHaveLength(1))
+  })
+
+  it('resets_credits_when_node_is_null', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    setNode(null)
+    await waitFor(() => expect(result.current.credits).toEqual([]))
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('increments_retry_and_refetches', async () => {
+    getAssetDetailsMock.mockRejectedValueOnce(new Error('Network error'))
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.error).toBe('Network error'))
+    act(() => result.current.retry())
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    expect(getAssetDetailsMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('set_filter_updates_selected_filter', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.setFilter('last-3-months'))
+    expect(result.current.selectedFilter).toBe('last-3-months')
+  })
+
+  it('set_mode_updates_selected_mode', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.setMode('Grouped'))
+    expect(result.current.selectedMode).toBe('Grouped')
+  })
+
+  it('persists_filter_and_mode_per_selection_key', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.setFilter('last-3-months'))
+    act(() => result.current.setMode('Grouped'))
+    expect(result.current.selectedFilter).toBe('last-3-months')
+    expect(result.current.selectedMode).toBe('Grouped')
+
+    setNode(ASSET_NODE_B)
+    await waitFor(() => expect(getAssetDetailsMock).toHaveBeenCalledWith('XPI', 'Acoes', 'TASA4'))
+    expect(result.current.selectedFilter).toBe('last-year')
+    expect(result.current.selectedMode).toBe('Stacked')
+
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(getAssetDetailsMock).toHaveBeenCalledWith('XPI', 'Acoes', 'KLBN4'))
+    await waitFor(() => expect(result.current.selectedFilter).toBe('last-3-months'))
+    expect(result.current.selectedMode).toBe('Grouped')
+  })
+
+  it('defaults_to_last_year_stacked_on_first_selection', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.selectedFilter).toBe('last-year')
+    expect(result.current.selectedMode).toBe('Stacked')
+  })
+
+  it('show_new_form_opens_blank_form', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.showNewForm())
+    expect(result.current.isFormVisible).toBe(true)
+    expect(result.current.editingId).toBeNull()
+    expect(result.current.formDate).toBe('')
+    expect(result.current.formType).toBe('Dividend')
+    expect(result.current.formValue).toBe('')
+  })
+
+  it('show_edit_form_populates_fields', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.showEditForm(CREDIT_A))
+    expect(result.current.isFormVisible).toBe(true)
+    expect(result.current.editingId).toBe('aaa')
+    expect(result.current.formDate).toBe('2024-03-15')
+    expect(result.current.formType).toBe('Dividend')
+    expect(result.current.formValue).toBe('120.5')
+  })
+
+  it('cancel_form_hides_form_and_resets', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.showNewForm())
+    expect(result.current.isFormVisible).toBe(true)
+    act(() => result.current.cancelForm())
+    expect(result.current.isFormVisible).toBe(false)
+    expect(result.current.formDate).toBe('')
+    expect(result.current.formValue).toBe('')
+  })
+
+  it('save_new_credit_calls_add_and_updates_asset', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const updatedAsset = { ...ASSET_DETAILS, credits: [CREDIT_A] }
+    addCreditMock.mockResolvedValue(updatedAsset)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.showNewForm())
+    act(() => {
+      result.current.setFormField('formDate', '2024-06-01')
+      result.current.setFormField('formType', 'Dividend')
+      result.current.setFormField('formValue', '120.50')
+    })
+    act(() => result.current.saveForm())
+    await waitFor(() =>
+      expect(addCreditMock).toHaveBeenCalledWith({
+        brokerName: 'XPI',
+        portfolioName: 'Acoes',
+        assetName: 'KLBN4',
+        date: '2024-06-01',
+        type: 'Dividend',
+        value: 120.5,
+      }),
+    )
+    await waitFor(() => expect(result.current.isFormVisible).toBe(false))
+    expect(result.current.credits).toEqual([CREDIT_A])
+  })
+
+  it('save_edit_credit_calls_update', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const updatedAsset = { ...ASSET_DETAILS }
+    updateCreditMock.mockResolvedValue(updatedAsset)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.showEditForm(CREDIT_A))
+    act(() => result.current.setFormField('formValue', '200'))
+    act(() => result.current.saveForm())
+    await waitFor(() =>
+      expect(updateCreditMock).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'aaa', value: 200 }),
+      ),
+    )
+    expect(result.current.credits).toEqual(ASSET_DETAILS.credits.slice().sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+    ))
+  })
+
+  it('save_sets_error_on_api_failure', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    addCreditMock.mockRejectedValue(new Error('Server error'))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.showNewForm())
+    act(() => {
+      result.current.setFormField('formDate', '2024-06-01')
+      result.current.setFormField('formValue', '50')
+    })
+    act(() => result.current.saveForm())
+    await waitFor(() => expect(result.current.saveError).toBe('Server error'))
+    expect(result.current.isFormVisible).toBe(true)
+    expect(result.current.isSaving).toBe(false)
+  })
+
+  it('save_validates_date_required', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.showNewForm())
+    act(() => result.current.setFormField('formValue', '50'))
+    act(() => result.current.saveForm())
+    expect(result.current.saveError).not.toBeNull()
+    expect(addCreditMock).not.toHaveBeenCalled()
+  })
+
+  it('save_validates_value_greater_than_zero', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.showNewForm())
+    act(() => {
+      result.current.setFormField('formDate', '2024-06-01')
+      result.current.setFormField('formValue', '0')
+    })
+    act(() => result.current.saveForm())
+    expect(result.current.saveError).not.toBeNull()
+    expect(addCreditMock).not.toHaveBeenCalled()
+  })
+
+  it('delete_credit_calls_api_and_updates_asset', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const updatedAsset = { ...ASSET_DETAILS, credits: [CREDIT_B] }
+    deleteCreditMock.mockResolvedValue(updatedAsset)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.deleteCredit('aaa'))
+    await waitFor(() =>
+      expect(deleteCreditMock).toHaveBeenCalledWith({
+        brokerName: 'XPI',
+        portfolioName: 'Acoes',
+        assetName: 'KLBN4',
+        id: 'aaa',
+      }),
+    )
+    await waitFor(() => expect(result.current.credits).toEqual([CREDIT_B]))
+  })
+
+  it('delete_failure_sets_delete_error', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    deleteCreditMock.mockRejectedValue(new Error('Delete failed'))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.deleteCredit('aaa'))
+    await waitFor(() => expect(result.current.deleteError).toBe('Delete failed'))
+    expect(result.current.credits).toHaveLength(2)
+  })
+
+  it('sorts_credits_by_date_descending', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    expect(result.current.credits[0].id).toBe('aaa')
+    expect(result.current.credits[1].id).toBe('bbb')
+  })
+})

--- a/Financial.Web/src/hooks/useCredits.ts
+++ b/Financial.Web/src/hooks/useCredits.ts
@@ -1,0 +1,427 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react'
+import { createFinancialApiClient } from '../api/financialApiClient'
+import type { CreditDto, SelectedNode } from '../api/types'
+import { useSelectedNode } from '../context/SelectedNodeContext'
+
+export type FilterOption = 'this-month' | 'last-3-months' | 'last-6-months' | 'last-year' | 'all'
+export type ViewMode = 'Stacked' | 'Grouped'
+export type CreditType = 'Dividend' | 'Rent'
+export type CreditFormField = 'formDate' | 'formType' | 'formValue'
+
+export interface MonthBucket {
+  month: string
+  Dividend: number
+  Rent: number
+}
+
+interface PersistedPrefs {
+  filter: FilterOption
+  mode: ViewMode
+}
+
+const DEFAULT_FILTER: FilterOption = 'last-year'
+const DEFAULT_MODE: ViewMode = 'Stacked'
+
+interface CreditsState {
+  credits: CreditDto[]
+  isLoading: boolean
+  error: string | null
+  retryCount: number
+  selectedFilter: FilterOption
+  selectedMode: ViewMode
+  filterPersistence: Map<string, PersistedPrefs>
+  isFormVisible: boolean
+  editingId: string | null
+  formDate: string
+  formType: string
+  formValue: string
+  isSaving: boolean
+  saveError: string | null
+  deleteError: string | null
+}
+
+type CreditsAction =
+  | { type: 'RESET' }
+  | { type: 'FETCH_START'; payload: { key: string } }
+  | { type: 'FETCH_SUCCESS'; payload: CreditDto[] }
+  | { type: 'FETCH_ERROR'; payload: string }
+  | { type: 'RETRY' }
+  | { type: 'SET_FILTER'; payload: { filter: FilterOption; key: string } }
+  | { type: 'SET_MODE'; payload: { mode: ViewMode; key: string } }
+  | { type: 'SHOW_NEW_FORM' }
+  | { type: 'SHOW_EDIT_FORM'; payload: CreditDto }
+  | { type: 'CANCEL_FORM' }
+  | { type: 'SET_FORM_FIELD'; payload: { field: CreditFormField; value: string } }
+  | { type: 'SAVE_START' }
+  | { type: 'SAVE_SUCCESS'; payload: CreditDto[] }
+  | { type: 'SAVE_ERROR'; payload: string }
+  | { type: 'DELETE_SUCCESS'; payload: CreditDto[] }
+  | { type: 'DELETE_ERROR'; payload: string }
+
+const BLANK_FORM = {
+  isFormVisible: false,
+  editingId: null,
+  formDate: '',
+  formType: 'Dividend',
+  formValue: '',
+  isSaving: false,
+  saveError: null,
+} as const
+
+const INITIAL_STATE: CreditsState = {
+  credits: [],
+  isLoading: false,
+  error: null,
+  retryCount: 0,
+  selectedFilter: DEFAULT_FILTER,
+  selectedMode: DEFAULT_MODE,
+  filterPersistence: new Map(),
+  ...BLANK_FORM,
+  deleteError: null,
+}
+
+function toInputDate(isoString: string): string {
+  return isoString.split('T')[0]
+}
+
+function reducer(state: CreditsState, action: CreditsAction): CreditsState {
+  switch (action.type) {
+    case 'RESET':
+      return { ...INITIAL_STATE, filterPersistence: state.filterPersistence }
+    case 'FETCH_START': {
+      const prefs = state.filterPersistence.get(action.payload.key)
+      return {
+        ...INITIAL_STATE,
+        isLoading: true,
+        retryCount: state.retryCount,
+        filterPersistence: state.filterPersistence,
+        selectedFilter: prefs?.filter ?? DEFAULT_FILTER,
+        selectedMode: prefs?.mode ?? DEFAULT_MODE,
+      }
+    }
+    case 'FETCH_SUCCESS':
+      return { ...state, isLoading: false, credits: action.payload }
+    case 'FETCH_ERROR':
+      return { ...state, isLoading: false, error: action.payload }
+    case 'RETRY':
+      return { ...state, retryCount: state.retryCount + 1, error: null }
+    case 'SET_FILTER': {
+      const newMap = new Map(state.filterPersistence)
+      newMap.set(action.payload.key, { filter: action.payload.filter, mode: state.selectedMode })
+      return { ...state, selectedFilter: action.payload.filter, filterPersistence: newMap }
+    }
+    case 'SET_MODE': {
+      const newMap = new Map(state.filterPersistence)
+      newMap.set(action.payload.key, { filter: state.selectedFilter, mode: action.payload.mode })
+      return { ...state, selectedMode: action.payload.mode, filterPersistence: newMap }
+    }
+    case 'SHOW_NEW_FORM':
+      return {
+        ...state,
+        isFormVisible: true,
+        editingId: null,
+        formDate: '',
+        formType: 'Dividend',
+        formValue: '',
+        saveError: null,
+        isSaving: false,
+      }
+    case 'SHOW_EDIT_FORM': {
+      const c = action.payload
+      return {
+        ...state,
+        isFormVisible: true,
+        editingId: c.id,
+        formDate: toInputDate(c.date),
+        formType: c.type,
+        formValue: String(c.value),
+        saveError: null,
+        isSaving: false,
+      }
+    }
+    case 'CANCEL_FORM':
+      return { ...state, ...BLANK_FORM }
+    case 'SET_FORM_FIELD':
+      return { ...state, [action.payload.field]: action.payload.value }
+    case 'SAVE_START':
+      return { ...state, isSaving: true, saveError: null }
+    case 'SAVE_SUCCESS':
+      return { ...state, ...BLANK_FORM, credits: action.payload, deleteError: state.deleteError }
+    case 'SAVE_ERROR':
+      return { ...state, isSaving: false, saveError: action.payload }
+    case 'DELETE_SUCCESS':
+      return { ...state, credits: action.payload, deleteError: null }
+    case 'DELETE_ERROR':
+      return { ...state, deleteError: action.payload }
+    default:
+      return state
+  }
+}
+
+export function buildSelectionKey(node: SelectedNode): string {
+  if (node.nodeType === 'Asset') {
+    return `Asset|${node.brokerName}|${node.portfolioName ?? ''}|${node.assetName ?? ''}`
+  }
+  if (node.nodeType === 'Portfolio') {
+    return `Portfolio|${node.brokerName}|${node.portfolioName ?? ''}`
+  }
+  return `Broker|${node.brokerName}`
+}
+
+function getFilterStartDate(filter: FilterOption): Date | null {
+  if (filter === 'all') return null
+  const now = new Date()
+  const startOfCurrentMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+  switch (filter) {
+    case 'this-month':
+      return startOfCurrentMonth
+    case 'last-3-months':
+      return new Date(startOfCurrentMonth.getFullYear(), startOfCurrentMonth.getMonth() - 2, 1)
+    case 'last-6-months':
+      return new Date(startOfCurrentMonth.getFullYear(), startOfCurrentMonth.getMonth() - 5, 1)
+    case 'last-year':
+      return new Date(startOfCurrentMonth.getFullYear(), startOfCurrentMonth.getMonth() - 11, 1)
+    default:
+      return null
+  }
+}
+
+function buildMonthKey(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${pad(date.getMonth() + 1)}/${date.getFullYear()}`
+}
+
+function aggregateByMonth(credits: CreditDto[]): MonthBucket[] {
+  const map = new Map<string, MonthBucket>()
+  for (const c of credits) {
+    const key = buildMonthKey(new Date(c.date))
+    const existing = map.get(key) ?? { month: key, Dividend: 0, Rent: 0 }
+    const bucket: MonthBucket = { ...existing }
+    if (c.type === 'Dividend') bucket.Dividend += c.value
+    else if (c.type === 'Rent') bucket.Rent += c.value
+    map.set(key, bucket)
+  }
+  return [...map.values()].sort((a, b) => {
+    const [am, ay] = a.month.split('/').map(Number)
+    const [bm, by] = b.month.split('/').map(Number)
+    if (ay !== by) return ay - by
+    return am - bm
+  })
+}
+
+export interface CreditsData {
+  credits: CreditDto[]
+  filteredCredits: CreditDto[]
+  chartData: MonthBucket[]
+  isLoading: boolean
+  error: string | null
+  retry: () => void
+  selectedFilter: FilterOption
+  selectedMode: ViewMode
+  setFilter: (filter: FilterOption) => void
+  setMode: (mode: ViewMode) => void
+  isFormVisible: boolean
+  editingId: string | null
+  formDate: string
+  formType: string
+  formValue: string
+  isSaving: boolean
+  saveError: string | null
+  deleteError: string | null
+  nodeType: string | undefined
+  showNewForm: () => void
+  showEditForm: (credit: CreditDto) => void
+  cancelForm: () => void
+  setFormField: (field: CreditFormField, value: string) => void
+  saveForm: () => void
+  deleteCredit: (id: string) => void
+}
+
+export function useCredits(): CreditsData {
+  const { selectedNode } = useSelectedNode()
+  const apiClient = useMemo(() => createFinancialApiClient(), [])
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  useEffect(() => {
+    if (!selectedNode) {
+      dispatch({ type: 'RESET' })
+      return
+    }
+
+    const key = buildSelectionKey(selectedNode)
+    dispatch({ type: 'FETCH_START', payload: { key } })
+
+    const { nodeType, brokerName, portfolioName, assetName } = selectedNode
+
+    if (nodeType === 'Asset' && portfolioName && assetName) {
+      void apiClient
+        .getAssetDetails(brokerName, portfolioName, assetName)
+        .then((result) => dispatch({ type: 'FETCH_SUCCESS', payload: result.credits }))
+        .catch((err: unknown) => {
+          dispatch({
+            type: 'FETCH_ERROR',
+            payload: err instanceof Error ? err.message : 'Unable to load credits',
+          })
+        })
+    } else if (nodeType === 'Broker') {
+      void apiClient
+        .getCreditsByBroker(brokerName)
+        .then((result) => dispatch({ type: 'FETCH_SUCCESS', payload: result }))
+        .catch((err: unknown) => {
+          dispatch({
+            type: 'FETCH_ERROR',
+            payload: err instanceof Error ? err.message : 'Unable to load credits',
+          })
+        })
+    } else if (nodeType === 'Portfolio' && portfolioName) {
+      void apiClient
+        .getCreditsByPortfolio(brokerName, portfolioName)
+        .then((result) => dispatch({ type: 'FETCH_SUCCESS', payload: result }))
+        .catch((err: unknown) => {
+          dispatch({
+            type: 'FETCH_ERROR',
+            payload: err instanceof Error ? err.message : 'Unable to load credits',
+          })
+        })
+    }
+  }, [selectedNode, apiClient, state.retryCount])
+
+  const credits = useMemo(
+    () =>
+      [...state.credits].sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+      ),
+    [state.credits],
+  )
+
+  const filteredCredits = useMemo(() => {
+    const start = getFilterStartDate(state.selectedFilter)
+    if (!start) return credits
+    return credits.filter((c) => new Date(c.date) >= start)
+  }, [credits, state.selectedFilter])
+
+  const chartData = useMemo(() => aggregateByMonth(filteredCredits), [filteredCredits])
+
+  const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
+
+  const setFilter = useCallback(
+    (filter: FilterOption) => {
+      if (!selectedNode) return
+      dispatch({ type: 'SET_FILTER', payload: { filter, key: buildSelectionKey(selectedNode) } })
+    },
+    [selectedNode],
+  )
+
+  const setMode = useCallback(
+    (mode: ViewMode) => {
+      if (!selectedNode) return
+      dispatch({ type: 'SET_MODE', payload: { mode, key: buildSelectionKey(selectedNode) } })
+    },
+    [selectedNode],
+  )
+
+  const showNewForm = useCallback(() => dispatch({ type: 'SHOW_NEW_FORM' }), [])
+
+  const showEditForm = useCallback(
+    (credit: CreditDto) => dispatch({ type: 'SHOW_EDIT_FORM', payload: credit }),
+    [],
+  )
+
+  const cancelForm = useCallback(() => dispatch({ type: 'CANCEL_FORM' }), [])
+
+  const setFormField = useCallback((field: CreditFormField, value: string) => {
+    dispatch({ type: 'SET_FORM_FIELD', payload: { field, value } })
+  }, [])
+
+  const saveForm = useCallback(() => {
+    if (!selectedNode?.portfolioName || !selectedNode.assetName) return
+
+    const { formDate, formType, formValue, editingId } = state
+
+    if (!formDate.trim()) {
+      dispatch({ type: 'SAVE_ERROR', payload: 'Date is required' })
+      return
+    }
+
+    const value = parseFloat(formValue)
+    if (!formValue.trim() || !isFinite(value) || value <= 0) {
+      dispatch({ type: 'SAVE_ERROR', payload: 'Value must be a positive number' })
+      return
+    }
+
+    dispatch({ type: 'SAVE_START' })
+
+    const base = {
+      brokerName: selectedNode.brokerName,
+      portfolioName: selectedNode.portfolioName,
+      assetName: selectedNode.assetName,
+      date: formDate,
+      type: formType,
+      value,
+    }
+
+    const call = editingId
+      ? apiClient.updateCredit({ ...base, id: editingId })
+      : apiClient.addCredit(base)
+
+    void call
+      .then((result) => dispatch({ type: 'SAVE_SUCCESS', payload: result.credits }))
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'SAVE_ERROR',
+          payload: err instanceof Error ? err.message : 'Failed to save credit',
+        })
+      })
+  }, [selectedNode, state, apiClient])
+
+  const deleteCredit = useCallback(
+    (id: string) => {
+      if (!selectedNode?.portfolioName || !selectedNode.assetName) return
+      if (!window.confirm('Delete this credit?')) return
+
+      void apiClient
+        .deleteCredit({
+          brokerName: selectedNode.brokerName,
+          portfolioName: selectedNode.portfolioName,
+          assetName: selectedNode.assetName,
+          id,
+        })
+        .then((result) => dispatch({ type: 'DELETE_SUCCESS', payload: result.credits }))
+        .catch((err: unknown) => {
+          dispatch({
+            type: 'DELETE_ERROR',
+            payload: err instanceof Error ? err.message : 'Failed to delete credit',
+          })
+        })
+    },
+    [selectedNode, apiClient],
+  )
+
+  return {
+    credits,
+    filteredCredits,
+    chartData,
+    isLoading: state.isLoading,
+    error: state.error,
+    retry,
+    selectedFilter: state.selectedFilter,
+    selectedMode: state.selectedMode,
+    setFilter,
+    setMode,
+    isFormVisible: state.isFormVisible,
+    editingId: state.editingId,
+    formDate: state.formDate,
+    formType: state.formType,
+    formValue: state.formValue,
+    isSaving: state.isSaving,
+    saveError: state.saveError,
+    deleteError: state.deleteError,
+    nodeType: selectedNode?.nodeType,
+    showNewForm,
+    showEditForm,
+    cancelForm,
+    setFormField,
+    saveForm,
+    deleteCredit,
+  }
+}

--- a/docs/F06-credits-tab/plan.md
+++ b/docs/F06-credits-tab/plan.md
@@ -1,0 +1,123 @@
+# Implementation Plan: F06 — Portfolio Navigator: Credits Tab
+
+**Prerequisites:**
+- F02 implemented and merged (`SelectedNodeContext` available) ✅
+- All credit DTOs and API client methods exist in `types.ts` and `financialApiClient.ts` ✅
+- `CreditsController` and `CreditService` already exist on the backend ✅
+- `LoadingState` and `ErrorState` shared components available ✅
+- Recharts v3.8.1 already installed ✅
+
+---
+
+### Phase 1: Hook — `useCredits`
+
+**1. State, actions, and reducer** — Create `Financial.Web/src/hooks/useCredits.ts`. Define the
+full state shape: credits array, loading/error flags, retry counter, `selectedFilter`
+(`FilterOption`), `selectedMode` (`ViewMode`), a `filterPersistence` Map keyed by selection key,
+and inline form fields (`isFormVisible`, `editingId`, `formDate`, `formType`, `formValue`,
+`isSaving`, `saveError`, `deleteError`). Define the discriminated union of actions and implement
+the reducer handling all state transitions — including reset on node change, fetch lifecycle, form
+actions, and filter/mode updates with persistence.
+
+**2. Data fetching — all node types** — Wire a `useEffect` watching `SelectedNodeContext`. For
+asset nodes call `getAssetDetails` and extract `AssetDetailsDto.credits`; for broker nodes call
+`getCreditsByBroker`; for portfolio nodes call `getCreditsByPortfolio`. On each node change,
+compute the selection key, look up saved preferences in the persistence Map, and restore them (or
+apply defaults `last-year` + `Stacked` if unseen). Reset credits and form state when node is null.
+Include `retryCount` as a `useEffect` dependency so `retry()` triggers a re-fetch.
+
+**3. Filter/mode and persistence** — Implement `setFilter` and `setMode` actions that update the
+active filter/mode in reducer state and simultaneously write the new preference into the
+persistence Map under the current selection key. Implement a `buildSelectionKey(node)` pure
+function that returns `Asset|{b}|{p}|{n}`, `Portfolio|{b}|{n}`, or `Broker|{n}`.
+
+**4. Derived chart data** — Using `useMemo` in the hook body (not in the reducer), derive
+`filteredCredits` by applying the active `FilterOption` against the current date, then derive
+`chartData` (`MonthBucket[]`) by grouping filtered credits by month (MM/yyyy) and summing values
+per credit type. Sort buckets chronologically so the X-axis is ordered oldest-to-newest. Return
+both derived values as part of the hook interface.
+
+**5. Mutation operations** — Implement `showNewForm` (opens blank form with `formType: 'Dividend'`
+as default), `showEditForm` (populates fields from `CreditDto`, converts ISO date to `yyyy-MM-dd`
+for the date input), `cancelForm` (hides and resets the form), `setFormField` (updates individual
+field values), `saveForm` (validates date required and value > 0, calls `addCredit` or
+`updateCredit` depending on `editingId`, updates credits from the returned `AssetDetailsDto` on
+success, hides form), and `deleteCredit` (prompts via `window.confirm`, calls API `deleteCredit`,
+updates credits on success). Return the full hook interface.
+
+---
+
+### Phase 2: Component and Styles
+
+**6. `CreditsTab` component skeleton** — Create `Financial.Web/src/components/CreditsTab.tsx`.
+Import `useCredits`, `LoadingState`, and `ErrorState`. Render the loading guard first, then the
+error guard with retry callback. Confirm guards work correctly before adding further content.
+
+**7. Filter and mode controls** — Render the filter toolbar above the main content area with 5
+buttons ("This month", "Last 3 months", "Last 6 months", "Last year", "All") and 2 mode toggles
+("Stacked", "Grouped"). Wire each to `setFilter`/`setMode`. Apply a `--active` CSS class modifier
+to the currently selected option in each group.
+
+**8. Inner horizontal split (asset) and chart-only layout (broker/portfolio)** — For asset nodes,
+render a resizable horizontal split: credits section on the left (flex: 2 default) and chart
+section on the right (flex: 1 default), separated by a draggable divider. Implement the drag
+handle using `onMouseDown`/`onMouseMove`/`onMouseUp` on the document, storing the left panel
+pixel width in component `useState`, following the same pattern as `SplitPanel.tsx`. For
+broker/portfolio nodes, render the chart section full-width without the table or split.
+
+**9. Credits table** — Inside the left panel (asset only), render the credits table with columns:
+edit/delete icon buttons, Date, Type, Value. Format cells with local utility functions
+(`formatDate`, `formatN2`). Apply type CSS classes (`credits-tab__type--dividend`,
+`credits-tab__type--rent`). Apply a bold class to the Value cell. Wire the edit icon to
+`showEditForm(credit)` and the delete icon to `deleteCredit(credit.id)`. Render a "New credit"
+button in the toolbar above the table; clicking it calls `showNewForm()`.
+
+**10. Inline form** — Render the add/edit form (above the table, when `isFormVisible` is true)
+with controlled inputs: Date (`<input type="date">`), Type (`<select>` with Dividend/Rent
+options), Value (`<input type="number" min="0" step="0.01">`). Show "New credit" or "Edit credit"
+as the form title based on whether `editingId` is set. Wire Save to `saveForm()` (disabled +
+label "Saving..." while `isSaving`), Cancel to `cancelForm()`. Render `saveError` below the form
+when set and the form is visible. Render `deleteError` below the table when set.
+
+**11. Bar chart** — Inside the right panel (all node types), render a Recharts
+`ResponsiveContainer` containing a `BarChart` bound to `chartData`. For Stacked mode, both `Bar`
+components (Dividend, Rent) share `stackId="credits"`. For Grouped mode, omit `stackId`. Format
+X-axis ticks as MM/yyyy. Format Y-axis ticks with `formatN2`. Add `LabelList` on each bar
+segment. Display "Credits by Month" as a heading above the chart container.
+
+**12. Styles** — Create `Financial.Web/src/components/CreditsTab.css` with BEM classes covering:
+outer container, filter toolbar and active modifier, mode toggles and active modifier, inner split
+container, left/right panels, drag handle cursor/appearance, credits table, type colour modifiers
+(blue family for both Dividend and Rent, visually differentiated), bold value column, chart
+heading, chart container height, save and delete error message placements. Use CSS variable values
+from `index.css` for colours and typography.
+
+---
+
+### Phase 3: Integration
+
+**13. Wire into `DetailPanel`** — In `Financial.Web/src/components/DetailPanel.tsx`, replace the
+credits tab placeholder blocks with `{activeTab === 'credits' && <CreditsTab />}` and add the
+import statement. Node-type branching (table vs chart-only) is handled inside `CreditsTab` via
+the hook, so `DetailPanel` requires no further changes.
+
+---
+
+### Phase 4: Tests
+
+**14. Hook unit tests** — Create `Financial.Web/src/hooks/useCredits.test.ts` mocking
+`createFinancialApiClient`. Cover: fetch lifecycle for all 3 node types (asset/broker/portfolio),
+null node reset, retry, filter/mode state updates, persistence save and restore across
+re-selections, default filter/mode on first visit, all form state transitions (new, edit, cancel,
+field change), each mutation path (add success, update success, delete success), all error paths
+(save error, delete error, validation blocks for date required and value > 0), and sorted credits
+output. See spec Section 7 for the complete test function list.
+
+**15. Component unit tests** — Create
+`Financial.Web/src/components/__tests__/CreditsTab.test.tsx` mocking both `useCredits` and
+`recharts`. Cover: loading state, error state, chart-only for broker/portfolio nodes, table + chart
+for asset, date formatting (dd/MM/yyyy), N2 bold value, type CSS classes (dividend/rent), filter
+button rendering and active state, mode toggle rendering and active state, click callbacks for
+filter and mode, New button visibility (asset only), form visibility and titles, Save disabled
+state, edit/delete icon callbacks, save/delete error messages, and empty table. See spec Section 7
+for the complete test function list.

--- a/docs/F06-credits-tab/spec.md
+++ b/docs/F06-credits-tab/spec.md
@@ -1,0 +1,450 @@
+# F06 — Portfolio Navigator: Credits Tab
+
+## 1. Technical Overview
+
+F06 implements the Credits tab within the Portfolio Navigator's right-panel detail view. For asset
+selection, the tab renders a horizontal resizable split layout: a credits table with inline CRUD on
+the left and a "Credits by Month" bar chart on the right. For broker and portfolio selections, only
+the chart is shown (no table, no CRUD).
+
+Time filters (5 options) and chart view mode (Stacked/Grouped) persist per selection key and are
+restored when the user navigates back to a previously visited node. Defaults on first visit are
+"Last year" + Stacked.
+
+All backend infrastructure is already in place: `CreditsController`, `CreditService`, the `Credit`
+domain entity, and all request/response DTOs exist. The `financialApiClient` already exposes
+`getCreditsByBroker`, `getCreditsByPortfolio`, `addCredit`, `updateCredit`, and `deleteCredit`.
+All TypeScript DTOs (`CreditDto`, `CreditCreateDto`, `CreditUpdateDto`, `CreditDeleteDto`) are
+defined in `api/types.ts`. This feature is a pure frontend addition — no backend changes required.
+
+`CreditsTab` follows the self-contained hook pattern established by `TransactionsTab` (F05): a
+`useCredits` hook manages all data-fetching, filter/mode persistence, chart data derivation, and
+mutation state via `useReducer`. The component renders from the hook's output. The tab replaces
+the existing placeholder in `DetailPanel.tsx`.
+
+**Scope — Included:**
+- `useCredits` hook: fetches credits for all 3 node types, manages inline form state, CRUD
+  mutations, filter/mode state with per-key persistence
+- `CreditsTab` component: inner horizontal resizable split (table + chart) for asset; chart-only
+  for broker/portfolio
+- "Credits by Month" bar chart via Recharts `BarChart`, with Stacked and Grouped modes
+- Time filter controls: This month, Last 3 months, Last 6 months, Last year, All (client-side,
+  no new API calls on filter/mode change)
+- Filter/mode persistence per selection key (Map in hook state, ephemeral — resets on page reload)
+- Loading, error, and empty states
+- `DetailPanel.tsx` updated to render `<CreditsTab />` in place of the placeholder
+
+**Scope — Excluded:**
+- Shared cross-tab asset state (Summary tab totals remain unchanged after credits mutations;
+  matches F05 precedent)
+- Backend changes (all endpoints already exist)
+- Cross-session persistence of filter/mode preferences
+
+---
+
+## 2. Architecture Impact
+
+**Affected components:**
+
+```mermaid
+graph TD
+    User["User (browser)"] --> DetailPanel
+    DetailPanel --> CreditsTab
+    CreditsTab --> useCredits
+    useCredits --> SelectedNodeContext
+    useCredits --> FinancialApiClient["FinancialApiClient"]
+    FinancialApiClient --> CreditsController["CreditsController (existing)"]
+    FinancialApiClient --> AssetsController["AssetsController (existing, getAssetDetails)"]
+    CreditsController --> CreditService["CreditService (existing)"]
+    CreditService --> JSONRepository["JSONRepository (existing)"]
+```
+
+**Data flow — read path (asset):** On asset node selection, `useCredits` calls `getAssetDetails`
+and stores `AssetDetailsDto.credits`. Credits are sorted by date descending, filtered client-side
+by the active time filter, and aggregated into `MonthBucket[]` for the chart.
+
+**Data flow — read path (broker):** On broker node selection, `useCredits` calls
+`getCreditsByBroker(brokerName)` and stores the returned `CreditDto[]`. Same filter + aggregation
+pipeline applies.
+
+**Data flow — read path (portfolio):** On portfolio node selection, `useCredits` calls
+`getCreditsByPortfolio(brokerName, portfolioName)`. Same pipeline.
+
+**Data flow — write path (asset only):** User submits the inline form → `useCredits` validates
+and calls `addCredit`, `updateCredit`, or `deleteCredit` → on success the returned
+`AssetDetailsDto.credits` replaces stored credits → form resets, table re-renders.
+
+**Data flow — filter/mode change:** User clicks a filter or mode toggle → hook updates
+`selectedFilter`/`selectedMode` in reducer state and saves to the persistence Map keyed by
+current selection key → `filteredCredits` and `chartData` recomputed via `useMemo` (no API
+calls).
+
+---
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Node type handling | Single `useCredits` hook handles all 3 node types by branching on node type in the fetch `useEffect` | Separate hooks per node type | Single hook keeps the tab self-contained; branching is limited to the fetch effect and one conditional in the component. |
+| Chart library | Recharts `BarChart` (already in `package.json` v3.8.1) | Canvas-based alternatives (Chart.js) | No new dependency; declarative React components integrate cleanly with the existing stack. |
+| Derived state | `filteredCredits` and `chartData` computed via `useMemo` in the hook body; not stored in reducer | Storing derived arrays in reducer | Avoids stale derived state and double-dispatch on every filter/mode change. Reducer only holds raw credits and filter/mode preferences. |
+| Filter/mode persistence | `Map<string, { filter; mode }>` in `useReducer` state, keyed by selection key | `useRef` with Map | Storing in reducer state makes persistence changes visible to React's reconciler and testable via `renderHook`. |
+| Inner horizontal split | Inline resizable split within `CreditsTab` using the same mouse-drag pattern as `SplitPanel` | Reuse `SplitPanel` component directly | Reusing `SplitPanel` would require modifying its internal `MIN_LEFT_WIDTH` constant (shared component concern). An inline split keeps `CreditsTab` self-contained. |
+| Recharts in tests | Mock all Recharts components at module level (`vi.mock('recharts', ...)`) | Integration test with real SVG | JSDOM has limited SVG support; mocking Recharts is the standard pattern and sufficient to verify chart is rendered with correct data props. |
+| Credit form value field | Store as `string` during editing; parse to `number` on submit | Store as `number` | Consistent with `formQuantity` in F05 — prevents loss of partial input while typing (e.g., `"2."` → `2` prematurely). |
+
+---
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/hooks/useCredits.ts` | New | All data, filter/mode, persistence, and mutation state | Fetch credits for all 3 node types; manage filter/mode with persistence Map; compute chart data; execute CRUD mutations; manage inline form state |
+| `Financial.Web/src/components/CreditsTab.tsx` | New | Credits tab UI | Loading/error guards; inner resizable split (asset: table + chart; broker/portfolio: chart only); filter buttons; mode toggles; Recharts bar chart |
+| `Financial.Web/src/components/CreditsTab.css` | New | Scoped styles | BEM layout for inner split, drag handle, filter/mode toolbar, table with type colour modifiers, N2 bold values, chart container, error messages |
+| `Financial.Web/src/components/DetailPanel.tsx` | Modified | Tab container | Replace credits placeholder with `<CreditsTab />`; add import |
+| `Financial.Web/src/hooks/useCredits.test.ts` | New | Unit tests for `useCredits` | Fetch lifecycle for all 3 node types; filter/mode state and persistence; CRUD mutations; form state |
+| `Financial.Web/src/components/__tests__/CreditsTab.test.tsx` | New | Unit tests for `CreditsTab` | All render states; filter/mode controls; table formatting; chart rendered; form interaction |
+
+**Backend:** No changes required.
+
+---
+
+## 5. API Contracts
+
+All endpoints already exist. Documented here for implementation reference.
+
+---
+
+### Read — Asset Credits (via Asset Details)
+
+- **Method:** GET
+- **Path:** `/api/v1/financial/assets/{brokerName}/{portfolioName}/{assetName}`
+
+**Relevant Response Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `credits` | `CreditDto[]` | Full credit list for the asset |
+| `credits[].id` | `string (UUID)` | Credit identifier |
+| `credits[].date` | `string (ISO 8601)` | Credit date |
+| `credits[].type` | `string` | `"Dividend"` or `"Rent"` |
+| `credits[].value` | `number` | Credit value |
+
+**Response Example:**
+```json
+{
+  "name": "KLBN4",
+  "credits": [
+    {
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "date": "2024-03-15T00:00:00",
+      "type": "Dividend",
+      "value": 120.50
+    }
+  ]
+}
+```
+
+---
+
+### Read — Broker Credits
+
+- **Method:** GET
+- **Path:** `/api/v1/financial/credits/broker/{brokerName}`
+
+**Response (200):** `CreditDto[]`
+
+**Response Example:**
+```json
+[
+  {
+    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "date": "2024-03-15T00:00:00",
+    "type": "Rent",
+    "value": 350.00
+  }
+]
+```
+
+**Error Codes:**
+
+| HTTP Status | Description |
+|-------------|-------------|
+| 404 | Broker not found |
+
+---
+
+### Read — Portfolio Credits
+
+- **Method:** GET
+- **Path:** `/api/v1/financial/credits/portfolio/{brokerName}/{portfolioName}`
+
+**Response (200):** `CreditDto[]`
+
+**Error Codes:**
+
+| HTTP Status | Description |
+|-------------|-------------|
+| 404 | Broker or portfolio not found |
+
+---
+
+### Create Credit
+
+- **Method:** POST
+- **Path:** `/api/v1/financial/credits`
+
+**Request:**
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|-------------|
+| `brokerName` | `string` | Yes | Non-empty | Broker identifier |
+| `portfolioName` | `string` | Yes | Non-empty | Portfolio identifier |
+| `assetName` | `string` | Yes | Non-empty | Asset identifier |
+| `date` | `string` | Yes | `yyyy-MM-dd` | Credit date |
+| `type` | `string` | Yes | `"Dividend"` or `"Rent"` | Credit type |
+| `value` | `number` | Yes | > 0 | Credit value |
+
+**Request Example:**
+```json
+{
+  "brokerName": "XPI",
+  "portfolioName": "Acoes",
+  "assetName": "KLBN4",
+  "date": "2024-03-15",
+  "type": "Dividend",
+  "value": 120.50
+}
+```
+
+**Response (200):** Updated `AssetDetailsDto`
+
+**Error Codes:**
+
+| HTTP Status | Description |
+|-------------|-------------|
+| 400 | Null request, unknown type, or missing required fields |
+
+---
+
+### Update Credit
+
+- **Method:** PUT
+- **Path:** `/api/v1/financial/credits`
+
+**Request:** Same as Create, plus `id` (UUID of the credit to update).
+
+**Request Example:**
+```json
+{
+  "brokerName": "XPI",
+  "portfolioName": "Acoes",
+  "assetName": "KLBN4",
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "date": "2024-03-15",
+  "type": "Rent",
+  "value": 200.00
+}
+```
+
+**Response (200):** Updated `AssetDetailsDto`
+
+**Error Codes:**
+
+| HTTP Status | Description |
+|-------------|-------------|
+| 400 | Null request, credit ID not found, or unknown type |
+
+---
+
+### Delete Credit
+
+- **Method:** DELETE
+- **Path:** `/api/v1/financial/credits`
+
+**Request:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `brokerName` | `string` | Yes | Broker identifier |
+| `portfolioName` | `string` | Yes | Portfolio identifier |
+| `assetName` | `string` | Yes | Asset identifier |
+| `id` | `string (UUID)` | Yes | Credit to delete |
+
+**Request Example:**
+```json
+{
+  "brokerName": "XPI",
+  "portfolioName": "Acoes",
+  "assetName": "KLBN4",
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+}
+```
+
+**Response (200):** Updated `AssetDetailsDto` (credit removed)
+
+**Error Codes:**
+
+| HTTP Status | Description |
+|-------------|-------------|
+| 400 | Null request or credit ID not found |
+
+---
+
+## 6. Data Model
+
+No backend schema changes. All entities, DTOs, and repository methods are already implemented.
+
+**Existing types used by this feature (`Financial.Web/src/api/types.ts`):**
+
+| Type | Description |
+|------|-------------|
+| `CreditDto` | Read model: `id`, `date`, `type`, `value` |
+| `CreditCreateDto` | Write model for POST: `brokerName`, `portfolioName`, `assetName`, `date`, `type`, `value` |
+| `CreditUpdateDto` | Write model for PUT: all Create fields plus `id` |
+| `CreditDeleteDto` | Write model for DELETE: `brokerName`, `portfolioName`, `assetName`, `id` |
+| `AssetDetailsDto` | Contains `credits: CreditDto[]`; returned by all CRUD mutation endpoints |
+
+**New TypeScript types introduced in `useCredits.ts`:**
+
+| Type | Description |
+|------|-------------|
+| `FilterOption` | `'this-month' \| 'last-3-months' \| 'last-6-months' \| 'last-year' \| 'all'` |
+| `ViewMode` | `'Stacked' \| 'Grouped'` |
+| `CreditType` | `'Dividend' \| 'Rent'` |
+| `CreditFormField` | `'formDate' \| 'formType' \| 'formValue'` |
+| `MonthBucket` | `{ month: string; Dividend: number; Rent: number }` — one chart data point per MM/yyyy |
+| `PersistedPrefs` | `{ filter: FilterOption; mode: ViewMode }` — stored per selection key in the Map |
+| `CreditsState` | Full hook state shape |
+| `CreditsAction` | Discriminated union of all reducer actions |
+| `CreditsData` | Hook return type (state flags + callbacks) |
+
+---
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/hooks/useCredits.test.ts` | Unit | `useCredits` hook | Fetch lifecycle for all 3 node types; filter/mode state and persistence; CRUD mutations; form state |
+| `Financial.Web/src/components/__tests__/CreditsTab.test.tsx` | Unit | `CreditsTab` component | All render states; filter/mode controls; table formatting; chart rendered; form interaction |
+
+---
+
+### `useCredits.test.ts`
+
+Follow the pattern from `useTransactions.test.ts`: mock `createFinancialApiClient`, create a
+context wrapper with `SelectedNodeProvider`, use `renderHook` + `act` + `waitFor`.
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `returns_initial_empty_state` | Hook with no node | `isLoading: false`, `credits: []`, `error: null`, `selectedFilter: 'last-year'`, `selectedMode: 'Stacked'` |
+| `fetches_asset_credits_on_asset_selection` | Asset node in context | `getAssetDetails` called; credits from `AssetDetailsDto.credits`; `isLoading` true→false |
+| `fetches_broker_credits_on_broker_selection` | Broker node in context | `getCreditsByBroker(brokerName)` called; credits populated |
+| `fetches_portfolio_credits_on_portfolio_selection` | Portfolio node in context | `getCreditsByPortfolio(brokerName, portfolioName)` called; credits populated |
+| `resets_credits_when_node_is_null` | Node set to null | `credits: []`, `isLoading: false` |
+| `increments_retry_and_refetches` | `retry()` after error | Fetch method called a second time |
+| `set_filter_updates_selected_filter` | `setFilter('last-3-months')` | `selectedFilter: 'last-3-months'` |
+| `set_mode_updates_selected_mode` | `setMode('Grouped')` | `selectedMode: 'Grouped'` |
+| `persists_filter_and_mode_per_selection_key` | Set filter for asset A; switch to asset B; return to A | Filter from A restored; B has default |
+| `defaults_to_last_year_stacked_on_first_selection` | New node never visited before | `selectedFilter: 'last-year'`, `selectedMode: 'Stacked'` |
+| `show_new_form_opens_blank_form` | `showNewForm()` | `isFormVisible: true`, `editingId: null`, `formDate: ''`, `formType: 'Dividend'`, `formValue: ''` |
+| `show_edit_form_populates_fields` | `showEditForm(creditDto)` | `isFormVisible: true`, `editingId` set, `formDate` in `yyyy-MM-dd`, fields match credit |
+| `cancel_form_hides_form_and_resets` | `cancelForm()` after `showNewForm()` | `isFormVisible: false`, fields cleared |
+| `save_new_credit_calls_add_and_updates_asset` | Valid form → `saveForm()` | `addCredit` called with correct DTO; credits updated from `AssetDetailsDto.credits`; `isFormVisible: false` |
+| `save_edit_credit_calls_update` | Form pre-filled via edit → `saveForm()` | `updateCredit` called with `id`; credits updated |
+| `save_sets_error_on_api_failure` | `addCredit` rejects → `saveForm()` | `saveError` non-null; `isFormVisible` remains true; `isSaving: false` |
+| `save_validates_date_required` | `formDate: ''` → `saveForm()` | `saveError` set; `addCredit` not called |
+| `save_validates_value_greater_than_zero` | `formValue: '0'` → `saveForm()` | `saveError` set; `addCredit` not called |
+| `delete_credit_calls_api_and_updates_asset` | `deleteCredit(id)`, `window.confirm` returns true | API `deleteCredit` called; credits updated |
+| `delete_failure_sets_delete_error` | API `deleteCredit` rejects | `deleteError` non-null; credits unchanged |
+| `sorts_credits_by_date_descending` | Multiple credits with different dates | `credits[0].date` is most recent |
+
+---
+
+### `CreditsTab.test.tsx`
+
+Follow the pattern from `TransactionsTab.test.tsx`: mock `useCredits` at module level and provide
+an override helper. Also mock `recharts` at module level:
+
+```typescript
+vi.mock('recharts', () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) =>
+    <div data-testid="bar-chart">{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) =>
+    <div data-testid="responsive-container">{children}</div>,
+  LabelList: () => null,
+}))
+```
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `renders_loading_state` | `isLoading: true` | `<LoadingState>` rendered |
+| `renders_error_state_with_retry` | `error: 'msg'` | `<ErrorState>` rendered with message and retry callback |
+| `renders_chart_only_for_broker_node` | Broker node, no error/loading | `data-testid="responsive-container"` present; no table; no New button |
+| `renders_chart_only_for_portfolio_node` | Portfolio node | Same as broker |
+| `renders_table_and_chart_for_asset_node` | Asset node | Table and `data-testid="responsive-container"` both present |
+| `renders_table_columns_date_type_value` | Asset with credits | Columns Date, Type, Value visible |
+| `renders_date_in_dd_MM_yyyy_format` | Credit with `date: "2024-03-15T00:00:00"` | Cell shows `15/03/2024` |
+| `renders_dividend_type_with_dividend_class` | Dividend credit | Type cell has `credits-tab__type--dividend` class |
+| `renders_rent_type_with_rent_class` | Rent credit | Type cell has `credits-tab__type--rent` class |
+| `renders_value_in_n2_bold` | Credit with value | Cell shows N2-formatted value with bold class |
+| `new_button_present_for_asset_only` | Asset node: New visible; broker/portfolio: not present | |
+| `new_button_calls_show_new_form` | Click New | `showNewForm` called |
+| `renders_form_when_form_visible` | `isFormVisible: true` | Date, Type, Value inputs rendered |
+| `form_title_is_new_credit_when_no_editing_id` | `editingId: null` | Form title "New credit" |
+| `form_title_is_edit_credit_when_editing_id_set` | `editingId: 'some-id'` | Form title "Edit credit" |
+| `save_button_disabled_while_saving` | `isSaving: true` | Save button `disabled`; label "Saving..." |
+| `edit_icon_calls_show_edit_form` | Click edit icon on row | `showEditForm` called with that credit |
+| `delete_icon_calls_delete_credit` | Click delete icon on row | `deleteCredit` called with credit id |
+| `renders_save_error_below_form` | `saveError: 'Failed'`, `isFormVisible: true` | Error message below form |
+| `renders_delete_error_below_table` | `deleteError: 'Failed'` | Error message below table |
+| `renders_five_filter_buttons` | Default state | "This month", "Last 3 months", "Last 6 months", "Last year", "All" |
+| `active_filter_has_active_class` | `selectedFilter: 'last-year'` | "Last year" button has `--active` modifier |
+| `clicking_filter_calls_set_filter` | Click "Last 3 months" | `setFilter('last-3-months')` called |
+| `renders_mode_toggles` | Default state | "Stacked" and "Grouped" buttons rendered |
+| `active_mode_has_active_class` | `selectedMode: 'Stacked'` | "Stacked" button has `--active` modifier |
+| `clicking_mode_calls_set_mode` | Click "Grouped" | `setMode('Grouped')` called |
+| `empty_table_renders_no_rows` | `credits: []` | Table body has no data rows |
+
+---
+
+### Formatting Conventions
+
+Utility functions defined locally in `CreditsTab.tsx`, following `TransactionsTab.tsx` conventions:
+
+| Function | Format | Example Input | Example Output |
+|----------|--------|---------------|----------------|
+| `formatN2(value)` | 2 decimal places | `120.5` | `"120.50"` |
+| `formatDate(iso)` | `dd/MM/yyyy` | `"2024-03-15T00:00:00"` | `"15/03/2024"` |
+| `toInputDate(iso)` | `yyyy-MM-dd` | `"2024-03-15T00:00:00"` | `"2024-03-15"` |
+| `buildMonthKey(date)` | `MM/yyyy` | `new Date("2024-03-15")` | `"03/2024"` |
+
+---
+
+### Acceptance Criteria Mapping
+
+| AC from PRD §9 | Covered by |
+|----------------|-----------|
+| Asset: table with Date (dd/MM/yyyy), Type, Value (N2 bold) | `renders_table_columns_date_type_value`, `renders_date_in_dd_MM_yyyy_format`, `renders_value_in_n2_bold` |
+| New button present (asset only); POST on save; list refreshes | `new_button_present_for_asset_only`, `save_new_credit_calls_add_and_updates_asset` |
+| Edit → PUT; Delete → confirm → DELETE | `save_edit_credit_calls_update`, `delete_credit_calls_api_and_updates_asset` |
+| Broker/portfolio: chart only (no table/New) | `renders_chart_only_for_broker_node`, `renders_chart_only_for_portfolio_node` |
+| X-axis MM/yyyy, chronological | `buildMonthKey` format + chronological sort in `aggregateByMonth` |
+| Stacked vs Grouped toggle | `renders_mode_toggles`, `clicking_mode_calls_set_mode` |
+| Default: Last year + Stacked | `returns_initial_empty_state`, `defaults_to_last_year_stacked_on_first_selection` |
+| Filter controls (5 options) | `renders_five_filter_buttons`, `clicking_filter_calls_set_filter` |
+| Persistence: filter/mode restored on re-selection | `persists_filter_and_mode_per_selection_key` |
+| Broker chart data: `GET /credits/broker/{brokerName}` | `fetches_broker_credits_on_broker_selection` |
+| Portfolio chart data: `GET /credits/portfolio/{b}/{p}` | `fetches_portfolio_credits_on_portfolio_selection` |
+| Cross-feature: F02 context passed to F06 | `fetches_asset_credits_on_asset_selection`, `fetches_broker_credits_on_broker_selection` |


### PR DESCRIPTION
## Summary

- Implements `useCredits` hook — fetches credits for all 3 node types (asset/broker/portfolio), manages filter/mode state with per-selection-key persistence (`Map` in `useReducer`), computes `filteredCredits` and `chartData` via `useMemo`, handles full CRUD (add/update/delete) for asset credits
- Implements `CreditsTab` component — table + inline form + resizable split for asset selections; chart-only for broker/portfolio; 5 filter buttons (This month → All) and Stacked/Grouped mode toggles
- Adds "Credits by Month" Recharts `BarChart` with Dividend/Rent bars, MM/yyyy X-axis, and N2-formatted Y-axis ticks
- Wires `<CreditsTab />` into `DetailPanel.tsx` replacing the F06 placeholder

## Test plan

- [x] 25 hook unit tests (`useCredits.test.ts`) — fetch lifecycle for all 3 node types, filter/mode persistence, form state, all CRUD paths, validation, error handling, sort order
- [x] 24 component unit tests (`CreditsTab.test.tsx`) — all render states, filter/mode controls, table formatting (date/type/value), form interaction, edit/delete callbacks
- [x] Full suite: 197/197 tests pass, TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)