### PR TITLE
feat(F01): Portfolio Assets Summary Service and Endpoint

### DIFF
--- a/Financial.Api/Controllers/SummaryController.cs
+++ b/Financial.Api/Controllers/SummaryController.cs
@@ -9,10 +9,14 @@ namespace Financial.Api.Controllers;
 public sealed class SummaryController : ControllerBase
 {
     private readonly ISummaryQueryService _summaryQueryService;
+    private readonly IPortfolioAssetSummaryQueryService _portfolioAssetSummaryQueryService;
 
-    public SummaryController(ISummaryQueryService summaryQueryService)
+    public SummaryController(
+        ISummaryQueryService summaryQueryService,
+        IPortfolioAssetSummaryQueryService portfolioAssetSummaryQueryService)
     {
         _summaryQueryService = summaryQueryService ?? throw new ArgumentNullException(nameof(summaryQueryService));
+        _portfolioAssetSummaryQueryService = portfolioAssetSummaryQueryService ?? throw new ArgumentNullException(nameof(portfolioAssetSummaryQueryService));
     }
 
     [HttpGet("broker/{brokerName}")]
@@ -33,5 +37,19 @@ public sealed class SummaryController : ControllerBase
     {
         var dto = _summaryQueryService.GetPortfolioSummary(brokerName, portfolioName);
         return Ok(dto);
+    }
+
+    [HttpGet("portfolio/{brokerName}/{portfolioName}/assets")]
+    [ProducesResponseType(typeof(IReadOnlyList<PortfolioAssetSummaryItemDTO>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult<IReadOnlyList<PortfolioAssetSummaryItemDTO>> GetPortfolioAssetsSummary(
+        string brokerName,
+        string portfolioName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
+            return BadRequest();
+
+        var result = _portfolioAssetSummaryQueryService.GetPortfolioAssetsSummary(brokerName, portfolioName);
+        return Ok(result);
     }
 }

--- a/Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs
+++ b/Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs
@@ -1,0 +1,14 @@
+namespace Financial.Application.DTOs;
+
+public sealed class PortfolioAssetSummaryItemDTO
+{
+    public string AssetName { get; init; } = string.Empty;
+    public string Ticker { get; init; } = string.Empty;
+    public string Exchange { get; init; } = string.Empty;
+    public DateTime? FirstInvestmentDate { get; init; }
+    public decimal CurrentQuantity { get; init; }
+    public decimal TotalBought { get; init; }
+    public decimal TotalSold { get; init; }
+    public decimal TotalInvested { get; init; }
+    public decimal PortfolioWeight { get; init; }
+}

--- a/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<ITransactionService, TransactionService>();
         services.AddSingleton<ICreditService, CreditService>();
         services.AddSingleton<IDividendService, DividendService>();
+        services.AddSingleton<IPortfolioAssetSummaryQueryService, PortfolioAssetSummaryQueryService>();
 
         return services;
     }

--- a/Financial.Application/Interfaces/IPortfolioAssetSummaryQueryService.cs
+++ b/Financial.Application/Interfaces/IPortfolioAssetSummaryQueryService.cs
@@ -1,0 +1,8 @@
+using Financial.Application.DTOs;
+
+namespace Financial.Application.Interfaces;
+
+public interface IPortfolioAssetSummaryQueryService
+{
+    IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName);
+}

--- a/Financial.Application/Services/PortfolioAssetSummaryQueryService.cs
+++ b/Financial.Application/Services/PortfolioAssetSummaryQueryService.cs
@@ -1,0 +1,71 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Domain.Entities;
+
+namespace Financial.Application.Services;
+
+public sealed class PortfolioAssetSummaryQueryService : IPortfolioAssetSummaryQueryService
+{
+    private readonly IRepository _repository;
+
+    public PortfolioAssetSummaryQueryService(IRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
+            return [];
+
+        var assets = _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName).ToList();
+
+        if (assets.Count == 0)
+            return [];
+
+        var computed = assets.Select(ComputeAssetData).ToList();
+        var portfolioTotalInvested = computed.Sum(c => c.TotalInvested);
+
+        return NavigationMapper
+            .OrderByNameWithEncerradasLast(computed, c => c.AssetName)
+            .Select(c => ToDTO(c, CalculateWeight(c.TotalInvested, portfolioTotalInvested)))
+            .ToList();
+    }
+
+    private static AssetComputedData ComputeAssetData(Asset asset)
+    {
+        var (totalBought, totalSold, _) = NavigationMapper.CalculateTotals(asset);
+        var firstBuyDate = asset.Transactions
+            .Where(t => t.Type == Transaction.TransactionType.Buy)
+            .Select(t => (DateTime?)t.Date)
+            .DefaultIfEmpty(null)
+            .Min();
+
+        return new AssetComputedData(
+            asset.Name, asset.Ticker, asset.Exchange,
+            firstBuyDate, asset.Quantity,
+            totalBought, totalSold, totalBought - totalSold);
+    }
+
+    private static PortfolioAssetSummaryItemDTO ToDTO(AssetComputedData c, decimal weight) =>
+        new()
+        {
+            AssetName = c.AssetName,
+            Ticker = c.Ticker,
+            Exchange = c.Exchange,
+            FirstInvestmentDate = c.FirstInvestmentDate,
+            CurrentQuantity = c.CurrentQuantity,
+            TotalBought = c.TotalBought,
+            TotalSold = c.TotalSold,
+            TotalInvested = c.TotalInvested,
+            PortfolioWeight = weight
+        };
+
+    private static decimal CalculateWeight(decimal totalInvested, decimal portfolioTotalInvested) =>
+        portfolioTotalInvested == 0m ? 0m : totalInvested / portfolioTotalInvested * 100m;
+
+    private sealed record AssetComputedData(
+        string AssetName, string Ticker, string Exchange,
+        DateTime? FirstInvestmentDate, decimal CurrentQuantity,
+        decimal TotalBought, decimal TotalSold, decimal TotalInvested);
+}

