### PR TITLE
docs(F02): spec and plan for Portfolio Summary Tab — Web Frontend

### DIFF
--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -10,6 +10,7 @@ import type {
   CreditUpdateDto,
   DividendHistoryItemDto,
   DividendSummaryDto,
+  PortfolioAssetSummaryItemDto,
   PortfolioReferenceDto,
   TransactionCreateDto,
   TransactionDeleteDto,
@@ -37,6 +38,7 @@ export interface FinancialApiClient {
   getCurrentPrice: (exchange: string, ticker: string) => Promise<AssetPriceDto>
   getWatchlist: () => Promise<WatchlistItemDto[]>
   getAssetPriceFetchScope: () => Promise<PortfolioReferenceDto[]>
+  getPortfolioAssetsSummary: (brokerName: string, portfolioName: string) => Promise<PortfolioAssetSummaryItemDto[]>
 }
 
 export interface FinancialApiClientOptions {
@@ -150,5 +152,9 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       ),
     getWatchlist: () => request<WatchlistItemDto[]>('/watchlist'),
     getAssetPriceFetchScope: () => request<PortfolioReferenceDto[]>('/asset-price-fetch'),
+    getPortfolioAssetsSummary: (brokerName, portfolioName) =>
+      request<PortfolioAssetSummaryItemDto[]>(
+        `/summary/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}/assets`,
+      ),
   }
 }

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -193,3 +193,15 @@ export interface PortfolioReferenceDto {
   brokerName: string
   portfolioName: string
 }
+
+export interface PortfolioAssetSummaryItemDto {
+  assetName: string
+  ticker: string
+  exchange: string
+  firstInvestmentDate: string | null
+  currentQuantity: number
+  totalBought: number
+  totalSold: number
+  totalInvested: number
+  portfolioWeight: number
+}

--- a/Financial.Web/src/components/DetailPanel.tsx
+++ b/Financial.Web/src/components/DetailPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import { useSelectedNode } from '../context/SelectedNodeContext'
 import AggregatedSummaryTab from './AggregatedSummaryTab'
 import AssetSummaryTab from './AssetSummaryTab'
+import PortfolioSummaryTab from './PortfolioSummaryTab'
 import CreditsTab from './CreditsTab'
 import TransactionsTab from './TransactionsTab'
 import './DetailPanel.css'
@@ -101,7 +102,8 @@ export default function DetailPanel() {
 
       <div className="detail-panel__content">
         {activeTab === 'summary' && isAsset && <AssetSummaryTab />}
-        {activeTab === 'summary' && !isAsset && <AggregatedSummaryTab />}
+        {activeTab === 'summary' && isPortfolio && <PortfolioSummaryTab />}
+        {activeTab === 'summary' && !isAsset && !isPortfolio && <AggregatedSummaryTab />}
         {activeTab === 'transactions' && <TransactionsTab />}
         {activeTab === 'credits' && <CreditsTab />}
       </div>

--- a/Financial.Web/src/components/PortfolioSummaryTab.css
+++ b/Financial.Web/src/components/PortfolioSummaryTab.css
@@ -41,6 +41,11 @@
   white-space: nowrap;
 }
 
+.portfolio-summary__table th:nth-child(n+3),
+.portfolio-summary__table td:nth-child(n+3) {
+  text-align: right;
+}
+
 .portfolio-summary__profit--green {
   color: #2e7d32;
 }

