### PR TITLE
docs(F03): add spec and plan for portfolio summary tab WPF

### DIFF
--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -179,146 +179,261 @@
             <TabControl Grid.Row="1">
                 <!-- Summary Tab -->
                 <TabItem Header="Summary">
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <Grid Margin="10">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="*"/>
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
+                    <TabItem.Resources>
+                        <DataTemplate x:Key="AssetSummaryTemplate">
+                            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                <Grid Margin="10">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
 
-                            <!-- Row 0: Quantity & Average Price -->
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Quantity:" FontWeight="Bold" Margin="0,5"/>
-                            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding AssetDetails.Quantity, Mode=OneWay, StringFormat=N8}" TextAlignment="Right" FontFamily="Consolas" Margin="10,5"/>
+                                    <!-- Row 0: Quantity & Average Price -->
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Quantity:" FontWeight="Bold" Margin="0,5"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding AssetDetails.Quantity, Mode=OneWay, StringFormat=N8}" TextAlignment="Right" FontFamily="Consolas" Margin="10,5"/>
 
-                            <TextBlock Grid.Row="0" Grid.Column="2" Text="Average Price:" FontWeight="Bold" Margin="20,5,0,5"/>
-                            <TextBlock Grid.Row="0" Grid.Column="3" Text="{Binding AssetDetails.AveragePrice, Mode=OneWay, StringFormat=N2}" TextAlignment="Right" FontFamily="Consolas" Margin="10,5"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="2" Text="Average Price:" FontWeight="Bold" Margin="20,5,0,5"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="3" Text="{Binding AssetDetails.AveragePrice, Mode=OneWay, StringFormat=N2}" TextAlignment="Right" FontFamily="Consolas" Margin="10,5"/>
 
-                            <!-- Row 1: ISIN & Country -->
-                            <TextBlock Grid.Row="1" Grid.Column="0" Text="ISIN:" FontWeight="Bold" Margin="0,5"/>
-                            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding AssetDetails.ISIN, Mode=OneWay}" Margin="10,5"/>
-                            <TextBlock Grid.Row="1" Grid.Column="2" Text="Country:" FontWeight="Bold" Margin="20,5,0,5"/>
-                            <TextBlock Grid.Row="1" Grid.Column="3" Text="{Binding AssetDetails.Country, Mode=OneWay}" Margin="10,5"/>
+                                    <!-- Row 1: ISIN & Country -->
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="ISIN:" FontWeight="Bold" Margin="0,5"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding AssetDetails.ISIN, Mode=OneWay}" Margin="10,5"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="2" Text="Country:" FontWeight="Bold" Margin="20,5,0,5"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="3" Text="{Binding AssetDetails.Country, Mode=OneWay}" Margin="10,5"/>
 
-                            <!-- Row 2: Local Type & Asset Class -->
-                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Local Type:" FontWeight="Bold" Margin="0,5"/>
-                            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding AssetDetails.LocalTypeCode, Mode=OneWay}" Margin="10,5"/>
-                            <TextBlock Grid.Row="2" Grid.Column="2" Text="Asset Class:" FontWeight="Bold" Margin="20,5,0,5"/>
-                            <TextBlock Grid.Row="2" Grid.Column="3" Text="{Binding AssetDetails.Class, Mode=OneWay}" Margin="10,5"/>
+                                    <!-- Row 2: Local Type & Asset Class -->
+                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Local Type:" FontWeight="Bold" Margin="0,5"/>
+                                    <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding AssetDetails.LocalTypeCode, Mode=OneWay}" Margin="10,5"/>
+                                    <TextBlock Grid.Row="2" Grid.Column="2" Text="Asset Class:" FontWeight="Bold" Margin="20,5,0,5"/>
+                                    <TextBlock Grid.Row="2" Grid.Column="3" Text="{Binding AssetDetails.Class, Mode=OneWay}" Margin="10,5"/>
 
-                            <!-- Separator -->
-                            <Border Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="4" 
-                                    BorderBrush="#EEEEEE" BorderThickness="0,1,0,0" Margin="0,15,0,15"/>
+                                    <!-- Separator -->
+                                    <Border Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="4"
+                                            BorderBrush="#EEEEEE" BorderThickness="0,1,0,0" Margin="0,15,0,15"/>
 
-                            <!-- Row 4: Total Bought & Total Sold -->
-                            <TextBlock Grid.Row="4" Grid.Column="0" Text="Total Bought:" FontWeight="Bold" Margin="0,5"/>
-                            <TextBlock Grid.Row="4" Grid.Column="1" 
-                                       Text="{Binding AssetDetails.TotalBought, Mode=OneWay, StringFormat=N2}" 
-                                       TextAlignment="Right"
-                                       FontFamily="Consolas"
-                                       Margin="10,5"
-                                       Foreground="Green"/>
+                                    <!-- Row 4: Total Bought & Total Sold -->
+                                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Total Bought:" FontWeight="Bold" Margin="0,5"/>
+                                    <TextBlock Grid.Row="4" Grid.Column="1"
+                                               Text="{Binding AssetDetails.TotalBought, Mode=OneWay, StringFormat=N2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Margin="10,5"
+                                               Foreground="Green"/>
 
-                            <TextBlock Grid.Row="4" Grid.Column="2" Text="Total Sold:" FontWeight="Bold" Margin="20,5,0,5"/>
-                            <TextBlock Grid.Row="4" Grid.Column="3" 
-                                       Text="{Binding AssetDetails.TotalSold, Mode=OneWay, StringFormat=N2}" 
-                                       Margin="10,5"
-                                       Foreground="Red"/>
+                                    <TextBlock Grid.Row="4" Grid.Column="2" Text="Total Sold:" FontWeight="Bold" Margin="20,5,0,5"/>
+                                    <TextBlock Grid.Row="4" Grid.Column="3"
+                                               Text="{Binding AssetDetails.TotalSold, Mode=OneWay, StringFormat=N2}"
+                                               Margin="10,5"
+                                               Foreground="Red"/>
 
-                            <!-- Row 5: Total Credits -->
-                            <TextBlock Grid.Row="5" Grid.Column="0" Text="Total Credits:" FontWeight="Bold" Margin="0,5"/>
-                            <TextBlock Grid.Row="5" Grid.Column="1" 
-                                       Text="{Binding AssetDetails.TotalCredits, Mode=OneWay, StringFormat=N2}" 
-                                       TextAlignment="Right"
-                                       FontFamily="Consolas"
-                                       Margin="10,5"
-                                       Foreground="Blue"/>
+                                    <!-- Row 5: Total Credits -->
+                                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Total Credits:" FontWeight="Bold" Margin="0,5"/>
+                                    <TextBlock Grid.Row="5" Grid.Column="1"
+                                               Text="{Binding AssetDetails.TotalCredits, Mode=OneWay, StringFormat=N2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Margin="10,5"
+                                               Foreground="Blue"/>
 
-                            <!-- Separator -->
-                            <Border Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="4" 
-                                    BorderBrush="#EEEEEE" BorderThickness="0,1,0,0" Margin="0,15,0,15"/>
+                                    <!-- Separator -->
+                                    <Border Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="4"
+                                            BorderBrush="#EEEEEE" BorderThickness="0,1,0,0" Margin="0,15,0,15"/>
 
-                            <!-- Row 7: Current Header -->
-                            <TextBlock Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Text="Current" FontWeight="Bold" FontSize="13" Margin="0,5"/>
-                            <Button Grid.Row="7" Grid.Column="2" Grid.ColumnSpan="2"
-                                    Command="{Binding AssetDetails.RefreshTodayInfoCommand}"
-                                    Content="Refresh"
-                                    HorizontalAlignment="Right"
-                                    Margin="0,5"/>
+                                    <!-- Row 7: Current Header -->
+                                    <TextBlock Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Text="Current" FontWeight="Bold" FontSize="13" Margin="0,5"/>
+                                    <Button Grid.Row="7" Grid.Column="2" Grid.ColumnSpan="2"
+                                            Command="{Binding AssetDetails.RefreshTodayInfoCommand}"
+                                            Content="Refresh"
+                                            HorizontalAlignment="Right"
+                                            Margin="0,5"/>
 
-                            <!-- Row 8: Current Value & As Of -->
-                            <TextBlock Grid.Row="8" Grid.Column="0" Text="Current Value:" FontWeight="Bold" Margin="0,5"/>
-                            <TextBlock Grid.Row="8" Grid.Column="1" 
-                                       Text="{Binding AssetDetails.TodayCurrentValue, Mode=OneWay, StringFormat=N2}" 
-                                       TextAlignment="Right"
-                                       FontFamily="Consolas"
-                                       Margin="10,5"/>
-                            <TextBlock Grid.Row="8" Grid.Column="2" Text="As of:" FontWeight="Bold" Margin="20,5,0,5"/>
-                            <TextBlock Grid.Row="8" Grid.Column="3" 
-                                       Text="{Binding AssetDetails.TodayCurrentValueAsOf, Mode=OneWay}" 
-                                       Margin="10,5"/>
+                                    <!-- Row 8: Current Value & As Of -->
+                                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Current Value:" FontWeight="Bold" Margin="0,5"/>
+                                    <TextBlock Grid.Row="8" Grid.Column="1"
+                                               Text="{Binding AssetDetails.TodayCurrentValue, Mode=OneWay, StringFormat=N2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Margin="10,5"/>
+                                    <TextBlock Grid.Row="8" Grid.Column="2" Text="As of:" FontWeight="Bold" Margin="20,5,0,5"/>
+                                    <TextBlock Grid.Row="8" Grid.Column="3"
+                                               Text="{Binding AssetDetails.TodayCurrentValueAsOf, Mode=OneWay}"
+                                               Margin="10,5"/>
 
