### PR TITLE
fix(web): right-align Value and Total columns in Dividend Check tables

### DIFF
--- a/Financial.Web/src/pages/DividendCheckPage.css
+++ b/Financial.Web/src/pages/DividendCheckPage.css
@@ -90,3 +90,7 @@
 .dividend-check__placeholder {
   color: var(--text);
 }
+
+.dividend-check__tables .table-number {
+  text-align: right;
+}


### PR DESCRIPTION
## Summary
- Added `text-align: right` for the `.table-number` CSS class in `DividendCheckPage.css`
- The class was already applied to Value and Total column headers/cells in the TSX but had no effect because it was not defined in the stylesheet
- Affects both the Dividend History table (Value column) and the By Year table (Total column)

## Test plan
- [ ] Open Shares Dividend Check page, enter a ticker and click Check
- [ ] Verify the "Value" column values and header are right-aligned in the Dividend History table
- [ ] Verify the "Total" column values and header are right-aligned in the By Year table

🤖 Generated with [Claude Code](https://claude.com/claude-code)