### PR TITLE
feat: add GET /asset-price-fetch endpoint and remove hardcoded frontend scope

### DIFF
--- a/Financial.Api/Controllers/AssetPriceFetchController.cs
+++ b/Financial.Api/Controllers/AssetPriceFetchController.cs
@@ -1,0 +1,21 @@
+using Financial.Api.Options;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Financial.Api.Controllers;
+
+[ApiController]
+[Route("asset-price-fetch")]
+public sealed class AssetPriceFetchController : ControllerBase
+{
+    private readonly AssetPriceFetchOptions _options;
+
+    public AssetPriceFetchController(IOptions<AssetPriceFetchOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(IReadOnlyList<PortfolioReference>), StatusCodes.Status200OK)]
+    public ActionResult<IReadOnlyList<PortfolioReference>> Get() => Ok(_options.Portfolios);
+}

--- a/Financial.Api/Options/AssetPriceFetchOptions.cs
+++ b/Financial.Api/Options/AssetPriceFetchOptions.cs
@@ -1,0 +1,7 @@
+namespace Financial.Api.Options;
+
+public sealed class AssetPriceFetchOptions
+{
+    public const string SectionName = "AssetPriceFetch";
+    public List<PortfolioReference> Portfolios { get; set; } = [];
+}

--- a/Financial.Api/Options/PortfolioReference.cs
+++ b/Financial.Api/Options/PortfolioReference.cs
@@ -1,0 +1,7 @@
+namespace Financial.Api.Options;
+
+public sealed class PortfolioReference
+{
+    public required string BrokerName { get; set; }
+    public required string PortfolioName { get; set; }
+}

--- a/Financial.Api/Program.cs
+++ b/Financial.Api/Program.cs
@@ -31,6 +31,7 @@ builder.Services.AddCors(options =>
 
 builder.Services.Configure<DividendOptions>(configuration.GetSection(DividendOptions.SectionName));
 builder.Services.Configure<Financial.Api.Options.WatchlistOptions>(configuration.GetSection(Financial.Api.Options.WatchlistOptions.SectionName));
+builder.Services.Configure<Financial.Api.Options.AssetPriceFetchOptions>(configuration.GetSection(Financial.Api.Options.AssetPriceFetchOptions.SectionName));
 builder.Services.AddFinancialApplication();
 builder.Services.AddFinancialInfrastructure(configuration);
 

--- a/Financial.Api/appsettings.json
+++ b/Financial.Api/appsettings.json
@@ -28,5 +28,11 @@
       { "Group": "Outras Barse", "Name": "TRPL4" },
       { "Group": "Outras",       "Name": "CSAN3" }
     ]
+  },
+  "AssetPriceFetch": {
+    "Portfolios": [
+      { "BrokerName": "XPI", "PortfolioName": "FII" },
+      { "BrokerName": "XPI", "PortfolioName": "Acoes" }
+    ]
   }
 }

--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -116,6 +116,24 @@ describe('financialApiClient', () => {
     expect(url).toBe(`${API_BASE_URL}/watchlist`)
   })
 