-                            <!-- Row 9: Total Current Value & Result % -->
-                            <TextBlock Grid.Row="9" Grid.Column="0" Text="Total Current Value:" FontWeight="Bold" Margin="0,5"
-                                       Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                            <TextBlock Grid.Row="9" Grid.Column="1" 
-                                       Text="{Binding AssetDetails.TotalCurrentValue, Mode=OneWay, StringFormat=N2}" 
-                                       TextAlignment="Right"
-                                       FontFamily="Consolas"
-                                       Margin="10,5"
-                                       Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                            <TextBlock Grid.Row="9" Grid.Column="2" Text="Result %:" FontWeight="Bold" Margin="20,5,0,5"
-                                       Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                            <TextBlock Grid.Row="9" Grid.Column="3" 
-                                       Text="{Binding AssetDetails.ResultPercent, Mode=OneWay, StringFormat=P2}" 
-                                       TextAlignment="Right"
-                                       FontFamily="Consolas"
-                                       Foreground="{Binding AssetDetails.ResultPercent, Converter={StaticResource SignedValueToBrushConverter}}"
-                                       Margin="10,5"
-                                       Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <!-- Row 9: Total Current Value & Result % -->
+                                    <TextBlock Grid.Row="9" Grid.Column="0" Text="Total Current Value:" FontWeight="Bold" Margin="0,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="9" Grid.Column="1"
+                                               Text="{Binding AssetDetails.TotalCurrentValue, Mode=OneWay, StringFormat=N2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Margin="10,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="9" Grid.Column="2" Text="Result %:" FontWeight="Bold" Margin="20,5,0,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="9" Grid.Column="3"
+                                               Text="{Binding AssetDetails.ResultPercent, Mode=OneWay, StringFormat=P2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Foreground="{Binding AssetDetails.ResultPercent, Converter={StaticResource SignedValueToBrushConverter}}"
+                                               Margin="10,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-                            <!-- Row 10: Total Current + Credits & Result % -->
-                            <TextBlock Grid.Row="10" Grid.Column="0" Text="Total Current + Credits:" FontWeight="Bold" Margin="0,5"
-                                       Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                            <TextBlock Grid.Row="10" Grid.Column="1" 
-                                       Text="{Binding AssetDetails.TotalCurrentValueWithCredits, Mode=OneWay, StringFormat=N2}" 
-                                       TextAlignment="Right"
-                                       FontFamily="Consolas"
-                                       Margin="10,5"
-                                       Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                            <TextBlock Grid.Row="10" Grid.Column="2" Text="Result %:" FontWeight="Bold" Margin="20,5,0,5"
-                                       Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                            <TextBlock Grid.Row="10" Grid.Column="3" 
-                                       Text="{Binding AssetDetails.ResultPercentWithCredits, Mode=OneWay, StringFormat=P2}" 
-                                       TextAlignment="Right"
-                                       FontFamily="Consolas"
-                                       Foreground="{Binding AssetDetails.ResultPercentWithCredits, Converter={StaticResource SignedValueToBrushConverter}}"
-                                       Margin="10,5"
-                                       Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <!-- Row 10: Total Current + Credits & Result % -->
+                                    <TextBlock Grid.Row="10" Grid.Column="0" Text="Total Current + Credits:" FontWeight="Bold" Margin="0,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="10" Grid.Column="1"
+                                               Text="{Binding AssetDetails.TotalCurrentValueWithCredits, Mode=OneWay, StringFormat=N2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Margin="10,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="10" Grid.Column="2" Text="Result %:" FontWeight="Bold" Margin="20,5,0,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="10" Grid.Column="3"
+                                               Text="{Binding AssetDetails.ResultPercentWithCredits, Mode=OneWay, StringFormat=P2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Foreground="{Binding AssetDetails.ResultPercentWithCredits, Converter={StaticResource SignedValueToBrushConverter}}"
+                                               Margin="10,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-                            <!-- Row 11: Status/Error -->
-                            <TextBlock Grid.Row="11" Grid.Column="0" Text="Status:" FontWeight="Bold" Margin="0,5"/>
-                            <TextBlock Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="3"
-                                       Text="{Binding AssetDetails.TodayInfoMessage, Mode=OneWay}" 
-                                       Margin="10,5"
-                                       Foreground="DarkRed"/>
-                        </Grid>
-                    </ScrollViewer>
+                                    <!-- Row 11: Status/Error -->
+                                    <TextBlock Grid.Row="11" Grid.Column="0" Text="Status:" FontWeight="Bold" Margin="0,5"/>
+                                    <TextBlock Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="3"
+                                               Text="{Binding AssetDetails.TodayInfoMessage, Mode=OneWay}"
+                                               Margin="10,5"
+                                               Foreground="DarkRed"/>
+                                </Grid>
+                            </ScrollViewer>
+                        </DataTemplate>
+                        <DataTemplate x:Key="PortfolioSummaryTemplate">
+                            <Grid Margin="10">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+
+                                <!-- Aggregated Totals -->
+                                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
+                                    <TextBlock Text="Total Bought:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                    <TextBlock Text="{Binding AssetDetails.TotalBought, Mode=OneWay, StringFormat=N2}"
+                                               FontFamily="Consolas" Foreground="Green" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Total Sold:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                    <TextBlock Text="{Binding AssetDetails.TotalSold, Mode=OneWay, StringFormat=N2}"
+                                               FontFamily="Consolas" Foreground="Red" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Total Credits:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                    <TextBlock Text="{Binding AssetDetails.TotalCredits, Mode=OneWay, StringFormat=N2}"
+                                               FontFamily="Consolas" Foreground="Blue"/>
+                                </StackPanel>
+
+                                <!-- Per-Asset DataGrid -->
+                                <DataGrid Grid.Row="1"
+                                          ItemsSource="{Binding AssetDetails.PortfolioAssetSummaryRows}"
+                                          AutoGenerateColumns="False"
+                                          CanUserAddRows="False"
+                                          IsReadOnly="True">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Asset Name" Binding="{Binding AssetName}" Width="*"/>
+                                        <DataGridTextColumn Header="First Investment" Binding="{Binding DisplayFirstInvestmentDate}" Width="Auto"/>
+                                        <DataGridTextColumn Header="Quantity" Binding="{Binding DisplayCurrentQuantity}" Width="Auto">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                    <Setter Property="FontFamily" Value="Consolas"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Total Invested" Binding="{Binding DisplayTotalInvested}" Width="Auto">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                    <Setter Property="FontFamily" Value="Consolas"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="% Portfolio" Binding="{Binding DisplayPortfolioWeight}" Width="Auto">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                    <Setter Property="FontFamily" Value="Consolas"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTemplateColumn Header="Current Value" Width="Auto">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock FontFamily="Consolas" TextAlignment="Right">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Text" Value="{Binding DisplayCurrentValue}"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsLoadingPrice}" Value="True">
+                                                                        <Setter Property="Text" Value="..."/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+                                        <DataGridTemplateColumn Header="% Profit" Width="Auto">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock FontFamily="Consolas" TextAlignment="Right">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Text" Value="{Binding DisplayProfitPercent}"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsLoadingPrice}" Value="True">
+                                                                        <Setter Property="Text" Value="..."/>
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding ProfitIsPositive}" Value="True">
+                                                                        <Setter Property="Foreground" Value="Green"/>
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding ProfitIsNegative}" Value="True">
+                                                                        <Setter Property="Foreground" Value="Red"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            </Grid>
+                        </DataTemplate>
+                    </TabItem.Resources>
+                    <ContentControl Content="{Binding}">
+                        <ContentControl.Style>
+                            <Style TargetType="ContentControl">
+                                <Setter Property="ContentTemplate" Value="{StaticResource AssetSummaryTemplate}"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding AssetDetails.IsPortfolioView}" Value="True">
+                                        <Setter Property="ContentTemplate" Value="{StaticResource PortfolioSummaryTemplate}"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ContentControl.Style>
+                    </ContentControl>
                 </TabItem>
 
                 <!-- Transactions Tab -->

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -52,6 +52,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private double _creditsPlotWidth;
     private bool _isCreditsAggregateView;
     private bool _hasCreditsContext;
