### PR TITLE
fix: remove read-only flag from data volume so CRUD writes succeed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
       DataJsonFile: /app/data/data.json
       Repository__Provider: LocalJson
     volumes:
-      - ./data:/app/data:ro
+      - ./data:/app/data


### PR DESCRIPTION
## Root cause

`docker-compose.yml` mounted the data directory as read-only:

```yaml
volumes:
  - ./data:/app/data:ro   # ← :ro blocks all writes
```

Every Add / Update / Delete operation calls `SaveChangesAsync` → `File.WriteAllTextAsync("/app/data/data.json", ...)`, which throws `UnauthorizedAccessException` against a read-only mount. ASP.NET Core catches the unhandled exception and returns **HTTP 500**. The `data.json` file has not been modified since before the Transactions and Credits tabs were added, confirming writes have never worked in the container.

## Fix

Removed the `:ro` flag so the container can write back to the host-mounted file:

```yaml
volumes:
  - ./data:/app/data
```

## Test plan
- [ ] Rebuild and restart the Docker container (`docker compose up --build`)
- [ ] Add a transaction → should return 200 and persist to `data/data.json`
- [ ] Edit a transaction → should return 200
- [ ] Delete a transaction → should return 200
- [ ] Repeat for credits
- [ ] Restart the container and verify the changes survived (data loaded from updated file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)