### PR TITLE
fix(wpf): TotalSold always 0 when selecting broker/portfolio node

### DIFF
--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -259,14 +259,14 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         UpdateCommandStates();
     }
 
-    public void LoadBrokerCredits(string brokerName, IReadOnlyList<CreditDTO> credits)
+    public void LoadBrokerCredits(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
     {
-        LoadAggregateCredits(BuildBrokerKey(brokerName), credits);
+        LoadAggregateCredits(BuildBrokerKey(brokerName), summary, credits);
     }
 
-    public void LoadPortfolioCredits(string brokerName, string portfolioName, IReadOnlyList<CreditDTO> credits)
+    public void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
     {
-        LoadAggregateCredits(BuildPortfolioKey(brokerName, portfolioName), credits);
+        LoadAggregateCredits(BuildPortfolioKey(brokerName, portfolioName), summary, credits);
     }
 
     private bool HasAssetContext =>
@@ -327,9 +327,11 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         OnPropertyChanged(nameof(ResultPercentWithCredits));
     }
 
-    private void LoadAggregateCredits(string contextKey, IReadOnlyList<CreditDTO> credits)
+    private void LoadAggregateCredits(string contextKey, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
     {
         ClearAssetContext();
+        TotalBought = summary.TotalBought;
+        TotalSold = summary.TotalSold;
         IsCreditsAggregateView = true;
         HasCreditsContext = true;
         SetCreditsContext(contextKey, rebuild: false);

--- a/Financial.App/ViewModels/IAssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/IAssetDetailsViewModel.cs
@@ -5,8 +5,8 @@ namespace Financial.Presentation.App.ViewModels;
 public interface IAssetDetailsViewModel
 {
     void LoadAssetDetails(AssetDetailsDTO details);
-    void LoadBrokerCredits(string brokerName, IReadOnlyList<CreditDTO> credits);
-    void LoadPortfolioCredits(string brokerName, string portfolioName, IReadOnlyList<CreditDTO> credits);
+    void LoadBrokerCredits(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
+    void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
     void Clear();
     Task EnsureTodayInfoLoadedAsync();
     void UpdateCreditsPlotWidth(double plotWidth);

--- a/Financial.App/ViewModels/MainNavigationViewModel.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModel.cs
@@ -10,12 +10,14 @@ public class MainNavigationViewModel : MainNavigationViewModelBase<AssetDetailsV
     public MainNavigationViewModel(
         INavigationService navigationService,
         ICreditQueryService creditQueryService,
+        ISummaryQueryService summaryQueryService,
         ITransactionService transactionService,
         ICreditService creditService,
         IAssetPriceService assetPriceService)
         : base(
             navigationService ?? throw new ArgumentNullException(nameof(navigationService)),
             creditQueryService ?? throw new ArgumentNullException(nameof(creditQueryService)),
+            summaryQueryService ?? throw new ArgumentNullException(nameof(summaryQueryService)),
             new AssetDetailsViewModel(
                 transactionService ?? throw new ArgumentNullException(nameof(transactionService)),
                 creditService ?? throw new ArgumentNullException(nameof(creditService)),

--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -13,6 +13,7 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
 {
     private readonly INavigationService _navigationService;
     private readonly ICreditQueryService _creditQueryService;
+    private readonly ISummaryQueryService _summaryQueryService;
     private TreeNodeViewModel? _selectedNode;
     private bool _isLoading;
     private TreeNodeDTO? _fullTree;
@@ -56,10 +57,12 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
     protected MainNavigationViewModelBase(
         INavigationService navigationService,
         ICreditQueryService creditQueryService,
+        ISummaryQueryService summaryQueryService,
         TAssetDetailsViewModel assetDetails)
     {
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
         _creditQueryService = creditQueryService ?? throw new ArgumentNullException(nameof(creditQueryService));
+        _summaryQueryService = summaryQueryService ?? throw new ArgumentNullException(nameof(summaryQueryService));
         AssetDetails = assetDetails ?? throw new ArgumentNullException(nameof(assetDetails));
         InitializeAssetClassFilters();
     }
@@ -268,8 +271,9 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
             return;
         }
 
+        var summary = _summaryQueryService.GetPortfolioSummary(brokerName, portfolioName);
         var credits = _creditQueryService.GetCreditsByPortfolio(brokerName, portfolioName);
-        AssetDetails.LoadPortfolioCredits(brokerName, portfolioName, credits);
+        AssetDetails.LoadPortfolioCredits(brokerName, portfolioName, summary, credits);
     }
 
     private void LoadBrokerCredits(TreeNodeViewModel brokerNode)
@@ -281,7 +285,8 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
             return;
         }
 
+        var summary = _summaryQueryService.GetBrokerSummary(brokerName);
         var credits = _creditQueryService.GetCreditsByBroker(brokerName);
-        AssetDetails.LoadBrokerCredits(brokerName, credits);
+        AssetDetails.LoadBrokerCredits(brokerName, summary, credits);
     }
 }

--- a/Financial.slnx
+++ b/Financial.slnx
@@ -15,6 +15,7 @@
 		<Project Path="Tests/Financial.Api.Tests/Financial.Api.Tests.csproj" />
 		<Project Path="Tests/Financial.Domain.Tests/Financial.Domain.Tests.csproj" />
 		<Project Path="Tests/Financial.Infrastructure.Tests/Financial.Infrastructure.Tests.csproj" />
+		<Project Path="Tests/Financial.Presentation.Tests/Financial.Presentation.Tests.csproj" />
 	</Folder>
 	<Project Path="Financial.App/Financial.App.csproj" />
 	<Project Path="Financial.Api/Financial.Api.csproj" />

--- a/Tests/Financial.Presentation.Tests/Financial.Presentation.Tests.csproj
+++ b/Tests/Financial.Presentation.Tests/Financial.Presentation.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Financial.App\Financial.App.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -1,0 +1,197 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Domain.Entities;
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class MainNavigationViewModelBaseTests
+{
+    [Fact]
+    public void SelectingPortfolioNode_LoadsTotalSoldFromSummaryService()
+    {
+        var summary = new AggregatedSummaryDTO { TotalBought = 10000m, TotalSold = 4706.65m, TotalCredits = 500m };
+        var summaryService = new StubSummaryQueryService { PortfolioSummary = summary };
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var portfolioNode = BuildPortfolioNode("XPI", "FII");
+        vm.SelectedNode = portfolioNode;
+
+        spy.LastPortfolioSummary.Should().NotBeNull();
+        spy.LastPortfolioSummary!.TotalSold.Should().Be(4706.65m);
+        spy.LastPortfolioSummary.TotalBought.Should().Be(10000m);
+    }
+
+    [Fact]
+    public void SelectingBrokerNode_LoadsTotalSoldFromSummaryService()
+    {
+        var summary = new AggregatedSummaryDTO { TotalBought = 20000m, TotalSold = 9000m, TotalCredits = 800m };
+        var summaryService = new StubSummaryQueryService { BrokerSummary = summary };
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var brokerNode = BuildBrokerNode("XPI");
+        vm.SelectedNode = brokerNode;
+
+        spy.LastBrokerSummary.Should().NotBeNull();
+        spy.LastBrokerSummary!.TotalSold.Should().Be(9000m);
+        spy.LastBrokerSummary.TotalBought.Should().Be(20000m);
+    }
+
+    [Fact]
+    public void SelectingPortfolioNode_PassesCorrectBrokerAndPortfolioNameToSummaryService()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var portfolioNode = BuildPortfolioNode("XPI", "FII");
+        vm.SelectedNode = portfolioNode;
+
+        summaryService.LastBrokerNameForPortfolio.Should().Be("XPI");
+        summaryService.LastPortfolioName.Should().Be("FII");
+    }
+
+    [Fact]
+    public void SelectingBrokerNode_PassesCorrectBrokerNameToSummaryService()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var brokerNode = BuildBrokerNode("XPI");
+        vm.SelectedNode = brokerNode;
+
+        summaryService.LastBrokerNameForBroker.Should().Be("XPI");
+    }
+
+    [Fact]
+    public void SelectingPortfolioNode_WhenMissingMetadata_ClearsDetails()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var nodeWithoutMetadata = BuildNodeWithoutMetadata(TreeNodeTypes.Portfolio);
+        vm.SelectedNode = nodeWithoutMetadata;
+
+        spy.WasCleared.Should().BeTrue();
+        spy.LastPortfolioSummary.Should().BeNull();
+    }
+
+    private static TreeNodeViewModel BuildPortfolioNode(string brokerName, string portfolioName)
+    {
+        var brokerDto = new TreeNodeDTO
+        {
+            NodeType = TreeNodeTypes.Broker,
+            DisplayName = brokerName,
+            Metadata = new Dictionary<string, object> { ["BrokerName"] = brokerName },
+            Children = []
+        };
+
+        var portfolioDto = new TreeNodeDTO
+        {
+            NodeType = TreeNodeTypes.Portfolio,
+            DisplayName = portfolioName,
+            Metadata = new Dictionary<string, object> { ["PortfolioName"] = portfolioName },
+            Children = []
+        };
+
+        var brokerNode = new TreeNodeViewModel(brokerDto);
+        var portfolioNode = new TreeNodeViewModel(portfolioDto, brokerNode);
+        return portfolioNode;
+    }
+
+    private static TreeNodeViewModel BuildBrokerNode(string brokerName)
+    {
+        var brokerDto = new TreeNodeDTO
+        {
+            NodeType = TreeNodeTypes.Broker,
+            DisplayName = brokerName,
+            Metadata = new Dictionary<string, object> { ["BrokerName"] = brokerName },
+            Children = []
+        };
+        return new TreeNodeViewModel(brokerDto);
+    }
+
+    private static TreeNodeViewModel BuildNodeWithoutMetadata(string nodeType)
+    {
+        var dto = new TreeNodeDTO
+        {
+            NodeType = nodeType,
+            DisplayName = "Unknown",
+            Metadata = new Dictionary<string, object>(),
+            Children = []
+        };
+        return new TreeNodeViewModel(dto);
+    }
+
+    private sealed class TestableNavigationViewModel : MainNavigationViewModelBase<SpyAssetDetailsViewModel>
+    {
+        public TestableNavigationViewModel(ISummaryQueryService summaryQueryService, SpyAssetDetailsViewModel spy)
+            : base(new StubNavigationService(), new StubCreditQueryService(), summaryQueryService, spy)
+        {
+        }
+    }
+
+    private sealed class SpyAssetDetailsViewModel : IAssetDetailsViewModel
+    {
+        public AggregatedSummaryDTO? LastPortfolioSummary { get; private set; }
+        public AggregatedSummaryDTO? LastBrokerSummary { get; private set; }
+        public bool WasCleared { get; private set; }
+
+        public void LoadAssetDetails(AssetDetailsDTO details) { }
+
+        public void LoadBrokerCredits(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
+        {
+            LastBrokerSummary = summary;
+        }
+
+        public void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
+        {
+            LastPortfolioSummary = summary;
+        }
+
+        public void Clear() => WasCleared = true;
+        public Task EnsureTodayInfoLoadedAsync() => Task.CompletedTask;
+        public void UpdateCreditsPlotWidth(double plotWidth) { }
+    }
+
+    private sealed class StubSummaryQueryService : ISummaryQueryService
+    {
+        public AggregatedSummaryDTO BrokerSummary { get; set; } = new();
+        public AggregatedSummaryDTO PortfolioSummary { get; set; } = new();
+        public string? LastBrokerNameForBroker { get; private set; }
+        public string? LastBrokerNameForPortfolio { get; private set; }
+        public string? LastPortfolioName { get; private set; }
+
+        public AggregatedSummaryDTO GetBrokerSummary(string brokerName)
+        {
+            LastBrokerNameForBroker = brokerName;
+            return BrokerSummary;
+        }
+
+        public AggregatedSummaryDTO GetPortfolioSummary(string brokerName, string portfolioName)
+        {
+            LastBrokerNameForPortfolio = brokerName;
+            LastPortfolioName = portfolioName;
+            return PortfolioSummary;
+        }
+    }
+
+    private sealed class StubNavigationService : INavigationService
+    {
+        public TreeNodeDTO GetNavigationTree() => new() { NodeType = TreeNodeTypes.Broker, DisplayName = "Root", Metadata = [], Children = [] };
+        public AssetDetailsDTO? GetAssetDetails(string brokerName, string portfolioName, string assetName) => null;
+        public IEnumerable<BrokerNodeDTO> GetBrokers() => [];
+        public IEnumerable<AssetNodeDTO> GetAssetsByBrokerPortfolio(string brokerName, string portfolioName) => [];
+    }
+
+    private sealed class StubCreditQueryService : ICreditQueryService
+    {
+        public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName) => [];
+        public IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName) => [];
+    }
+}


