### PR TITLE
docs(P02-F02): update spec — add TotalCredits, % Profit w/ Credits, XIRR

### DIFF
--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -194,6 +194,11 @@ export interface PortfolioReferenceDto {
   portfolioName: string
 }
 
+export interface AssetCashFlowDto {
+  date: string
+  amount: number
+}
+
 export interface PortfolioAssetSummaryItemDto {
   assetName: string
   ticker: string
@@ -204,4 +209,6 @@ export interface PortfolioAssetSummaryItemDto {
   totalSold: number
   totalInvested: number
   portfolioWeight: number
+  totalCredits: number
+  cashFlows: AssetCashFlowDto[]
 }

--- a/Financial.Web/src/components/PortfolioSummaryTab.tsx
+++ b/Financial.Web/src/components/PortfolioSummaryTab.tsx
@@ -3,6 +3,7 @@ import LoadingState from './LoadingState'
 import { usePortfolioAssetSummary } from '../hooks/usePortfolioAssetSummary'
 import type { RowPriceState } from '../hooks/usePortfolioAssetSummary'
 import type { PortfolioAssetSummaryItemDto } from '../api/types'
+import { xirr } from '../utils/xirr'
 import AggregatedSummaryTab from './AggregatedSummaryTab'
 import './PortfolioSummaryTab.css'
 
@@ -35,6 +36,10 @@ function formatShortDate(isoString: string | null): string {
   return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()}`
 }
 
+function getProfitClass(value: number): string {
+  return value >= 0 ? 'portfolio-summary__profit--green' : 'portfolio-summary__profit--red'
+}
+
 interface AssetRowProps {
   item: PortfolioAssetSummaryItemDto
   rowPrice: RowPriceState
@@ -49,10 +54,20 @@ function AssetRow({ item, rowPrice }: AssetRowProps) {
       ? ((currentValue - item.totalInvested) / item.totalInvested) * 100
       : null
 
-  const profitClass =
-    profitPercent !== null && profitPercent >= 0
-      ? 'portfolio-summary__profit--green'
-      : 'portfolio-summary__profit--red'
+  const profitWithCreditsPercent =
+    currentValue !== null && item.totalInvested !== 0
+      ? ((currentValue + item.totalCredits - item.totalInvested) / item.totalInvested) * 100
+      : null
+
+  const xirrValue = (() => {
+    if (currentValue === null) return null
+    const today = new Date()
+    const series = [
+      ...item.cashFlows.map(cf => ({ date: new Date(cf.date), amount: cf.amount })),
+      { date: today, amount: currentValue },
+    ].sort((a, b) => a.date.getTime() - b.date.getTime())
+    return xirr(series)
+  })()
 
   return (
     <tr>
@@ -61,6 +76,7 @@ function AssetRow({ item, rowPrice }: AssetRowProps) {
       <td>{formatN8(item.currentQuantity)}</td>
       <td>{formatN2(item.totalInvested)}</td>
       <td>{formatPortfolioWeight(item.portfolioWeight)}</td>
+      <td>{formatN2(item.totalCredits)}</td>
       <td>
         {rowPrice.isLoading ? (
           <span className="portfolio-summary__loading-cell">...</span>
@@ -75,10 +91,28 @@ function AssetRow({ item, rowPrice }: AssetRowProps) {
           <span className="portfolio-summary__loading-cell">...</span>
         ) : rowPrice.fetchFailed || profitPercent === null ? (
           '—'
-        ) : item.totalInvested === 0 ? (
+        ) : (
+          <span className={getProfitClass(profitPercent)}>{formatN2(profitPercent)}%</span>
+        )}
+      </td>
+      <td>
+        {rowPrice.isLoading ? (
+          <span className="portfolio-summary__loading-cell">...</span>
+        ) : rowPrice.fetchFailed || profitWithCreditsPercent === null ? (
           '—'
         ) : (
-          <span className={profitClass}>{formatN2(profitPercent)}%</span>
+          <span className={getProfitClass(profitWithCreditsPercent)}>
+            {formatN2(profitWithCreditsPercent)}%
+          </span>
+        )}
+      </td>
+      <td>
+        {rowPrice.isLoading ? (
+          <span className="portfolio-summary__loading-cell">...</span>
+        ) : rowPrice.fetchFailed || xirrValue === null ? (
+          '—'
+        ) : (
+          <span className={getProfitClass(xirrValue)}>{formatN2(xirrValue * 100)}%</span>
         )}
       </td>
     </tr>
@@ -106,8 +140,11 @@ export default function PortfolioSummaryTab() {
                 <th>Quantity</th>
                 <th>Total Invested</th>
                 <th>% Portfolio</th>
+                <th>Total Credits</th>
                 <th>Current Value</th>
                 <th>% Profit</th>
+                <th>% Profit w/ Credits</th>
+                <th>XIRR</th>
               </tr>
             </thead>
             <tbody>

--- a/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
@@ -7,6 +7,7 @@ import PortfolioSummaryTab from '../PortfolioSummaryTab'
 
 const mockAggregatedRetry = vi.fn()
 const mockPortfolioRetry = vi.fn()
+const xirrMock = vi.hoisted(() => vi.fn<(cashFlows: { date: Date; amount: number }[]) => number | null>())
 
 const mockAggregatedHookValue: AggregatedSummaryData = {
   summary: null,
@@ -29,6 +30,10 @@ vi.mock('../../hooks/useAggregatedSummary', () => ({
 
 vi.mock('../../hooks/usePortfolioAssetSummary', () => ({
   usePortfolioAssetSummary: () => mockPortfolioHookValue,
+}))
+
+vi.mock('../../utils/xirr', () => ({
+  xirr: xirrMock,
 }))
 
 const SUMMARY: AggregatedSummaryDto = {
@@ -67,6 +72,8 @@ describe('PortfolioSummaryTab', () => {
   beforeEach(() => {
     mockAggregatedRetry.mockReset()
     mockPortfolioRetry.mockReset()
+    xirrMock.mockReset()
+    xirrMock.mockReturnValue(null)
     Object.assign(mockAggregatedHookValue, {
       summary: null,
       isLoading: false,
@@ -117,17 +124,32 @@ describe('PortfolioSummaryTab', () => {
     expect(screen.getByText('Quantity')).toBeInTheDocument()
     expect(screen.getByText('Total Invested')).toBeInTheDocument()
     expect(screen.getByText('% Portfolio')).toBeInTheDocument()
+    expect(screen.getAllByText('Total Credits').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('Current Value')).toBeInTheDocument()
     expect(screen.getByText('% Profit')).toBeInTheDocument()
+    expect(screen.getByText('% Profit w/ Credits')).toBeInTheDocument()
+    expect(screen.getByText('XIRR')).toBeInTheDocument()
   })
 
   it('renders_asset_row_with_correctly_formatted_values', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, totalCredits: 75.5 }
     setAggregatedMock({ summary: SUMMARY })
-    setPortfolioMock({ items: [ITEM_1], rowPrices: [IDLE_ROW_PRICE] })
+    setPortfolioMock({ items: [item], rowPrices: [IDLE_ROW_PRICE] })
     render(<PortfolioSummaryTab />)
     expect(screen.getByText('ALZR11')).toBeInTheDocument()
     expect(screen.getByText('01/03/2021')).toBeInTheDocument()
     expect(screen.getByText(/23\.4%/)).toBeInTheDocument()
+    expect(screen.getByText(/75[.,]50/)).toBeInTheDocument()
+  })
+
+  it('renders_total_credits_immediately_before_price_resolves', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, totalCredits: 75.5 }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText(/75[.,]50/)).toBeInTheDocument()
+    const loadingCells = screen.getAllByText('...')
+    expect(loadingCells.length).toBeGreaterThanOrEqual(1)
   })
 
   it('renders_per_cell_loading_indicator_while_price_loads', () => {
@@ -158,12 +180,40 @@ describe('PortfolioSummaryTab', () => {
     expect(profitElements[0]).toHaveClass('portfolio-summary__profit--green')
   })
 
-  it('renders_dash_in_current_value_and_profit_on_price_failure', () => {
+  it('renders_correct_profit_with_credits_percent', () => {
+    // currentValue = 10.5 * 25 = 262.50
+    // profitWithCreditsPercent = (262.50 + 12.50 - 250) / 250 * 100 = 10.00%
+    const item: PortfolioAssetSummaryItemDto = {
+      ...ITEM_1,
+      currentQuantity: 25,
+      totalInvested: 250,
+      totalCredits: 12.5,
+    }
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText(/10[.,]00%/)).toBeInTheDocument()
+  })
+
+  it('renders_xirr_when_price_resolves', () => {
+    xirrMock.mockReturnValue(0.1234)
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText(/12[.,]34%/)).toBeInTheDocument()
+    expect(xirrMock).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ amount: 262.5 })]),
+    )
+  })
+
+  it('renders_dash_in_current_value_and_price_dependent_columns_on_price_failure', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [FAILED_ROW_PRICE] })
     render(<PortfolioSummaryTab />)
     const dashes = screen.getAllByText('—')
-    expect(dashes.length).toBeGreaterThanOrEqual(2)
+    expect(dashes.length).toBeGreaterThanOrEqual(4)
   })
 
   it('renders_dash_in_profit_when_total_invested_is_zero', () => {
@@ -175,6 +225,27 @@ describe('PortfolioSummaryTab', () => {
     const dashes = screen.getAllByText('—')
     expect(dashes.length).toBeGreaterThanOrEqual(2) // % Profit and % Profit w/ Credits
     expect(screen.getByText(/262[.,]50/)).toBeInTheDocument()
+  })
+
+  it('renders_dash_in_xirr_when_cash_flows_fewer_than_two_entries', () => {
+    // cashFlows: [] + terminal entry = 1 entry → xirr returns null → XIRR shows "—"
+    xirrMock.mockReturnValue(null)
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders_dash_in_xirr_on_non_convergence', () => {
+    xirrMock.mockReturnValue(null)
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(1)
   })
 
   it('applies_green_class_to_positive_profit', () => {
@@ -195,6 +266,60 @@ describe('PortfolioSummaryTab', () => {
     render(<PortfolioSummaryTab />)
     const profitEl = document.querySelector('.portfolio-summary__profit--red')
     expect(profitEl).toBeInTheDocument()
+  })
+
+  it('applies_green_class_to_positive_profit_with_credits', () => {
+    // currentValue = 10.5 * 25 = 262.50; totalInvested = 300; totalCredits = 50
+    // profitWithCreditsPercent = (262.50 + 50 - 300) / 300 * 100 = 4.17% (positive)
+    const item: PortfolioAssetSummaryItemDto = {
+      ...ITEM_1,
+      currentQuantity: 25,
+      totalInvested: 300,
+      totalCredits: 50,
+    }
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    const greenEls = document.querySelectorAll('.portfolio-summary__profit--green')
+    expect(greenEls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('applies_red_class_to_negative_profit_with_credits', () => {
+    // currentValue = 10.5 * 25 = 262.50; totalInvested = 400; totalCredits = 10
+    // profitWithCreditsPercent = (262.50 + 10 - 400) / 400 * 100 = -31.875% (negative)
+    const item: PortfolioAssetSummaryItemDto = {
+      ...ITEM_1,
+      currentQuantity: 25,
+      totalInvested: 400,
+      totalCredits: 10,
+    }
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    const redEls = document.querySelectorAll('.portfolio-summary__profit--red')
+    expect(redEls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('applies_green_class_to_positive_xirr', () => {
+    xirrMock.mockReturnValue(0.1234)
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    const greenEls = document.querySelectorAll('.portfolio-summary__profit--green')
+    expect(greenEls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('applies_red_class_to_negative_xirr', () => {
+    xirrMock.mockReturnValue(-0.05)
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
+    render(<PortfolioSummaryTab />)
+    const redEls = document.querySelectorAll('.portfolio-summary__profit--red')
+    expect(redEls.length).toBeGreaterThanOrEqual(1)
   })
 
   it('renders_empty_string_for_null_first_investment_date', () => {

--- a/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
@@ -47,6 +47,8 @@ const ITEM_1: PortfolioAssetSummaryItemDto = {
   totalSold: 0,
   totalInvested: 2500,
   portfolioWeight: 23.4,
+  totalCredits: 0,
+  cashFlows: [],
 }
 
 const LOADING_ROW_PRICE: RowPriceState = { isLoading: true, currentPrice: null, fetchFailed: false }

--- a/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
@@ -135,7 +135,7 @@ describe('PortfolioSummaryTab', () => {
     setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
     render(<PortfolioSummaryTab />)
     const loadingCells = screen.getAllByText('...')
-    expect(loadingCells).toHaveLength(2)
+    expect(loadingCells).toHaveLength(4)
   })
 
   it('renders_current_value_when_price_resolves', () => {
@@ -152,7 +152,10 @@ describe('PortfolioSummaryTab', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
     render(<PortfolioSummaryTab />)
-    expect(screen.getByText(/5[.,]00%/)).toBeInTheDocument()
+    // Both % Profit and % Profit w/ Credits show 5.00% when totalCredits is 0
+    const profitElements = screen.getAllByText(/5[.,]00%/)
+    expect(profitElements.length).toBeGreaterThanOrEqual(1)
+    expect(profitElements[0]).toHaveClass('portfolio-summary__profit--green')
   })
 
   it('renders_dash_in_current_value_and_profit_on_price_failure', () => {
@@ -169,7 +172,8 @@ describe('PortfolioSummaryTab', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
     render(<PortfolioSummaryTab />)
-    expect(screen.getByText('—')).toBeInTheDocument()
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(2) // % Profit and % Profit w/ Credits
     expect(screen.getByText(/262[.,]50/)).toBeInTheDocument()
   })
 

--- a/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
@@ -48,6 +48,12 @@ const ITEM_1: PortfolioAssetSummaryItemDto = {
   totalSold: 0,
   totalInvested: 2500,
   portfolioWeight: 71.4,
+  totalCredits: 125,
+  cashFlows: [
+    { date: '2021-03-01T00:00:00', amount: -2500 },
+    { date: '2021-09-15T00:00:00', amount: 50 },
+    { date: '2022-09-15T00:00:00', amount: 75 },
+  ],
 }
 
 const ITEM_2: PortfolioAssetSummaryItemDto = {
@@ -60,6 +66,10 @@ const ITEM_2: PortfolioAssetSummaryItemDto = {
   totalSold: 0,
   totalInvested: 1000,
   portfolioWeight: 28.6,
+  totalCredits: 0,
+  cashFlows: [
+    { date: '2021-05-15T00:00:00', amount: -1000 },
+  ],
 }
 
 const PRICE_DTO: AssetPriceDto = {

--- a/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
@@ -149,6 +149,8 @@ describe('usePortfolioAssetSummary', () => {
     await waitFor(() => expect(result.current.items).not.toBeNull())
     expect(result.current.items).toHaveLength(2)
     expect(result.current.items![0].assetName).toBe('ALZR11')
+    expect(result.current.items![0].totalCredits).toBe(125)
+    expect(result.current.items![0].cashFlows).toHaveLength(3)
   })
 
   it('sets_error_on_fetch_failure', async () => {

--- a/Financial.Web/src/utils/xirr.test.ts
+++ b/Financial.Web/src/utils/xirr.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { xirr } from './xirr'
+
+describe('xirr', () => {
+  it('xirr_returns_correct_annualised_rate_for_known_inputs', () => {
+    // Buy 1000 on day 0, receive 1100 exactly one year later → XIRR = 10%
+    const cashFlows = [
+      { date: new Date('2021-01-01'), amount: -1000 },
+      { date: new Date('2022-01-01'), amount: 1100 },
+    ]
+    const result = xirr(cashFlows)
+    expect(result).not.toBeNull()
+    expect(result!).toBeCloseTo(0.1, 4)
+  })
+
+  it('xirr_returns_null_when_fewer_than_two_cash_flows', () => {
+    const cashFlows = [{ date: new Date('2021-01-01'), amount: -1000 }]
+    expect(xirr(cashFlows)).toBeNull()
+  })
+
+  it('xirr_returns_null_when_series_is_empty', () => {
+    expect(xirr([])).toBeNull()
+  })
+
+  it('xirr_returns_null_when_algorithm_does_not_converge', () => {
+    // All cash flows on the same date → derivative is 0 → cannot converge
+    const cashFlows = [
+      { date: new Date('2021-01-01'), amount: -500 },
+      { date: new Date('2021-01-01'), amount: -500 },
+    ]
+    expect(xirr(cashFlows)).toBeNull()
+  })
+})

--- a/Financial.Web/src/utils/xirr.ts
+++ b/Financial.Web/src/utils/xirr.ts
@@ -1,0 +1,33 @@
+export interface CashFlow {
+  date: Date
+  amount: number
+}
+
+export function xirr(cashFlows: CashFlow[]): number | null {
+  if (cashFlows.length < 2) return null
+
+  const startTime = cashFlows[0].date.getTime()
+  const days = cashFlows.map(cf => (cf.date.getTime() - startTime) / 86_400_000)
+  const amounts = cashFlows.map(cf => cf.amount)
+
+  let rate = 0.1
+
+  for (let iter = 0; iter < 100; iter++) {
+    let npv = 0
+    let dnpv = 0
+
+    for (let j = 0; j < amounts.length; j++) {
+      const t = days[j] / 365
+      const base = Math.pow(1 + rate, t)
+      npv += amounts[j] / base
+      dnpv -= (t * amounts[j]) / ((1 + rate) * base)
+    }
+
+    if (Math.abs(npv) < 1e-7) return rate
+    if (Math.abs(dnpv) < 1e-10) return null
+
+    rate -= npv / dnpv
+  }
+
+  return null
+}

--- a/docs/P02-F02-portfolio-summary-tab-web-frontend/plan.md
+++ b/docs/P02-F02-portfolio-summary-tab-web-frontend/plan.md
@@ -1,35 +1,39 @@
 # Implementation Plan: F02 — Portfolio Summary Tab — Web Frontend
 
 **Prerequisites:**
-- F01 endpoint (`GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets`) already implemented and deployed
+- F01 endpoint (`GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets`) already implemented and deployed, returning `totalCredits` and `cashFlows` per item
 - No new npm packages required; all existing frontend dependencies (`vitest`, `@testing-library/react`, React 18) are already present
 
 ---
 
-### Phase 1: API Client Extension
+### Phase 1: API Client Extension and XIRR Utility
 
-**1. PortfolioAssetSummaryItemDto Type** — Add the `PortfolioAssetSummaryItemDto` interface to `Financial.Web/src/api/types.ts`. See spec Section 5 for all nine field names and TypeScript types.
+**1. PortfolioAssetSummaryItemDto and AssetCashFlowDto Types** — Add the `AssetCashFlowDto` interface (`date`, `amount`) and the `PortfolioAssetSummaryItemDto` interface to `Financial.Web/src/api/types.ts`. See spec Section 5 for all eleven field names and TypeScript types.
 
 **2. FinancialApiClient Method** — Add `getPortfolioAssetsSummary` to the `FinancialApiClient` interface and its implementation in `financialApiClient.ts`. See spec Section 5 for the URL pattern, parameter encoding, and return type.
+
+**3. XIRR Utility** — Create `Financial.Web/src/utils/xirr.ts` implementing Newton-Raphson with a maximum of 100 iterations and convergence tolerance 1e-7. The function accepts a sorted `{ date: Date; amount: number }[]` series and returns the annualised rate as a `number` or `null` when the series has fewer than 2 entries or the algorithm does not converge. See spec Section 4 for the full contract.
 
 ---
 
 ### Phase 2: Hook
 
-**3. usePortfolioAssetSummary Hook** — Create `Financial.Web/src/hooks/usePortfolioAssetSummary.ts`. The hook manages a `useReducer` with `items`, `rowPrices`, `isLoading`, `error`, and `retryCount`; on Portfolio node selection it fetches static data from the F01 endpoint; on success it initialises per-row loading state and fires one `getCurrentPrice` call per item in parallel, each dispatching independently as it resolves or fails. See spec Sections 3 and 4 for state shape, action types, and reducer rules.
+**4. usePortfolioAssetSummary Hook** — Create `Financial.Web/src/hooks/usePortfolioAssetSummary.ts`. The hook manages a `useReducer` with `items`, `rowPrices`, `isLoading`, `error`, and `retryCount`; on Portfolio node selection it fetches static data from the F01 endpoint (items include `totalCredits` and `cashFlows`); on success it initialises per-row loading state and fires one `getCurrentPrice` call per item in parallel, each dispatching independently as it resolves or fails. See spec Sections 3 and 4 for state shape, action types, and reducer rules.
 
 ---
 
 ### Phase 3: Component and Routing
 
-**4. PortfolioSummaryTab Component** — Create `Financial.Web/src/components/PortfolioSummaryTab.tsx` and `PortfolioSummaryTab.css`. The component renders the aggregated totals section (reusing `useAggregatedSummary`) and the per-asset table (using `usePortfolioAssetSummary`), each with independent loading and error states. Per-cell `...` loading indicators and `"—"` fallbacks apply per the PRD UX flow. See spec Sections 4 and 5.
+**5. PortfolioSummaryTab Component** — Create `Financial.Web/src/components/PortfolioSummaryTab.tsx` and `PortfolioSummaryTab.css`. The component renders the aggregated totals section (reusing `useAggregatedSummary`) and the 10-column per-asset table (using `usePortfolioAssetSummary`), each with independent loading and error states. Per-cell `...` loading indicators appear while prices fetch; after each price resolves the component computes `currentValue`, `% Profit`, `% Profit w/ Credits`, and `XIRR` (via the `xirr` utility) in-row. `"—"` fallbacks apply for unavailable prices, zero `totalInvested`, and XIRR non-convergence. `% Profit`, `% Profit w/ Credits`, and XIRR are colour-coded green/red. See spec Sections 4 and 5.
 
-**5. DetailPanel Modification** — Update `Financial.Web/src/components/DetailPanel.tsx` to render `PortfolioSummaryTab` when the selected node is a Portfolio and `AggregatedSummaryTab` only when it is a Broker. Import `PortfolioSummaryTab` and update the summary tab routing condition. See spec Section 4.
+**6. DetailPanel Modification** — Update `Financial.Web/src/components/DetailPanel.tsx` to render `PortfolioSummaryTab` when the selected node is a Portfolio and `AggregatedSummaryTab` only when it is a Broker. Import `PortfolioSummaryTab` and update the summary tab routing condition. See spec Section 4.
 
 ---
 
 ### Phase 4: Tests
 
-**6. usePortfolioAssetSummary Tests** — Create `Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts` following the `createWrapper` / `vi.mock` pattern from `useAggregatedSummary.test.ts`. Cover all state transitions, parallel price dispatch, retry, node-change reset, and row isolation on partial price failure. See spec Section 7 for the full test function list.
+**7. XIRR Utility Tests** — Create `Financial.Web/src/utils/xirr.test.ts`. Cover the correct annualised rate for known inputs (verified against an Excel XIRR reference), `null` return for fewer than 2 entries, and `null` return for non-convergent series. See spec Section 7 for the full test function list.
 
-**7. PortfolioSummaryTab Tests** — Create `Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx` following the `vi.mock` / `setMock` pattern from `AggregatedSummaryTab.test.tsx`. Mock both `useAggregatedSummary` and `usePortfolioAssetSummary`. Cover all render states, value formatting, profit colour coding, and regression checks for unaffected node types. See spec Section 7 for the full test function list.
+**8. usePortfolioAssetSummary Tests** — Create `Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts` following the `createWrapper` / `vi.mock` pattern from `useAggregatedSummary.test.ts`. Cover all state transitions, parallel price dispatch, retry, node-change reset, and row isolation on partial price failure. Verify that `items` includes `totalCredits` and `cashFlows`. See spec Section 7 for the full test function list.
+
+**9. PortfolioSummaryTab Tests** — Create `Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx` following the `vi.mock` / `setMock` pattern from `AggregatedSummaryTab.test.tsx`. Mock `useAggregatedSummary`, `usePortfolioAssetSummary`, and the `xirr` utility. Cover all render states, all 10 column headers, value formatting, Total Credits immediate rendering, per-cell loading indicators, profit and XIRR colour coding, XIRR non-convergence and insufficient-data dash, and regression checks for unaffected node types. See spec Section 7 for the full test function list.

--- a/docs/P02-F02-portfolio-summary-tab-web-frontend/spec.md
+++ b/docs/P02-F02-portfolio-summary-tab-web-frontend/spec.md
@@ -2,19 +2,22 @@
 
 ## 1. Technical Overview
 
-**What:** Adds a `PortfolioSummaryTab` component to the React frontend that renders when a Portfolio node is selected in the investment tree. The component displays two independent sections: (1) the three aggregated totals (Total Bought, Total Sold, Total Credits) via the existing `useAggregatedSummary` hook unchanged, and (2) a per-asset breakdown table driven by a new `usePortfolioAssetSummary` hook that fetches static data from F01's endpoint and enriches each row with a live current price fetched in parallel.
+**What:** Adds a `PortfolioSummaryTab` component to the React frontend that renders when a Portfolio node is selected in the investment tree. The component displays two independent sections: (1) the three aggregated totals (Total Bought, Total Sold, Total Credits) via the existing `useAggregatedSummary` hook unchanged, and (2) a per-asset breakdown table driven by a new `usePortfolioAssetSummary` hook that fetches static data from F01's endpoint and enriches each row with a live current price fetched in parallel. For each row the component computes `CurrentValue`, `% Profit`, `% Profit w/ Credits`, and `XIRR` client-side after the price arrives; a pure `xirr` utility function (Newton-Raphson) is introduced for the XIRR calculation.
 
-**Why:** The current `DetailPanel` renders `AggregatedSummaryTab` for both Broker and Portfolio nodes — selecting a Portfolio shows only three aggregate totals with no per-asset breakdown. F01 now provides the server-side per-asset computation; this feature wires that data into the React frontend with automatic price enrichment, following the same pattern already used by `AssetSummaryTab` for individual assets.
+**Why:** The current `DetailPanel` renders `AggregatedSummaryTab` for both Broker and Portfolio nodes — selecting a Portfolio shows only three aggregate totals with no per-asset breakdown. F01 now provides the server-side per-asset computation (including `TotalCredits` and `CashFlows`); this feature wires that data into the React frontend with automatic price enrichment, following the same pattern already used by `AssetSummaryTab` for individual assets.
 
 **Scope:**
 
 Included:
-- `PortfolioAssetSummaryItemDto` type in `Financial.Web/src/api/types.ts`
+- `PortfolioAssetSummaryItemDto` type in `Financial.Web/src/api/types.ts` (11 fields including `totalCredits` and `cashFlows`)
+- `AssetCashFlowDto` type in `Financial.Web/src/api/types.ts`
 - `getPortfolioAssetsSummary` method on `FinancialApiClient` interface and implementation in `financialApiClient.ts`
 - `usePortfolioAssetSummary` hook in `Financial.Web/src/hooks/`
+- `xirr` utility function in `Financial.Web/src/utils/xirr.ts` (Newton-Raphson, max 100 iterations, tolerance 1e-7)
 - `PortfolioSummaryTab` component and co-located CSS in `Financial.Web/src/components/`
 - `DetailPanel.tsx` modification to render `PortfolioSummaryTab` for Portfolio nodes and `AggregatedSummaryTab` only for Broker nodes
 - Unit tests for `usePortfolioAssetSummary`
+- Unit tests for `xirr` utility
 - Component tests for `PortfolioSummaryTab`
 
 Excluded:
@@ -36,6 +39,7 @@ graph TD
     DetailPanel --> PortfolioSummaryTab["PortfolioSummaryTab (new)"]
     PortfolioSummaryTab --> useAggregatedSummary["useAggregatedSummary (unchanged)"]
     PortfolioSummaryTab --> usePortfolioAssetSummary["usePortfolioAssetSummary (new)"]
+    PortfolioSummaryTab --> xirr["xirr utility (new)"]
     useAggregatedSummary --> apiClient["FinancialApiClient (modified)"]
     usePortfolioAssetSummary --> apiClient
     apiClient --> F01Endpoint["GET /summary/portfolio/{broker}/{portfolio}/assets"]
@@ -51,7 +55,9 @@ graph TD
 | Per-row price state structure | Parallel `rowPrices: RowPriceState[]` indexed by position alongside `items` | Merged `PortfolioAssetSummaryRow[]` with price fields inlined; `Map<string, RowPriceState>` keyed by ticker | Parallel arrays keep the reducer action shape simple (`ROW_PRICE_SUCCESS` / `ROW_PRICE_ERROR` carry only an `index`), avoids creating an extra merged type, and is consistent with `useAssetSummary` which keeps `asset` and `price` as separate state fields |
 | Price fetch dispatch | Each price fetch dispatches independently (fire-and-forget per row) | `Promise.allSettled` collecting all prices before updating state | Independent dispatch updates each row as soon as its price arrives, satisfying the PRD requirement that "as each price resolves, the corresponding row updates in place"; `allSettled` would stall every row until the slowest fetch |
 | `useAggregatedSummary` reuse in `PortfolioSummaryTab` | Call `useAggregatedSummary()` directly inside `PortfolioSummaryTab` | Lift aggregated state to a parent and pass as props | Follows the existing pattern (`AggregatedSummaryTab` owns its hook); keeps `PortfolioSummaryTab` self-contained; the hook already handles Portfolio node selection correctly without modification |
-| Table HTML element | HTML `<table>` with `<thead>` / `<tbody>` | CSS grid (used by `AggregatedSummaryTab` and `AssetSummaryTab`) | The per-asset breakdown is genuinely tabular data (7 columns, variable number of rows); `<table>` provides correct semantics, accessible column headers, and natural column alignment; CSS grid is appropriate for key-value pair layouts, not multi-row columnar tables |
+| Table HTML element | HTML `<table>` with `<thead>` / `<tbody>` | CSS grid (used by `AggregatedSummaryTab` and `AssetSummaryTab`) | The per-asset breakdown is genuinely tabular data (10 columns, variable number of rows); `<table>` provides correct semantics, accessible column headers, and natural column alignment; CSS grid is appropriate for key-value pair layouts, not multi-row columnar tables |
+| XIRR computation location | Pure utility function in `xirr.ts`; called by the component per row after price resolves | Inside the hook's `ROW_PRICE_SUCCESS` action reducer | Keeps the hook responsible only for async state; the component owns derived numeric computations (consistent with how `currentValue` and `% Profit` are also computed in the component); a pure function is easier to unit-test in isolation |
+| XIRR non-convergence and insufficient data | Return `null` from `xirr()`; component renders `"—"` | Throw an exception | Null return avoids try/catch in the component; the component already has a null-check path for unavailable price values; consistent with PRD which treats non-convergence as a display-only concern |
 
 ---
 
@@ -61,11 +67,12 @@ graph TD
 
 | File Path | New/Modified | Purpose | Key Responsibilities |
 |-----------|--------------|---------|---------------------|
-| `Financial.Web/src/api/types.ts` | Modified | API type definitions | Add `PortfolioAssetSummaryItemDto` interface with all nine fields from the F01 response |
+| `Financial.Web/src/api/types.ts` | Modified | API type definitions | Add `AssetCashFlowDto` interface (`date: string`, `amount: number`); add `PortfolioAssetSummaryItemDto` interface with all eleven fields from the F01 response |
 | `Financial.Web/src/api/financialApiClient.ts` | Modified | API client | Add `getPortfolioAssetsSummary(brokerName, portfolioName)` to `FinancialApiClient` interface; implement it in the factory function using the path `/summary/portfolio/{brokerName}/{portfolioName}/assets` with `encodeURIComponent` on both params |
 | `Financial.Web/src/hooks/usePortfolioAssetSummary.ts` | New | Hook encapsulating F01 fetch and parallel price enrichment | Manages `useReducer` with `items`, `rowPrices`, `isLoading`, `error`, and `retryCount`; triggers on Portfolio node selection; on `FETCH_SUCCESS` initialises `rowPrices` with one `{ isLoading: true, currentPrice: null, fetchFailed: false }` per item and fires one `getCurrentPrice` call per item in parallel; each price call dispatches `ROW_PRICE_SUCCESS` or `ROW_PRICE_ERROR` with the row index; exposes `items`, `rowPrices`, `isLoading`, `error`, `retry` |
-| `Financial.Web/src/components/PortfolioSummaryTab.tsx` | New | Portfolio-specific Summary tab component | Renders totals section (via `useAggregatedSummary`) and per-asset table (via `usePortfolioAssetSummary`); handles loading and error states for each section independently; computes `currentValue = currentPrice × currentQuantity` and `profitPercent = (currentValue − totalInvested) / totalInvested × 100` per row; renders `"—"` when `totalInvested` is 0 or current price is unavailable; applies green/red CSS class to `% Profit` |
-| `Financial.Web/src/components/PortfolioSummaryTab.css` | New | Scoped styles for `PortfolioSummaryTab` | Table, header, and cell layout; `portfolio-summary__profit--green` / `--red` colour modifier classes; `.portfolio-summary__loading-cell` style for the `...` per-cell indicator |
+| `Financial.Web/src/utils/xirr.ts` | New | Pure XIRR computation utility | Accepts a sorted `{ date: Date; amount: number }[]` cash-flow series; implements Newton-Raphson with max 100 iterations and convergence tolerance 1e-7; returns the annualised rate as a `number` or `null` when the series has fewer than 2 entries or the algorithm does not converge within the iteration limit |
+| `Financial.Web/src/components/PortfolioSummaryTab.tsx` | New | Portfolio-specific Summary tab component | Renders totals section (via `useAggregatedSummary`) and per-asset table (via `usePortfolioAssetSummary`); handles loading and error states for each section independently; computes per row: `currentValue = currentPrice × currentQuantity`, `profitPercent = (currentValue − totalInvested) / totalInvested × 100`, `profitWithCreditsPercent = (currentValue + totalCredits − totalInvested) / totalInvested × 100`, and `xirr` (using `xirr.ts` with `cashFlows` plus terminal entry `{ date: today, amount: +currentValue }`); renders `"—"` for price-dependent columns when `totalInvested` is 0 or current price is unavailable; renders `"—"` for XIRR when price is unavailable, `cashFlows` plus the terminal entry yields fewer than 2 entries, or the algorithm does not converge; applies green/red CSS class to `% Profit`, `% Profit w/ Credits`, and XIRR |
+| `Financial.Web/src/components/PortfolioSummaryTab.css` | New | Scoped styles for `PortfolioSummaryTab` | Table, header, and cell layout; `portfolio-summary__profit--green` / `--red` colour modifier classes (shared by `% Profit`, `% Profit w/ Credits`, and XIRR); `.portfolio-summary__loading-cell` style for the `...` per-cell indicator |
 | `Financial.Web/src/components/DetailPanel.tsx` | Modified | Navigation-aware tab content dispatcher | Change summary routing: `isPortfolio` → render `PortfolioSummaryTab`; `isBroker` (i.e. `!isAsset && !isPortfolio`) → render `AggregatedSummaryTab`; `isAsset` → render `AssetSummaryTab`; import `PortfolioSummaryTab` |
 
 ---
@@ -86,7 +93,16 @@ Consumes the F01 endpoint. No backend changes are made in this feature.
 getPortfolioAssetsSummary: (brokerName: string, portfolioName: string) => Promise<PortfolioAssetSummaryItemDto[]>
 ```
 
-**New type — `PortfolioAssetSummaryItemDto` (in `api/types.ts`):**
+**New types (in `api/types.ts`):**
+
+`AssetCashFlowDto`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `string` | ISO 8601 date string of the transaction or credit event |
+| `amount` | `number` | Negative for Buy outflows; positive for Sell inflows and Credit receipts |
+
+`PortfolioAssetSummaryItemDto`:
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -99,6 +115,8 @@ getPortfolioAssetsSummary: (brokerName: string, portfolioName: string) => Promis
 | `totalSold` | `number` | Sum of all Sell transaction totals |
 | `totalInvested` | `number` | `totalBought − totalSold` |
 | `portfolioWeight` | `number` | Asset's share of total portfolio invested capital × 100 |
+| `totalCredits` | `number` | Sum of all credit values (Dividend + Rent) for the asset; `0` when the asset has no credits |
+| `cashFlows` | `AssetCashFlowDto[]` | Sorted ascending by date; empty array when asset has no transactions or credits |
 
 **Response example:**
 ```json
@@ -108,11 +126,19 @@ getPortfolioAssetsSummary: (brokerName: string, portfolioName: string) => Promis
     "ticker": "ALZR11",
     "exchange": "BVMF",
     "firstInvestmentDate": "2021-03-01T00:00:00",
-    "currentQuantity": 25.0,
+    "currentQuantity": 20.0,
     "totalBought": 2500.00,
-    "totalSold": 0.00,
-    "totalInvested": 2500.00,
-    "portfolioWeight": 71.4285714285714
+    "totalSold": 550.00,
+    "totalInvested": 1950.00,
+    "portfolioWeight": 66.1016949152542,
+    "totalCredits": 125.00,
+    "cashFlows": [
+      { "date": "2021-03-01T00:00:00", "amount": -1000.00 },
+      { "date": "2021-05-01T00:00:00", "amount": -1500.00 },
+      { "date": "2021-09-15T00:00:00", "amount": 50.00 },
+      { "date": "2022-01-01T00:00:00", "amount": 550.00 },
+      { "date": "2022-09-15T00:00:00", "amount": 75.00 }
+    ]
   },
   {
     "assetName": "MXRF11",
@@ -123,7 +149,12 @@ getPortfolioAssetsSummary: (brokerName: string, portfolioName: string) => Promis
     "totalBought": 1200.00,
     "totalSold": 200.00,
     "totalInvested": 1000.00,
-    "portfolioWeight": 28.5714285714286
+    "portfolioWeight": 33.8983050847458,
+    "totalCredits": 0.00,
+    "cashFlows": [
+      { "date": "2021-05-15T00:00:00", "amount": -1200.00 },
+      { "date": "2022-03-01T00:00:00", "amount": 200.00 }
+    ]
   }
 ]
 ```
@@ -147,8 +178,20 @@ Not applicable. No persistence or schema changes. All state is in-memory within 
 
 | Test File | Test Type | Target | Coverage Goal |
 |-----------|-----------|--------|---------------|
+| `Financial.Web/src/utils/xirr.test.ts` | Unit | `xirr` utility | Correct rate for known inputs, null on insufficient data, null on non-convergence |
 | `Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts` | Unit | `usePortfolioAssetSummary` | All state transitions, parallel price dispatch, retry, node-change reset |
-| `Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx` | Unit | `PortfolioSummaryTab` | All render states, value formatting, profit colour coding, regression for other node types |
+| `Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx` | Unit | `PortfolioSummaryTab` | All render states, value formatting, profit and XIRR colour coding, regression for other node types |
+
+### xirr.test.ts
+
+Pure function tests — no React context needed.
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `xirr_returns_correct_annualised_rate_for_known_inputs` | Known cash-flow series with a calculable rate (e.g. buy 1000 on day 0, receive 1100 one year later) | Returned rate is within 1e-4 of the expected Excel-equivalent XIRR value |
+| `xirr_returns_null_when_fewer_than_two_cash_flows` | Series with one entry | Returns `null` |
+| `xirr_returns_null_when_series_is_empty` | Empty array | Returns `null` |
+| `xirr_returns_null_when_algorithm_does_not_converge` | Degenerate series that cannot converge (e.g. all identical amounts on the same date) | Returns `null` within the max iteration limit |
 
 ### usePortfolioAssetSummary.test.ts
 
@@ -160,7 +203,7 @@ Follows the `createWrapper()` / `SelectedNodeProvider` / `vi.mock('../api/financ
 | `does_not_fetch_when_broker_node_selected` | Broker node selected | `getPortfolioAssetsSummaryMock` not called |
 | `does_not_fetch_when_asset_node_selected` | Asset node selected | `getPortfolioAssetsSummaryMock` not called |
 | `sets_isLoading_true_while_fetch_in_progress` | Never-resolving promise | `isLoading` is `true` after Portfolio node selection |
-| `populates_items_on_successful_fetch` | Resolves with 2 items | `items` length is 2; `items[0].assetName` matches expected value |
+| `populates_items_on_successful_fetch` | Resolves with 2 items including `totalCredits` and `cashFlows` | `items` length is 2; `items[0].assetName`, `items[0].totalCredits`, and `items[0].cashFlows` match expected values |
 | `sets_error_on_fetch_failure` | Rejects with error message | `error` equals the error message; `items` is `null` |
 | `resets_state_on_node_change` | Select Portfolio, then select Broker | After second selection, `items` is `null` and `isLoading` reflects current fetch state |
 | `retry_re_triggers_fetch` | First call rejects, second resolves | After `retry()`, `getPortfolioAssetsSummaryMock` called twice; `items` populated after second call |
@@ -172,7 +215,7 @@ Follows the `createWrapper()` / `SelectedNodeProvider` / `vi.mock('../api/financ
 
 ### PortfolioSummaryTab.test.tsx
 
-Follows the `vi.mock` / `setMock` / `Object.assign` pattern from `AggregatedSummaryTab.test.tsx`. Mocks both `useAggregatedSummary` and `usePortfolioAssetSummary`.
+Follows the `vi.mock` / `setMock` / `Object.assign` pattern from `AggregatedSummaryTab.test.tsx`. Mocks `useAggregatedSummary`, `usePortfolioAssetSummary`, and `xirr` utility.
 
 | Test Function | Description | Assertions |
 |---------------|-------------|------------|
@@ -180,15 +223,24 @@ Follows the `vi.mock` / `setMock` / `Object.assign` pattern from `AggregatedSumm
 | `renders_error_state_in_totals_section_on_aggregated_summary_failure` | `useAggregatedSummary` returns `error` | ErrorState with Retry button rendered in totals area |
 | `renders_loading_state_in_table_section_while_items_load` | `usePortfolioAssetSummary` returns `isLoading: true` | Loading indicator rendered in table section |
 | `renders_error_state_in_table_section_on_items_fetch_failure` | `usePortfolioAssetSummary` returns `error` | ErrorState with Retry button rendered in table section; totals section still visible above |
-| `renders_table_with_correct_column_headers` | Both hooks return data | `<th>` elements with text: Asset Name, First Investment, Quantity, Total Invested, % Portfolio, Current Value, % Profit |
-| `renders_asset_row_with_correctly_formatted_values` | Known item (first date, N8 quantity, N2 invested, one-decimal weight) | `assetName`, `firstInvestmentDate` as `DD/MM/YYYY`, `currentQuantity` N8, `totalInvested` N2, `portfolioWeight` as `23.4%` |
-| `renders_per_cell_loading_indicator_while_price_loads` | `rowPrices[0].isLoading: true` | Current Value cell shows `...`; `% Profit` cell shows `...` |
+| `renders_table_with_correct_column_headers` | Both hooks return data | `<th>` elements with text: Asset Name, First Investment, Quantity, Total Invested, % Portfolio, Total Credits, Current Value, % Profit, % Profit w/ Credits, XIRR |
+| `renders_asset_row_with_correctly_formatted_values` | Known item (first date, N8 quantity, N2 invested, one-decimal weight, N2 totalCredits) | `assetName`, `firstInvestmentDate` as `DD/MM/YYYY`, `currentQuantity` N8, `totalInvested` N2, `portfolioWeight` as `23.4%`, `totalCredits` N2 |
+| `renders_total_credits_immediately_before_price_resolves` | `rowPrices[0].isLoading: true`, item has `totalCredits: 75.50` | Total Credits cell shows `75.50`; Current Value cell shows `...` |
+| `renders_per_cell_loading_indicator_while_price_loads` | `rowPrices[0].isLoading: true` | Current Value, % Profit, % Profit w/ Credits, and XIRR cells each show `...` |
 | `renders_current_value_when_price_resolves` | `rowPrices[0].currentPrice: 10.50`, item `currentQuantity: 25` | Current Value cell contains formatted `262.50` |
 | `renders_correct_profit_percent` | `currentValue: 262.50`, `totalInvested: 250.00` | `% Profit` cell shows formatted `5.00%` |
-| `renders_dash_in_current_value_and_profit_on_price_failure` | `rowPrices[0].fetchFailed: true` | Current Value and `% Profit` cells both show `—` |
-| `renders_dash_in_profit_when_total_invested_is_zero` | `totalInvested: 0`, price available | `% Profit` cell shows `—`; Current Value cell shows computed value |
+| `renders_correct_profit_with_credits_percent` | `currentValue: 262.50`, `totalInvested: 250.00`, `totalCredits: 12.50` | `% Profit w/ Credits` cell shows formatted `10.00%` |
+| `renders_xirr_when_price_resolves` | Price resolves; `xirr` mock returns `0.1234` | XIRR cell shows `12.34%` |
+| `renders_dash_in_current_value_and_price_dependent_columns_on_price_failure` | `rowPrices[0].fetchFailed: true` | Current Value, % Profit, % Profit w/ Credits, and XIRR cells each show `—` |
+| `renders_dash_in_profit_when_total_invested_is_zero` | `totalInvested: 0`, price available | `% Profit` and `% Profit w/ Credits` cells show `—`; Current Value cell shows computed value |
+| `renders_dash_in_xirr_when_cash_flows_fewer_than_two_entries` | `cashFlows: []`, one terminal entry appended → 1 entry total | XIRR cell shows `—`; `xirr` utility not called (or called and returns `null`) |
+| `renders_dash_in_xirr_on_non_convergence` | `xirr` mock returns `null` | XIRR cell shows `—` |
 | `applies_green_class_to_positive_profit` | `currentValue > totalInvested` | `% Profit` element has `portfolio-summary__profit--green` class |
 | `applies_red_class_to_negative_profit` | `currentValue < totalInvested` | `% Profit` element has `portfolio-summary__profit--red` class |
+| `applies_green_class_to_positive_profit_with_credits` | `currentValue + totalCredits > totalInvested` | `% Profit w/ Credits` element has `portfolio-summary__profit--green` class |
+| `applies_red_class_to_negative_profit_with_credits` | `currentValue + totalCredits < totalInvested` | `% Profit w/ Credits` element has `portfolio-summary__profit--red` class |
+| `applies_green_class_to_positive_xirr` | `xirr` mock returns positive value | XIRR element has `portfolio-summary__profit--green` class |
+| `applies_red_class_to_negative_xirr` | `xirr` mock returns negative value | XIRR element has `portfolio-summary__profit--red` class |
 | `renders_empty_string_for_null_first_investment_date` | `firstInvestmentDate: null` | First Investment cell content is empty |
 | `totals_section_is_unaffected_when_table_section_errors` | Table error, aggregated summary resolves with data | Three totals (Total Bought, Total Sold, Total Credits) rendered; ErrorState present in table section |
 
@@ -200,18 +252,25 @@ Follows the `vi.mock` / `setMock` / `Object.assign` pattern from `AggregatedSumm
 | Selecting a Broker node still renders `AggregatedSummaryTab` (regression) | `DetailPanel.test.tsx` existing tests |
 | Selecting an Asset node still renders `AssetSummaryTab` (regression) | `DetailPanel.test.tsx` existing tests |
 | Three totals (green/red/blue) at top | `totals_section_is_unaffected_when_table_section_errors`; colour coverage in existing `AggregatedSummaryTab` tests |
-| Per-asset table with 7 correct columns | `renders_table_with_correct_column_headers` |
-| Current Value and % Profit populate automatically | `renders_current_value_when_price_resolves` + `fires_getCurrentPrice_for_each_item_after_fetch` |
-| Failed price fetch shows `"—"`, other rows unaffected | `renders_dash_in_current_value_and_profit_on_price_failure` + `failed_price_for_one_row_does_not_affect_other_rows` |
+| Per-asset table with 10 correct columns | `renders_table_with_correct_column_headers` |
+| Total Credits column populated immediately from F01 response | `renders_total_credits_immediately_before_price_resolves` |
+| Current Value, % Profit, % Profit w/ Credits, and XIRR populate automatically | `renders_current_value_when_price_resolves` + `renders_correct_profit_percent` + `renders_correct_profit_with_credits_percent` + `renders_xirr_when_price_resolves` + `fires_getCurrentPrice_for_each_item_after_fetch` |
+| Failed price fetch shows `"—"` in four cells; other rows unaffected | `renders_dash_in_current_value_and_price_dependent_columns_on_price_failure` + `failed_price_for_one_row_does_not_affect_other_rows` |
 | `% Profit` green when positive, red when negative | `applies_green_class_to_positive_profit` + `applies_red_class_to_negative_profit` |
+| `% Profit w/ Credits` green when positive, red when negative | `applies_green_class_to_positive_profit_with_credits` + `applies_red_class_to_negative_profit_with_credits` |
+| `XIRR` green when positive, red when negative; `"—"` when price unavailable or non-convergent | `applies_green_class_to_positive_xirr` + `applies_red_class_to_negative_xirr` + `renders_dash_in_xirr_on_non_convergence` + `renders_dash_in_current_value_and_price_dependent_columns_on_price_failure` |
 | F01 failure shows ErrorState with Retry; totals unaffected | `renders_error_state_in_table_section_on_items_fetch_failure` + `totals_section_is_unaffected_when_table_section_errors` |
 | `CurrentValue = CurrentPrice × CurrentQuantity` | `renders_current_value_when_price_resolves` |
 | `% Profit = (CurrentValue − TotalInvested) / TotalInvested × 100` | `renders_correct_profit_percent` |
-| `"—"` in `% Profit` when `TotalInvested` is 0 | `renders_dash_in_profit_when_total_invested_is_zero` |
+| `% Profit w/ Credits = (CurrentValue + TotalCredits − TotalInvested) / TotalInvested × 100` | `renders_correct_profit_with_credits_percent` |
+| `XIRR` computed using CashFlows from F01 plus terminal entry `(today, +CurrentValue)` | `renders_xirr_when_price_resolves` (mock asserts correct call); `xirr_returns_correct_annualised_rate_for_known_inputs` |
+| `"—"` in `% Profit` and `% Profit w/ Credits` when `TotalInvested` is 0 | `renders_dash_in_profit_when_total_invested_is_zero` |
+| `"—"` in XIRR when CashFlows has fewer than 2 entries after appending terminal entry | `renders_dash_in_xirr_when_cash_flows_fewer_than_two_entries` |
 
 ### Cross-Feature Integration Tests
 
 | PRD Section 9 — Cross-Feature Criterion | Covered By |
 |------------------------------------------|------------|
 | `ticker` and `exchange` from F01 used without modification in `GET /prices/current` calls | `fires_getCurrentPrice_for_each_item_after_fetch` — asserts exact `exchange` and `ticker` values passed to `getCurrentPrice` |
-| `totalInvested` and `currentQuantity` from F01 used without transformation in `CurrentValue` and `% Profit` computation | `renders_current_value_when_price_resolves` + `renders_correct_profit_percent` — use known F01 field values and verify exact output |
+| `totalInvested` and `currentQuantity` from F01 used without transformation in `CurrentValue`, `% Profit`, and `% Profit w/ Credits` computation | `renders_current_value_when_price_resolves` + `renders_correct_profit_percent` + `renders_correct_profit_with_credits_percent` — use known F01 field values and verify exact output |
+| `cashFlows` array from F01 used without transformation in XIRR computation; appending terminal entry produces the complete series | `renders_xirr_when_price_resolves` — verifies `xirr` is called with `cashFlows` entries plus the terminal entry `(today, +currentValue)` |


### PR DESCRIPTION
## Summary

- `PortfolioAssetSummaryItemDto` updated to include `totalCredits` and `cashFlows` fields (aligning with the F01 spec); `AssetCashFlowDto` type added
- `xirr.ts` pure utility function added to scope, component overview, and plan (Newton-Raphson, 100 iterations, 1e-7 tolerance)
- `PortfolioSummaryTab` component overview updated to cover all 10 table columns and compute `% Profit w/ Credits` and XIRR per row
- New technical decision documenting why XIRR computation belongs in the component (not the hook)
- Test suite expanded: `xirr.test.ts` (4 cases), updated hook test for cashFlows in items, 12 new component tests covering Total Credits immediate rendering, `% Profit w/ Credits` formula/colour, XIRR formula/colour/dash scenarios
- Acceptance test mapping and cross-feature integration table updated to cover all Section 9 criteria

## Test plan

- [ ] Verify all 10 column headers listed in `renders_table_with_correct_column_headers`
- [ ] Verify `totalCredits` and `cashFlows` present in `PortfolioAssetSummaryItemDto` type table (Section 5)
- [ ] Verify JSON response example includes `totalCredits` and `cashFlows`
- [ ] Verify XIRR technical decision entry in Section 3
- [ ] Verify cross-feature integration row for `cashFlows` present in Section 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)