+    private bool _isPortfolioView;
+    private CancellationTokenSource? _rowPriceCts;
     private TransactionDTO? _selectedTransaction;
     private CreditDTO? _selectedCredit;
     private IReadOnlyList<CreditsMonthTypeTotals> _creditsChartMonths = Array.Empty<CreditsMonthTypeTotals>();
@@ -139,6 +141,13 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public decimal ResultPercentWithCredits => AssetDetailsCalculations.CalculateResultPercentWithCredits(AveragePrice, Quantity, TotalCurrentValueWithCredits);
     public bool HasAveragePrice => AssetDetailsCalculations.HasAveragePrice(AveragePrice, Quantity);
 
+    public bool IsPortfolioView
+    {
+        get => _isPortfolioView;
+        private set => SetProperty(ref _isPortfolioView, value);
+    }
+
+    public ObservableCollection<PortfolioAssetSummaryRowViewModel> PortfolioAssetSummaryRows { get; } = new();
     public ObservableCollection<TransactionDTO> Transactions { get; } = new();
     public ObservableCollection<CreditDTO> Credits { get; } = new();
     public ObservableCollection<KeyValuePair<string, decimal>> CreditsByMonthChart { get; } = new();
@@ -207,8 +216,25 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         InitializeCreditsTypeModes();
     }
 
