### PR TITLE
feat(web): replace X delete icon with eraser icon in grids

### DIFF
--- a/Financial.Web/src/components/CreditsTab.tsx
+++ b/Financial.Web/src/components/CreditsTab.tsx
@@ -76,7 +76,10 @@ function CreditRow({ credit, onEdit, onDelete }: CreditRowProps) {
           aria-label="Delete credit"
           onClick={() => onDelete(credit.id)}
         >
-          ✕
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M20 20H7L3 16a2 2 0 0 1 0-2.83L14.59 1.58a2 2 0 0 1 2.83 0l4 4a2 2 0 0 1 0 2.83L8 20" />
+            <path d="M6.5 15.5 15 7" />
+          </svg>
         </button>
       </td>
       <td>{formatDate(credit.date)}</td>

--- a/Financial.Web/src/components/TransactionsTab.tsx
+++ b/Financial.Web/src/components/TransactionsTab.tsx
@@ -57,7 +57,10 @@ function TransactionRow({ transaction, onEdit, onDelete }: TransactionRowProps) 
           aria-label="Delete transaction"
           onClick={() => onDelete(transaction.id)}
         >
-          ✕
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M20 20H7L3 16a2 2 0 0 1 0-2.83L14.59 1.58a2 2 0 0 1 2.83 0l4 4a2 2 0 0 1 0 2.83L8 20" />
+            <path d="M6.5 15.5 15 7" />
+          </svg>
         </button>
       </td>
       <td>{formatDate(transaction.date)}</td>


### PR DESCRIPTION
## Summary
- Replaced the `✕` (multiplication X) Unicode character on delete buttons in `TransactionsTab` and `CreditsTab` grids with an inline SVG eraser icon
- The eraser icon better communicates the delete/erase intent compared to a generic close/X symbol
- No icon library dependency added — uses an inline SVG consistent with the existing pattern

## Test plan
- [x] Open Transactions tab, verify delete button shows an eraser icon instead of ✕
- [x] Open Credits tab, verify delete button shows an eraser icon instead of ✕
- [x] Confirm eraser icon is visually distinct from the pencil edit icon
- [x] Verify delete functionality still works after clicking the eraser

🤖 Generated with [Claude Code](https://claude.com/claude-code)