+  it('calls asset-price-fetch endpoint', async () => {
+    const responseBody = [
+      { brokerName: 'XPI', portfolioName: 'FII' },
+      { brokerName: 'XPI', portfolioName: 'Acoes' },
+    ]
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({
+      baseUrl: API_BASE_URL,
+      fetch: fetchMock,
+    })
+
+    const result = await client.getAssetPriceFetchScope()
+
+    expect(result).toEqual(responseBody)
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/asset-price-fetch`)
+  })
+
   it('throws when the API returns an error', async () => {
     const fetchMock = vi.fn().mockResolvedValue(errorResponse())
     const client = createFinancialApiClient({

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -10,6 +10,7 @@ import type {
   CreditUpdateDto,
   DividendHistoryItemDto,
   DividendSummaryDto,
+  PortfolioReferenceDto,
   TransactionCreateDto,
   TransactionDeleteDto,
   TransactionUpdateDto,
@@ -35,6 +36,7 @@ export interface FinancialApiClient {
   getDividendSummary: (ticker: string, exchange?: string) => Promise<DividendSummaryDto>
   getCurrentPrice: (exchange: string, ticker: string) => Promise<AssetPriceDto>
   getWatchlist: () => Promise<WatchlistItemDto[]>
+  getAssetPriceFetchScope: () => Promise<PortfolioReferenceDto[]>
 }
 
 export interface FinancialApiClientOptions {
@@ -147,5 +149,6 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
         `/prices/current?exchange=${encodeURIComponent(exchange)}&ticker=${encodeURIComponent(ticker)}`,
       ),
     getWatchlist: () => request<WatchlistItemDto[]>('/watchlist'),
+    getAssetPriceFetchScope: () => request<PortfolioReferenceDto[]>('/asset-price-fetch'),
   }
 }

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -188,3 +188,8 @@ export interface WatchlistItemDto {
   group: string
   name: string
 }
+
+export interface PortfolioReferenceDto {
+  brokerName: string
+  portfolioName: string
+}

--- a/Financial.Web/src/config/portfolioScopeConfig.ts
+++ b/Financial.Web/src/config/portfolioScopeConfig.ts
@@ -1,4 +1,0 @@
-export const FIXED_PORTFOLIO_SCOPE: readonly { brokerName: string; portfolioName: string }[] = [
-  { brokerName: 'XPI', portfolioName: 'Default' },
-  { brokerName: 'XPI', portfolioName: 'Acoes' },
-]

--- a/Financial.Web/src/pages/CurrentValuesPage.tsx
+++ b/Financial.Web/src/pages/CurrentValuesPage.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { createFinancialApiClient } from '../api/financialApiClient'
-import type { BrokerNodeDto } from '../api/types'
+import type { BrokerNodeDto, PortfolioReferenceDto } from '../api/types'
 import ErrorState from '../components/ErrorState'
 import LoadingState from '../components/LoadingState'
-import { FIXED_PORTFOLIO_SCOPE } from '../config/portfolioScopeConfig'
 import './CurrentValuesPage.css'
 
 interface PriceResult {
@@ -18,6 +17,7 @@ interface PriceResult {
 export default function CurrentValuesPage() {
   const apiClient = useMemo(() => createFinancialApiClient(), [])
   const [brokers, setBrokers] = useState<BrokerNodeDto[]>([])
+  const [scope, setScope] = useState<PortfolioReferenceDto[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [isRunning, setIsRunning] = useState(false)
@@ -36,10 +36,10 @@ export default function CurrentValuesPage() {
   )
 
   useEffect(() => {
-    apiClient
-      .getBrokers()
-      .then((data) => {
-        setBrokers(data)
+    Promise.all([apiClient.getBrokers(), apiClient.getAssetPriceFetchScope()])
+      .then(([brokersData, scopeData]) => {
+        setBrokers(brokersData)
+        setScope(scopeData)
         setError(null)
       })
       .catch((err: unknown) => {
@@ -56,7 +56,7 @@ export default function CurrentValuesPage() {
   }, [])
 
   const assetsToCheck = useMemo(() => {
-    const assets = FIXED_PORTFOLIO_SCOPE.flatMap(({ brokerName, portfolioName }) => {
+    const assets = scope.flatMap(({ brokerName, portfolioName }) => {
       const broker = brokers.find((b) => b.name === brokerName)
       if (!broker) return []
       const portfolio = broker.portfolios.find((p) => p.name === portfolioName)
@@ -69,7 +69,7 @@ export default function CurrentValuesPage() {
       }))
     })
     return assets.filter((asset) => asset.isActive && asset.ticker && asset.exchange)
-  }, [brokers])
+  }, [brokers, scope])
 
   const runPriceCheck = useCallback(async () => {
     if (assetsToCheck.length === 0) return
@@ -118,7 +118,7 @@ export default function CurrentValuesPage() {
   }, [apiClient, assetsToCheck])
 
   if (isLoading) {
-    return <LoadingState message="Loading brokers..." />
+    return <LoadingState message="Loading data..." />
   }
 
   if (error) {

--- a/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
@@ -2,15 +2,17 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CurrentValuesPage from '../CurrentValuesPage'
 import type { FinancialApiClient } from '../../api/financialApiClient'
-import type { AssetPriceDto, BrokerNodeDto } from '../../api/types'
+import type { AssetPriceDto, BrokerNodeDto, PortfolioReferenceDto } from '../../api/types'
 
 const getBrokersMock = vi.fn()
 const getCurrentPriceMock = vi.fn()
+const getAssetPriceFetchScopeMock = vi.fn()
 
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: () => ({
     getBrokers: getBrokersMock,
     getCurrentPrice: getCurrentPriceMock,
+    getAssetPriceFetchScope: getAssetPriceFetchScopeMock,
   } satisfies Partial<FinancialApiClient>),
 }))
 
@@ -49,9 +51,16 @@ const makePrice = (ticker: string, price = 10.5): AssetPriceDto => ({
 })
 
 describe('CurrentValuesPage', () => {
+  const defaultScope: PortfolioReferenceDto[] = [
+    { brokerName: 'XPI', portfolioName: 'Default' },
+    { brokerName: 'XPI', portfolioName: 'Acoes' },
+  ]
+
   beforeEach(() => {
     getBrokersMock.mockReset()
     getCurrentPriceMock.mockReset()
+    getAssetPriceFetchScopeMock.mockReset()
+    getAssetPriceFetchScopeMock.mockResolvedValue(defaultScope)
   })
 
   it('fetches prices only for assets in XPI/Default and XPI/Acoes', async () => {

--- a/Tests/Financial.Api.Tests/AssetPriceFetchEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/AssetPriceFetchEndpointsTests.cs
@@ -1,0 +1,88 @@
+using Financial.Api.Options;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Financial.Api.Tests;
+
+public class AssetPriceFetchEndpointsTests
+{
+    [Fact]
+    public async Task GetAssetPriceFetch_ReturnsOk_WithConfiguredPortfolios()
+    {
+        await using var factory = new ApiTestFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.PostConfigure<AssetPriceFetchOptions>(options =>
+                {
+                    options.Portfolios =
+                    [
+                        new PortfolioReference { BrokerName = "XPI", PortfolioName = "FII" },
+                        new PortfolioReference { BrokerName = "XPI", PortfolioName = "Acoes" },
+                    ];
+                });
+            });
+        });
+
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/financial/asset-price-fetch");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var portfolios = await response.Content.ReadFromJsonAsync<PortfolioReference[]>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        portfolios.Should().HaveCount(2);
+        portfolios![0].BrokerName.Should().Be("XPI");
+        portfolios[0].PortfolioName.Should().Be("FII");
+        portfolios[1].PortfolioName.Should().Be("Acoes");
+    }
+
+    [Fact]
+    public async Task GetAssetPriceFetch_ReturnsEmptyArray_WhenNoPortfoliosConfigured()
+    {
+        await using var factory = new ApiTestFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.PostConfigure<AssetPriceFetchOptions>(options => options.Portfolios.Clear());
+            });
+        });
+
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/financial/asset-price-fetch");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var portfolios = await response.Content.ReadFromJsonAsync<PortfolioReference[]>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        portfolios.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAssetPriceFetch_JsonUsesBrokerNameAndPortfolioNameProperties()
+    {
+        await using var factory = new ApiTestFactory().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.PostConfigure<AssetPriceFetchOptions>(options =>
+                {
+                    options.Portfolios = [new PortfolioReference { BrokerName = "XPI", PortfolioName = "FII" }];
+                });
+            });
+        });
+
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/financial/asset-price-fetch");
+        var json = await response.Content.ReadAsStringAsync();
+
+        using var doc = JsonDocument.Parse(json);
+        var first = doc.RootElement[0];
+        first.TryGetProperty("brokerName", out _).Should().BeTrue("frontend expects camelCase 'brokerName'");
+        first.TryGetProperty("portfolioName", out _).Should().BeTrue("frontend expects camelCase 'portfolioName'");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `GET /asset-price-fetch` endpoint to `Financial.Api` reading `AssetPriceFetch.Portfolios` from `appsettings.json`
- Remove hardcoded `FIXED_PORTFOLIO_SCOPE` constant from `CurrentValuesPage.tsx` — scope is now fetched from the API on mount (same pattern as Watchlist PR #101)
- Delete `portfolioScopeConfig.ts` (no longer needed)

## Changes

**Backend:**
- `Financial.Api/Options/AssetPriceFetchOptions.cs` — new options class bound to `AssetPriceFetch` config section
- `Financial.Api/Options/PortfolioReference.cs` — new model: `BrokerName` + `PortfolioName`
- `Financial.Api/Controllers/AssetPriceFetchController.cs` — `GET /asset-price-fetch` returns configured portfolios
- `Financial.Api/Program.cs` — registers `AssetPriceFetchOptions` via `Configure<T>`
- `Financial.Api/appsettings.json` — `AssetPriceFetch` section with XPI/FII and XPI/Acoes
- `Tests/Financial.Api.Tests/AssetPriceFetchEndpointsTests.cs` — 3 integration tests using `PostConfigure<T>` pattern

**Frontend:**
- `types.ts` — adds `PortfolioReferenceDto { brokerName, portfolioName }`
- `financialApiClient.ts` — adds `getAssetPriceFetchScope()` to interface and implementation
- `CurrentValuesPage.tsx` — fetches scope in parallel with brokers via `Promise.all`; `assetsToCheck` useMemo uses `scope` state
- `financialApiClient.test.ts` — adds test for `/asset-price-fetch` call
- `CurrentValuesPage.test.tsx` — adds `getAssetPriceFetchScopeMock`, wired in `beforeEach` with default XPI/Default + XPI/Acoes scope

## Test plan

- [x] All 21 API tests pass (`dotnet test Tests/Financial.Api.Tests`)
- [x] All 227 frontend tests pass (`npx vitest run`)
- [x] TypeScript compiles cleanly (`tsc -b --noEmit`)
- [x] Changing `AssetPriceFetch.Portfolios` in `Financial.Api/appsettings.json` and restarting the API changes which portfolios are fetched by `CurrentValuesPage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)