+    public void LoadPortfolioSummary(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits, IReadOnlyList<PortfolioAssetSummaryItemDTO> assetItems)
+    {
+        CancelAndResetRowPriceFetch();
+        LoadAggregateCredits(BuildPortfolioKey(brokerName, portfolioName), summary, credits);
+        IsPortfolioView = true;
+
+        PortfolioAssetSummaryRows.Clear();
+        foreach (var item in assetItems)
+            PortfolioAssetSummaryRows.Add(new PortfolioAssetSummaryRowViewModel(item));
+
+        var rows = PortfolioAssetSummaryRows.ToList();
+        _rowPriceCts = new CancellationTokenSource();
+        var token = _rowPriceCts.Token;
+        FetchRowPricesAsync(rows, token);
+    }
+
     public void LoadAssetDetails(AssetDetailsDTO details)
     {
+        IsPortfolioView = false;
         var assetKey = BuildAssetKey(details.BrokerName, details.PortfolioName, details.Name);
         _todayInfo.UpdateAssetKey(assetKey);
 
@@ -247,6 +273,9 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
 
     public void Clear()
     {
+        CancelAndResetRowPriceFetch();
+        PortfolioAssetSummaryRows.Clear();
+        IsPortfolioView = false;
         ClearAssetContext();
         Credits.Clear();
         CreditsByMonthChart.Clear();
@@ -329,6 +358,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
 
     private void LoadAggregateCredits(string contextKey, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
     {
+        IsPortfolioView = false;
         ClearAssetContext();
         TotalBought = summary.TotalBought;
         TotalSold = summary.TotalSold;
@@ -345,6 +375,36 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         SelectedTransaction = null;
         SelectedCredit = null;
         UpdateCommandStates();
+    }
+
+    private void FetchRowPricesAsync(IReadOnlyList<PortfolioAssetSummaryRowViewModel> rows, CancellationToken cancellationToken)
+    {
+        foreach (var row in rows)
+        {
+            var capturedRow = row;
+            Task.Run(() =>
+            {
+                try
+                {
+                    if (cancellationToken.IsCancellationRequested) return;
+                    var price = _assetPriceService.GetCurrentPrice(new Application.DTOs.AssetPriceRequestDTO { Exchange = capturedRow.Exchange, Ticker = capturedRow.Ticker });
+                    if (cancellationToken.IsCancellationRequested) return;
+                    capturedRow.ApplyPrice(price.Price);
+                }
+                catch
+                {
+                    if (!cancellationToken.IsCancellationRequested)
+                        capturedRow.MarkPriceFailed();
+                }
+            }, cancellationToken);
+        }
+    }
+
+    private void CancelAndResetRowPriceFetch()
+    {
+        _rowPriceCts?.Cancel();
+        _rowPriceCts?.Dispose();
+        _rowPriceCts = null;
     }
 
     private void ClearAssetContext()

--- a/Financial.App/ViewModels/IAssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/IAssetDetailsViewModel.cs
@@ -4,9 +4,11 @@ namespace Financial.Presentation.App.ViewModels;
 
 public interface IAssetDetailsViewModel
 {
+    bool IsPortfolioView { get; }
     void LoadAssetDetails(AssetDetailsDTO details);
     void LoadBrokerCredits(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
     void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
+    void LoadPortfolioSummary(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits, IReadOnlyList<PortfolioAssetSummaryItemDTO> assetItems);
     void Clear();
     Task EnsureTodayInfoLoadedAsync();
     void UpdateCreditsPlotWidth(double plotWidth);

--- a/Financial.App/ViewModels/MainNavigationViewModel.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModel.cs
@@ -11,6 +11,7 @@ public class MainNavigationViewModel : MainNavigationViewModelBase<AssetDetailsV
         INavigationService navigationService,
         ICreditQueryService creditQueryService,
         ISummaryQueryService summaryQueryService,
+        IPortfolioAssetSummaryQueryService portfolioAssetSummaryQueryService,
         ITransactionService transactionService,
         ICreditService creditService,
         IAssetPriceService assetPriceService)
@@ -18,6 +19,7 @@ public class MainNavigationViewModel : MainNavigationViewModelBase<AssetDetailsV
             navigationService ?? throw new ArgumentNullException(nameof(navigationService)),
             creditQueryService ?? throw new ArgumentNullException(nameof(creditQueryService)),
             summaryQueryService ?? throw new ArgumentNullException(nameof(summaryQueryService)),
+            portfolioAssetSummaryQueryService ?? throw new ArgumentNullException(nameof(portfolioAssetSummaryQueryService)),
             new AssetDetailsViewModel(
                 transactionService ?? throw new ArgumentNullException(nameof(transactionService)),
                 creditService ?? throw new ArgumentNullException(nameof(creditService)),

--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -14,6 +14,7 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
     private readonly INavigationService _navigationService;
     private readonly ICreditQueryService _creditQueryService;
     private readonly ISummaryQueryService _summaryQueryService;
+    private readonly IPortfolioAssetSummaryQueryService _portfolioAssetSummaryQueryService;
     private TreeNodeViewModel? _selectedNode;
     private bool _isLoading;
     private TreeNodeDTO? _fullTree;
@@ -58,11 +59,13 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
         INavigationService navigationService,
         ICreditQueryService creditQueryService,
         ISummaryQueryService summaryQueryService,
+        IPortfolioAssetSummaryQueryService portfolioAssetSummaryQueryService,
         TAssetDetailsViewModel assetDetails)
     {
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
         _creditQueryService = creditQueryService ?? throw new ArgumentNullException(nameof(creditQueryService));
         _summaryQueryService = summaryQueryService ?? throw new ArgumentNullException(nameof(summaryQueryService));
+        _portfolioAssetSummaryQueryService = portfolioAssetSummaryQueryService ?? throw new ArgumentNullException(nameof(portfolioAssetSummaryQueryService));
         AssetDetails = assetDetails ?? throw new ArgumentNullException(nameof(assetDetails));
         InitializeAssetClassFilters();
     }
@@ -273,7 +276,8 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
 
         var summary = _summaryQueryService.GetPortfolioSummary(brokerName, portfolioName);
         var credits = _creditQueryService.GetCreditsByPortfolio(brokerName, portfolioName);
-        AssetDetails.LoadPortfolioCredits(brokerName, portfolioName, summary, credits);
+        var assetItems = _portfolioAssetSummaryQueryService.GetPortfolioAssetsSummary(brokerName, portfolioName);
+        AssetDetails.LoadPortfolioSummary(brokerName, portfolioName, summary, credits, assetItems);
     }
 
     private void LoadBrokerCredits(TreeNodeViewModel brokerNode)

--- a/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
+++ b/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
@@ -1,0 +1,75 @@
+using Financial.Application.DTOs;
+
+namespace Financial.Presentation.App.ViewModels;
+
+public class PortfolioAssetSummaryRowViewModel : ViewModelBase
+{
+    private bool _isLoadingPrice = true;
+    private bool _priceFetchFailed;
+    private decimal? _currentValue;
+    private decimal? _profitPercent;
+
+    public string AssetName { get; }
+    public string Ticker { get; }
+    public string Exchange { get; }
+    public DateTime? FirstInvestmentDate { get; }
+    public decimal CurrentQuantity { get; }
+    public decimal TotalInvested { get; }
+    public decimal PortfolioWeight { get; }
+
+    public bool IsLoadingPrice => _isLoadingPrice;
+    public bool PriceFetchFailed => _priceFetchFailed;
+    public decimal? CurrentValue => _currentValue;
+    public decimal? ProfitPercent => _profitPercent;
+
+    public string DisplayFirstInvestmentDate =>
+        FirstInvestmentDate.HasValue ? FirstInvestmentDate.Value.ToString("dd/MM/yyyy") : string.Empty;
+
+    public string DisplayCurrentQuantity => CurrentQuantity.ToString("N8");
+    public string DisplayTotalInvested => TotalInvested.ToString("N2");
+    public string DisplayPortfolioWeight => $"{PortfolioWeight:F1}%";
+
+    public string DisplayCurrentValue =>
+        _isLoadingPrice || _priceFetchFailed || !_currentValue.HasValue ? "—" : _currentValue.Value.ToString("N2");
+
+    public string DisplayProfitPercent =>
+        _isLoadingPrice || _priceFetchFailed || !_profitPercent.HasValue ? "—" : $"{_profitPercent.Value:F2}%";
+
+    public bool ProfitIsPositive => _currentValue.HasValue && _currentValue.Value > TotalInvested;
+    public bool ProfitIsNegative => _currentValue.HasValue && _currentValue.Value < TotalInvested;
+
+    public PortfolioAssetSummaryRowViewModel(PortfolioAssetSummaryItemDTO dto)
+    {
+        AssetName = dto.AssetName;
+        Ticker = dto.Ticker;
+        Exchange = dto.Exchange;
+        FirstInvestmentDate = dto.FirstInvestmentDate;
+        CurrentQuantity = dto.CurrentQuantity;
+        TotalInvested = dto.TotalInvested;
+        PortfolioWeight = dto.PortfolioWeight;
+    }
+
+    public void ApplyPrice(decimal price)
+    {
+        _currentValue = price * CurrentQuantity;
+        _profitPercent = TotalInvested != 0
+            ? (_currentValue.Value - TotalInvested) / TotalInvested * 100
+            : (decimal?)null;
+        _isLoadingPrice = false;
+        OnPropertyChanged(nameof(IsLoadingPrice));
+        OnPropertyChanged(nameof(DisplayCurrentValue));
+        OnPropertyChanged(nameof(DisplayProfitPercent));
+        OnPropertyChanged(nameof(ProfitIsPositive));
+        OnPropertyChanged(nameof(ProfitIsNegative));
+    }
+
+    public void MarkPriceFailed()
+    {
+        _isLoadingPrice = false;
+        _priceFetchFailed = true;
+        OnPropertyChanged(nameof(IsLoadingPrice));
+        OnPropertyChanged(nameof(PriceFetchFailed));
+        OnPropertyChanged(nameof(DisplayCurrentValue));
+        OnPropertyChanged(nameof(DisplayProfitPercent));
+    }
+}

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
@@ -1,0 +1,149 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class AssetDetailsViewModelPortfolioSummaryTests
+{
+    private static AssetDetailsViewModel BuildViewModel(IAssetPriceService? priceService = null)
+    {
+        return new AssetDetailsViewModel(
+            new StubTransactionService(),
+            new StubCreditService(),
+            priceService ?? new NeverResolvingPriceService());
+    }
+
+    private static IReadOnlyList<PortfolioAssetSummaryItemDTO> BuildItems(int count = 2)
+    {
+        return Enumerable.Range(1, count).Select(i => new PortfolioAssetSummaryItemDTO
+        {
+            AssetName = $"Asset {i}",
+            Ticker = $"T{i}",
+            Exchange = "LSE",
+            CurrentQuantity = 10m * i,
+            TotalBought = 1000m * i,
+            TotalSold = 0m,
+            TotalInvested = 1000m * i,
+            PortfolioWeight = 50m
+        }).ToList();
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_SetsIsPortfolioViewTrue()
+    {
+        var vm = BuildViewModel();
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], BuildItems());
+        vm.IsPortfolioView.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_PopulatesPortfolioAssetSummaryRows()
+    {
+        var vm = BuildViewModel();
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], BuildItems(2));
+        vm.PortfolioAssetSummaryRows.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_RowsAreInCorrectOrder()
+    {
+        var vm = BuildViewModel();
+        var items = BuildItems(2);
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], items);
+        vm.PortfolioAssetSummaryRows[0].AssetName.Should().Be(items[0].AssetName);
+        vm.PortfolioAssetSummaryRows[1].AssetName.Should().Be(items[1].AssetName);
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_SetsAggregatedTotals()
+    {
+        var vm = BuildViewModel();
+        var summary = new AggregatedSummaryDTO { TotalBought = 10000m, TotalSold = 2000m };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", summary, [], BuildItems());
+        vm.TotalBought.Should().Be(10000m);
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_LoadsCreditsForCreditsTab()
+    {
+        var vm = BuildViewModel();
+        var credits = new List<CreditDTO>
+        {
+            new() { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Dividend", Value = 100m },
+            new() { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Interest", Value = 50m }
+        };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), credits, BuildItems());
+        vm.Credits.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_RowsInitiallyShowLoadingPrice()
+    {
+        var vm = BuildViewModel(new NeverResolvingPriceService());
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], BuildItems(3));
+        vm.PortfolioAssetSummaryRows.All(r => r.IsLoadingPrice).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Clear_AfterLoadPortfolioSummary_ClearsRows()
+    {
+        var vm = BuildViewModel();
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], BuildItems(2));
+        vm.Clear();
+        vm.PortfolioAssetSummaryRows.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Clear_AfterLoadPortfolioSummary_SetsIsPortfolioViewFalse()
+    {
+        var vm = BuildViewModel();
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], BuildItems());
+        vm.Clear();
+        vm.IsPortfolioView.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LoadAssetDetails_AfterPortfolioSummary_SetsIsPortfolioViewFalse()
+    {
+        var vm = BuildViewModel();
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], BuildItems());
+        vm.LoadAssetDetails(new AssetDetailsDTO
+        {
+            Name = "Asset A", BrokerName = "Broker", PortfolioName = "Portfolio",
+            Ticker = "T", ISIN = "", Exchange = "LSE",
+            Country = Financial.Domain.Entities.CountryCode.Unknown,
+            LocalTypeCode = "", Class = Financial.Domain.Entities.GlobalAssetClass.Unknown,
+            Quantity = 0m, AveragePrice = 0m, IsActive = true,
+            TotalBought = 0m, TotalSold = 0m, TotalCredits = 0m,
+            Transactions = [], Credits = []
+        });
+        vm.IsPortfolioView.Should().BeFalse();
+    }
+
+    private sealed class NeverResolvingPriceService : IAssetPriceService
+    {
+        private readonly SemaphoreSlim _blocker = new SemaphoreSlim(0);
+
+        public AssetPriceDTO GetCurrentPrice(AssetPriceRequestDTO request)
+        {
+            _blocker.Wait();
+            return new AssetPriceDTO { Exchange = request.Exchange, Ticker = request.Ticker, Price = 0m };
+        }
+    }
+
+    private sealed class StubTransactionService : ITransactionService
+    {
+        public Task<AssetDetailsDTO?> AddTransactionAsync(TransactionCreateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> UpdateTransactionAsync(TransactionUpdateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> DeleteTransactionAsync(TransactionDeleteDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+    }
+
+    private sealed class StubCreditService : ICreditService
+    {
+        public Task<AssetDetailsDTO?> AddCreditAsync(CreditCreateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> UpdateCreditAsync(CreditUpdateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> DeleteCreditAsync(CreditDeleteDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+    }
+}

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -81,6 +81,69 @@ public class MainNavigationViewModelBaseTests
         spy.LastPortfolioSummary.Should().BeNull();
     }
 
+    [Fact]
+    public void SelectingPortfolioNode_CallsLoadPortfolioSummaryOnDetailsViewModel()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var portfolioNode = BuildPortfolioNode("XPI", "FII");
+        vm.SelectedNode = portfolioNode;
+
+        spy.WasPortfolioSummaryLoaded.Should().BeTrue();
+        spy.LastPortfolioSummary.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void SelectingPortfolioNode_PassesCorrectAssetItemsFromService()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var assetSummaryService = new StubPortfolioAssetSummaryQueryService
+        {
+            Items =
+            [
+                new PortfolioAssetSummaryItemDTO { AssetName = "A", Ticker = "A", Exchange = "LSE", TotalInvested = 100m },
+                new PortfolioAssetSummaryItemDTO { AssetName = "B", Ticker = "B", Exchange = "LSE", TotalInvested = 200m }
+            ]
+        };
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy, assetSummaryService);
+
+        var portfolioNode = BuildPortfolioNode("XPI", "FII");
+        vm.SelectedNode = portfolioNode;
+
+        spy.LastPortfolioAssetItems.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void SelectingPortfolioNode_PassesCorrectBrokerAndPortfolioNameToAssetSummaryService()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var assetSummaryService = new StubPortfolioAssetSummaryQueryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy, assetSummaryService);
+
+        var portfolioNode = BuildPortfolioNode("XPI", "FII");
+        vm.SelectedNode = portfolioNode;
+
+        assetSummaryService.LastBrokerName.Should().Be("XPI");
+        assetSummaryService.LastPortfolioName.Should().Be("FII");
+    }
+
+    [Fact]
+    public void SelectingBrokerNode_DoesNotCallLoadPortfolioSummary()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var brokerNode = BuildBrokerNode("XPI");
+        vm.SelectedNode = brokerNode;
+
+        spy.WasPortfolioSummaryLoaded.Should().BeFalse();
+    }
+
     private static TreeNodeViewModel BuildPortfolioNode(string brokerName, string portfolioName)
     {
         var brokerDto = new TreeNodeDTO
@@ -130,8 +193,8 @@ public class MainNavigationViewModelBaseTests
 
     private sealed class TestableNavigationViewModel : MainNavigationViewModelBase<SpyAssetDetailsViewModel>
     {
-        public TestableNavigationViewModel(ISummaryQueryService summaryQueryService, SpyAssetDetailsViewModel spy)
-            : base(new StubNavigationService(), new StubCreditQueryService(), summaryQueryService, spy)
+        public TestableNavigationViewModel(ISummaryQueryService summaryQueryService, SpyAssetDetailsViewModel spy, IPortfolioAssetSummaryQueryService? portfolioAssetSummaryQueryService = null)
+            : base(new StubNavigationService(), new StubCreditQueryService(), summaryQueryService, portfolioAssetSummaryQueryService ?? new StubPortfolioAssetSummaryQueryService(), spy)
         {
         }
     }
@@ -140,7 +203,10 @@ public class MainNavigationViewModelBaseTests
     {
         public AggregatedSummaryDTO? LastPortfolioSummary { get; private set; }
         public AggregatedSummaryDTO? LastBrokerSummary { get; private set; }
+        public IReadOnlyList<PortfolioAssetSummaryItemDTO>? LastPortfolioAssetItems { get; private set; }
         public bool WasCleared { get; private set; }
+        public bool WasPortfolioSummaryLoaded { get; private set; }
+        public bool IsPortfolioView => false;
 
         public void LoadAssetDetails(AssetDetailsDTO details) { }
 
@@ -149,14 +215,32 @@ public class MainNavigationViewModelBaseTests
             LastBrokerSummary = summary;
         }
 
-        public void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
+        public void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits) { }
+
+        public void LoadPortfolioSummary(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits, IReadOnlyList<PortfolioAssetSummaryItemDTO> assetItems)
         {
             LastPortfolioSummary = summary;
+            LastPortfolioAssetItems = assetItems;
+            WasPortfolioSummaryLoaded = true;
         }
 
         public void Clear() => WasCleared = true;
         public Task EnsureTodayInfoLoadedAsync() => Task.CompletedTask;
         public void UpdateCreditsPlotWidth(double plotWidth) { }
