### PR TITLE
feat(web): add zebra stripe effect to grid tables

### DIFF
--- a/Financial.Web/src/components/CreditsTab.css
+++ b/Financial.Web/src/components/CreditsTab.css
@@ -248,6 +248,10 @@
   white-space: nowrap;
 }
 
+.credits-tab__table tbody tr:nth-child(even) {
+  background: #f5f5f5;
+}
+
 .credits-tab__action-btn {
   background: none;
   border: none;

--- a/Financial.Web/src/components/TransactionsTab.css
+++ b/Financial.Web/src/components/TransactionsTab.css
@@ -147,6 +147,10 @@
   white-space: nowrap;
 }
 
+.transactions-tab__table tbody tr:nth-child(even) {
+  background: #f5f5f5;
+}
+
 .transactions-tab__action-btn {
   background: none;
   border: none;

--- a/Financial.Web/src/pages/CurrentValuesPage.css
+++ b/Financial.Web/src/pages/CurrentValuesPage.css
@@ -67,6 +67,10 @@
   color: var(--text-h);
 }
 
+.current-values__results tbody tr:nth-child(even) {
+  background: #f5f5f5;
+}
+
 th.current-values__col--price,
 td.current-values__col--price {
   text-align: right;

--- a/Financial.Web/src/pages/DividendCheckPage.css
+++ b/Financial.Web/src/pages/DividendCheckPage.css
@@ -87,6 +87,10 @@
   color: var(--text-h);
 }
 
+.dividend-check__tables tbody tr:nth-child(even) {
+  background: #f5f5f5;
+}
+
 .dividend-check__placeholder {
   color: var(--text);
 }


### PR DESCRIPTION
## Summary
- Added alternating row background (`#f5f5f5` on even rows) to all three web tables: Transactions, Credits, and Dividend Check (History and By Year)
- Matches the `AlternatingRowBackground="#F5F5F5"` already used in the WPF DataGrids
- Pure CSS change using `tbody tr:nth-child(even)` — no TSX changes needed

## Test plan
- [ ] Open Transactions tab — verify even rows have a light grey background
- [ ] Open Credits tab — verify even rows have a light grey background
- [ ] Open Shares Dividend Check, run a check — verify both Dividend History and By Year tables show alternating row colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)