--- a/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
@@ -8,6 +8,39 @@ namespace Financial.Api.Tests;
 public class SummaryEndpointsTests
 {
     [Fact]
+    public async Task GetPortfolioAssetsSummary_Returns200WithItems()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/portfolio/XPI/Default/assets");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var items = await response.Content.ReadFromJsonAsync<List<PortfolioAssetSummaryItemDTO>>();
+        items.Should().NotBeNull();
+        items.Should().NotBeEmpty();
+        items![0].AssetName.Should().NotBeNullOrEmpty();
+        items.Should().AllSatisfy(i =>
+        {
+            i.TotalBought.Should().BeGreaterThanOrEqualTo(0m);
+            i.PortfolioWeight.Should().BeGreaterThanOrEqualTo(0m);
+        });
+    }
+
+    [Fact]
+    public async Task GetPortfolioAssetsSummary_Returns400ForWhitespaceBrokerName()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/portfolio/%20/Default/assets");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+
+    [Fact]
     public async Task GetBrokerSummary_Returns200WithDto()
     {
         await using var factory = new ApiTestFactory();

--- a/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryQueryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryQueryServiceTests.cs
@@ -1,0 +1,181 @@
+using Financial.Application.Interfaces;
+using Financial.Application.Services;
+using Financial.Domain.Entities;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace Financial.Application.Tests.Services;
+
+public class PortfolioAssetSummaryQueryServiceTests
+{
+    private readonly StubRepository _repository = new();
+
+    [Fact]
+    public void Constructor_WithNullRepository_Throws()
+    {
+        Action act = () => new PortfolioAssetSummaryQueryService(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsSingleAsset_WithCorrectFields()
+    {
+        var asset = MakeAsset("ALZR11", "ALZR11", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 3, 1), Transaction.TransactionType.Buy, 10m, 100m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 5, 1), Transaction.TransactionType.Buy, 15m, 100m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2022, 1, 1), Transaction.TransactionType.Sell, 5m, 110m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        using var _ = new AssertionScope();
+        result.Should().HaveCount(1);
+        var item = result[0];
+        item.AssetName.Should().Be("ALZR11");
+        item.Ticker.Should().Be("ALZR11");
+        item.Exchange.Should().Be("BVMF");
+        item.CurrentQuantity.Should().Be(20m);
+        item.TotalBought.Should().Be(2500m);
+        item.TotalSold.Should().Be(550m);
+        item.TotalInvested.Should().Be(1950m);
+        item.PortfolioWeight.Should().Be(100m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_SortsAlphabetically()
+    {
+        _repository.Assets = [
+            MakeAsset("ZEBRA", "ZBR", "BVMF"),
+            MakeAsset("APPLE", "APL", "BVMF"),
+            MakeAsset("MANGO", "MNG", "BVMF"),
+        ];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result.Select(i => i.AssetName).Should().Equal("APPLE", "MANGO", "ZEBRA");
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ComputesPortfolioWeight()
+    {
+        var asset1 = MakeAsset("ALPHA", "ALP", "BVMF");
+        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 300m, 0m));
+
+        var asset2 = MakeAsset("BETA", "BET", "BVMF");
+        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 700m, 0m));
+
+        _repository.Assets = [asset1, asset2];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        using var _ = new AssertionScope();
+        result.First(i => i.AssetName == "ALPHA").PortfolioWeight.Should().Be(30m);
+        result.First(i => i.AssetName == "BETA").PortfolioWeight.Should().Be(70m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsZeroPortfolioWeight_WhenAllTotalInvestedAreZero()
+    {
+        var asset1 = MakeAsset("ALPHA", "ALP", "BVMF");
+        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 100m, 0m));
+
+        var asset2 = MakeAsset("BETA", "BET", "BVMF");
+        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 200m, 0m));
+        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 200m, 0m));
+
+        _repository.Assets = [asset1, asset2];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result.Should().AllSatisfy(i => i.PortfolioWeight.Should().Be(0m));
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_SetsFirstInvestmentDate_FromEarliestBuyTransaction()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 6, 1), Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 15), Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].FirstInvestmentDate.Should().Be(new DateTime(2020, 1, 15));
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_SetsFirstInvestmentDate_Null_WhenNoBuyTransactions()
+    {
+        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].FirstInvestmentDate.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_IncludesAllAssets_RegardlessOfActiveStatus()
+    {
+        var active = MakeAsset("ACTIVE", "ACT", "BVMF");
+        active.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+
+        var inactive = MakeAsset("INACTIVE", "INA", "BVMF");
+        inactive.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        inactive.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 10m, 0m));
+
+        _repository.Assets = [active, inactive];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEmptyList_WhenPortfolioHasNoAssets()
+    {
+        _repository.Assets = [];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetPortfolioAssetsSummary_ReturnsEmptyList_OnNullOrWhitespaceBrokerName(string? brokerName)
+    {
+        var result = CreateService().GetPortfolioAssetsSummary(brokerName!, "Default");
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetPortfolioAssetsSummary_ReturnsEmptyList_OnNullOrWhitespacePortfolioName(string? portfolioName)
+    {
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", portfolioName!);
+
+        result.Should().BeEmpty();
+    }
+
+    private PortfolioAssetSummaryQueryService CreateService() => new(_repository);
+
+    private static Asset MakeAsset(string name, string ticker, string exchange) =>
+        Asset.Create(name, "ISIN", exchange, ticker);
+
+    private sealed class StubRepository : IRepository
+    {
+        public IEnumerable<Asset> Assets { get; set; } = [];
+
+        public IEnumerable<Asset> GetAssetsByBroker(string name) => [];
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => Assets;
+        public IEnumerable<Broker> GetBrokerList() => [];
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => null;
+        public Task SaveChangesAsync() => Task.CompletedTask;
+    }
+}

--- a/docs/F01-portfolio-assets-summary-service-and-endpoint/plan.md
+++ b/docs/F01-portfolio-assets-summary-service-and-endpoint/plan.md
@@ -1,0 +1,32 @@
+# Implementation Plan: F01 — Portfolio Assets Summary Service and Endpoint
+
+**Prerequisites:**
+- No new packages or tools required
+- All existing dependencies (`FluentAssertions`, `xUnit`, `WebApplicationFactory`) already present in the test projects
+- `NavigationMapper.CalculateTotals` and `NavigationMapper.OrderByNameWithEncerradasLast` are accessible from within `Financial.Application` (same assembly, `internal` visibility)
+
+---
+
+### Phase 1: Application Layer
+
+**1. PortfolioAssetSummaryItemDTO** — Create the response DTO in `Financial.Application/DTOs/`. Follow the `AggregatedSummaryDTO` sealed-class-with-init pattern. See spec Section 4 for all property names and types.
+
+**2. IPortfolioAssetSummaryQueryService Interface** — Create the service interface in `Financial.Application/Interfaces/` declaring the single `GetPortfolioAssetsSummary` method. See spec Section 4 for the method signature.
+
+**3. PortfolioAssetSummaryQueryService Implementation** — Create the service in `Financial.Application/Services/`. Guard null/whitespace inputs; retrieve assets from the repository; compute all per-asset values including `TotalInvested`, `FirstInvestmentDate`, and `PortfolioWeight`; sort; return. See spec Sections 4 and 5 for the full computation rules.
+
+**4. DI Registration** — Add the singleton registration for `IPortfolioAssetSummaryQueryService` to `ApplicationServiceCollectionExtensions.AddFinancialApplication()`. See spec Section 4.
+
+---
+
+### Phase 2: API Layer
+
+**5. SummaryController Update** — Inject `IPortfolioAssetSummaryQueryService` as a second constructor parameter into `SummaryController` and add the new `GetPortfolioAssetsSummary` action on route `portfolio/{brokerName}/{portfolioName}/assets`. Validate both path parameters and return HTTP 400 on whitespace; otherwise return HTTP 200 with the service result. See spec Sections 4 and 5 for the route, attributes, and error response.
+
+---
+
+### Phase 3: Tests
+
+**6. PortfolioAssetSummaryQueryServiceTests** — Create the unit test class in `Tests/Financial.Application.Tests/Services/` using the inner `StubRepository` pattern from `SummaryQueryServiceTests`. Cover all computation cases, sort order, null/whitespace inputs, and edge cases (no assets, all-zero TotalInvested, no Buy transactions). See spec Section 7 for the full test function list.
+
+**7. SummaryEndpointsTests Additions** — Add the two integration tests to the existing `SummaryEndpointsTests.cs` using the same `ApiTestFactory` pattern: one verifying HTTP 200 with items against the real test data file, one verifying HTTP 400 for a whitespace broker name. See spec Section 7.

--- a/docs/F01-portfolio-assets-summary-service-and-endpoint/spec.md
+++ b/docs/F01-portfolio-assets-summary-service-and-endpoint/spec.md
@@ -1,0 +1,196 @@
+# Spec: F01 — Portfolio Assets Summary Service and Endpoint
+
+## 1. Technical Overview
+
+**What:** Introduces `IPortfolioAssetSummaryQueryService` / `PortfolioAssetSummaryQueryService` in the Application layer and a new GET action in the existing `SummaryController` that returns all assets of a portfolio as a list of per-asset summary items. Each item carries the static fields that F02 (web) and F03 (WPF) need to render the breakdown table before enriching it with live prices: asset name, ticker, exchange, date of first investment, current quantity, total bought, total sold, total invested, and portfolio weight.
+
+**Why:** The existing `ISummaryQueryService` aggregates across all assets into three scalar totals; a separate service interface keeps per-asset enumeration orthogonal to that concern, respecting ISP. Both F02 and F03 need the same computation, so centralising it in the Application layer eliminates duplication across the two UI implementations.
+
+**Scope:**
+
+Included:
+- `PortfolioAssetSummaryItemDTO` in `Financial.Application/DTOs/`
+- `IPortfolioAssetSummaryQueryService` interface in `Financial.Application/Interfaces/`
+- `PortfolioAssetSummaryQueryService` implementation in `Financial.Application/Services/`
+- DI singleton registration in `ApplicationServiceCollectionExtensions`
+- New `GetPortfolioAssetsSummary` action in the existing `SummaryController`
+- Unit tests for `PortfolioAssetSummaryQueryService`
+- Integration test additions to `SummaryEndpointsTests`
+
+Excluded:
+- `CurrentValue` and `% Profit` — computed by frontends after fetching live prices
+- Broker-level per-asset breakdown — portfolio scope only
+- Any changes to `ISummaryQueryService`, `SummaryQueryService`, or existing controller actions
+
+---
+
+## 2. Architecture Impact
+
+**Affected components:**
+
+```mermaid
+graph TD
+    Caller["Web browser / WPF"] --> Controller["SummaryController"]
+    Controller --> IService["IPortfolioAssetSummaryQueryService"]
+    IService --> Service["PortfolioAssetSummaryQueryService"]
+    Service --> Repository["IRepository.GetAssetsByBrokerPortfolio()"]
+    Service --> NavMapper["NavigationMapper (CalculateTotals, OrderByNameWithEncerradasLast)"]
+    Repository --> JSONRepo["JSONRepository (Financial.Infrastructure)"]
+```
+
+---
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| New interface vs. extending `ISummaryQueryService` | New `IPortfolioAssetSummaryQueryService` | Add `GetPortfolioAssetsSummary` to `ISummaryQueryService` | Respects ISP — aggregate totals and per-item list are distinct query shapes; adding to the existing interface couples two responsibilities and expands the surface area for all existing consumers |
+| Null/whitespace handling | Controller validates; returns HTTP 400 | Service returns empty list silently (existing `SummaryQueryService` pattern) | PRD acceptance criterion explicitly requires 400; for a list endpoint, returning an empty list for a meaningless input would silently swallow an API misuse |
+| Sort algorithm | `NavigationMapper.OrderByNameWithEncerradasLast` with `StringComparer.CurrentCultureIgnoreCase` | Plain `StringComparer.OrdinalIgnoreCase` sort | Consistency with navigation tree — asset nodes are already sorted this way in `MapPortfolio`; using the same method keeps list order identical to tree order |
+| TotalBought / TotalSold computation | Reuse `NavigationMapper.CalculateTotals(asset)` | Inline LINQ | Avoids duplicating tested transaction-iteration logic; `CalculateTotals` is `internal` to the Application assembly and accessible from the new service |
+| `PortfolioWeight` precision | Raw `decimal` in DTO — no server-side rounding | Round to 2 decimal places in service | Formatting is a UI concern; keeping full decimal precision lets both frontends format independently |
+| DTO style | `sealed class` with `{ get; init; }` | `class` with `{ get; set; }` (used by `AssetDetailsDTO`) | Follows the `AggregatedSummaryDTO` pattern — the most recent DTO in the Summary feature; init setters prevent accidental mutation after construction |
+
+---
+
+## 4. Component Overview
+
+### Backend
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs` | New | Response DTO | Sealed class with `init` properties: `AssetName` (string), `Ticker` (string), `Exchange` (string), `FirstInvestmentDate` (`DateTime?`), `CurrentQuantity` (decimal), `TotalBought` (decimal), `TotalSold` (decimal), `TotalInvested` (decimal), `PortfolioWeight` (decimal) |
+| `Financial.Application/Interfaces/IPortfolioAssetSummaryQueryService.cs` | New | Service abstraction | Single method `GetPortfolioAssetsSummary(string brokerName, string portfolioName)` returning `IReadOnlyList<PortfolioAssetSummaryItemDTO>` |
+| `Financial.Application/Services/PortfolioAssetSummaryQueryService.cs` | New | Query and mapping logic | Guard null/whitespace inputs (return empty list); call `_repository.GetAssetsByBrokerPortfolio`; for each asset compute `TotalBought`/`TotalSold` via `NavigationMapper.CalculateTotals`, derive `TotalInvested`, find `FirstInvestmentDate` from the earliest Buy transaction, read `CurrentQuantity` from `asset.Quantity`; compute `PortfolioWeight` per asset after summing all `TotalInvested` values (return 0 when denominator is 0); sort via `NavigationMapper.OrderByNameWithEncerradasLast`; return list |
+| `Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs` | Modified | DI registration | Add `services.AddSingleton<IPortfolioAssetSummaryQueryService, PortfolioAssetSummaryQueryService>()` |
+| `Financial.Api/Controllers/SummaryController.cs` | Modified | New GET action | Add `IPortfolioAssetSummaryQueryService` as second constructor parameter; add `GetPortfolioAssetsSummary(string brokerName, string portfolioName)` action on route `portfolio/{brokerName}/{portfolioName}/assets`; validate both params with `string.IsNullOrWhiteSpace`, return `BadRequest()` if either is whitespace; otherwise return `Ok(result)` |
+
+---
+
+## 5. API Contracts
+
+### GET Portfolio Assets Summary
+
+- **Method:** GET
+- **Path:** `/api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets`
+- **Authentication:** None
+
+**Path Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `brokerName` | `string` | Yes | Exact broker name (e.g., `XPI`) |
+| `portfolioName` | `string` | Yes | Exact portfolio name within the broker (e.g., `Default`) |
+
+**Response (200 OK):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `[].assetName` | `string` | Asset name, sorted alphabetically (Encerradas-last) |
+| `[].ticker` | `string` | Ticker symbol |
+| `[].exchange` | `string` | Exchange code (e.g., `BVMF`, `LSE`) |
+| `[].firstInvestmentDate` | `string` (ISO 8601) \| `null` | Date of earliest Buy transaction; `null` when asset has no Buy transactions |
+| `[].currentQuantity` | `decimal` | Net quantity held after all Buy and Sell transactions |
+| `[].totalBought` | `decimal` | Sum of `TotalPrice` for all Buy transactions |
+| `[].totalSold` | `decimal` | Sum of `TotalPrice` for all Sell transactions |
+| `[].totalInvested` | `decimal` | `totalBought − totalSold` |
+| `[].portfolioWeight` | `decimal` | `totalInvested / portfolioTotalInvested × 100`; `0` when `portfolioTotalInvested` is `0` |
+
+**Response Example (200):**
+```json
+[
+  {
+    "assetName": "ALZR11",
+    "ticker": "ALZR11",
+    "exchange": "BVMF",
+    "firstInvestmentDate": "2021-03-01T00:00:00",
+    "currentQuantity": 25.0,
+    "totalBought": 2500.00,
+    "totalSold": 0.00,
+    "totalInvested": 2500.00,
+    "portfolioWeight": 71.4285714285714
+  },
+  {
+    "assetName": "MXRF11",
+    "ticker": "MXRF11",
+    "exchange": "BVMF",
+    "firstInvestmentDate": "2021-05-15T00:00:00",
+    "currentQuantity": 0.0,
+    "totalBought": 1200.00,
+    "totalSold": 200.00,
+    "totalInvested": 1000.00,
+    "portfolioWeight": 28.5714285714286
+  }
+]
+```
+
+**Empty portfolio response (200):**
+```json
+[]
+```
+
+**Error Codes:**
+
+| HTTP Status | Condition |
+|-------------|-----------|
+| 200 | Successful — includes empty array when portfolio has no assets |
+| 400 | `brokerName` or `portfolioName` is null, empty, or whitespace |
+
+---
+
+## 6. Data Model
+
+Not applicable. No persistence schema changes. All values are computed at query time from the in-memory JSON-backed repository via the existing `IRepository.GetAssetsByBrokerPortfolio` method. The `Asset` entity already tracks `Quantity`, `Transactions`, and `Credits` in memory.
+
+---
+
+## 7. Testing Strategy
+
+### Test File Structure
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryQueryServiceTests.cs` | Unit | `PortfolioAssetSummaryQueryService` | All computation paths, sort, edge cases |
+| `Tests/Financial.Api.Tests/SummaryEndpointsTests.cs` | Integration | `SummaryController.GetPortfolioAssetsSummary` | HTTP 200 with valid data; HTTP 400 on whitespace param |
+
+### PortfolioAssetSummaryQueryServiceTests.cs
+
+Follows the same structure as `SummaryQueryServiceTests.cs`: inner `StubRepository : IRepository`, `FluentAssertions` with `AssertionScope` for multi-field assertions, `[Theory][InlineData]` for null/whitespace variants.
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `Constructor_WithNullRepository_Throws` | Pass `null` as `IRepository` | Throws `ArgumentNullException` with parameter name `"repository"` |
+| `GetPortfolioAssetsSummary_ReturnsSingleAsset_WithCorrectFields` | One asset with 2 Buy + 1 Sell transactions | `AssetName`, `Ticker`, `Exchange`, `CurrentQuantity`, `TotalBought`, `TotalSold`, `TotalInvested` all match expected values; `PortfolioWeight` is `100m` |
+| `GetPortfolioAssetsSummary_SortsAlphabetically` | Three assets named `"ZEBRA"`, `"APPLE"`, `"MANGO"` | Returned list order is `APPLE`, `MANGO`, `ZEBRA` |
+| `GetPortfolioAssetsSummary_ComputesPortfolioWeight` | Two assets with `TotalInvested` of `300m` and `700m` | First asset `PortfolioWeight` is `30m`; second is `70m` |
+| `GetPortfolioAssetsSummary_ReturnsZeroPortfolioWeight_WhenAllTotalInvestedAreZero` | All assets have `TotalBought = TotalSold` | All `PortfolioWeight` values are `0m` |
+| `GetPortfolioAssetsSummary_SetsFirstInvestmentDate_FromEarliestBuyTransaction` | Asset with Buy on `2020-01-15` and Buy on `2021-06-01` | `FirstInvestmentDate` equals `2020-01-15` (date portion only) |
+| `GetPortfolioAssetsSummary_SetsFirstInvestmentDate_Null_WhenNoBuyTransactions` | Asset with no transactions | `FirstInvestmentDate` is `null` |
+| `GetPortfolioAssetsSummary_IncludesAllAssets_RegardlessOfActiveStatus` | One asset with Quantity > 0 and one with Quantity = 0 | Both assets appear in result; count is 2 |
+| `GetPortfolioAssetsSummary_ReturnsEmptyList_WhenPortfolioHasNoAssets` | Repository returns empty collection | Result is empty; no exception thrown |
+| `GetPortfolioAssetsSummary_ReturnsEmptyList_OnNullOrWhitespaceBrokerName` | `brokerName` is `null`, `""`, `"   "` | Returns empty list without throwing — `[Theory][InlineData(null), InlineData(""), InlineData("   ")]` |
+| `GetPortfolioAssetsSummary_ReturnsEmptyList_OnNullOrWhitespacePortfolioName` | `portfolioName` is `null`, `""`, `"   "` | Returns empty list without throwing — `[Theory][InlineData(null), InlineData(""), InlineData("   ")]` |
+
+### SummaryEndpointsTests.cs (additions)
+
+Follows the same `ApiTestFactory` / `WebApplicationFactory<Program>` pattern as existing summary tests.
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `GetPortfolioAssetsSummary_Returns200WithItems` | `GET /api/v1/financial/summary/portfolio/XPI/Default/assets` against the real test data file | HTTP 200; deserialised array is non-null and non-empty; first item has non-null `assetName`; all `totalBought ≥ 0` and `portfolioWeight ≥ 0` |
+| `GetPortfolioAssetsSummary_Returns400ForWhitespaceBrokerName` | `GET /api/v1/financial/summary/portfolio/%20/Default/assets` | HTTP 400 |
+
+### Acceptance Test Mapping
+
+| PRD Acceptance Criterion (Section 9 — F01) | Covered By |
+|---------------------------------------------|------------|
+| Returns HTTP 200 with JSON array | `GetPortfolioAssetsSummary_Returns200WithItems` |
+| Each item contains required fields | `GetPortfolioAssetsSummary_Returns200WithItems` + `GetPortfolioAssetsSummary_ReturnsSingleAsset_WithCorrectFields` |
+| `totalInvested = totalBought − totalSold` | `GetPortfolioAssetsSummary_ReturnsSingleAsset_WithCorrectFields` |
+| `portfolioWeight` values sum to 100 | `GetPortfolioAssetsSummary_ComputesPortfolioWeight` |
+| All values 0 when `portfolioTotalInvested` is 0 | `GetPortfolioAssetsSummary_ReturnsZeroPortfolioWeight_WhenAllTotalInvestedAreZero` |
+| Assets sorted alphabetically | `GetPortfolioAssetsSummary_SortsAlphabetically` |
+| `firstInvestmentDate` from earliest Buy | `GetPortfolioAssetsSummary_SetsFirstInvestmentDate_FromEarliestBuyTransaction` |
+| `firstInvestmentDate` is null with no Buys | `GetPortfolioAssetsSummary_SetsFirstInvestmentDate_Null_WhenNoBuyTransactions` |
+| HTTP 400 on null/whitespace params | `GetPortfolioAssetsSummary_Returns400ForWhitespaceBrokerName` |
+| Empty array on empty portfolio | `GetPortfolioAssetsSummary_ReturnsEmptyList_WhenPortfolioHasNoAssets` |

--- a/docs/prd/prd-portfolio-asset-summary/prd-portfolio-asset-summary.md
+++ b/docs/prd/prd-portfolio-asset-summary/prd-portfolio-asset-summary.md
@@ -1,0 +1,263 @@
+# Portfolio Summary — Per-Asset Breakdown
+
+## 1. Executive Summary
+
+The Portfolio Summary — Per-Asset Breakdown feature extends the existing Portfolio Navigator in both the WPF desktop application and the React web application. When a portfolio node is selected in the investment tree, the Summary tab is enhanced to display a table of all assets in that portfolio alongside their key performance metrics: date of first investment, current quantity held, total amount invested (net of sell proceeds), portfolio weight (each asset's share of total invested capital), current market value, and profit/loss percentage.
+
+This builds on the aggregated totals already shown for portfolio selections (Total Bought, Total Sold, Total Credits from F04) by adding per-asset visibility into the portfolio composition. The feature replicates the "total" summary sheet the user currently maintains manually in a spreadsheet, bringing this overview directly into the application interface for both UIs.
+
+The backend introduces a new Application-layer service and API endpoint that returns static per-asset data. Live current prices are fetched automatically on portfolio selection using the same Google Finance scraping mechanism already used by the individual asset summary view (F03) and the bulk price fetch feature. Failed price fetches are handled gracefully per row — the affected asset shows a dash in Current Value and % Profit while the rest of the table remains usable.
+
+---
+
+## 2. Problem and Opportunity
+
+### The Problem
+
+**Missing portfolio-level asset breakdown**
+- When a portfolio is selected, the Summary tab shows only three aggregate totals (Total Bought, Total Sold, Total Credits); no breakdown of individual asset contributions is available
+- Reviewing portfolio composition — which assets are largest positions, which are in profit or loss — requires switching to a separate spreadsheet maintained outside the application
+- The WPF Summary tab currently renders asset-specific fields (ISIN, Country, Local Type, Asset Class, Quantity, Average Price, Current Value section) when a portfolio is selected; these fields are meaningless at portfolio level, occupying space that could show useful portfolio data
+
+### The Opportunity
+
+Each problem maps to a concrete deliverable:
+- Missing asset breakdown → F01: Portfolio Assets Summary Service and Endpoint computes per-asset static data server-side; F02 and F03 surface it in the respective UIs
+- Spreadsheet dependency → F02 and F03 together eliminate the need for a manual "total tab" by showing First Investment Date, Quantity, Total Invested, % Portfolio, Current Value, and % Profit in the Summary tab
+- Misleading WPF fields → F03 introduces a portfolio-specific layout that hides asset-only fields when a portfolio node is selected
+
+---
+
+## 3. Target Audience
+
+### Primary Users
+
+**Personal Investor**
+- Manages a multi-broker portfolio spanning UK (GBP) and Brazil (BRL) markets with assets across equities, real estate funds, ETFs, and fixed income
+- Currently cross-references a manually maintained spreadsheet "total tab" to review portfolio composition — which positions are largest and whether each is in profit or loss
+- Uses both the WPF desktop application and the React web application interchangeably and expects consistent information across both interfaces
+
+---
+
+## 4. Objectives
+
+**Replace the spreadsheet summary sheet** with an in-app per-asset breakdown on the portfolio Summary tab
+- Metric: Selecting any portfolio node in the investment tree shows the per-asset breakdown table with Asset Name, Total Invested, % Portfolio, and % Profit populated within 5 seconds of portfolio selection
+
+**Remove misleading asset-specific fields** from the WPF portfolio-level Summary tab
+- Metric: Selecting a Portfolio node in WPF shows no Quantity, Average Price, ISIN, Country, Local Type, or Asset Class fields; only the three aggregated totals and the per-asset breakdown table are visible in the Summary tab
+
+**Provide automatic current value enrichment** without a manual refresh step
+- Metric: Current Value and % Profit columns populate automatically on portfolio selection for all assets whose price fetch succeeds; failed fetches display "—" without blocking data for other assets
+
+---
+
+## 5. User Stories
+
+### F01. Portfolio Assets Summary Service and Endpoint
+
+- As the system, I want to compute per-asset summary data for a portfolio so that both frontends can display the breakdown without duplicating business logic
+- As the system, I want to return assets sorted alphabetically by name so that the order matches the navigation tree
+
+### F02. Portfolio Summary Tab — Web Frontend
+
+- As a user, I want to see a per-asset breakdown table when I select a portfolio so that I can review each position's size, cost, and performance in one place
+- As a user, I want the three portfolio totals (Total Bought, Total Sold, Total Credits) to remain visible at the top of the tab so that I retain the aggregated view I already had
+- As a user, I want Current Value and % Profit to populate automatically on portfolio selection so that I do not have to click a Refresh button
+- As a user, I want assets whose price cannot be fetched to show a dash instead of blocking the rest of the table so that I can still see data for all other assets
+- As a user, I want % Profit to be colour-coded green for gains and red for losses so that I can scan the table quickly
+
+### F03. Portfolio Summary Tab — WPF
+
+- As a user, I want the WPF Summary tab to show the per-asset breakdown table when a portfolio is selected so that the WPF and web experiences are consistent
+- As a user, I want the WPF Summary tab to hide asset-specific fields (ISIN, Country, Quantity, etc.) when a portfolio is selected so that I see only relevant portfolio-level information
+- As a user, I want current prices to load automatically in the WPF table on portfolio selection so that Current Value and % Profit populate without manual interaction
+- As a user, I want failed price fetches to show "—" in the affected row without impacting the rest of the table so that I can still read all other rows
+
+---
+
+## 6. Functionalities
+
+### F01. Portfolio Assets Summary Service and Endpoint
+
+**Provides:**
+- Portfolio asset summary items: per-asset records containing AssetName, Ticker, Exchange, FirstInvestmentDate (nullable), CurrentQuantity, TotalBought, TotalSold, TotalInvested, PortfolioWeight (used by F02, F03)
+
+**Capabilities:**
+- Returns all assets in the specified portfolio regardless of active status (Quantity = 0 or > 0); this covers both active positions and fully sold assets that may exist in edge-case portfolios
+- Assets are sorted alphabetically by AssetName, matching the navigation tree order
+- `FirstInvestmentDate` is the date of the earliest Buy transaction for the asset; null when the asset has no Buy transactions
+- `CurrentQuantity` is the net quantity held as tracked by the Asset entity (sum of Buy quantities minus sum of Sell quantities)
+- `TotalBought` = sum of `TotalPrice` for all Buy transactions; `TotalSold` = sum of `TotalPrice` for all Sell transactions; `TotalInvested` = `TotalBought − TotalSold`
+- `PortfolioWeight` = `TotalInvested / portfolioTotalInvested × 100`, where `portfolioTotalInvested` = sum of all assets' TotalInvested; returns 0 for all assets when the denominator is 0
+- Returns an empty list when the portfolio has no assets (valid response, not an error)
+- Returns HTTP 400 when `brokerName` or `portfolioName` is null or whitespace
+- New service interface: `IPortfolioAssetSummaryQueryService` with method `GetPortfolioAssetsSummary(string brokerName, string portfolioName)` returning `IReadOnlyList<PortfolioAssetSummaryItemDTO>`
+- New DTO `PortfolioAssetSummaryItemDTO` in the Application layer with properties: `AssetName`, `Ticker`, `Exchange`, `FirstInvestmentDate` (`DateTime?`), `CurrentQuantity`, `TotalBought`, `TotalSold`, `TotalInvested`, `PortfolioWeight` (all decimal where applicable)
+- New API endpoint `GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets` under the existing `/summary` route prefix in `SummaryController`
+
+**Experience:**
+- Endpoint responds within 200 ms (data is in-memory JSON repository; no external calls)
+- Empty portfolio returns `[]` with HTTP 200
+- HTTP 400 response includes standard problem details body
+
+---
+
+### F02. Portfolio Summary Tab — Web Frontend
+
+**Consumes:**
+- F01: portfolio asset summary items (AssetName, Ticker, Exchange, FirstInvestmentDate, CurrentQuantity, TotalBought, TotalSold, TotalInvested, PortfolioWeight)
+
+**Capabilities:**
+- New `PortfolioSummaryTab` component is rendered in `DetailPanel.tsx` for Portfolio nodes; `AggregatedSummaryTab` is still rendered for Broker nodes without modification; `AssetSummaryTab` is still rendered for Asset nodes without modification
+- `PortfolioSummaryTab` contains two sections: (1) the aggregated totals section reusing `useAggregatedSummary` hook unchanged, and (2) the per-asset table driven by a new `usePortfolioAssetSummary` hook
+- `usePortfolioAssetSummary` calls `GET /summary/portfolio/{brokerName}/{portfolioName}/assets`, then fires one `GET /prices/current?exchange={exchange}&ticker={ticker}` request per asset in parallel
+- Prices are fetched once automatically on portfolio selection; there is no Refresh button
+- A failed price fetch for an individual asset (network error or scraper error) sets that row's Current Value to unavailable; other rows are unaffected
+- `CurrentValue` = `CurrentPrice × CurrentQuantity` (client-side computation)
+- `% Profit` = `(CurrentValue − TotalInvested) / TotalInvested × 100` (client-side computation); displays `"—"` when TotalInvested is 0 or CurrentValue is unavailable
+- `PortfolioWeight` displayed as a percentage with one decimal place (e.g. `23.4%`)
+- `FirstInvestmentDate` displayed as a short date (e.g. `01/03/2021`); empty string when null
+- `CurrentQuantity` formatted N8 to match existing transaction quantity display
+- Monetary values (`TotalInvested`, `CurrentValue`) formatted N2
+- `% Profit` formatted N2 with `%` suffix; positive values styled green, negative values styled red
+- Table columns in fixed order: Asset Name | First Investment | Quantity | Total Invested | % Portfolio | Current Value | % Profit
+
+**Experience:**
+1. User selects a Portfolio node in the investment tree
+2. `PortfolioSummaryTab` renders; the three totals section shows a loading indicator while `useAggregatedSummary` resolves; the table section shows a loading indicator while the F01 fetch resolves
+3. Once static data arrives, the table rows render with Current Value and % Profit cells showing a per-cell loading indicator (`...`) while parallel price fetches are in flight
+4. As each price resolves, the corresponding row's Current Value and % Profit update in place; rows whose price fetch fails show `"—"` in those two cells
+5. If the F01 fetch itself fails, the table area shows an `ErrorState` component with a Retry button; the three totals section above is unaffected and continues to display normally
+
+**Error Handling:**
+- F01 endpoint failure: table area shows `ErrorState` with Retry; the `useAggregatedSummary` totals section operates independently and is not affected
+- Individual price fetch failure: affected row's Current Value and % Profit display `"—"`; no error state or banner is shown for the row
+
+---
+
+### F03. Portfolio Summary Tab — WPF
+
+**Consumes:**
+- F01: portfolio asset summary items (AssetName, Ticker, Exchange, FirstInvestmentDate, CurrentQuantity, TotalBought, TotalSold, TotalInvested, PortfolioWeight)
+
+**Capabilities:**
+- When a Portfolio node is selected, the WPF Summary tab renders a portfolio-specific layout containing: (1) three colour-coded total labels (Total Bought in green, Total Sold in red, Total Credits in blue) and (2) a read-only DataGrid with one row per asset
+- All fields currently shown in the WPF Summary tab that are only meaningful for assets (Quantity, Average Price, ISIN, Country, Local Type, Asset Class, Current Value section with Refresh button, Status) are hidden when a Portfolio node is selected; these fields remain visible and unchanged when an Asset node is selected
+- The Credits tab behaviour is unchanged for all node types
+- The Transactions tab behaviour is unchanged for all node types
+- A new `LoadPortfolioSummary(string brokerName, string portfolioName)` method on `IAssetDetailsViewModel` replaces the existing `LoadPortfolioCredits` call when a Portfolio node is selected, or alternatively `LoadPortfolioCredits` is extended to also invoke the portfolio asset summary service and populate the new DataGrid rows
+- Row view model properties: AssetName, FirstInvestmentDate (DateTime?, displayed as short date or empty), CurrentQuantity (N8), TotalInvested (N2), PortfolioWeight (one decimal %, e.g. `23.4%`), CurrentValue (N2 or `"—"` when unavailable), ProfitPercent (N2 % or `"—"` when unavailable), IsLoadingPrice (bool), PriceFetchFailed (bool)
+- For each asset row, `IAssetPriceService` is called asynchronously; on success `CurrentValue = CurrentPrice × CurrentQuantity` and `ProfitPercent = (CurrentValue − TotalInvested) / TotalInvested × 100`; on failure or when TotalInvested is 0, the respective cell shows `"—"`
+- `ProfitPercent` is coloured green when positive, red when negative, and default foreground when unavailable
+- DataGrid columns in fixed order: Asset Name | First Investment | Quantity | Total Invested | % Portfolio | Current Value | % Profit
+- DataGrid rows are read-only (no selection action, no double-click action)
+
+**Experience:**
+1. User selects a Portfolio node
+2. WPF Summary tab switches to the portfolio layout: three colour-coded totals appear, DataGrid rows load synchronously from `IPortfolioAssetSummaryQueryService`
+3. Each row's Current Value cell shows a loading indicator (e.g. `...`) while `IAssetPriceService` fetches in background per asset
+4. As each price resolves, the row's Current Value and % Profit update in place via property change notification; failed price fetches update the row to show `"—"` in those cells
+5. When the user selects a different node (asset, broker, or clears selection), the portfolio summary state is cleared from the ViewModel
+
+---
+
+## 7. Out of Scope
+
+**Broker-level per-asset breakdown**
+- The per-asset table is shown only for Portfolio nodes; selecting a Broker node continues to show only the three aggregated totals (Total Bought, Total Sold, Total Credits) from F04 in both UIs
+
+**Column sorting and filtering**
+- The table uses a fixed alphabetical sort; column header sorting and row filtering are not included in this release
+
+**Clicking an asset row to navigate**
+- Row selection in the per-asset table produces no navigation and loads no detail panel; the table is purely read-only
+
+**Currency conversion**
+- No cross-currency conversion is applied; all amounts are displayed in the portfolio's native currency as stored in transactions
+
+**Overall portfolio % Profit**
+- A total/footer row showing aggregate profit across all assets in the portfolio is not included; only individual asset rows are shown
+
+**WPF Broker-node Summary tab changes**
+- The WPF Summary tab layout change (hiding asset-specific fields) applies only when a Portfolio node is selected; the Broker node layout in WPF is not changed by this feature
+
+**Manual price refresh**
+- There is no per-asset or per-table Refresh button; prices are fetched once automatically on portfolio selection
+
+---
+
+## 8. Dependency Graph
+
+| # | Feature | Priority | Dependencies |
+|---|---------|----------|--------------|
+| F01 | Portfolio Assets Summary Service and Endpoint | 1 | None |
+| F02 | Portfolio Summary Tab — Web Frontend | 1 | F01 |
+| F03 | Portfolio Summary Tab — WPF | 1 | F01 |
+
+### Execution Waves
+Features within the same wave can be built in parallel. A wave starts only after every feature in earlier waves is complete.
+
+- **Wave 1**: F01
+- **Wave 2**: F02, F03
+
+### Priority levels
+- **1** = Essential — product does not work without it
+- **2** = Important — significant value addition
+- **3** = Desirable — incremental improvement
+
+```mermaid
+graph TD
+  F01[Portfolio Assets Summary Service] --> F02[Web Frontend]
+  F01 --> F03[WPF Frontend]
+```
+
+---
+
+## 9. Acceptance Criteria
+
+### F01. Portfolio Assets Summary Service and Endpoint
+
+- [ ] `GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets` returns HTTP 200 with a JSON array
+- [ ] Each item in the array contains `assetName`, `ticker`, `exchange`, `firstInvestmentDate` (nullable), `currentQuantity`, `totalBought`, `totalSold`, `totalInvested`, `portfolioWeight`
+- [ ] `totalInvested` equals `totalBought − totalSold` for each item
+- [ ] `portfolioWeight` values sum to 100 (within floating-point rounding tolerance) when at least one asset has a positive TotalInvested; all values are 0 when portfolioTotalInvested is 0
+- [ ] Assets are returned sorted alphabetically by `assetName`
+- [ ] `firstInvestmentDate` is the date of the earliest Buy transaction for that asset; null when the asset has no Buy transactions
+- [ ] Endpoint returns HTTP 400 when `brokerName` or `portfolioName` is null or whitespace
+- [ ] Endpoint returns an empty array (`[]`) with HTTP 200 when the portfolio has no assets
+
+### F02. Portfolio Summary Tab — Web Frontend
+
+- [ ] Selecting a Portfolio node renders `PortfolioSummaryTab` in the Summary tab
+- [ ] Selecting a Broker node still renders `AggregatedSummaryTab` without the per-asset table (regression check)
+- [ ] Selecting an Asset node still renders `AssetSummaryTab` (regression check)
+- [ ] Three totals (Total Bought in green, Total Sold in red, Total Credits in blue) appear at the top of the Portfolio Summary tab
+- [ ] Per-asset table appears below the totals with columns: Asset Name, First Investment, Quantity, Total Invested, % Portfolio, Current Value, % Profit
+- [ ] Current Value and % Profit populate automatically without a Refresh button
+- [ ] A failed price fetch for one asset shows `"—"` in that row's Current Value and % Profit; other rows are unaffected
+- [ ] `% Profit` is displayed in green when positive and red when negative
+- [ ] When the F01 endpoint call fails, an error state with a Retry button is shown in the table area; the three totals section above continues to display normally
+- [ ] `CurrentValue = CurrentPrice × CurrentQuantity` verified with known test data
+- [ ] `% Profit = (CurrentValue − TotalInvested) / TotalInvested × 100` verified with known test data
+- [ ] `"—"` is shown in % Profit when TotalInvested is 0
+
+### F03. Portfolio Summary Tab — WPF
+
+- [ ] Selecting a Portfolio node in WPF shows the three colour-coded totals and the per-asset DataGrid in the Summary tab
+- [ ] Selecting a Portfolio node in WPF shows no Quantity, Average Price, ISIN, Country, Local Type, Asset Class, or Current section fields in the Summary tab
+- [ ] Selecting an Asset node in WPF still shows all asset-specific Summary tab fields (regression check)
+- [ ] DataGrid rows load immediately from the Application service on portfolio selection (no async wait for the initial data)
+- [ ] Current Value column populates automatically as price fetches complete; no Refresh button is present
+- [ ] A failed price fetch shows `"—"` in that row's Current Value and % Profit; other rows update normally
+- [ ] `% Profit` is green when positive, red when negative, and default foreground when null
+- [ ] DataGrid rows are read-only; no double-click or selection action occurs
+- [ ] Credits tab behaviour is unchanged when a Portfolio node is selected (regression check)
+- [ ] Transactions tab behaviour is unchanged when a Portfolio node is selected (regression check)
+
+### Cross-Feature Integration
+
+- [ ] The `ticker` and `exchange` values returned by F01's endpoint are used without modification in F02's `GET /prices/current?exchange={exchange}&ticker={ticker}` calls, producing correct price lookups
+- [ ] The `ticker` and `exchange` values from F01's Application service are used without modification in F03's `IAssetPriceService` calls, producing correct price lookups
+- [ ] The `totalInvested` and `currentQuantity` values from F01's endpoint are used without transformation in F02's client-side computation of `CurrentValue` and `% Profit`
+- [ ] The `totalInvested` and `currentQuantity` values from F01's Application service are used without transformation in F03's ViewModel computation of `CurrentValue` and `% Profit`


### PR DESCRIPTION
## Summary

- Adds `IPortfolioAssetSummaryQueryService` and `PortfolioAssetSummaryQueryService` in the Application layer, computing per-asset `TotalBought`, `TotalSold`, `TotalInvested`, `PortfolioWeight`, `FirstInvestmentDate`, and `CurrentQuantity`
- Adds `GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets` endpoint in `SummaryController` — returns HTTP 200 with a sorted JSON array, HTTP 400 on null/whitespace params
- Adds `PortfolioAssetSummaryItemDTO` sealed class following the `AggregatedSummaryDTO` pattern

## Test plan

- [x] Unit tests: `PortfolioAssetSummaryQueryServiceTests` — 15 tests covering all computation paths, sort order, portfolio weight, first investment date, null/whitespace guards, and edge cases (no assets, zero total invested, inactive assets)
- [x] Integration tests: 2 new tests in `SummaryEndpointsTests` — HTTP 200 with real test data, HTTP 400 for whitespace broker name
- [x] Full test suite passes (237 tests, 0 failures)
- [x] Clean build with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)