--- a/Financial.Web/src/components/PortfolioSummaryTab.css
+++ b/Financial.Web/src/components/PortfolioSummaryTab.css
@@ -1,0 +1,55 @@
+.portfolio-summary {
+  padding: 16px;
+  overflow-y: auto;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.portfolio-summary__totals {
+  flex-shrink: 0;
+}
+
+.portfolio-summary__table-section {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.portfolio-summary__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.portfolio-summary__table th {
+  text-align: left;
+  font-size: 11px;
+  color: var(--text-muted, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding: 4px 8px 6px 0;
+  border-bottom: 1px solid var(--border, #e0e0e0);
+  white-space: nowrap;
+}
+
+.portfolio-summary__table td {
+  padding: 5px 8px 5px 0;
+  border-bottom: 1px solid var(--border-subtle, #f0f0f0);
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.portfolio-summary__profit--green {
+  color: #2e7d32;
+}
+
+.portfolio-summary__profit--red {
+  color: #c62828;
+}
+
+.portfolio-summary__loading-cell {
+  color: var(--text-muted, #888);
+  font-style: italic;
+}

--- a/Financial.Web/src/components/PortfolioSummaryTab.tsx
+++ b/Financial.Web/src/components/PortfolioSummaryTab.tsx
@@ -1,0 +1,127 @@
+import ErrorState from './ErrorState'
+import LoadingState from './LoadingState'
+import { usePortfolioAssetSummary } from '../hooks/usePortfolioAssetSummary'
+import type { RowPriceState } from '../hooks/usePortfolioAssetSummary'
+import type { PortfolioAssetSummaryItemDto } from '../api/types'
+import AggregatedSummaryTab from './AggregatedSummaryTab'
+import './PortfolioSummaryTab.css'
+
+function formatN2(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+function formatN8(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 8,
+    maximumFractionDigits: 8,
+  }).format(value)
+}
+
+function formatPortfolioWeight(value: number): string {
+  return `${new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(value)}%`
+}
+
+function formatShortDate(isoString: string | null): string {
+  if (!isoString) return ''
+  const d = new Date(isoString)
+  if (Number.isNaN(d.getTime())) return ''
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()}`
+}
+
+interface AssetRowProps {
+  item: PortfolioAssetSummaryItemDto
+  rowPrice: RowPriceState
+}
+
+function AssetRow({ item, rowPrice }: AssetRowProps) {
+  const currentValue =
+    rowPrice.currentPrice !== null ? rowPrice.currentPrice * item.currentQuantity : null
+
+  const profitPercent =
+    currentValue !== null && item.totalInvested !== 0
+      ? ((currentValue - item.totalInvested) / item.totalInvested) * 100
+      : null
+
+  const profitClass =
+    profitPercent !== null && profitPercent >= 0
+      ? 'portfolio-summary__profit--green'
+      : 'portfolio-summary__profit--red'
+
+  return (
+    <tr>
+      <td>{item.assetName}</td>
+      <td>{formatShortDate(item.firstInvestmentDate)}</td>
+      <td>{formatN8(item.currentQuantity)}</td>
+      <td>{formatN2(item.totalInvested)}</td>
+      <td>{formatPortfolioWeight(item.portfolioWeight)}</td>
+      <td>
+        {rowPrice.isLoading ? (
+          <span className="portfolio-summary__loading-cell">...</span>
+        ) : rowPrice.fetchFailed || currentValue === null ? (
+          '—'
+        ) : (
+          formatN2(currentValue)
+        )}
+      </td>
+      <td>
+        {rowPrice.isLoading ? (
+          <span className="portfolio-summary__loading-cell">...</span>
+        ) : rowPrice.fetchFailed || profitPercent === null ? (
+          '—'
+        ) : item.totalInvested === 0 ? (
+          '—'
+        ) : (
+          <span className={profitClass}>{formatN2(profitPercent)}%</span>
+        )}
+      </td>
+    </tr>
+  )
+}
+
+export default function PortfolioSummaryTab() {
+  const { items, rowPrices, isLoading, error, retry } = usePortfolioAssetSummary()
+
+  return (
+    <div className="portfolio-summary">
+      <div className="portfolio-summary__totals">
+        <AggregatedSummaryTab />
+      </div>
+
+      <div className="portfolio-summary__table-section">
+        {isLoading && <LoadingState />}
+        {error && <ErrorState message={error} onRetry={retry} />}
+        {!isLoading && !error && items && (
+          <table className="portfolio-summary__table">
+            <thead>
+              <tr>
+                <th>Asset Name</th>
+                <th>First Investment</th>
+                <th>Quantity</th>
+                <th>Total Invested</th>
+                <th>% Portfolio</th>
+                <th>Current Value</th>
+                <th>% Profit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item, index) => (
+                <AssetRow
+                  key={item.assetName}
+                  item={item}
+                  rowPrice={rowPrices[index] ?? { isLoading: false, currentPrice: null, fetchFailed: false }}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/Financial.Web/src/components/__tests__/DetailPanel.test.tsx
+++ b/Financial.Web/src/components/__tests__/DetailPanel.test.tsx
@@ -9,6 +9,7 @@ const getAssetDetailsMock = vi.fn()
 const getCurrentPriceMock = vi.fn()
 const getSummaryByBrokerMock = vi.fn()
 const getSummaryByPortfolioMock = vi.fn()
+const getPortfolioAssetsSummaryMock = vi.fn()
 
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
@@ -16,6 +17,7 @@ vi.mock('../../api/financialApiClient', () => ({
     getCurrentPrice: getCurrentPriceMock,
     getSummaryByBroker: getSummaryByBrokerMock,
     getSummaryByPortfolio: getSummaryByPortfolioMock,
+    getPortfolioAssetsSummary: getPortfolioAssetsSummaryMock,
   }),
 }))
 
@@ -65,6 +67,7 @@ describe('DetailPanel', () => {
     getCurrentPriceMock.mockReturnValue(new Promise(() => {}))
     getSummaryByBrokerMock.mockReturnValue(new Promise(() => {}))
     getSummaryByPortfolioMock.mockReturnValue(new Promise(() => {}))
+    getPortfolioAssetsSummaryMock.mockReturnValue(new Promise(() => {}))
   })
 
   it('shows empty state when selectedNode is null', () => {
@@ -167,10 +170,11 @@ describe('DetailPanel', () => {
     expect(screen.getByText('Loading...')).toBeInTheDocument()
   })
 
-  it('renders_aggregated_summary_tab_for_portfolio_node', () => {
+  it('renders_portfolio_summary_tab_for_portfolio_node', () => {
     renderPanel(portfolioNode)
     act(() => screen.getByTestId('setter').click())
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    const loadingItems = screen.getAllByText('Loading...')
+    expect(loadingItems.length).toBeGreaterThanOrEqual(1)
   })
 
   it('renders_asset_summary_tab_for_asset_node_regression', () => {

--- a/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
@@ -1,0 +1,211 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AggregatedSummaryData } from '../../hooks/useAggregatedSummary'
+import type { PortfolioAssetSummaryData, RowPriceState } from '../../hooks/usePortfolioAssetSummary'
+import type { AggregatedSummaryDto, PortfolioAssetSummaryItemDto } from '../../api/types'
+import PortfolioSummaryTab from '../PortfolioSummaryTab'
+
+const mockAggregatedRetry = vi.fn()
+const mockPortfolioRetry = vi.fn()
+
+const mockAggregatedHookValue: AggregatedSummaryData = {
+  summary: null,
+  isLoading: false,
+  error: null,
+  retry: mockAggregatedRetry,
+}
+
+const mockPortfolioHookValue: PortfolioAssetSummaryData = {
+  items: null,
+  rowPrices: [],
+  isLoading: false,
+  error: null,
+  retry: mockPortfolioRetry,
+}
+
+vi.mock('../../hooks/useAggregatedSummary', () => ({
+  useAggregatedSummary: () => mockAggregatedHookValue,
+}))
+
+vi.mock('../../hooks/usePortfolioAssetSummary', () => ({
+  usePortfolioAssetSummary: () => mockPortfolioHookValue,
+}))
+
+const SUMMARY: AggregatedSummaryDto = {
+  totalBought: 15420.5,
+  totalSold: 3200.0,
+  totalCredits: 842.3,
+}
+
+const ITEM_1: PortfolioAssetSummaryItemDto = {
+  assetName: 'ALZR11',
+  ticker: 'ALZR11',
+  exchange: 'BVMF',
+  firstInvestmentDate: '2021-03-01T00:00:00',
+  currentQuantity: 25,
+  totalBought: 2500,
+  totalSold: 0,
+  totalInvested: 2500,
+  portfolioWeight: 23.4,
+}
+
+const LOADING_ROW_PRICE: RowPriceState = { isLoading: true, currentPrice: null, fetchFailed: false }
+const FAILED_ROW_PRICE: RowPriceState = { isLoading: false, currentPrice: null, fetchFailed: true }
+const IDLE_ROW_PRICE: RowPriceState = { isLoading: false, currentPrice: null, fetchFailed: false }
+
+function setAggregatedMock(overrides: Partial<AggregatedSummaryData>) {
+  Object.assign(mockAggregatedHookValue, overrides)
+}
+
+function setPortfolioMock(overrides: Partial<PortfolioAssetSummaryData>) {
+  Object.assign(mockPortfolioHookValue, overrides)
+}
+
+describe('PortfolioSummaryTab', () => {
+  beforeEach(() => {
+    mockAggregatedRetry.mockReset()
+    mockPortfolioRetry.mockReset()
+    Object.assign(mockAggregatedHookValue, {
+      summary: null,
+      isLoading: false,
+      error: null,
+    })
+    Object.assign(mockPortfolioHookValue, {
+      items: null,
+      rowPrices: [],
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it('renders_loading_state_in_totals_section_while_aggregated_summary_loads', () => {
+    setAggregatedMock({ isLoading: true })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('renders_error_state_in_totals_section_on_aggregated_summary_failure', () => {
+    setAggregatedMock({ error: 'Unable to load summary' })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText('Unable to load summary')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('renders_loading_state_in_table_section_while_items_load', () => {
+    setPortfolioMock({ isLoading: true })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('renders_error_state_in_table_section_on_items_fetch_failure', () => {
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ error: 'Unable to load portfolio assets' })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText('Unable to load portfolio assets')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+    expect(screen.getByText('Total Bought')).toBeInTheDocument()
+  })
+
+  it('renders_table_with_correct_column_headers', () => {
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText('Asset Name')).toBeInTheDocument()
+    expect(screen.getByText('First Investment')).toBeInTheDocument()
+    expect(screen.getByText('Quantity')).toBeInTheDocument()
+    expect(screen.getByText('Total Invested')).toBeInTheDocument()
+    expect(screen.getByText('% Portfolio')).toBeInTheDocument()
+    expect(screen.getByText('Current Value')).toBeInTheDocument()
+    expect(screen.getByText('% Profit')).toBeInTheDocument()
+  })
+
+  it('renders_asset_row_with_correctly_formatted_values', () => {
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [IDLE_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText('ALZR11')).toBeInTheDocument()
+    expect(screen.getByText('01/03/2021')).toBeInTheDocument()
+    expect(screen.getByText(/23\.4%/)).toBeInTheDocument()
+  })
+
+  it('renders_per_cell_loading_indicator_while_price_loads', () => {
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    const loadingCells = screen.getAllByText('...')
+    expect(loadingCells).toHaveLength(2)
+  })
+
+  it('renders_current_value_when_price_resolves', () => {
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText(/262[.,]50/)).toBeInTheDocument()
+  })
+
+  it('renders_correct_profit_percent', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentQuantity: 25, totalInvested: 250 }
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText(/5[.,]00%/)).toBeInTheDocument()
+  })
+
+  it('renders_dash_in_current_value_and_profit_on_price_failure', () => {
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [FAILED_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders_dash_in_profit_when_total_invested_is_zero', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, totalInvested: 0 }
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.getByText(/262[.,]50/)).toBeInTheDocument()
+  })
+
+  it('applies_green_class_to_positive_profit', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentQuantity: 25, totalInvested: 200 }
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    const profitEl = document.querySelector('.portfolio-summary__profit--green')
+    expect(profitEl).toBeInTheDocument()
+  })
+
+  it('applies_red_class_to_negative_profit', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentQuantity: 25, totalInvested: 300 }
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    const profitEl = document.querySelector('.portfolio-summary__profit--red')
+    expect(profitEl).toBeInTheDocument()
+  })
+
+  it('renders_empty_string_for_null_first_investment_date', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, firstInvestmentDate: null }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [IDLE_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.queryByText('01/03/2021')).not.toBeInTheDocument()
+  })
+
+  it('totals_section_is_unaffected_when_table_section_errors', () => {
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ error: 'F01 fetch failed' })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText('Total Bought')).toBeInTheDocument()
+    expect(screen.getByText('Total Sold')).toBeInTheDocument()
+    expect(screen.getByText('Total Credits')).toBeInTheDocument()
+    expect(screen.getByText('F01 fetch failed')).toBeInTheDocument()
+  })
+})

--- a/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
@@ -1,0 +1,241 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { createElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FinancialApiClient } from '../api/financialApiClient'
+import type { AssetPriceDto, PortfolioAssetSummaryItemDto, SelectedNode } from '../api/types'
+import { SelectedNodeProvider, useSelectedNode } from '../context/SelectedNodeContext'
+import { usePortfolioAssetSummary } from './usePortfolioAssetSummary'
+
+const getPortfolioAssetsSummaryMock = vi.fn<FinancialApiClient['getPortfolioAssetsSummary']>()
+const getCurrentPriceMock = vi.fn<FinancialApiClient['getCurrentPrice']>()
+
+vi.mock('../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getPortfolioAssetsSummary: getPortfolioAssetsSummaryMock,
+    getCurrentPrice: getCurrentPriceMock,
+  }),
+}))
+
+const BROKER_NODE: SelectedNode = {
+  nodeType: 'Broker',
+  brokerName: 'XPI',
+  currency: 'BRL',
+}
+
+const PORTFOLIO_NODE: SelectedNode = {
+  nodeType: 'Portfolio',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+}
+
+const ASSET_NODE: SelectedNode = {
+  nodeType: 'Asset',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+  assetName: 'KLBN4',
+  ticker: 'KLBN4',
+  exchange: 'BVMF',
+}
+
+const ITEM_1: PortfolioAssetSummaryItemDto = {
+  assetName: 'ALZR11',
+  ticker: 'ALZR11',
+  exchange: 'BVMF',
+  firstInvestmentDate: '2021-03-01T00:00:00',
+  currentQuantity: 25,
+  totalBought: 2500,
+  totalSold: 0,
+  totalInvested: 2500,
+  portfolioWeight: 71.4,
+}
+
+const ITEM_2: PortfolioAssetSummaryItemDto = {
+  assetName: 'MXRF11',
+  ticker: 'MXRF11',
+  exchange: 'BVMF',
+  firstInvestmentDate: '2021-05-15T00:00:00',
+  currentQuantity: 10,
+  totalBought: 1000,
+  totalSold: 0,
+  totalInvested: 1000,
+  portfolioWeight: 28.6,
+}
+
+const PRICE_DTO: AssetPriceDto = {
+  exchange: 'BVMF',
+  ticker: 'ALZR11',
+  name: 'ALZR11',
+  price: 100.5,
+  asOf: '2024-01-01T10:00:00',
+}
+
+function createWrapper() {
+  let setNodeRef: ((node: SelectedNode | null) => void) | undefined
+
+  function NodeControl() {
+    const { setSelectedNode } = useSelectedNode()
+    setNodeRef = setSelectedNode
+    return null
+  }
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(SelectedNodeProvider, null, createElement(NodeControl), children)
+  }
+
+  return {
+    wrapper: Wrapper,
+    setNode: (node: SelectedNode | null) => act(() => { setNodeRef?.(node) }),
+  }
+}
+
+describe('usePortfolioAssetSummary', () => {
+  beforeEach(() => {
+    getPortfolioAssetsSummaryMock.mockReset()
+    getCurrentPriceMock.mockReset()
+  })
+
+  it('calls_getPortfolioAssetsSummary_on_portfolio_node_selection', async () => {
+    getPortfolioAssetsSummaryMock.mockResolvedValue([ITEM_1])
+    getCurrentPriceMock.mockReturnValue(new Promise(() => {}))
+    const { wrapper, setNode } = createWrapper()
+    renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => {
+      expect(getPortfolioAssetsSummaryMock).toHaveBeenCalledWith('XPI', 'Acoes')
+    })
+  })
+
+  it('does_not_fetch_when_broker_node_selected', async () => {
+    const { wrapper, setNode } = createWrapper()
+    renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(BROKER_NODE)
+    await act(async () => {})
+    expect(getPortfolioAssetsSummaryMock).not.toHaveBeenCalled()
+  })
+
+  it('does_not_fetch_when_asset_node_selected', async () => {
+    const { wrapper, setNode } = createWrapper()
+    renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(ASSET_NODE)
+    await act(async () => {})
+    expect(getPortfolioAssetsSummaryMock).not.toHaveBeenCalled()
+  })
+
+  it('sets_isLoading_true_while_fetch_in_progress', async () => {
+    getPortfolioAssetsSummaryMock.mockReturnValue(new Promise(() => {}))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(result.current.isLoading).toBe(true))
+  })
+
+  it('populates_items_on_successful_fetch', async () => {
+    getPortfolioAssetsSummaryMock.mockResolvedValue([ITEM_1, ITEM_2])
+    getCurrentPriceMock.mockReturnValue(new Promise(() => {}))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(result.current.items).not.toBeNull())
+    expect(result.current.items).toHaveLength(2)
+    expect(result.current.items![0].assetName).toBe('ALZR11')
+  })
+
+  it('sets_error_on_fetch_failure', async () => {
+    getPortfolioAssetsSummaryMock.mockRejectedValue(new Error('Network error'))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(result.current.error).toBe('Network error'))
+    expect(result.current.items).toBeNull()
+  })
+
+  it('resets_state_on_node_change', async () => {
+    getPortfolioAssetsSummaryMock.mockResolvedValue([ITEM_1])
+    getCurrentPriceMock.mockReturnValue(new Promise(() => {}))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(result.current.items).not.toBeNull())
+
+    setNode(BROKER_NODE)
+    await waitFor(() => {
+      expect(result.current.items).toBeNull()
+      expect(result.current.isLoading).toBe(false)
+    })
+  })
+
+  it('retry_re_triggers_fetch', async () => {
+    getPortfolioAssetsSummaryMock.mockRejectedValueOnce(new Error('Fail'))
+    getPortfolioAssetsSummaryMock.mockResolvedValue([ITEM_1])
+    getCurrentPriceMock.mockReturnValue(new Promise(() => {}))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(result.current.error).toBe('Fail'))
+
+    act(() => result.current.retry())
+    await waitFor(() => expect(result.current.items).not.toBeNull())
+    expect(getPortfolioAssetsSummaryMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('fires_getCurrentPrice_for_each_item_after_fetch', async () => {
+    getPortfolioAssetsSummaryMock.mockResolvedValue([ITEM_1, ITEM_2])
+    getCurrentPriceMock.mockReturnValue(new Promise(() => {}))
+    const { wrapper, setNode } = createWrapper()
+    renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(getCurrentPriceMock).toHaveBeenCalledTimes(2))
+    expect(getCurrentPriceMock).toHaveBeenCalledWith('BVMF', 'ALZR11')
+    expect(getCurrentPriceMock).toHaveBeenCalledWith('BVMF', 'MXRF11')
+  })
+
+  it('sets_row_price_loading_true_after_items_arrive', async () => {
+    getPortfolioAssetsSummaryMock.mockResolvedValue([ITEM_1])
+    getCurrentPriceMock.mockReturnValue(new Promise(() => {}))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(result.current.items).not.toBeNull())
+    expect(result.current.rowPrices[0].isLoading).toBe(true)
+  })
+
+  it('populates_row_price_on_price_success', async () => {
+    getPortfolioAssetsSummaryMock.mockResolvedValue([ITEM_1])
+    getCurrentPriceMock.mockResolvedValue(PRICE_DTO)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(result.current.rowPrices[0]?.isLoading).toBe(false))
+    expect(result.current.rowPrices[0].currentPrice).toBe(100.5)
+    expect(result.current.rowPrices[0].fetchFailed).toBe(false)
+  })
+
+  it('sets_row_fetch_failed_on_price_error', async () => {
+    getPortfolioAssetsSummaryMock.mockResolvedValue([ITEM_1])
+    getCurrentPriceMock.mockRejectedValue(new Error('Price fetch failed'))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(result.current.rowPrices[0]?.fetchFailed).toBe(true))
+    expect(result.current.rowPrices[0].currentPrice).toBeNull()
+    expect(result.current.rowPrices[0].isLoading).toBe(false)
+  })
+
+  it('failed_price_for_one_row_does_not_affect_other_rows', async () => {
+    getPortfolioAssetsSummaryMock.mockResolvedValue([ITEM_1, ITEM_2])
+    getCurrentPriceMock
+      .mockRejectedValueOnce(new Error('Price fetch failed'))
+      .mockResolvedValueOnce(PRICE_DTO)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => usePortfolioAssetSummary(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => {
+      expect(result.current.rowPrices[0]?.isLoading).toBe(false)
+      expect(result.current.rowPrices[1]?.isLoading).toBe(false)
+    })
+    expect(result.current.rowPrices[0].fetchFailed).toBe(true)
+    expect(result.current.rowPrices[1].currentPrice).toBe(100.5)
+    expect(result.current.rowPrices[1].fetchFailed).toBe(false)
+  })
+})

--- a/Financial.Web/src/hooks/usePortfolioAssetSummary.ts
+++ b/Financial.Web/src/hooks/usePortfolioAssetSummary.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react'
+import { createFinancialApiClient } from '../api/financialApiClient'
+import type { PortfolioAssetSummaryItemDto } from '../api/types'
+import { useSelectedNode } from '../context/SelectedNodeContext'
+
+export interface RowPriceState {
+  isLoading: boolean
+  currentPrice: number | null
+  fetchFailed: boolean
+}
+
+interface PortfolioAssetSummaryState {
+  items: PortfolioAssetSummaryItemDto[] | null
+  rowPrices: RowPriceState[]
+  isLoading: boolean
+  error: string | null
+  retryCount: number
+}
+
+type PortfolioAssetSummaryAction =
+  | { type: 'RESET' }
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; payload: PortfolioAssetSummaryItemDto[] }
+  | { type: 'FETCH_ERROR'; payload: string }
+  | { type: 'RETRY' }
+  | { type: 'ROW_PRICE_SUCCESS'; index: number; currentPrice: number }
+  | { type: 'ROW_PRICE_ERROR'; index: number }
+
+const INITIAL_STATE: PortfolioAssetSummaryState = {
+  items: null,
+  rowPrices: [],
+  isLoading: false,
+  error: null,
+  retryCount: 0,
+}
+
+function reducer(
+  state: PortfolioAssetSummaryState,
+  action: PortfolioAssetSummaryAction,
+): PortfolioAssetSummaryState {
+  switch (action.type) {
+    case 'RESET':
+      return INITIAL_STATE
+    case 'FETCH_START':
+      return { ...state, isLoading: true, error: null, items: null, rowPrices: [] }
+    case 'FETCH_SUCCESS': {
+      const rowPrices: RowPriceState[] = action.payload.map(() => ({
+        isLoading: true,
+        currentPrice: null,
+        fetchFailed: false,
+      }))
+      return { ...state, isLoading: false, items: action.payload, rowPrices }
+    }
+    case 'FETCH_ERROR':
+      return { ...state, isLoading: false, error: action.payload }
+    case 'RETRY':
+      return { ...state, retryCount: state.retryCount + 1 }
+    case 'ROW_PRICE_SUCCESS': {
+      const rowPrices = state.rowPrices.map((row, i) =>
+        i === action.index
+          ? { isLoading: false, currentPrice: action.currentPrice, fetchFailed: false }
+          : row,
+      )
+      return { ...state, rowPrices }
+    }
+    case 'ROW_PRICE_ERROR': {
+      const rowPrices = state.rowPrices.map((row, i) =>
+        i === action.index ? { isLoading: false, currentPrice: null, fetchFailed: true } : row,
+      )
+      return { ...state, rowPrices }
+    }
+    default:
+      return state
+  }
+}
+
+export interface PortfolioAssetSummaryData {
+  items: PortfolioAssetSummaryItemDto[] | null
+  rowPrices: RowPriceState[]
+  isLoading: boolean
+  error: string | null
+  retry: () => void
+}
+
+export function usePortfolioAssetSummary(): PortfolioAssetSummaryData {
+  const { selectedNode } = useSelectedNode()
+  const apiClient = useMemo(() => createFinancialApiClient(), [])
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  const isPortfolio = selectedNode?.nodeType === 'Portfolio'
+
+  useEffect(() => {
+    if (!isPortfolio || !selectedNode) {
+      dispatch({ type: 'RESET' })
+      return
+    }
+
+    const { brokerName, portfolioName } = selectedNode
+    if (!portfolioName) {
+      dispatch({ type: 'RESET' })
+      return
+    }
+
+    dispatch({ type: 'FETCH_START' })
+
+    void apiClient
+      .getPortfolioAssetsSummary(brokerName, portfolioName)
+      .then((items) => {
+        dispatch({ type: 'FETCH_SUCCESS', payload: items })
+        items.forEach((item, index) => {
+          void apiClient
+            .getCurrentPrice(item.exchange, item.ticker)
+            .then((priceDto) => {
+              dispatch({ type: 'ROW_PRICE_SUCCESS', index, currentPrice: priceDto.price })
+            })
+            .catch(() => {
+              dispatch({ type: 'ROW_PRICE_ERROR', index })
+            })
+        })
+      })
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'FETCH_ERROR',
+          payload: err instanceof Error ? err.message : 'Unable to load portfolio assets',
+        })
+      })
+  }, [selectedNode, isPortfolio, apiClient, state.retryCount])
+
+  const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
+
+  return {
+    items: state.items,
+    rowPrices: state.rowPrices,
+    isLoading: state.isLoading,
+    error: state.error,
+    retry,
+  }
+}

--- a/docs/F02-portfolio-summary-tab-web-frontend/plan.md
+++ b/docs/F02-portfolio-summary-tab-web-frontend/plan.md
@@ -1,0 +1,35 @@
+# Implementation Plan: F02 — Portfolio Summary Tab — Web Frontend
+
+**Prerequisites:**
+- F01 endpoint (`GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets`) already implemented and deployed
+- No new npm packages required; all existing frontend dependencies (`vitest`, `@testing-library/react`, React 18) are already present
+
+---
+
+### Phase 1: API Client Extension
+
+**1. PortfolioAssetSummaryItemDto Type** — Add the `PortfolioAssetSummaryItemDto` interface to `Financial.Web/src/api/types.ts`. See spec Section 5 for all nine field names and TypeScript types.
+
+**2. FinancialApiClient Method** — Add `getPortfolioAssetsSummary` to the `FinancialApiClient` interface and its implementation in `financialApiClient.ts`. See spec Section 5 for the URL pattern, parameter encoding, and return type.
+
+---
+
+### Phase 2: Hook
+
+**3. usePortfolioAssetSummary Hook** — Create `Financial.Web/src/hooks/usePortfolioAssetSummary.ts`. The hook manages a `useReducer` with `items`, `rowPrices`, `isLoading`, `error`, and `retryCount`; on Portfolio node selection it fetches static data from the F01 endpoint; on success it initialises per-row loading state and fires one `getCurrentPrice` call per item in parallel, each dispatching independently as it resolves or fails. See spec Sections 3 and 4 for state shape, action types, and reducer rules.
+
+---
+
+### Phase 3: Component and Routing
+
+**4. PortfolioSummaryTab Component** — Create `Financial.Web/src/components/PortfolioSummaryTab.tsx` and `PortfolioSummaryTab.css`. The component renders the aggregated totals section (reusing `useAggregatedSummary`) and the per-asset table (using `usePortfolioAssetSummary`), each with independent loading and error states. Per-cell `...` loading indicators and `"—"` fallbacks apply per the PRD UX flow. See spec Sections 4 and 5.
+
+**5. DetailPanel Modification** — Update `Financial.Web/src/components/DetailPanel.tsx` to render `PortfolioSummaryTab` when the selected node is a Portfolio and `AggregatedSummaryTab` only when it is a Broker. Import `PortfolioSummaryTab` and update the summary tab routing condition. See spec Section 4.
+
+---
+
+### Phase 4: Tests
+
+**6. usePortfolioAssetSummary Tests** — Create `Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts` following the `createWrapper` / `vi.mock` pattern from `useAggregatedSummary.test.ts`. Cover all state transitions, parallel price dispatch, retry, node-change reset, and row isolation on partial price failure. See spec Section 7 for the full test function list.
+
+**7. PortfolioSummaryTab Tests** — Create `Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx` following the `vi.mock` / `setMock` pattern from `AggregatedSummaryTab.test.tsx`. Mock both `useAggregatedSummary` and `usePortfolioAssetSummary`. Cover all render states, value formatting, profit colour coding, and regression checks for unaffected node types. See spec Section 7 for the full test function list.

--- a/docs/F02-portfolio-summary-tab-web-frontend/spec.md
+++ b/docs/F02-portfolio-summary-tab-web-frontend/spec.md
@@ -1,0 +1,217 @@
+# Spec: F02 — Portfolio Summary Tab — Web Frontend
+
+## 1. Technical Overview
+
+**What:** Adds a `PortfolioSummaryTab` component to the React frontend that renders when a Portfolio node is selected in the investment tree. The component displays two independent sections: (1) the three aggregated totals (Total Bought, Total Sold, Total Credits) via the existing `useAggregatedSummary` hook unchanged, and (2) a per-asset breakdown table driven by a new `usePortfolioAssetSummary` hook that fetches static data from F01's endpoint and enriches each row with a live current price fetched in parallel.
+
+**Why:** The current `DetailPanel` renders `AggregatedSummaryTab` for both Broker and Portfolio nodes — selecting a Portfolio shows only three aggregate totals with no per-asset breakdown. F01 now provides the server-side per-asset computation; this feature wires that data into the React frontend with automatic price enrichment, following the same pattern already used by `AssetSummaryTab` for individual assets.
+
+**Scope:**
+
+Included:
+- `PortfolioAssetSummaryItemDto` type in `Financial.Web/src/api/types.ts`
+- `getPortfolioAssetsSummary` method on `FinancialApiClient` interface and implementation in `financialApiClient.ts`
+- `usePortfolioAssetSummary` hook in `Financial.Web/src/hooks/`
+- `PortfolioSummaryTab` component and co-located CSS in `Financial.Web/src/components/`
+- `DetailPanel.tsx` modification to render `PortfolioSummaryTab` for Portfolio nodes and `AggregatedSummaryTab` only for Broker nodes
+- Unit tests for `usePortfolioAssetSummary`
+- Component tests for `PortfolioSummaryTab`
+
+Excluded:
+- Broker-level per-asset breakdown (no change to `AggregatedSummaryTab`)
+- Column sorting or filtering in the table
+- Manual price refresh (prices are fetched once automatically on portfolio selection)
+- Any backend, API endpoint, or data model changes
+- Changes to `AssetSummaryTab`, `TransactionsTab`, or `CreditsTab`
+
+---
+
+## 2. Architecture Impact
+
+**Affected components:**
+
+```mermaid
+graph TD
+    User["User selects Portfolio node"] --> DetailPanel["DetailPanel.tsx (modified)"]
+    DetailPanel --> PortfolioSummaryTab["PortfolioSummaryTab (new)"]
+    PortfolioSummaryTab --> useAggregatedSummary["useAggregatedSummary (unchanged)"]
+    PortfolioSummaryTab --> usePortfolioAssetSummary["usePortfolioAssetSummary (new)"]
+    useAggregatedSummary --> apiClient["FinancialApiClient (modified)"]
+    usePortfolioAssetSummary --> apiClient
+    apiClient --> F01Endpoint["GET /summary/portfolio/{broker}/{portfolio}/assets"]
+    apiClient --> PriceEndpoint["GET /prices/current?exchange=...&ticker=..."]
+```
+
+---
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Per-row price state structure | Parallel `rowPrices: RowPriceState[]` indexed by position alongside `items` | Merged `PortfolioAssetSummaryRow[]` with price fields inlined; `Map<string, RowPriceState>` keyed by ticker | Parallel arrays keep the reducer action shape simple (`ROW_PRICE_SUCCESS` / `ROW_PRICE_ERROR` carry only an `index`), avoids creating an extra merged type, and is consistent with `useAssetSummary` which keeps `asset` and `price` as separate state fields |
+| Price fetch dispatch | Each price fetch dispatches independently (fire-and-forget per row) | `Promise.allSettled` collecting all prices before updating state | Independent dispatch updates each row as soon as its price arrives, satisfying the PRD requirement that "as each price resolves, the corresponding row updates in place"; `allSettled` would stall every row until the slowest fetch |
+| `useAggregatedSummary` reuse in `PortfolioSummaryTab` | Call `useAggregatedSummary()` directly inside `PortfolioSummaryTab` | Lift aggregated state to a parent and pass as props | Follows the existing pattern (`AggregatedSummaryTab` owns its hook); keeps `PortfolioSummaryTab` self-contained; the hook already handles Portfolio node selection correctly without modification |
+| Table HTML element | HTML `<table>` with `<thead>` / `<tbody>` | CSS grid (used by `AggregatedSummaryTab` and `AssetSummaryTab`) | The per-asset breakdown is genuinely tabular data (7 columns, variable number of rows); `<table>` provides correct semantics, accessible column headers, and natural column alignment; CSS grid is appropriate for key-value pair layouts, not multi-row columnar tables |
+
+---
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/api/types.ts` | Modified | API type definitions | Add `PortfolioAssetSummaryItemDto` interface with all nine fields from the F01 response |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | API client | Add `getPortfolioAssetsSummary(brokerName, portfolioName)` to `FinancialApiClient` interface; implement it in the factory function using the path `/summary/portfolio/{brokerName}/{portfolioName}/assets` with `encodeURIComponent` on both params |
+| `Financial.Web/src/hooks/usePortfolioAssetSummary.ts` | New | Hook encapsulating F01 fetch and parallel price enrichment | Manages `useReducer` with `items`, `rowPrices`, `isLoading`, `error`, and `retryCount`; triggers on Portfolio node selection; on `FETCH_SUCCESS` initialises `rowPrices` with one `{ isLoading: true, currentPrice: null, fetchFailed: false }` per item and fires one `getCurrentPrice` call per item in parallel; each price call dispatches `ROW_PRICE_SUCCESS` or `ROW_PRICE_ERROR` with the row index; exposes `items`, `rowPrices`, `isLoading`, `error`, `retry` |
+| `Financial.Web/src/components/PortfolioSummaryTab.tsx` | New | Portfolio-specific Summary tab component | Renders totals section (via `useAggregatedSummary`) and per-asset table (via `usePortfolioAssetSummary`); handles loading and error states for each section independently; computes `currentValue = currentPrice × currentQuantity` and `profitPercent = (currentValue − totalInvested) / totalInvested × 100` per row; renders `"—"` when `totalInvested` is 0 or current price is unavailable; applies green/red CSS class to `% Profit` |
+| `Financial.Web/src/components/PortfolioSummaryTab.css` | New | Scoped styles for `PortfolioSummaryTab` | Table, header, and cell layout; `portfolio-summary__profit--green` / `--red` colour modifier classes; `.portfolio-summary__loading-cell` style for the `...` per-cell indicator |
+| `Financial.Web/src/components/DetailPanel.tsx` | Modified | Navigation-aware tab content dispatcher | Change summary routing: `isPortfolio` → render `PortfolioSummaryTab`; `isBroker` (i.e. `!isAsset && !isPortfolio`) → render `AggregatedSummaryTab`; `isAsset` → render `AssetSummaryTab`; import `PortfolioSummaryTab` |
+
+---
+
+## 5. API Contracts
+
+### New API client method: `getPortfolioAssetsSummary`
+
+Consumes the F01 endpoint. No backend changes are made in this feature.
+
+- **Method:** GET
+- **Path:** `/summary/portfolio/{brokerName}/{portfolioName}/assets`
+- **Caller:** `usePortfolioAssetSummary` hook, triggered on Portfolio node selection
+
+**Client method signature:**
+
+```typescript
+getPortfolioAssetsSummary: (brokerName: string, portfolioName: string) => Promise<PortfolioAssetSummaryItemDto[]>
+```
+
+**New type — `PortfolioAssetSummaryItemDto` (in `api/types.ts`):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `assetName` | `string` | Asset name, sorted alphabetically |
+| `ticker` | `string` | Ticker symbol |
+| `exchange` | `string` | Exchange code (e.g., `BVMF`, `LSE`) |
+| `firstInvestmentDate` | `string \| null` | ISO 8601 date string; `null` when asset has no Buy transactions |
+| `currentQuantity` | `number` | Net quantity held after all Buy and Sell transactions |
+| `totalBought` | `number` | Sum of all Buy transaction totals |
+| `totalSold` | `number` | Sum of all Sell transaction totals |
+| `totalInvested` | `number` | `totalBought − totalSold` |
+| `portfolioWeight` | `number` | Asset's share of total portfolio invested capital × 100 |
+
+**Response example:**
+```json
+[
+  {
+    "assetName": "ALZR11",
+    "ticker": "ALZR11",
+    "exchange": "BVMF",
+    "firstInvestmentDate": "2021-03-01T00:00:00",
+    "currentQuantity": 25.0,
+    "totalBought": 2500.00,
+    "totalSold": 0.00,
+    "totalInvested": 2500.00,
+    "portfolioWeight": 71.4285714285714
+  },
+  {
+    "assetName": "MXRF11",
+    "ticker": "MXRF11",
+    "exchange": "BVMF",
+    "firstInvestmentDate": "2021-05-15T00:00:00",
+    "currentQuantity": 0.0,
+    "totalBought": 1200.00,
+    "totalSold": 200.00,
+    "totalInvested": 1000.00,
+    "portfolioWeight": 28.5714285714286
+  }
+]
+```
+
+**Price fetch per row (existing endpoint, no changes):**
+- **Method:** GET
+- **Path:** `/prices/current?exchange={exchange}&ticker={ticker}`
+- Used by `usePortfolioAssetSummary` in parallel after items are loaded; one call per asset row using the `ticker` and `exchange` values from the F01 response without transformation.
+
+---
+
+## 6. Data Model
+
+Not applicable. No persistence or schema changes. All state is in-memory within the React component lifecycle.
+
+---
+
+## 7. Testing Strategy
+
+### Test File Structure
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts` | Unit | `usePortfolioAssetSummary` | All state transitions, parallel price dispatch, retry, node-change reset |
+| `Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx` | Unit | `PortfolioSummaryTab` | All render states, value formatting, profit colour coding, regression for other node types |
+
+### usePortfolioAssetSummary.test.ts
+
+Follows the `createWrapper()` / `SelectedNodeProvider` / `vi.mock('../api/financialApiClient')` pattern from `useAggregatedSummary.test.ts`. Mock both `getPortfolioAssetsSummaryMock` and `getCurrentPriceMock`.
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `calls_getPortfolioAssetsSummary_on_portfolio_node_selection` | Portfolio node selected | `getPortfolioAssetsSummaryMock` called with correct `brokerName` and `portfolioName` |
+| `does_not_fetch_when_broker_node_selected` | Broker node selected | `getPortfolioAssetsSummaryMock` not called |
+| `does_not_fetch_when_asset_node_selected` | Asset node selected | `getPortfolioAssetsSummaryMock` not called |
+| `sets_isLoading_true_while_fetch_in_progress` | Never-resolving promise | `isLoading` is `true` after Portfolio node selection |
+| `populates_items_on_successful_fetch` | Resolves with 2 items | `items` length is 2; `items[0].assetName` matches expected value |
+| `sets_error_on_fetch_failure` | Rejects with error message | `error` equals the error message; `items` is `null` |
+| `resets_state_on_node_change` | Select Portfolio, then select Broker | After second selection, `items` is `null` and `isLoading` reflects current fetch state |
+| `retry_re_triggers_fetch` | First call rejects, second resolves | After `retry()`, `getPortfolioAssetsSummaryMock` called twice; `items` populated after second call |
+| `fires_getCurrentPrice_for_each_item_after_fetch` | Fetch resolves with 2 items | `getCurrentPriceMock` called twice with correct `exchange` and `ticker` pairs from the items |
+| `sets_row_price_loading_true_after_items_arrive` | Price fetch never resolves | `rowPrices[0].isLoading` is `true` after items arrive |
+| `populates_row_price_on_price_success` | Price resolves for first item | `rowPrices[0].currentPrice` equals returned price; `rowPrices[0].isLoading` is `false`; `rowPrices[0].fetchFailed` is `false` |
+| `sets_row_fetch_failed_on_price_error` | Price rejects for first item | `rowPrices[0].fetchFailed` is `true`; `rowPrices[0].currentPrice` is `null`; `rowPrices[0].isLoading` is `false` |
+| `failed_price_for_one_row_does_not_affect_other_rows` | First price fails, second price resolves | `rowPrices[0].fetchFailed` is `true`; `rowPrices[1].currentPrice` is populated and `rowPrices[1].fetchFailed` is `false` |
+
+### PortfolioSummaryTab.test.tsx
+
+Follows the `vi.mock` / `setMock` / `Object.assign` pattern from `AggregatedSummaryTab.test.tsx`. Mocks both `useAggregatedSummary` and `usePortfolioAssetSummary`.
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `renders_loading_state_in_totals_section_while_aggregated_summary_loads` | `useAggregatedSummary` returns `isLoading: true` | Loading indicator rendered in totals section |
+| `renders_error_state_in_totals_section_on_aggregated_summary_failure` | `useAggregatedSummary` returns `error` | ErrorState with Retry button rendered in totals area |
+| `renders_loading_state_in_table_section_while_items_load` | `usePortfolioAssetSummary` returns `isLoading: true` | Loading indicator rendered in table section |
+| `renders_error_state_in_table_section_on_items_fetch_failure` | `usePortfolioAssetSummary` returns `error` | ErrorState with Retry button rendered in table section; totals section still visible above |
+| `renders_table_with_correct_column_headers` | Both hooks return data | `<th>` elements with text: Asset Name, First Investment, Quantity, Total Invested, % Portfolio, Current Value, % Profit |
+| `renders_asset_row_with_correctly_formatted_values` | Known item (first date, N8 quantity, N2 invested, one-decimal weight) | `assetName`, `firstInvestmentDate` as `DD/MM/YYYY`, `currentQuantity` N8, `totalInvested` N2, `portfolioWeight` as `23.4%` |
+| `renders_per_cell_loading_indicator_while_price_loads` | `rowPrices[0].isLoading: true` | Current Value cell shows `...`; `% Profit` cell shows `...` |
+| `renders_current_value_when_price_resolves` | `rowPrices[0].currentPrice: 10.50`, item `currentQuantity: 25` | Current Value cell contains formatted `262.50` |
+| `renders_correct_profit_percent` | `currentValue: 262.50`, `totalInvested: 250.00` | `% Profit` cell shows formatted `5.00%` |
+| `renders_dash_in_current_value_and_profit_on_price_failure` | `rowPrices[0].fetchFailed: true` | Current Value and `% Profit` cells both show `—` |
+| `renders_dash_in_profit_when_total_invested_is_zero` | `totalInvested: 0`, price available | `% Profit` cell shows `—`; Current Value cell shows computed value |
+| `applies_green_class_to_positive_profit` | `currentValue > totalInvested` | `% Profit` element has `portfolio-summary__profit--green` class |
+| `applies_red_class_to_negative_profit` | `currentValue < totalInvested` | `% Profit` element has `portfolio-summary__profit--red` class |
+| `renders_empty_string_for_null_first_investment_date` | `firstInvestmentDate: null` | First Investment cell content is empty |
+| `totals_section_is_unaffected_when_table_section_errors` | Table error, aggregated summary resolves with data | Three totals (Total Bought, Total Sold, Total Credits) rendered; ErrorState present in table section |
+
+### Acceptance Test Mapping
+
+| PRD Acceptance Criterion (Section 9 — F02) | Covered By |
+|---------------------------------------------|------------|
+| Selecting a Portfolio node renders `PortfolioSummaryTab` | `renders_table_with_correct_column_headers` + `DetailPanel.test.tsx` (regression) |
+| Selecting a Broker node still renders `AggregatedSummaryTab` (regression) | `DetailPanel.test.tsx` existing tests |
+| Selecting an Asset node still renders `AssetSummaryTab` (regression) | `DetailPanel.test.tsx` existing tests |
+| Three totals (green/red/blue) at top | `totals_section_is_unaffected_when_table_section_errors`; colour coverage in existing `AggregatedSummaryTab` tests |
+| Per-asset table with 7 correct columns | `renders_table_with_correct_column_headers` |
+| Current Value and % Profit populate automatically | `renders_current_value_when_price_resolves` + `fires_getCurrentPrice_for_each_item_after_fetch` |
+| Failed price fetch shows `"—"`, other rows unaffected | `renders_dash_in_current_value_and_profit_on_price_failure` + `failed_price_for_one_row_does_not_affect_other_rows` |
+| `% Profit` green when positive, red when negative | `applies_green_class_to_positive_profit` + `applies_red_class_to_negative_profit` |
+| F01 failure shows ErrorState with Retry; totals unaffected | `renders_error_state_in_table_section_on_items_fetch_failure` + `totals_section_is_unaffected_when_table_section_errors` |
+| `CurrentValue = CurrentPrice × CurrentQuantity` | `renders_current_value_when_price_resolves` |
+| `% Profit = (CurrentValue − TotalInvested) / TotalInvested × 100` | `renders_correct_profit_percent` |
+| `"—"` in `% Profit` when `TotalInvested` is 0 | `renders_dash_in_profit_when_total_invested_is_zero` |
+
+### Cross-Feature Integration Tests
+
+| PRD Section 9 — Cross-Feature Criterion | Covered By |
+|------------------------------------------|------------|
+| `ticker` and `exchange` from F01 used without modification in `GET /prices/current` calls | `fires_getCurrentPrice_for_each_item_after_fetch` — asserts exact `exchange` and `ticker` values passed to `getCurrentPrice` |
+| `totalInvested` and `currentQuantity` from F01 used without transformation in `CurrentValue` and `% Profit` computation | `renders_current_value_when_price_resolves` + `renders_correct_profit_percent` — use known F01 field values and verify exact output |


### PR DESCRIPTION
## Summary

- Adds `docs/F02-portfolio-summary-tab-web-frontend/spec.md` — full technical specification for the F02 web frontend feature (7 sections: overview, architecture, decisions, components, API contracts, data model, testing strategy)
- Adds `docs/F02-portfolio-summary-tab-web-frontend/plan.md` — 4-phase implementation plan with 7 numbered steps

## What F02 covers

F02 wires the F01 endpoint into the React frontend by introducing:
- `PortfolioAssetSummaryItemDto` type and `getPortfolioAssetsSummary` API client method
- `usePortfolioAssetSummary` hook with `useReducer`-based per-row price state and parallel price fetches
- `PortfolioSummaryTab` component (totals + per-asset table with independent loading/error handling)
- `DetailPanel.tsx` update to route Portfolio nodes to `PortfolioSummaryTab` instead of `AggregatedSummaryTab`

## Test plan

- [ ] Review spec sections match PRD F02 capabilities, experience, and error handling
- [ ] Verify all PRD Section 9 acceptance criteria are mapped in spec Section 7
- [ ] Verify cross-feature integration criteria (ticker/exchange passthrough, totalInvested/currentQuantity computation) are covered
- [ ] Confirm 4-phase plan order is correct: API Client → Hook → Component → Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)