### PR DESCRIPTION
## Root Cause

When selecting a **Portfolio** or **Broker** node in the WPF tree, `MainNavigationViewModelBase` called `LoadPortfolioCredits` / `LoadBrokerCredits`, which internally called `ClearAssetContext()` — zeroing `TotalBought` and `TotalSold` — then only set `TotalCredits` from the credits list. `ISummaryQueryService` was never called, so **TotalBought and TotalSold were always 0** regardless of how many buy/sell transactions existed.

The web was correct because it calls `SummaryQueryService.GetPortfolioSummary` / `GetBrokerSummary` when a portfolio or broker node is selected.

## Changes

- **`MainNavigationViewModelBase`**: inject `ISummaryQueryService`; call `GetPortfolioSummary` / `GetBrokerSummary` before loading credits
- **`IAssetDetailsViewModel`**: `LoadPortfolioCredits` and `LoadBrokerCredits` now receive `AggregatedSummaryDTO`
- **`AssetDetailsViewModel`**: `LoadAggregateCredits` sets `TotalBought` and `TotalSold` from the summary DTO
- **`MainNavigationViewModel`**: pass `ISummaryQueryService` through (already registered in DI)
- **New `Financial.Presentation.Tests`**: 5 unit tests covering portfolio/broker node selection to prevent regression

## Test plan

- [ ] Build solution — 0 errors
- [ ] Run all tests — 245 pass (5 new), 0 fail
- [ ] In WPF, select XPI / FII — verify Total Sold = 4706.65 (matches web)
- [ ] Select a broker node — verify TotalBought/TotalSold populated
- [ ] Select an individual asset — verify still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)