+    }
+
+    private sealed class StubPortfolioAssetSummaryQueryService : IPortfolioAssetSummaryQueryService
+    {
+        public IReadOnlyList<PortfolioAssetSummaryItemDTO> Items { get; set; } = [];
+        public string? LastBrokerName { get; private set; }
+        public string? LastPortfolioName { get; private set; }
+
+        public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName)
+        {
+            LastBrokerName = brokerName;
+            LastPortfolioName = portfolioName;
+            return Items;
+        }
     }
 
     private sealed class StubSummaryQueryService : ISummaryQueryService

--- a/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
@@ -1,0 +1,184 @@
+using Financial.Application.DTOs;
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class PortfolioAssetSummaryRowViewModelTests
+{
+    private static PortfolioAssetSummaryRowViewModel BuildRow(
+        decimal currentQuantity = 25m,
+        decimal totalInvested = 250m,
+        decimal portfolioWeight = 0m,
+        DateTime? firstInvestmentDate = null)
+    {
+        var dto = new PortfolioAssetSummaryItemDTO
+        {
+            AssetName = "Test Asset",
+            Ticker = "TST",
+            Exchange = "LSE",
+            FirstInvestmentDate = firstInvestmentDate,
+            CurrentQuantity = currentQuantity,
+            TotalBought = totalInvested,
+            TotalSold = 0m,
+            TotalInvested = totalInvested,
+            PortfolioWeight = portfolioWeight
+        };
+        return new PortfolioAssetSummaryRowViewModel(dto);
+    }
+
+    [Fact]
+    public void DisplayFirstInvestmentDate_WhenDateIsSet_ReturnsShortDateString()
+    {
+        var row = BuildRow(firstInvestmentDate: new DateTime(2021, 3, 1));
+        row.DisplayFirstInvestmentDate.Should().Be("01/03/2021");
+    }
+
+    [Fact]
+    public void DisplayFirstInvestmentDate_WhenDateIsNull_ReturnsEmptyString()
+    {
+        var row = BuildRow(firstInvestmentDate: null);
+        row.DisplayFirstInvestmentDate.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void DisplayCurrentQuantity_FormatsN8()
+    {
+        var row = BuildRow(currentQuantity: 25.0m);
+        row.DisplayCurrentQuantity.Should().Be("25.00000000");
+    }
+
+    [Fact]
+    public void DisplayTotalInvested_FormatsN2()
+    {
+        var row = BuildRow(totalInvested: 2500.5m);
+        row.DisplayTotalInvested.Should().Be("2,500.50");
+    }
+
+    [Fact]
+    public void DisplayPortfolioWeight_FormatsOneDecimalPercent()
+    {
+        var dto = new PortfolioAssetSummaryItemDTO
+        {
+            AssetName = "Test", Ticker = "T", Exchange = "E",
+            CurrentQuantity = 1m, TotalBought = 1m, TotalSold = 0m,
+            TotalInvested = 1m, PortfolioWeight = 23.4567m
+        };
+        var row = new PortfolioAssetSummaryRowViewModel(dto);
+        row.DisplayPortfolioWeight.Should().Be("23.5%");
+    }
+
+    [Fact]
+    public void DisplayCurrentValue_WhenIsLoadingPrice_ReturnsDash()
+    {
+        var row = BuildRow();
+        row.IsLoadingPrice.Should().BeTrue();
+        row.DisplayCurrentValue.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayCurrentValue_WhenPriceFetchFailed_ReturnsDash()
+    {
+        var row = BuildRow();
+        row.MarkPriceFailed();
+        row.DisplayCurrentValue.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayCurrentValue_AfterApplyPrice_ReturnsComputedValueN2()
+    {
+        var row = BuildRow(currentQuantity: 25m);
+        row.ApplyPrice(10.50m);
+        row.DisplayCurrentValue.Should().Be("262.50");
+    }
+
+    [Fact]
+    public void DisplayProfitPercent_WhenIsLoadingPrice_ReturnsDash()
+    {
+        var row = BuildRow();
+        row.IsLoadingPrice.Should().BeTrue();
+        row.DisplayProfitPercent.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayProfitPercent_WhenPriceFetchFailed_ReturnsDash()
+    {
+        var row = BuildRow();
+        row.MarkPriceFailed();
+        row.DisplayProfitPercent.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayProfitPercent_WhenTotalInvestedIsZero_ReturnsDash()
+    {
+        var row = BuildRow(totalInvested: 0m);
+        row.ApplyPrice(10.50m);
+        row.DisplayProfitPercent.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayProfitPercent_AfterApplyPrice_ReturnsFormattedPercent()
+    {
+        var row = BuildRow(currentQuantity: 25m, totalInvested: 250m);
+        row.ApplyPrice(10.50m);
+        row.DisplayProfitPercent.Should().Be("5.00%");
+    }
+
+    [Fact]
+    public void ProfitIsPositive_WhenCurrentValueExceedsTotalInvested_IsTrue()
+    {
+        var row = BuildRow(currentQuantity: 25m, totalInvested: 250m);
+        row.ApplyPrice(10.50m); // CurrentValue = 262.50 > 250
+        row.ProfitIsPositive.Should().BeTrue();
+        row.ProfitIsNegative.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ProfitIsNegative_WhenCurrentValueBelowTotalInvested_IsTrue()
+    {
+        var row = BuildRow(currentQuantity: 25m, totalInvested: 300m);
+        row.ApplyPrice(10.00m); // CurrentValue = 250 < 300
+        row.ProfitIsNegative.Should().BeTrue();
+        row.ProfitIsPositive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ProfitIsPositive_WhenPriceUnavailable_IsFalse()
+    {
+        var row = BuildRow();
+        row.MarkPriceFailed();
+        row.ProfitIsPositive.Should().BeFalse();
+        row.ProfitIsNegative.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ApplyPrice_RaisesPropertyChangedForDisplayProperties()
+    {
+        var row = BuildRow();
+        var raised = new List<string?>();
+        row.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        row.ApplyPrice(10.50m);
+
+        raised.Should().Contain(nameof(row.DisplayCurrentValue));
+        raised.Should().Contain(nameof(row.DisplayProfitPercent));
+        raised.Should().Contain(nameof(row.IsLoadingPrice));
+        raised.Should().Contain(nameof(row.ProfitIsPositive));
+        raised.Should().Contain(nameof(row.ProfitIsNegative));
+    }
+
+    [Fact]
+    public void MarkPriceFailed_RaisesPropertyChangedForDisplayProperties()
+    {
+        var row = BuildRow();
+        var raised = new List<string?>();
+        row.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        row.MarkPriceFailed();
+
+        raised.Should().Contain(nameof(row.DisplayCurrentValue));
+        raised.Should().Contain(nameof(row.DisplayProfitPercent));
+        raised.Should().Contain(nameof(row.PriceFetchFailed));
+        raised.Should().Contain(nameof(row.IsLoadingPrice));
+    }
+}

--- a/docs/F03-portfolio-summary-tab-wpf/plan.md
+++ b/docs/F03-portfolio-summary-tab-wpf/plan.md
@@ -1,0 +1,40 @@
+# Implementation Plan: F03 — Portfolio Summary Tab — WPF
+
+**Prerequisites:**
+- F01 (`IPortfolioAssetSummaryQueryService` and `GetPortfolioAssetsSummary`) already implemented and registered in DI (`ApplicationServiceCollectionExtensions`)
+- `IAssetPriceService` already available in `AssetDetailsViewModel`
+- xUnit and FluentAssertions already in use in `Financial.Presentation.Tests`
+
+---
+
+### Phase 1: Row ViewModel
+
+**1. PortfolioAssetSummaryRowViewModel** — Create `Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs` extending `ViewModelBase`. The class holds static values from `PortfolioAssetSummaryItemDTO` and tracks async price state via `IsLoadingPrice`, `PriceFetchFailed`, and nullable `CurrentValue`/`ProfitPercent`. Expose computed display strings and the `ProfitIsPositive`/`ProfitIsNegative` bool properties used for colour data-triggers in XAML. Include `ApplyPrice(decimal)` and `MarkPriceFailed()` methods that update state and raise `PropertyChanged`. See spec Section 4 for the complete property list and Section 7 for formatting rules.
+
+---
+
+### Phase 2: ViewModel and Interface
+
+**2. IAssetDetailsViewModel Extension** — Add `IsPortfolioView` (bool, read-only) and `LoadPortfolioSummary(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits, IReadOnlyList<PortfolioAssetSummaryItemDTO> assetItems)` to the `IAssetDetailsViewModel` interface. See spec Section 4 for the complete signature.
+
+**3. AssetDetailsViewModel — Portfolio Summary** — Add `IsPortfolioView` and `PortfolioAssetSummaryRows` (`ObservableCollection<PortfolioAssetSummaryRowViewModel>`) to `AssetDetailsViewModel`. Implement `LoadPortfolioSummary`: set `IsPortfolioView = true`, populate `PortfolioAssetSummaryRows` from the item list (same pattern as `Credits.Clear()` / `Add()`), and start background price fetch per row. Add `FetchRowPricesAsync` using a `CancellationTokenSource` that is cancelled and replaced on each new `LoadPortfolioSummary` call. Each row calls `IAssetPriceService.GetCurrentPrice` via `Task.Run`, then calls `ApplyPrice` or `MarkPriceFailed` on the row VM. Update `Clear()` to also cancel pending fetches, clear `PortfolioAssetSummaryRows`, and reset `IsPortfolioView`. Update `LoadAssetDetails` and `LoadAggregateCredits` to set `IsPortfolioView = false`. See spec Sections 3 and 4 for the cancellation and data-flow approach.
+
+**4. MainNavigationViewModelBase — Portfolio Asset Summary** — Add `IPortfolioAssetSummaryQueryService` as a constructor parameter to `MainNavigationViewModelBase<T>`. In the private `LoadPortfolioCredits` method (which handles Portfolio node selection), call `GetPortfolioAssetsSummary(brokerName, portfolioName)` and then call `AssetDetails.LoadPortfolioSummary(...)` passing the summary, credits, and item list. See spec Section 4. Update `MainNavigationViewModel` to accept and forward the new parameter; DI resolution is automatic as the service is already registered.
+
+---
+
+### Phase 3: XAML
+
+**5. NavigationView.xaml — Summary Tab Refactor** — Inside the Summary `TabItem`, move the existing content grid into a named `DataTemplate` resource (`AssetSummaryTemplate`). Create a new `PortfolioSummaryTemplate` DataTemplate containing: (a) a panel with three `TextBlock` labels for Total Bought (green), Total Sold (red), and Total Credits (blue) bound to `AssetDetails` properties; and (b) a read-only `DataGrid` bound to `AssetDetails.PortfolioAssetSummaryRows` with `IsReadOnly="True"`, `CanUserAddRows="False"`, and no `InputBindings`. Wrap the tab body in a `ContentControl` whose `ContentTemplate` defaults to `AssetSummaryTemplate` and switches to `PortfolioSummaryTemplate` via a `DataTrigger` on `AssetDetails.IsPortfolioView = True`. See spec Sections 3 and 4 for the DataTemplate switching pattern and DataGrid column specification.
+
+**6. DataGrid Columns** — Define DataGrid columns in the `PortfolioSummaryTemplate`: `Asset Name` (`DataGridTextColumn`, binds `AssetName`), `First Investment` (`DataGridTextColumn`, binds `DisplayFirstInvestmentDate`), `Quantity` (`DataGridTextColumn`, binds `DisplayCurrentQuantity`, right-aligned), `Total Invested` (`DataGridTextColumn`, binds `DisplayTotalInvested`, right-aligned), `% Portfolio` (`DataGridTextColumn`, binds `DisplayPortfolioWeight`, right-aligned), `Current Value` (`DataGridTemplateColumn` with `DataTrigger` on `IsLoadingPrice` to show `"..."`, otherwise `DisplayCurrentValue`), and `% Profit` (`DataGridTemplateColumn` with `DataTrigger` on `IsLoadingPrice` for `"..."`, otherwise `DisplayProfitPercent` with `DataTrigger` on `ProfitIsPositive`/`ProfitIsNegative` to set `Foreground`). See spec Section 7 (acceptance criteria) for exact display formats.
+
+---
+
+### Phase 4: Tests
+
+**7. PortfolioAssetSummaryRowViewModel Tests** — Create `Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs`. Cover display formatting for all fields, `ApplyPrice`/`MarkPriceFailed` state transitions, `ProfitIsPositive`/`ProfitIsNegative` values, zero `TotalInvested` edge case, and `PropertyChanged` events raised on state-changing methods. See spec Section 7 for the complete test function list.
+
+**8. AssetDetailsViewModel Portfolio Summary Tests** — Create `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs`. Use a stub `IAssetPriceService` that never completes to avoid async side effects. Cover `LoadPortfolioSummary` populating rows, `IsPortfolioView` toggling, `Clear()` reset, and regression checks that `LoadAssetDetails` resets `IsPortfolioView`. See spec Section 7 for the complete test function list.
+
+**9. MainNavigationViewModelBaseTests Extension** — Add the four new test cases to `MainNavigationViewModelBaseTests.cs`: portfolio node calls `LoadPortfolioSummary` with correct items, correct broker/portfolio names forwarded to the service, and broker node does not trigger `LoadPortfolioSummary`. Extend `SpyAssetDetailsViewModel` to implement the new interface method, and add `StubPortfolioAssetSummaryQueryService`. See spec Section 7 for the complete test function list.

--- a/docs/F03-portfolio-summary-tab-wpf/spec.md
+++ b/docs/F03-portfolio-summary-tab-wpf/spec.md
@@ -1,0 +1,180 @@
+# Spec: F03 — Portfolio Summary Tab — WPF
+
+## 1. Technical Overview
+
+**What:** Modifies the WPF desktop application's Summary tab to show a portfolio-specific layout when a Portfolio node is selected. The new layout hides all asset-only fields (Quantity, Average Price, ISIN, Country, Local Type, Asset Class, Current Value section, Status) and renders instead: (1) three colour-coded aggregate totals (Total Bought in green, Total Sold in red, Total Credits in blue) and (2) a read-only DataGrid listing every asset in the portfolio alongside its key performance metrics, with current prices fetched asynchronously per row from the existing `IAssetPriceService`.
+
+**Why:** The current `AssetDetailsViewModel.LoadPortfolioCredits` sets up the three aggregated totals but drives the same XAML layout as an individual asset, showing meaningless Quantity, Average Price, and ISIN fields. F01 now provides per-asset summary data via `IPortfolioAssetSummaryQueryService`; this feature wires that data into the WPF presentation layer with automatic background price enrichment per row, following the same MVVM and async patterns already established in `TodayInfoTracker` and `AssetDetailsViewModel`.
+
+**Scope:**
+
+Included:
+- `PortfolioAssetSummaryRowViewModel` in `Financial.App/ViewModels/` — per-row state with `INotifyPropertyChanged` for incremental price updates
+- `IAssetDetailsViewModel` modification — new `LoadPortfolioSummary` method and `IsPortfolioView` property
+- `AssetDetailsViewModel` modification — `LoadPortfolioSummary` implementation, `ObservableCollection<PortfolioAssetSummaryRowViewModel>`, per-row background price fetch with cancellation
+- `MainNavigationViewModelBase<T>` modification — inject `IPortfolioAssetSummaryQueryService`, call `LoadPortfolioSummary` instead of `LoadPortfolioCredits` for Portfolio nodes
+- `MainNavigationViewModel` modification — pass `IPortfolioAssetSummaryQueryService` to base constructor
+- `NavigationView.xaml` modification — Summary tab DataTemplate switching via `ContentControl` and `DataTrigger` on `IsPortfolioView`
+- Unit tests for `PortfolioAssetSummaryRowViewModel` and for `AssetDetailsViewModel` portfolio behaviour
+
+Excluded:
+- Broker-level per-asset breakdown (no change to the three-totals layout for Broker nodes)
+- Credits tab layout (unchanged for all node types)
+- Transactions tab layout (unchanged for all node types)
+- Column sorting or filtering in the DataGrid
+- Row click or double-click actions (DataGrid is read-only)
+- Currency conversion
+
+---
+
+## 2. Architecture Impact
+
+**Affected components:**
+
+```mermaid
+graph TD
+    User["User selects Portfolio node"] --> BaseVM["MainNavigationViewModelBase (modified)"]
+    BaseVM --> SummaryQS["ISummaryQueryService (unchanged)"]
+    BaseVM --> CreditQS["ICreditQueryService (unchanged)"]
+    BaseVM --> PortfolioAssetQS["IPortfolioAssetSummaryQueryService (injected)"]
+    BaseVM --> IAssetDetailsVM["IAssetDetailsViewModel.LoadPortfolioSummary (new method)"]
+    IAssetDetailsVM --> AssetDetailsVM["AssetDetailsViewModel (modified)"]
+    AssetDetailsVM --> RowVM["PortfolioAssetSummaryRowViewModel x N (new)"]
+    RowVM --> PriceService["IAssetPriceService (per row, background)"]
+    AssetDetailsVM --> NavXaml["NavigationView.xaml (DataTemplate switch)"]
+```
+
+---
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Summary tab layout switching | `ContentControl` with two named `DataTemplate` resources (`PortfolioSummaryTemplate` / `AssetSummaryTemplate`), switched via `DataTrigger` on `AssetDetails.IsPortfolioView` | Visibility converters per-element (collapse/show individual rows) | DataTemplate swap is already the pattern used by the Credits tab for aggregate vs asset view; keeps asset and portfolio layouts independently editable with no tangled visibility conditions |
+| `LoadPortfolioSummary` data flow | `MainNavigationViewModelBase` fetches items from `IPortfolioAssetSummaryQueryService` and passes them as `IReadOnlyList<PortfolioAssetSummaryItemDTO>` into the new `IAssetDetailsViewModel.LoadPortfolioSummary` method | Inject `IPortfolioAssetSummaryQueryService` into `AssetDetailsViewModel` and let it fetch internally | Follows the existing pattern where the base class fetches data and passes DTOs down; `AssetDetailsViewModel` stays free of service dependencies beyond price and transaction/credit services |
+| Per-row async price fetch | Fire-and-forget `Task.Run` per row inside `FetchRowPricesAsync`, gated by a `CancellationToken` captured at the start of each `LoadPortfolioSummary` call; previous token cancelled before new rows are set | `Task.WhenAll` collecting all prices before updating any row | Independent per-row dispatch mirrors the web frontend's behaviour and the PRD requirement that "as each price resolves, the row updates in place"; cancellation prevents stale updates when the user selects a different node before prices arrive |
+| Profit colour | `ProfitIsPositive` (bool) and `ProfitIsNegative` (bool) properties on the row VM, bound via `DataTrigger` in XAML to set `Foreground` to `Green` or `Red` | `SignedValueToBrushConverter` on a non-nullable `decimal` property | The profit value can be null (when unavailable), so a nullable decimal does not work with the existing converter; bool properties are unit-testable without XAML and avoid a new converter |
+
+---
+
+## 4. Component Overview
+
+**WPF Presentation Layer:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs` | New | Per-row DataGrid ViewModel | Holds static DTO values; exposes `IsLoadingPrice`, `PriceFetchFailed`, `CurrentValue?`, `ProfitPercent?`; provides `DisplayCurrentValue`, `DisplayProfitPercent`, `DisplayFirstInvestmentDate`, `ProfitIsPositive`, `ProfitIsNegative`; exposes `ApplyPrice(decimal)` and `MarkPriceFailed()` methods that raise `PropertyChanged` |
+| `Financial.App/ViewModels/IAssetDetailsViewModel.cs` | Modified | ViewModel interface | Add `IsPortfolioView` (bool, read-only); add `LoadPortfolioSummary(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits, IReadOnlyList<PortfolioAssetSummaryItemDTO> assetItems)` |
+| `Financial.App/ViewModels/AssetDetailsViewModel.cs` | Modified | Core details ViewModel | Add `IsPortfolioView` backing property; add `PortfolioAssetSummaryRows` (`ObservableCollection<PortfolioAssetSummaryRowViewModel>`); implement `LoadPortfolioSummary`; add `FetchRowPricesAsync` using `CancellationTokenSource`; reset rows and cancel on `Clear()` |
+| `Financial.App/ViewModels/MainNavigationViewModelBase.cs` | Modified | Navigation orchestration | Add `IPortfolioAssetSummaryQueryService` constructor parameter; update `LoadPortfolioCredits` (private) to also call `GetPortfolioAssetsSummary` and invoke `AssetDetails.LoadPortfolioSummary` instead of `LoadPortfolioCredits` |
+| `Financial.App/ViewModels/MainNavigationViewModel.cs` | Modified | Concrete navigation ViewModel | Add `IPortfolioAssetSummaryQueryService` constructor parameter; forward it to base |
+| `Financial.App/Components/NavigationView.xaml` | Modified | Main layout XAML | Move existing Summary tab grid content into `AssetSummaryTemplate` DataTemplate; add `PortfolioSummaryTemplate` DataTemplate with three colour-coded totals and DataGrid; wrap Summary tab in `ContentControl` with `DataTrigger` on `AssetDetails.IsPortfolioView` |
+
+**Tests:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs` | New | Unit tests for row VM | Cover display formatting, ApplyPrice/MarkPriceFailed state transitions, ProfitIsPositive/IsNegative, zero TotalInvested edge case |
+| `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs` | New | Unit tests for portfolio summary in AssetDetailsViewModel | Cover `LoadPortfolioSummary` populating rows, `IsPortfolioView` true/false toggle, `Clear()` resetting rows |
+| `Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs` | Modified | Extend existing test file | Add tests for `LoadPortfolioSummary` called on portfolio node selection, correct broker/portfolio names passed to service, regression for broker node still calling `LoadBrokerCredits` |
+
+---
+
+## 5. API Contracts
+
+Not applicable. F03 consumes the existing `IPortfolioAssetSummaryQueryService.GetPortfolioAssetsSummary(string, string)` (already implemented in F01) and the existing `IAssetPriceService.GetCurrentPrice(AssetPriceRequestDTO)` — both are synchronous/async internal Application layer calls. No new HTTP endpoints are added or modified in this feature.
+
+---
+
+## 6. Data Model
+
+Not applicable. No persistence changes. All new state is in-memory within the WPF ViewModel lifecycle.
+
+---
+
+## 7. Testing Strategy
+
+### Test File Structure
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs` | Unit | `PortfolioAssetSummaryRowViewModel` | Display formatting, price-state transitions, colour flags, null/zero edge cases |
+| `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs` | Unit | `AssetDetailsViewModel` (portfolio path) | `LoadPortfolioSummary` population, `IsPortfolioView` toggle, `Clear()` reset, row count |
+| `Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs` | Unit (extended) | `MainNavigationViewModelBase<T>` | Portfolio node routes to `LoadPortfolioSummary`; correct names forwarded to service; broker node unaffected |
+
+---
+
+### PortfolioAssetSummaryRowViewModelTests.cs
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `DisplayFirstInvestmentDate_WhenDateIsSet_ReturnsShortDateString` | DTO has `FirstInvestmentDate = new DateTime(2021, 3, 1)` | Returns `"01/03/2021"` |
+| `DisplayFirstInvestmentDate_WhenDateIsNull_ReturnsEmptyString` | DTO has `FirstInvestmentDate = null` | Returns `string.Empty` |
+| `DisplayCurrentQuantity_FormatsN8` | `CurrentQuantity = 25.0m` | Returns `"25.00000000"` |
+| `DisplayTotalInvested_FormatsN2` | `TotalInvested = 2500.5m` | Returns `"2,500.50"` |
+| `DisplayPortfolioWeight_FormatsOneDecimalPercent` | `PortfolioWeight = 23.4567m` | Returns `"23.5%"` |
+| `DisplayCurrentValue_WhenIsLoadingPrice_ReturnsDash` | `IsLoadingPrice = true` | `DisplayCurrentValue` returns `"—"` |
+| `DisplayCurrentValue_WhenPriceFetchFailed_ReturnsDash` | After `MarkPriceFailed()` | `DisplayCurrentValue` returns `"—"` |
+| `DisplayCurrentValue_AfterApplyPrice_ReturnsComputedValueN2` | `ApplyPrice(10.50m)`, `CurrentQuantity = 25m` | `DisplayCurrentValue` returns `"262.50"` |
+| `DisplayProfitPercent_WhenIsLoadingPrice_ReturnsDash` | `IsLoadingPrice = true` | `DisplayProfitPercent` returns `"—"` |
+| `DisplayProfitPercent_WhenPriceFetchFailed_ReturnsDash` | After `MarkPriceFailed()` | `DisplayProfitPercent` returns `"—"` |
+| `DisplayProfitPercent_WhenTotalInvestedIsZero_ReturnsDash` | `TotalInvested = 0`, `ApplyPrice(10.50m)` | `DisplayProfitPercent` returns `"—"` |
+| `DisplayProfitPercent_AfterApplyPrice_ReturnsFormattedPercent` | `ApplyPrice(10.50m)`, `CurrentQuantity = 25m`, `TotalInvested = 250m` | Returns `"5.00%"` |
+| `ProfitIsPositive_WhenCurrentValueExceedsTotalInvested_IsTrue` | `CurrentValue > TotalInvested` after `ApplyPrice` | `ProfitIsPositive = true`; `ProfitIsNegative = false` |
+| `ProfitIsNegative_WhenCurrentValueBelowTotalInvested_IsTrue` | `CurrentValue < TotalInvested` after `ApplyPrice` | `ProfitIsNegative = true`; `ProfitIsPositive = false` |
+| `ProfitIsPositive_WhenPriceUnavailable_IsFalse` | `MarkPriceFailed()` | `ProfitIsPositive = false`; `ProfitIsNegative = false` |
+| `ApplyPrice_RaisesPropertyChangedForDisplayProperties` | Subscribe to `PropertyChanged`, call `ApplyPrice` | `PropertyChanged` raised for `DisplayCurrentValue`, `DisplayProfitPercent`, `IsLoadingPrice`, `ProfitIsPositive`, `ProfitIsNegative` |
+| `MarkPriceFailed_RaisesPropertyChangedForDisplayProperties` | Subscribe to `PropertyChanged`, call `MarkPriceFailed` | `PropertyChanged` raised for `DisplayCurrentValue`, `DisplayProfitPercent`, `PriceFetchFailed`, `IsLoadingPrice` |
+
+---
+
+### AssetDetailsViewModelPortfolioSummaryTests.cs
+
+Uses a stub `IPortfolioAssetSummaryQueryService` (returns a canned list) and a stub `IAssetPriceService` (never resolves) to avoid async price-fetch side effects in synchronous test setup.
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `LoadPortfolioSummary_SetsIsPortfolioViewTrue` | Call `LoadPortfolioSummary` with items | `IsPortfolioView` is `true` |
+| `LoadPortfolioSummary_PopulatesPortfolioAssetSummaryRows` | Two-item list passed | `PortfolioAssetSummaryRows.Count` equals 2 |
+| `LoadPortfolioSummary_RowsAreInCorrectOrder` | Items passed in given order | Row 0 `AssetName` matches first item; row 1 matches second |
+| `LoadPortfolioSummary_SetsAggregatedTotals` | `AggregatedSummaryDTO` with `TotalBought = 10000m` | `TotalBought` equals 10000m |
+| `LoadPortfolioSummary_LoadsCreditsForCreditsTab` | Credits list with two entries | `Credits.Count` equals 2 |
+| `LoadPortfolioSummary_RowsInitiallyShowLoadingPrice` | Price service never resolves | All rows have `IsLoadingPrice = true` after `LoadPortfolioSummary` |
+| `Clear_AfterLoadPortfolioSummary_ClearsRows` | Load then `Clear()` | `PortfolioAssetSummaryRows.Count` equals 0 |
+| `Clear_AfterLoadPortfolioSummary_SetsIsPortfolioViewFalse` | Load then `Clear()` | `IsPortfolioView` is `false` |
+| `LoadAssetDetails_AfterPortfolioSummary_SetsIsPortfolioViewFalse` | Load portfolio then load asset | `IsPortfolioView` is `false` |
+
+---
+
+### MainNavigationViewModelBaseTests.cs — new tests
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `SelectingPortfolioNode_CallsLoadPortfolioSummaryOnDetailsViewModel` | Portfolio node selected | `spy.WasPortfolioSummaryLoaded` is `true`; `spy.LastPortfolioSummary` is not null |
+| `SelectingPortfolioNode_PassesCorrectAssetItemsFromService` | Stub returns 2 items | `spy.LastPortfolioAssetItems` has 2 elements |
+| `SelectingPortfolioNode_PassesCorrectBrokerAndPortfolioNameToAssetSummaryService` | Portfolio node selected | stub `LastBrokerName` and `LastPortfolioName` match node metadata |
+| `SelectingBrokerNode_DoesNotCallLoadPortfolioSummary` | Broker node selected | `spy.WasPortfolioSummaryLoaded` is `false` |
+
+---
+
+### Acceptance Test Mapping
+
+| PRD Acceptance Criterion (Section 9 — F03) | Covered By |
+|---------------------------------------------|------------|
+| Portfolio node shows three colour-coded totals and per-asset DataGrid | `LoadPortfolioSummary_SetsIsPortfolioViewTrue` + XAML DataTemplate (visual) |
+| Portfolio node shows no Quantity, Average Price, ISIN, Country, Local Type, Asset Class, Current section | Verified by `IsPortfolioView` switching in XAML — separate DataTemplate has no such fields |
+| Asset node still shows all asset-specific Summary fields (regression) | `LoadAssetDetails_AfterPortfolioSummary_SetsIsPortfolioViewFalse` |
+| DataGrid rows load immediately from Application service on portfolio selection | `LoadPortfolioSummary_PopulatesPortfolioAssetSummaryRows` (synchronous population) |
+| Current Value populates automatically; no Refresh button | `LoadPortfolioSummary_RowsInitiallyShowLoadingPrice` (fetch starts immediately) |
+| Failed price fetch shows `"—"` in affected row; others update normally | `DisplayCurrentValue_WhenPriceFetchFailed_ReturnsDash` + `MarkPriceFailed_RaisesPropertyChangedForDisplayProperties` |
+| `% Profit` green when positive, red when negative, default when null | `ProfitIsPositive_WhenCurrentValueExceedsTotalInvested_IsTrue` + `ProfitIsNegative_WhenCurrentValueBelowTotalInvested_IsTrue` + `ProfitIsPositive_WhenPriceUnavailable_IsFalse` |
+| DataGrid rows are read-only; no double-click or selection action | XAML `IsReadOnly="True"`, no `InputBindings` on portfolio DataGrid |
+| Credits tab unchanged when Portfolio node selected | `LoadPortfolioSummary_LoadsCreditsForCreditsTab` |
+| Transactions tab unchanged when Portfolio node selected | Transactions collection not touched by `LoadPortfolioSummary` (regression) |
+
+### Cross-Feature Integration Tests
+
+| PRD Section 9 — Cross-Feature Criterion | Covered By |
+|------------------------------------------|------------|
+| `ticker` and `exchange` values from F01 service used without modification in `IAssetPriceService` calls | `SelectingPortfolioNode_PassesCorrectAssetItemsFromService` (verifies items reach ViewModel); price fetch verified via `PortfolioAssetSummaryRowViewModel` exchange/ticker properties sourced directly from DTO |
+| `totalInvested` and `currentQuantity` from F01 service used without transformation in CurrentValue and % Profit | `DisplayCurrentValue_AfterApplyPrice_ReturnsComputedValueN2` + `DisplayProfitPercent_AfterApplyPrice_ReturnsFormattedPercent` use known DTO values and verify exact output |


### PR DESCRIPTION
## Summary

- Adds `docs/F03-portfolio-summary-tab-wpf/spec.md` — technical specification for the WPF portfolio summary tab feature
- Adds `docs/F03-portfolio-summary-tab-wpf/plan.md` — 4-phase, 9-step implementation plan

## Feature overview

F03 modifies the WPF Summary tab to show a portfolio-specific layout when a Portfolio node is selected:
- Hides asset-only fields (Quantity, Average Price, ISIN, Country, Local Type, Asset Class, Current Value section)
- Shows three colour-coded aggregate totals (Total Bought, Total Sold, Total Credits)
- Shows a read-only DataGrid with one row per asset, enriched with live prices fetched asynchronously per row via `IAssetPriceService`

## Key design decisions

- `ContentControl` DataTemplate switching on `IsPortfolioView` (mirrors Credits tab pattern)
- New `PortfolioAssetSummaryRowViewModel` with `ApplyPrice`/`MarkPriceFailed` for incremental per-row updates
- `CancellationTokenSource` per portfolio load to prevent stale price updates on node change
- `IPortfolioAssetSummaryQueryService` injected into `MainNavigationViewModelBase` (not `AssetDetailsViewModel`) to follow existing data-flow pattern

## Test plan

- [ ] Review spec Section 7 for test function list (17 row VM tests, 9 AssetDetailsViewModel tests, 4 base nav tests)
- [ ] Verify PRD→Spec mapping covers all F03 acceptance criteria from PRD Section 9
- [ ] Verify Cross-Feature Integration criteria from PRD Section 9 are present as integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)