### PR TITLE
feat(dividend): add dividend yield % to Shares Dividend Check summary

### DIFF
--- a/Financial.App/ViewModels/DividendCheckViewModel.cs
+++ b/Financial.App/ViewModels/DividendCheckViewModel.cs
@@ -15,6 +15,7 @@ public class DividendCheckViewModel : ViewModelBase
     private string _summaryName = string.Empty;
     private string _summaryPrice = string.Empty;
     private string _summaryAverageDividend = string.Empty;
+    private string _summaryDividendYield = string.Empty;
     private string _summaryPriceMaxBuy = string.Empty;
     private bool _isPriceGood;
 
@@ -40,6 +41,12 @@ public class DividendCheckViewModel : ViewModelBase
     {
         get => _summaryAverageDividend;
         private set => SetProperty(ref _summaryAverageDividend, value);
+    }
+
+    public string SummaryDividendYield
+    {
+        get => _summaryDividendYield;
+        private set => SetProperty(ref _summaryDividendYield, value);
     }
 
     public string SummaryPriceMaxBuy
@@ -82,6 +89,7 @@ public class DividendCheckViewModel : ViewModelBase
         SummaryName = $"{summary.Ticker} - {summary.Name}";
         SummaryPrice = $"Current price: {summary.CurrentPrice:N2}";
         SummaryAverageDividend = $"Average Dividend: {summary.AverageDividendLastFiveYears:F2} (last {DividendValuationRules.DividendYearsLookback} years)";
+        SummaryDividendYield = $"Dividend Yield: {summary.DividendYieldPercent:F2}% (annual avg / current price)";
         SummaryPriceMaxBuy = $"Price max buy: {summary.PriceMaxBuy:F2}   Discount {summary.DiscountPercent:F2}%";
         IsPriceGood = summary.PriceMaxBuy > summary.CurrentPrice;
     }

--- a/Financial.App/Views/DividendCheckView.xaml
+++ b/Financial.App/Views/DividendCheckView.xaml
@@ -80,6 +80,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <TextBlock Grid.Row="0" Text="{Binding SummaryName, FallbackValue='Select a ticker and click Check'}"
                            FontSize="18" FontWeight="Bold" Foreground="#333333" Margin="0,0,0,10"/>
@@ -87,7 +88,9 @@
                            FontSize="14" Margin="0,0,0,5"/>
                 <TextBlock Grid.Row="2" Text="{Binding SummaryAverageDividend, FallbackValue='Average Dividend: --'}"
                            FontSize="14" Foreground="Blue" Margin="0,0,0,5"/>
-                <TextBlock Grid.Row="3" Text="{Binding SummaryPriceMaxBuy, FallbackValue='Price max buy: --'}"
+                <TextBlock Grid.Row="3" Text="{Binding SummaryDividendYield, FallbackValue='Dividend Yield: --'}"
+                           FontSize="14" Foreground="Blue" Margin="0,0,0,5"/>
+                <TextBlock Grid.Row="4" Text="{Binding SummaryPriceMaxBuy, FallbackValue='Price max buy: --'}"
                            FontSize="14" FontWeight="Bold">
                     <TextBlock.Style>
                         <Style TargetType="TextBlock">

--- a/Financial.Application/DTOs/DividendSummaryDTO.cs
+++ b/Financial.Application/DTOs/DividendSummaryDTO.cs
@@ -8,6 +8,7 @@ public class DividendSummaryDTO
     public decimal CurrentPrice { get; set; }
     public DateTimeOffset PriceAsOf { get; set; }
     public decimal AverageDividendLastFiveYears { get; set; }
+    public decimal DividendYieldPercent { get; set; }
     public decimal PriceMaxBuy { get; set; }
     public decimal DiscountPercent { get; set; }
     public required IReadOnlyList<DividendHistoryItemDTO> History { get; set; }

--- a/Financial.Application/Services/DividendService.cs
+++ b/Financial.Application/Services/DividendService.cs
@@ -49,6 +49,7 @@ public sealed class DividendService : IDividendService
 
         var priceMax = averageDividend > 0m ? averageDividend / DividendValuationRules.RequiredYield : 0m;
         var discountPercent = priceMax > 0m ? (1m - (snapshot.Price / priceMax)) * 100m : 0m;
+        var dividendYieldPercent = snapshot.Price > 0m ? (averageDividend / snapshot.Price) * 100m : 0m;
 
         return new DividendSummaryDTO
         {
@@ -58,6 +59,7 @@ public sealed class DividendService : IDividendService
             CurrentPrice = snapshot.Price,
             PriceAsOf = snapshot.AsOf,
             AverageDividendLastFiveYears = averageDividend,
+            DividendYieldPercent = dividendYieldPercent,
             PriceMaxBuy = priceMax,
             DiscountPercent = discountPercent,
             History = history,

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -164,6 +164,7 @@ export interface DividendSummaryDto {
   currentPrice: number
   priceAsOf: string
   averageDividendLastFiveYears: number
+  dividendYieldPercent: number
   priceMaxBuy: number
   discountPercent: number
   yearTotals: DividendYearTotalDto[]

--- a/Financial.Web/src/pages/DividendCheckPage.tsx
+++ b/Financial.Web/src/pages/DividendCheckPage.tsx
@@ -114,7 +114,7 @@ export default function DividendCheckPage() {
             </p>
             <p>Current price: {formatNumber(summary.currentPrice)}</p>
             <p className="summary-card__avg-dividend">
-              Average Dividend: {formatNumber(summary.averageDividendLastFiveYears)} (last 5 years)
+              Average Dividend: {formatNumber(summary.averageDividendLastFiveYears)} (last 5 years) — Yield: {formatNumber(summary.dividendYieldPercent)}%
             </p>
             <p className={`summary-card__price-max ${priceMaxBuyClass}`}>
               Price max buy: {formatNumber(summary.priceMaxBuy)}&nbsp;&nbsp;&nbsp;Discount{' '}

--- a/Financial.Web/src/pages/__tests__/DividendCheckPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/DividendCheckPage.test.tsx
@@ -21,6 +21,7 @@ const baseSummary: DividendSummaryDto = {
   currentPrice: 10.5,
   priceAsOf: '2024-02-01T00:00:00Z',
   averageDividendLastFiveYears: 1.4,
+  dividendYieldPercent: 13.33,
   priceMaxBuy: 20.0,
   discountPercent: 47.5,
   yearTotals: [{ year: 2023, total: 1.4 }],


### PR DESCRIPTION
## Summary
- Added `DividendYieldPercent` field to `DividendSummaryDTO` (Application layer)
- Computed the yield in `DividendService` as `(averageDividend / currentPrice) * 100`, guarded against division by zero
- **Web**: rendered inline after the average dividend line — `Average Dividend: 0.22 (last 5 years) — Yield: X.XX%`
- **WPF**: added new `SummaryDividendYield` property to `DividendCheckViewModel` and a new `TextBlock` in `DividendCheckView.xaml` below the average dividend row
- Updated TypeScript type `DividendSummaryDto` and the test fixture

## Test plan
- [ ] Run the app (web or WPF), enter a ticker and click Check
- [ ] Verify the summary card shows `Average Dividend: X.XX (last 5 years) — Yield: X.XX%`
- [ ] WPF: verify a new "Dividend Yield: X.XX% (annual avg / current price)" line appears below Average Dividend
- [ ] Verify yield = 0.00% when current price is 0 (edge case guard)
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)