### PR TITLE
docs(P03-F01): add spec and plan for credits analysis service enhancement

### DIFF
--- a/Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs
+++ b/Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs
@@ -13,4 +13,11 @@ public sealed class PortfolioAssetSummaryItemDTO
     public decimal PortfolioWeight { get; init; }
     public decimal TotalCredits { get; init; }
     public IReadOnlyList<AssetCashFlowDTO> CashFlows { get; init; } = [];
+    public decimal LastMonthCredits { get; init; }
+    public string? LastCreditMonth { get; init; }
+    public decimal? LastMonthCreditsPercent { get; init; }
+    public int? CreditFrequencyPerYear { get; init; }
+    public decimal? EstimatedAnnualCredits { get; init; }
+    public decimal? EstimatedAnnualPercent { get; init; }
+    public decimal CurrentMonthCredits { get; init; }
 }

--- a/Financial.Application/Services/PortfolioAssetSummaryQueryService.cs
+++ b/Financial.Application/Services/PortfolioAssetSummaryQueryService.cs
@@ -23,7 +23,8 @@ public sealed class PortfolioAssetSummaryQueryService : IPortfolioAssetSummaryQu
         if (assets.Count == 0)
             return [];
 
-        var computed = assets.Select(ComputeAssetData).ToList();
+        var today = DateTime.Today;
+        var computed = assets.Select(a => ComputeAssetData(a, today)).ToList();
         var portfolioTotalInvested = computed.Sum(c => c.TotalInvested);
 
         return NavigationMapper
@@ -32,7 +33,7 @@ public sealed class PortfolioAssetSummaryQueryService : IPortfolioAssetSummaryQu
             .ToList();
     }
 
-    private static AssetComputedData ComputeAssetData(Asset asset)
+    private static AssetComputedData ComputeAssetData(Asset asset, DateTime today)
     {
         var (totalBought, totalSold, totalCredits) = NavigationMapper.CalculateTotals(asset);
         var firstBuyDate = asset.Transactions
@@ -42,12 +43,85 @@ public sealed class PortfolioAssetSummaryQueryService : IPortfolioAssetSummaryQu
             .Min();
 
         var cashFlows = BuildCashFlows(asset);
+        var creditsAnalysis = ComputeCreditsAnalysis(asset, totalBought - totalSold, today);
 
         return new AssetComputedData(
             asset.Name, asset.Ticker, asset.Exchange,
             firstBuyDate, asset.Quantity,
             totalBought, totalSold, totalBought - totalSold,
-            totalCredits, cashFlows);
+            totalCredits, cashFlows,
+            creditsAnalysis.LastMonthCredits, creditsAnalysis.LastCreditMonth,
+            creditsAnalysis.LastMonthCreditsPercent, creditsAnalysis.CreditFrequencyPerYear,
+            creditsAnalysis.EstimatedAnnualCredits, creditsAnalysis.EstimatedAnnualPercent,
+            creditsAnalysis.CurrentMonthCredits);
+    }
+
+    private static CreditsAnalysis ComputeCreditsAnalysis(Asset asset, decimal totalInvested, DateTime today)
+    {
+        var pastCredits = asset.Credits.Where(c => c.Date <= today).ToList();
+
+        var lastCreditMonth = pastCredits
+            .GroupBy(c => (c.Date.Year, c.Date.Month))
+            .Select(g => g.Key)
+            .OrderByDescending(g => g.Year).ThenByDescending(g => g.Month)
+            .Cast<(int Year, int Month)?>()
+            .FirstOrDefault();
+
+        var lastMonthCreditsString = lastCreditMonth.HasValue
+            ? $"{lastCreditMonth.Value.Year:D4}-{lastCreditMonth.Value.Month:D2}"
+            : null;
+
+        var lastMonthCredits = lastCreditMonth.HasValue
+            ? pastCredits
+                .Where(c => c.Date.Year == lastCreditMonth.Value.Year && c.Date.Month == lastCreditMonth.Value.Month)
+                .Sum(c => c.Value)
+            : 0m;
+
+        decimal? lastMonthCreditsPercent = lastCreditMonth.HasValue && totalInvested != 0m
+            ? lastMonthCredits / totalInvested * 100m
+            : null;
+
+        var frequencyPerYear = DetectCreditFrequency(asset.Credits);
+
+        decimal? estimatedAnnualCredits = frequencyPerYear.HasValue
+            ? lastMonthCredits * frequencyPerYear.Value
+            : null;
+
+        decimal? estimatedAnnualPercent = estimatedAnnualCredits.HasValue && totalInvested != 0m
+            ? estimatedAnnualCredits.Value / totalInvested * 100m
+            : null;
+
+        var currentMonthCredits = asset.Credits
+            .Where(c => c.Date.Year == today.Year && c.Date.Month == today.Month)
+            .Sum(c => c.Value);
+
+        return new CreditsAnalysis(
+            lastMonthCredits, lastMonthCreditsString, lastMonthCreditsPercent,
+            frequencyPerYear, estimatedAnnualCredits, estimatedAnnualPercent,
+            currentMonthCredits);
+    }
+
+    private static int? DetectCreditFrequency(IEnumerable<Credit> credits)
+    {
+        var distinctMonths = credits
+            .Select(c => c.Date.Year * 12 + (c.Date.Month - 1))
+            .Distinct()
+            .OrderBy(m => m)
+            .ToList();
+
+        if (distinctMonths.Count < 2)
+            return null;
+
+        var totalGap = distinctMonths[^1] - distinctMonths[0];
+        var averageGap = (double)totalGap / (distinctMonths.Count - 1);
+
+        return averageGap switch
+        {
+            <= 1.5 => 12,
+            <= 3.5 => 4,
+            <= 5.0 => 3,
+            _ => null
+        };
     }
 
     private static IReadOnlyList<AssetCashFlowDTO> BuildCashFlows(Asset asset)
@@ -80,7 +154,14 @@ public sealed class PortfolioAssetSummaryQueryService : IPortfolioAssetSummaryQu
             TotalInvested = c.TotalInvested,
             PortfolioWeight = weight,
             TotalCredits = c.TotalCredits,
-            CashFlows = c.CashFlows
+            CashFlows = c.CashFlows,
+            LastMonthCredits = c.LastMonthCredits,
+            LastCreditMonth = c.LastCreditMonth,
+            LastMonthCreditsPercent = c.LastMonthCreditsPercent,
+            CreditFrequencyPerYear = c.CreditFrequencyPerYear,
+            EstimatedAnnualCredits = c.EstimatedAnnualCredits,
+            EstimatedAnnualPercent = c.EstimatedAnnualPercent,
+            CurrentMonthCredits = c.CurrentMonthCredits
         };
 
     private static decimal CalculateWeight(decimal totalInvested, decimal portfolioTotalInvested) =>
@@ -90,5 +171,13 @@ public sealed class PortfolioAssetSummaryQueryService : IPortfolioAssetSummaryQu
         string AssetName, string Ticker, string Exchange,
         DateTime? FirstInvestmentDate, decimal CurrentQuantity,
         decimal TotalBought, decimal TotalSold, decimal TotalInvested,
-        decimal TotalCredits, IReadOnlyList<AssetCashFlowDTO> CashFlows);
+        decimal TotalCredits, IReadOnlyList<AssetCashFlowDTO> CashFlows,
+        decimal LastMonthCredits, string? LastCreditMonth, decimal? LastMonthCreditsPercent,
+        int? CreditFrequencyPerYear, decimal? EstimatedAnnualCredits, decimal? EstimatedAnnualPercent,
+        decimal CurrentMonthCredits);
+
+    private sealed record CreditsAnalysis(
+        decimal LastMonthCredits, string? LastCreditMonth, decimal? LastMonthCreditsPercent,
+        int? CreditFrequencyPerYear, decimal? EstimatedAnnualCredits, decimal? EstimatedAnnualPercent,
+        decimal CurrentMonthCredits);
 }

--- a/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
@@ -62,6 +62,30 @@ public class SummaryEndpointsTests
     }
 
     [Fact]
+    public async Task GetPortfolioAssetsSummary_Returns200WithCreditsAnalysisFields()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/portfolio/XPI/Default/assets");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var items = await response.Content.ReadFromJsonAsync<List<PortfolioAssetSummaryItemDTO>>();
+        items.Should().NotBeNull();
+        items.Should().NotBeEmpty();
+        items!.Should().AllSatisfy(i =>
+        {
+            i.LastMonthCredits.Should().BeGreaterThanOrEqualTo(0m);
+            i.CurrentMonthCredits.Should().BeGreaterThanOrEqualTo(0m);
+        });
+        items!.Where(i => i.LastCreditMonth != null && i.TotalInvested > 0)
+            .Should().AllSatisfy(i => i.LastMonthCreditsPercent.Should().NotBeNull());
+        items.Where(i => i.CreditFrequencyPerYear != null)
+            .Should().AllSatisfy(i => i.EstimatedAnnualCredits.Should().NotBeNull());
+    }
+
+    [Fact]
     public async Task GetBrokerSummary_Returns200WithDto()
     {
         await using var factory = new ApiTestFactory();

--- a/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryQueryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryQueryServiceTests.cs
@@ -289,6 +289,290 @@ public class PortfolioAssetSummaryQueryServiceTests
         result[0].CashFlows[0].Amount.Should().Be(-155m);
     }
 
+    // ── Phase 3: Credits-analysis unit tests ─────────────────────────────────
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastMonthCredits_SumOfMostRecentMonthCredits()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 20m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 10m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 15), Credit.CreditType.Dividend, 8m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastMonthCredits.Should().Be(18m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastMonthCredits_Zero_WhenNoCredits()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastMonthCredits.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastCreditMonth_FormattedYYYYMM()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 10), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastCreditMonth.Should().Be("2024-06");
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastCreditMonth_Null_WhenNoCredits()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastCreditMonth.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ExcludesFutureCreditDatesFromLastMonthCalculation()
+    {
+        var pastDate = DateTime.Today.AddMonths(-1);
+        var futureDate = DateTime.Today.AddDays(5);
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(pastDate, Credit.CreditType.Dividend, 10m));
+        asset.AddCredit(Credit.Create(futureDate, Credit.CreditType.Dividend, 99m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        using var _ = new AssertionScope();
+        result[0].LastCreditMonth.Should().Be($"{pastDate.Year:D4}-{pastDate.Month:D2}");
+        result[0].LastMonthCredits.Should().Be(10m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Computed()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 10m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastMonthCreditsPercent.Should().Be(1m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Null_WhenTotalInvestedIsZero()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 2, 1), Transaction.TransactionType.Sell, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastMonthCreditsPercent.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Null_WhenNoCredits()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastMonthCreditsPercent.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_DetectsMonthlyFrequency()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 15), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CreditFrequencyPerYear.Should().Be(12);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_DetectsQuarterlyFrequency()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 4, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 7, 15), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CreditFrequencyPerYear.Should().Be(4);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_DetectsFourMonthFrequency()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 5, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 9, 15), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CreditFrequencyPerYear.Should().Be(3);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsNullFrequency_WhenOnlyOneDistinctCreditMonth()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 15), Credit.CreditType.Dividend, 3m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CreditFrequencyPerYear.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsNullFrequency_WhenGapOutsideKnownRanges()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 9, 15), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CreditFrequencyPerYear.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualCredits_Computed()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 10000m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 50m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 50m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 50m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].EstimatedAnnualCredits.Should().Be(600m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualCredits_Null_WhenFrequencyNull()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].EstimatedAnnualCredits.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Computed()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 10000m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 50m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 50m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 50m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].EstimatedAnnualPercent.Should().Be(6m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Null_WhenEstimatedCreditsNull()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].EstimatedAnnualPercent.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Null_WhenTotalInvestedIsZero()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 2, 1), Transaction.TransactionType.Sell, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].EstimatedAnnualPercent.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsCurrentMonthCredits_SumOfCurrentMonthCredits()
+    {
+        var today = DateTime.Today;
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(today.Year, today.Month, 1), Credit.CreditType.Dividend, 12m));
+        asset.AddCredit(Credit.Create(new DateTime(today.Year, today.Month, 10), Credit.CreditType.Dividend, 8m));
+        asset.AddCredit(Credit.Create(today.AddMonths(-1), Credit.CreditType.Dividend, 99m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CurrentMonthCredits.Should().Be(20m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsCurrentMonthCredits_Zero_WhenNoneInCurrentMonth()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(DateTime.Today.AddMonths(-1), Credit.CreditType.Dividend, 15m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CurrentMonthCredits.Should().Be(0m);
+    }
+
     private PortfolioAssetSummaryQueryService CreateService() => new(_repository);
 
     private static Asset MakeAsset(string name, string ticker, string exchange) =>

--- a/docs/P03-F01-credits-analysis-service-enhancement/plan.md
+++ b/docs/P03-F01-credits-analysis-service-enhancement/plan.md
@@ -1,0 +1,26 @@
+# Implementation Plan: P03-F01 — Credits Analysis — Service Enhancement
+
+**Prerequisites:**
+- All existing dependencies (xUnit, FluentAssertions, WebApplicationFactory) already present in the test projects
+- `PortfolioAssetSummaryQueryService`, `PortfolioAssetSummaryItemDTO`, and the endpoint are already implemented and passing all P02 tests
+- `Credit.Date` and `Credit.Value` on the domain entity already provide all data needed for the new computations
+
+---
+
+### Phase 1: Application Layer — DTO Extension
+
+**1. PortfolioAssetSummaryItemDTO Update** — Add the seven new properties to the existing sealed class following the `{ get; init; }` pattern. Non-nullable fields with zero defaults (`LastMonthCredits`, `CurrentMonthCredits`) must not be declared nullable; nullable fields use the appropriate `?` types. See spec Sections 4 and 5 for property names and types.
+
+---
+
+### Phase 2: Application Layer — Service Update
+
+**2. PortfolioAssetSummaryQueryService Update** — Capture `DateTime.Today` once at the start of `GetPortfolioAssetsSummary` and pass it through to `ComputeAssetData`. Extend the private `AssetComputedData` record with the seven new fields. Add a new private static method `ComputeCreditsAnalysis` that computes all seven fields for a single asset: determines the last credit month by excluding future-dated credits, sums credits in that month, detects payment frequency from all distinct credit months using the average-gap algorithm, derives estimated annual values, and sums current-calendar-month credits. Update `ToDTO` to propagate all seven new fields. See spec Sections 3, 4, and 5 for field formulas, frequency ranges, and null rules.
+
+---
+
+### Phase 3: Tests
+
+**3. PortfolioAssetSummaryQueryServiceTests — New Unit Tests** — Add the twenty new unit test cases to the existing test class. Cover `LastMonthCredits` (most-recent-month sum, zero when no credits), `LastCreditMonth` (YYYY-MM format, null when no credits, future-date exclusion from both month determination and sum), `LastMonthCreditsPercent` (computed value, null when invested absent or last month null), the four frequency-detection scenarios (monthly, quarterly, four-month, undetectable by count and by gap range), `EstimatedAnnualCredits` (computed, null when no frequency), `EstimatedAnnualPercent` (computed, null when credits or invested absent), and `CurrentMonthCredits` (current-month sum and zero when none). See spec Section 7 for the full test function list and assertions.
+
+**4. SummaryEndpointsTests — New Integration Test** — Add `GetPortfolioAssetsSummary_Returns200WithCreditsAnalysisFields` to assert that the HTTP response includes all seven new fields with valid values for the real test data file. See spec Section 7.

--- a/docs/P03-F01-credits-analysis-service-enhancement/spec.md
+++ b/docs/P03-F01-credits-analysis-service-enhancement/spec.md
@@ -1,0 +1,213 @@
+# Spec: P03-F01 — Credits Analysis — Service Enhancement
+
+## 1. Technical Overview
+
+**What:** Extends `PortfolioAssetSummaryItemDTO` with seven new fields — `LastMonthCredits`, `LastCreditMonth`, `LastMonthCreditsPercent`, `CreditFrequencyPerYear`, `EstimatedAnnualCredits`, `EstimatedAnnualPercent`, and `CurrentMonthCredits` — and extends `PortfolioAssetSummaryQueryService` with the corresponding computation logic, including a payment-frequency detection algorithm derived from each asset's credit history. No new endpoint or route is introduced; the existing `GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets` response grows additively with no breaking change to existing fields.
+
+**Why:** F02 (web) and F03 (WPF) need per-asset last-month credit data, frequency-derived annual income estimates, and current-month credits (for the portfolio footer total) without re-fetching credit history or duplicating the frequency algorithm across two UI implementations. Centralising the computation in the Application layer keeps domain data access behind `IRepository` and avoids repeating the detection logic in each frontend.
+
+**Scope:**
+
+Included:
+- `PortfolioAssetSummaryItemDTO` — seven new nullable/zero-default properties, all `{ get; init; }`, following the existing sealed-class pattern
+- `PortfolioAssetSummaryQueryService` — extend private `AssetComputedData` record with the seven new fields; add private static `ComputeCreditsAnalysis` method encapsulating all seven computations; capture `DateTime.Today` once per call and propagate it; update `ComputeAssetData` and `ToDTO` to include the new fields
+- Unit tests covering all new computation paths (frequency detection variants, null paths, future-date exclusion, current-month matching)
+- Integration test verifying the seven new fields appear in the HTTP response
+
+Excluded:
+- Any changes to `SummaryController` routing, HTTP method, or status codes
+- Any changes to `ISummaryQueryService`, `SummaryQueryService`, or other controller actions
+- Broker-level per-asset breakdown
+- Timezone-aware "today" abstraction (`DateTime.Today` is sufficient for a personal app)
+- Manual frequency override per asset (out of scope per PRD Section 7)
+
+---
+
+## 2. Architecture Impact
+
+**Affected components:**
+
+```mermaid
+graph TD
+    Caller["Web browser / WPF"] --> Controller["SummaryController"]
+    Controller --> IService["IPortfolioAssetSummaryQueryService"]
+    IService --> Service["PortfolioAssetSummaryQueryService"]
+    Service --> Repository["IRepository.GetAssetsByBrokerPortfolio()"]
+    Service --> ComputeCredits["ComputeCreditsAnalysis() (new private static)"]
+    Service --> ItemDTO["PortfolioAssetSummaryItemDTO (modified)"]
+    Repository --> JSONRepo["JSONRepository (Financial.Infrastructure)"]
+```
+
+---
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Credits analysis computation location | Private static method `ComputeCreditsAnalysis` in `PortfolioAssetSummaryQueryService`, accepting `Asset` and `DateTime today` | Separate domain service or helper class | Consistent with `BuildCashFlows` already being a private static in the same class; avoids a new abstraction for logic that is only consumed here |
+| "Today" capture strategy | `DateTime today` captured once at the top of `GetPortfolioAssetsSummary` and passed through `ComputeAssetData` to `ComputeCreditsAnalysis` | Call `DateTime.Today` inline inside the method | All assets in a single call share the same logical "today", eliminating a day-boundary edge case; tests set up data relative to `DateTime.Today` without needing an injectable clock |
+| `AssetComputedData` extension | Add all seven new fields to the existing private record | Create a second intermediate record for credits-analysis fields | Keeps the two-step pipeline intact (compute → project to DTO) with a single record per asset; follows the P02-F01 pattern |
+| Frequency detection scope | Use all credits (past and future) for distinct-month enumeration | Filter to `Date ≤ today` before computing frequency | PRD algorithm step 1 specifies "all distinct (Year, Month) combinations from the asset's credit history"; the future-date exclusion rule is stated only for `lastCreditMonth` and `lastMonthCredits` |
+| Null handling for JSON serialisation | `null` values serialise as JSON `null` (ASP.NET Core default; no custom `JsonSerializerOptions` needed) | Omit null fields (`DefaultIgnoreCondition = WhenWritingNull`) | PRD Section 6 explicitly requires null fields to serialise as `null`, not to be omitted; the existing endpoint already serialises nulls this way |
+
+---
+
+## 4. Component Overview
+
+### Backend
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs` | Modified | Response DTO per asset | Add `LastMonthCredits` (decimal), `LastCreditMonth` (string?), `LastMonthCreditsPercent` (decimal?), `CreditFrequencyPerYear` (int?), `EstimatedAnnualCredits` (decimal?), `EstimatedAnnualPercent` (decimal?), `CurrentMonthCredits` (decimal); all use `{ get; init; }`; non-nullable fields default to `0` |
+| `Financial.Application/Services/PortfolioAssetSummaryQueryService.cs` | Modified | Query and mapping logic | Capture `DateTime.Today` once per call; add `ComputeCreditsAnalysis(Asset, DateTime)` private static method; extend `AssetComputedData` sealed record with seven new fields; update `ComputeAssetData` to call `ComputeCreditsAnalysis`; update `ToDTO` to propagate all seven fields |
+
+---
+
+## 5. API Contracts
+
+### GET Portfolio Assets Summary (additive change to existing endpoint)
+
+- **Method:** GET
+- **Path:** `/api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets`
+- **Authentication:** None
+
+**Response (200 OK) — seven new fields added to each item:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `[].lastMonthCredits` | `decimal` | Sum of Credit `Value` for all credits with `Date ≤ today` whose (Year, Month) matches the most recent such credit month; `0` when the asset has no credits |
+| `[].lastCreditMonth` | `string` \| `null` | Most recent credit month with `Date ≤ today`, formatted `"YYYY-MM"` (e.g., `"2026-06"`); `null` when no credits exist with `Date ≤ today` |
+| `[].lastMonthCreditsPercent` | `decimal` \| `null` | `lastMonthCredits / totalInvested × 100`; `null` when `totalInvested` is `0` or `lastCreditMonth` is `null` |
+| `[].creditFrequencyPerYear` | `integer` \| `null` | Detected payment periods per year from all distinct credit months: `12` (avg gap ≤ 1.5 mo), `4` (1.6–3.5 mo), `3` (3.6–5.0 mo); `null` when fewer than 2 distinct credit months exist or avg gap is outside all recognised ranges |
+| `[].estimatedAnnualCredits` | `decimal` \| `null` | `lastMonthCredits × creditFrequencyPerYear`; `null` when `creditFrequencyPerYear` is `null` |
+| `[].estimatedAnnualPercent` | `decimal` \| `null` | `estimatedAnnualCredits / totalInvested × 100`; `null` when `estimatedAnnualCredits` is `null` or `totalInvested` is `0` |
+| `[].currentMonthCredits` | `decimal` | Sum of Credit `Value` for all credits whose `Date.Year` and `Date.Month` match today (no `≤ today` constraint); `0` when none exist in the current calendar month |
+
+All existing fields (`assetName`, `ticker`, `exchange`, `firstInvestmentDate`, `currentQuantity`, `totalBought`, `totalSold`, `totalInvested`, `portfolioWeight`, `totalCredits`, `cashFlows`) are unchanged and unaffected.
+
+**Response Example (200):**
+
+```json
+[
+  {
+    "assetName": "ALZR11",
+    "ticker": "ALZR11",
+    "exchange": "BVMF",
+    "firstInvestmentDate": "2021-03-01T00:00:00",
+    "currentQuantity": 20.0,
+    "totalBought": 2500.00,
+    "totalSold": 0.00,
+    "totalInvested": 2500.00,
+    "portfolioWeight": 100.0,
+    "totalCredits": 125.00,
+    "cashFlows": [
+      { "date": "2021-03-01T00:00:00", "amount": -2500.00 },
+      { "date": "2026-06-10T00:00:00", "amount": 12.50 }
+    ],
+    "lastMonthCredits": 12.50,
+    "lastCreditMonth": "2026-06",
+    "lastMonthCreditsPercent": 0.50,
+    "creditFrequencyPerYear": 12,
+    "estimatedAnnualCredits": 150.00,
+    "estimatedAnnualPercent": 6.00,
+    "currentMonthCredits": 0.00
+  },
+  {
+    "assetName": "MXRF11",
+    "ticker": "MXRF11",
+    "exchange": "BVMF",
+    "firstInvestmentDate": "2021-05-15T00:00:00",
+    "currentQuantity": 0.0,
+    "totalBought": 1200.00,
+    "totalSold": 1200.00,
+    "totalInvested": 0.00,
+    "portfolioWeight": 0.0,
+    "totalCredits": 0.00,
+    "cashFlows": [
+      { "date": "2021-05-15T00:00:00", "amount": -1200.00 },
+      { "date": "2022-03-01T00:00:00", "amount": 1200.00 }
+    ],
+    "lastMonthCredits": 0.00,
+    "lastCreditMonth": null,
+    "lastMonthCreditsPercent": null,
+    "creditFrequencyPerYear": null,
+    "estimatedAnnualCredits": null,
+    "estimatedAnnualPercent": null,
+    "currentMonthCredits": 0.00
+  }
+]
+```
+
+**Error Codes:** Unchanged — `200` on success (including empty array), `400` when `brokerName` or `portfolioName` is null/empty/whitespace. No new error conditions.
+
+---
+
+## 6. Data Model
+
+Not applicable. No persistence schema changes. All new values are computed at query time from `Asset.Credits` (`Credit.Date` and `Credit.Value`) already loaded in memory by `IRepository.GetAssetsByBrokerPortfolio`. No infrastructure changes required.
+
+---
+
+## 7. Testing Strategy
+
+### Test File Structure
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryQueryServiceTests.cs` | Unit | `PortfolioAssetSummaryQueryService` | All seven new fields, four frequency-detection scenarios, null paths, future-date exclusion, current-month matching |
+| `Tests/Financial.Api.Tests/SummaryEndpointsTests.cs` | Integration | `SummaryController.GetPortfolioAssetsSummary` | Seven new fields present and valid in HTTP response |
+
+### PortfolioAssetSummaryQueryServiceTests.cs (additions)
+
+Follows the established pattern: inner `StubRepository`, `FluentAssertions` with `AssertionScope`, `[Theory][InlineData]` for variants. All existing tests remain and pass unchanged.
+
+| Test Function | Description | Assertions |
+|---|---|---|
+| `GetPortfolioAssetsSummary_ReturnsLastMonthCredits_SumOfMostRecentMonthCredits` | Asset with two credits in a more-recent past month (10m + 8m) and one credit in an earlier month (20m) | `LastMonthCredits` equals `18m` |
+| `GetPortfolioAssetsSummary_ReturnsLastMonthCredits_Zero_WhenNoCredits` | Asset with Buy transactions only, no credits | `LastMonthCredits` equals `0m` |
+| `GetPortfolioAssetsSummary_ReturnsLastCreditMonth_FormattedYYYYMM` | Asset with a single past credit | `LastCreditMonth` formatted `"YYYY-MM"` matching the credit's year and month |
+| `GetPortfolioAssetsSummary_ReturnsLastCreditMonth_Null_WhenNoCredits` | Asset with no credits | `LastCreditMonth` is `null` |
+| `GetPortfolioAssetsSummary_ExcludesFutureCreditDatesFromLastMonthCalculation` | Asset with one past credit (value 10m) and one future-dated credit (value 99m) | `LastCreditMonth` reflects the past credit's month; `LastMonthCredits` equals `10m` (excludes the future credit) |
+| `GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Computed` | Asset with `LastMonthCredits = 10m`, `TotalInvested = 1000m` | `LastMonthCreditsPercent` equals `1m` |
+| `GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Null_WhenTotalInvestedIsZero` | Asset with equal `TotalBought` and `TotalSold` (net zero invested) and one past credit | `LastMonthCreditsPercent` is `null` |
+| `GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Null_WhenNoCredits` | Asset with no credits | `LastMonthCreditsPercent` is `null` |
+| `GetPortfolioAssetsSummary_DetectsMonthlyFrequency` | Asset with credits in Jan, Feb, Mar of the same year (average gap 1.0 months) | `CreditFrequencyPerYear` equals `12` |
+| `GetPortfolioAssetsSummary_DetectsQuarterlyFrequency` | Asset with credits in Jan, Apr, Jul of the same year (average gap 3.0 months) | `CreditFrequencyPerYear` equals `4` |
+| `GetPortfolioAssetsSummary_DetectsFourMonthFrequency` | Asset with credits in Jan, May, Sep of the same year (average gap 4.0 months) | `CreditFrequencyPerYear` equals `3` |
+| `GetPortfolioAssetsSummary_ReturnsNullFrequency_WhenOnlyOneDistinctCreditMonth` | Asset with multiple credits all falling in the same calendar month | `CreditFrequencyPerYear` is `null` |
+| `GetPortfolioAssetsSummary_ReturnsNullFrequency_WhenGapOutsideKnownRanges` | Asset with credits in Jan and Sep of the same year (average gap 8.0 months) | `CreditFrequencyPerYear` is `null` |
+| `GetPortfolioAssetsSummary_ReturnsEstimatedAnnualCredits_Computed` | Asset where `LastMonthCredits = 50m` and detected `CreditFrequencyPerYear = 12` | `EstimatedAnnualCredits` equals `600m` |
+| `GetPortfolioAssetsSummary_ReturnsEstimatedAnnualCredits_Null_WhenFrequencyNull` | Asset with only one distinct credit month | `EstimatedAnnualCredits` is `null` |
+| `GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Computed` | Asset with `EstimatedAnnualCredits = 600m`, `TotalInvested = 10000m` | `EstimatedAnnualPercent` equals `6m` |
+| `GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Null_WhenEstimatedCreditsNull` | Asset with one distinct credit month | `EstimatedAnnualPercent` is `null` |
+| `GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Null_WhenTotalInvestedIsZero` | Asset with detectable frequency but equal `TotalBought`/`TotalSold` | `EstimatedAnnualPercent` is `null` |
+| `GetPortfolioAssetsSummary_ReturnsCurrentMonthCredits_SumOfCurrentMonthCredits` | Asset with credits in the current calendar month and in a prior month | `CurrentMonthCredits` equals the sum of current-month credits only |
+| `GetPortfolioAssetsSummary_ReturnsCurrentMonthCredits_Zero_WhenNoneInCurrentMonth` | Asset with credits only in months prior to the current month | `CurrentMonthCredits` equals `0m` |
+
+### SummaryEndpointsTests.cs (addition)
+
+Follows the same `ApiTestFactory` / `WebApplicationFactory<Program>` pattern as existing summary tests.
+
+| Test Function | Description | Assertions |
+|---|---|---|
+| `GetPortfolioAssetsSummary_Returns200WithCreditsAnalysisFields` | `GET /api/v1/financial/summary/portfolio/XPI/Default/assets` against the real test data file | HTTP 200; every item has `LastMonthCredits ≥ 0`; every item has `CurrentMonthCredits ≥ 0`; every item where `LastCreditMonth != null` has a non-null `LastMonthCreditsPercent` or `TotalInvested == 0`; every item where `CreditFrequencyPerYear != null` has a non-null `EstimatedAnnualCredits` |
+
+### Acceptance Test Mapping
+
+| PRD Acceptance Criterion (Section 9 — F01) | Covered By |
+|---|---|
+| Response includes all 7 new fields for every item | `GetPortfolioAssetsSummary_Returns200WithCreditsAnalysisFields` |
+| `lastMonthCredits` equals sum of credits in most recent credit month ≤ today | `GetPortfolioAssetsSummary_ReturnsLastMonthCredits_SumOfMostRecentMonthCredits` |
+| `lastMonthCredits` is `0` when no credits | `GetPortfolioAssetsSummary_ReturnsLastMonthCredits_Zero_WhenNoCredits` |
+| `lastCreditMonth` formatted `"YYYY-MM"`; `null` when no credits | `GetPortfolioAssetsSummary_ReturnsLastCreditMonth_FormattedYYYYMM` + `_Null_WhenNoCredits` |
+| `lastMonthCreditsPercent` formula; `null` when `totalInvested = 0` or `lastCreditMonth` null | `GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Computed` + `_Null_WhenTotalInvestedIsZero` + `_Null_WhenNoCredits` |
+| `currentMonthCredits` equals sum of credits in current calendar month; `0` when none | `GetPortfolioAssetsSummary_ReturnsCurrentMonthCredits_SumOfCurrentMonthCredits` + `_Zero_WhenNoneInCurrentMonth` |
+| Frequency detection — monthly (avg gap ≤ 1.5 mo → 12) | `GetPortfolioAssetsSummary_DetectsMonthlyFrequency` |
+| Frequency detection — quarterly (avg gap 1.6–3.5 mo → 4) | `GetPortfolioAssetsSummary_DetectsQuarterlyFrequency` |
+| Frequency detection — four-month (avg gap 3.6–5.0 mo → 3) | `GetPortfolioAssetsSummary_DetectsFourMonthFrequency` |
+| Frequency detection — undetectable (< 2 distinct months) | `GetPortfolioAssetsSummary_ReturnsNullFrequency_WhenOnlyOneDistinctCreditMonth` |
+| Frequency detection — undetectable (avg gap outside 0–5 mo) | `GetPortfolioAssetsSummary_ReturnsNullFrequency_WhenGapOutsideKnownRanges` |
+| `estimatedAnnualCredits = lastMonthCredits × creditFrequencyPerYear`; `null` when frequency null | `GetPortfolioAssetsSummary_ReturnsEstimatedAnnualCredits_Computed` + `_Null_WhenFrequencyNull` |
+| `estimatedAnnualPercent` formula; `null` when credits null or invested `0` | `GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Computed` + `_Null_WhenEstimatedCreditsNull` + `_Null_WhenTotalInvestedIsZero` |
+| Future-dated credits excluded from `lastCreditMonth` and `lastMonthCredits` | `GetPortfolioAssetsSummary_ExcludesFutureCreditDatesFromLastMonthCalculation` |
+| Existing fields unchanged — P02 regression | All existing tests in `PortfolioAssetSummaryQueryServiceTests.cs` pass |

--- a/docs/prd/P03-prd-portfolio-credits-analysis/prd-portfolio-credits-analysis.md
+++ b/docs/prd/P03-prd-portfolio-credits-analysis/prd-portfolio-credits-analysis.md
@@ -1,0 +1,306 @@
+# Portfolio Credits Analysis Enhancement
+
+## 1. Executive Summary
+
+The Portfolio Credits Analysis Enhancement (P03) extends the per-asset breakdown table introduced in P02 in both the WPF desktop application and the React web application. When a portfolio node is selected, the Summary tab's per-asset table gains a visually separated credits-analysis column group positioned after the XIRR column, plus a summary footer panel rendered below the table.
+
+The five new columns surface income-focused metrics that are not available anywhere else in the application: the total credits received in the most recent payment month for each asset, the month and year of that payment period, those credits expressed as a percentage of total amount invested, estimated annual credits (derived from automatic payment-frequency detection against the asset's credit history), and the corresponding estimated annual yield percentage. A thick column-group separator after XIRR makes the boundary between performance metrics and income-analysis metrics visually clear.
+
+A summary footer panel beneath the grid provides portfolio-level totals for all key monetary columns. The credits total in the footer is scoped explicitly to the current calendar month and labelled accordingly (e.g., "Credits Jul 2026"), so the user can see at a glance how much income has arrived this month across the whole portfolio without confusing it with the all-time total already shown in the table.
+
+---
+
+## 2. Problem and Opportunity
+
+### The Problem
+
+**No visibility into recent credit income per asset**
+- The per-asset table introduced in P02 shows only the lifetime total of credits received (Total Credits column); there is no way to see how much an individual asset paid last month or which payment period that corresponds to
+- The user cannot quickly compare which assets paid most recently or identify positions that have not produced income in several months
+
+**No forward income estimate**
+- There is no projected annual dividend or rent yield per asset; evaluating expected annual income from a position requires manual calculation outside the application
+- Payment frequency varies by asset class (real estate funds pay monthly, some shares pay quarterly or every four months); without frequency detection the user must recall or look up each asset's schedule separately
+
+**No portfolio-level monetary summary**
+- The existing table has no footer; comparing the sum of all invested capital, current value, and current-month credits requires mental arithmetic or a spreadsheet
+- The current-month credits total — a common checkpoint for income investors — is not visible anywhere in the interface
+
+### The Opportunity
+
+Each problem maps to a concrete deliverable:
+
+- No recent credit visibility → new Last Month Credits, Last Credit Month, and Last Month % columns give per-asset income context for the most recent payment period
+- No forward income estimate → automatic frequency detection from credit history feeds the Est. Annual Credits and Est. Annual % columns, eliminating manual calculation
+- No portfolio-level summary → a footer panel below the table aggregates Total Invested, Total Credits, Current Value, current-month credits (clearly labelled), and Est. Annual Credits into a single at-a-glance strip
+
+---
+
+## 3. Target Audience
+
+### Primary Users
+
+**Personal Investor**
+- Manages a multi-broker portfolio spanning UK (GBP) and Brazil (BRL) markets with assets across equities, real estate funds, ETFs, and fixed income
+- Monitors dividend and rent income regularly and wants to see, per position, how much was received last payment month and what the projected annual yield is
+- Uses both the WPF desktop application and the React web application interchangeably and expects consistent information across both interfaces
+
+---
+
+## 4. Objectives
+
+**Surface last-payment-month credits per asset** so the user can identify recent income without leaving the application
+- Metric: Every portfolio asset row displays Last Month Credits, Last Credit Month, and Last Month % immediately when the portfolio summary loads, before price fetches complete
+
+**Provide estimated annual income per asset** based on automatically detected payment frequency
+- Metric: Assets with at least 2 distinct credit months in history display Est. Annual Credits and Est. Annual %; assets with undetectable frequency display "—" in those two columns
+
+**Provide a portfolio-level monetary summary footer** that aggregates key columns including a clearly labelled current-month credits total
+- Metric: A summary footer panel is visible below the per-asset table showing Total Invested, Total Credits, Current Value, Credits [Month Year] (current calendar month), and Est. Annual Credits; the credits total label includes the month and year so it is unambiguous
+
+---
+
+## 5. User Stories
+
+### F01. Credits Analysis — Service Enhancement
+
+- As the system, I want to compute the last-payment-month credits per asset so that both frontends can display recent income without re-fetching the credit history separately
+- As the system, I want to detect the payment frequency of an asset from its credit history so that an estimated annual credit amount can be derived without manual configuration
+- As the system, I want to compute current-calendar-month credits per asset so that the frontend can sum them for the portfolio footer without having to distinguish credits from sell transactions in the existing CashFlows list
+- As the system, I want to return null for frequency-dependent fields when the payment pattern cannot be reliably detected so that frontends display "—" instead of misleading estimates
+
+### F02. Credits Analysis Columns and Footer — Web Frontend
+
+- As a user, I want to see a visual separator after the XIRR column so that the credits-analysis columns are clearly grouped and distinct from the performance metrics
+- As a user, I want to see Last Month Credits per asset so that I know how much each position paid in its most recent payment period
+- As a user, I want to see the month and year of the last credit payment per asset so that I can tell at a glance whether an asset paid recently or has not paid in some time
+- As a user, I want to see last-month credits as a percentage of total invested per asset so that I can compare the monthly yield across different positions
+- As a user, I want to see estimated annual credits and annual yield percentage per asset so that I can evaluate forward income without manual calculation
+- As a user, I want a summary footer panel below the table showing total invested, total credits, current value, current-month credits, and estimated annual credits so that I have a portfolio-level income summary in one place
+- As a user, I want the current-month credits total in the footer to be labelled with the month and year so that I can distinguish it from the all-time total credits figure
+
+### F03. Credits Analysis Columns and Footer — WPF
+
+- As a user, I want the WPF DataGrid to show the same credits-analysis columns as the web application so that both interfaces provide consistent information
+- As a user, I want a visual column-group separator after XIRR in the WPF DataGrid so that the credits-analysis section is visually distinct
+- As a user, I want a summary footer panel below the WPF DataGrid showing the same aggregated totals as the web footer so that the WPF experience is consistent
+- As a user, I want the current-month credits total in the WPF footer to be labelled with the month and year so that its scope is unambiguous
+
+---
+
+## 6. Functionalities
+
+### F01. Credits Analysis — Service Enhancement
+
+**Provides:**
+- Per-asset credits-analysis fields: LastMonthCredits, LastCreditMonth, LastMonthCreditsPercent, EstimatedAnnualCredits, EstimatedAnnualPercent, CreditFrequencyPerYear, CurrentMonthCredits (used by F02, F03)
+
+**Capabilities:**
+- Extends the existing `PortfolioAssetSummaryItemDTO` (introduced in P02-F01) with seven new nullable fields; no breaking change to existing fields
+- New DTO fields per asset item:
+  - `LastMonthCredits` (decimal): sum of `Value` for all Credit records whose date falls in the most recent month where at least one credit date is ≤ today; 0 when the asset has no credits at all
+  - `LastCreditMonth` (string, nullable): the year-month of the last credit period formatted as `"YYYY-MM"` (e.g., `"2026-06"`); null when the asset has no credits
+  - `LastMonthCreditsPercent` (decimal, nullable): `LastMonthCredits / TotalInvested × 100`; null when `TotalInvested` is 0 or `LastCreditMonth` is null
+  - `CreditFrequencyPerYear` (int, nullable): detected number of payment periods per year — 12 (monthly), 4 (quarterly), or 3 (four-month); null when fewer than 2 distinct credit months exist in history or when the average gap does not fall within a recognised range
+  - `EstimatedAnnualCredits` (decimal, nullable): `LastMonthCredits × CreditFrequencyPerYear`; null when `CreditFrequencyPerYear` is null
+  - `EstimatedAnnualPercent` (decimal, nullable): `EstimatedAnnualCredits / TotalInvested × 100`; null when `EstimatedAnnualCredits` is null or `TotalInvested` is 0
+  - `CurrentMonthCredits` (decimal): sum of `Value` for all Credit records whose date falls in the current calendar month (year and month matching today); 0 when no credits exist in the current month
+- **Frequency detection algorithm:**
+  1. Collect all distinct (Year, Month) combinations from the asset's credit history, sorted ascending
+  2. Require at least 2 distinct months; if fewer, `CreditFrequencyPerYear` = null
+  3. Compute the average gap in months between consecutive distinct credit months: `averageGap = totalMonths / (distinctMonthCount − 1)`
+  4. Map average gap to frequency: ≤ 1.5 months → 12; 1.6–3.5 months → 4; 3.6–5.0 months → 3; outside all ranges → null
+- **Last credit month rule:** the last credit month is the most recent `(Year, Month)` pair from the asset's credit history where at least one credit has `Date ≤ today`; credits with future dates are excluded
+- The endpoint responds within 200 ms (data is in-memory; no external calls)
+
+**Experience:**
+- Endpoint response is structurally identical to P02-F01's response with additional fields; clients that ignore unknown fields are unaffected
+- Null fields in the JSON response are serialised as `null` (not omitted)
+
+---
+
+### F02. Credits Analysis Columns and Footer — Web Frontend
+
+**Consumes:**
+- F01: per-asset credits-analysis fields (LastMonthCredits, LastCreditMonth, LastMonthCreditsPercent, EstimatedAnnualCredits, EstimatedAnnualPercent, CreditFrequencyPerYear, CurrentMonthCredits)
+
+**Capabilities:**
+- The existing `PortfolioSummaryTab` component is extended; no new top-level component is introduced
+- **Column group separator:** a thick left border (3 px, using the table's accent colour) is applied to the "Last Month Credits" column header and every cell in that column, visually separating the credits-analysis group from the XIRR column to its left; no additional separator column is inserted into the DOM
+- **Five new columns appended after XIRR** (in this order):
+
+  | Column | Source | Format | Unavailable |
+  |---|---|---|---|
+  | Last Month Credits | `LastMonthCredits` | N2 | "—" when no credits |
+  | Last Credit Month | `LastCreditMonth` | "MMM YYYY" (e.g., "Jun 2026") | "—" when null |
+  | Last Month % | `LastMonthCreditsPercent` | N2 with "%" suffix | "—" when null |
+  | Est. Annual Credits | `EstimatedAnnualCredits` | N2 | "—" when null |
+  | Est. Annual % | `EstimatedAnnualPercent` | N2 with "%" suffix | "—" when null |
+
+- Last Month Credits, Est. Annual Credits display in the same neutral style as other monetary columns; no colour coding
+- **Footer panel:** a styled `<div>` rendered immediately below the `<table>` element (not a `<tfoot>` or `<tr>`); always visible once the F01 data has loaded; not affected by price fetch status
+- Footer panel items (labelled value pairs, left-to-right):
+  1. **Total Invested** — sum of `TotalInvested` across all assets
+  2. **Total Credits** — sum of `TotalCredits` (all-time) across all assets
+  3. **Current Value** — sum of resolved `CurrentValue` across all assets; shows a partial sum with an asterisk (`*`) and footnote "excludes assets with pending prices" while price fetches are still in progress; updates in place as prices resolve
+  4. **Credits [Mon YYYY]** — sum of `CurrentMonthCredits` across all assets, where `[Mon YYYY]` is the current calendar month formatted as "Jul 2026"; label updates each calendar month automatically
+  5. **Est. Annual Credits** — sum of `EstimatedAnnualCredits` across all assets for which the value is non-null; shows "—" when no asset has a detectable frequency
+- Footer panel background is visually distinct from the table rows (e.g., light grey or the card's header colour); footer is not scrollable with the table — it stays anchored below the table's scroll area if the table overflows
+- Columns with no meaningful total (First Investment, Quantity, % Portfolio, % Profit, % Profit w/ Credits, XIRR, Last Credit Month, Last Month %, Est. Annual %) are not represented in the footer
+
+**Experience:**
+1. User selects a Portfolio node; `PortfolioSummaryTab` renders as before (P02 behaviour unchanged)
+2. F01 data loads; all five new columns populate immediately (Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, Est. Annual % are available before price fetches complete); the footer panel appears with Total Invested, Total Credits, Credits [Mon YYYY], and Est. Annual Credits populated; Current Value footer shows "Calculating…" 
+3. Price fetches resolve per row; Current Value footer updates incrementally; once all prices are resolved the asterisk and footnote are removed
+4. Assets with no credits show "—" in Last Month Credits, Last Credit Month, and Last Month %; assets with fewer than 2 distinct credit months or undetectable frequency show "—" in Est. Annual Credits and Est. Annual %
+
+**Error Handling:**
+- F01 endpoint failure: existing `ErrorState` with Retry is shown (P02 behaviour); footer panel is not rendered until data is available
+- Individual price fetch failure: no change to footer behaviour; that asset's CurrentValue is excluded from the footer sum with the asterisk notation
+
+---
+
+### F03. Credits Analysis Columns and Footer — WPF
+
+**Consumes:**
+- F01: per-asset credits-analysis fields (LastMonthCredits, LastCreditMonth, LastMonthCreditsPercent, EstimatedAnnualCredits, EstimatedAnnualPercent, CreditFrequencyPerYear, CurrentMonthCredits)
+
+**Capabilities:**
+- The existing WPF `PortfolioSummaryView` and its `PortfolioSummaryViewModel` are extended; no new top-level view is introduced
+- **Column group separator in DataGrid:** the "Last Month Credits" DataGrid column has its `CellStyle` and `HeaderStyle` overridden to apply a thick left border (3 px, accent brush) that visually separates the credits-analysis group from the XIRR column; no additional separator column is inserted into the DataGrid
+- **Five new DataGrid columns appended after XIRR** (in this order):
+
+  | Column Header | VM Property | Format | Unavailable |
+  |---|---|---|---|
+  | Last Month Credits | `LastMonthCredits` | N2 | "—" when no credits |
+  | Last Credit Month | `LastCreditMonth` | "MMM yyyy" (e.g., "Jun 2026") | "—" when null |
+  | Last Month % | `LastMonthCreditsPercent` | N2 "%" | "—" when null |
+  | Est. Annual Credits | `EstimatedAnnualCredits` | N2 | "—" when null |
+  | Est. Annual % | `EstimatedAnnualPercent` | N2 "%" | "—" when null |
+
+- Row view model adds: `LastMonthCredits` (decimal), `LastCreditMonthDisplay` (string, e.g. "Jun 2026" or "—"), `LastMonthCreditsPercentDisplay` (string, e.g. "1.25%" or "—"), `EstimatedAnnualCredits` (decimal?), `EstimatedAnnualCreditsDisplay` (string), `EstimatedAnnualPercentDisplay` (string)
+- No colour coding on credits-analysis columns (neutral foreground)
+- **Footer panel:** a `WrapPanel` or `UniformGrid` rendered in the same parent container as the DataGrid, positioned below it via `StackPanel` layout; it is a separate XAML element, not a DataGrid row or `DataGrid.FooterTemplate`
+- Footer panel items (labelled `TextBlock` pairs):
+  1. **Total Invested** — sum of `TotalInvested` across all row view models
+  2. **Total Credits** — sum of `TotalCredits` (all-time) across all row view models
+  3. **Current Value** — sum of resolved `CurrentValue` across all row view models; shows "Calculating…" while any `IsLoadingPrice` is true; updates via `INotifyPropertyChanged` as prices resolve
+  4. **Credits [Mon yyyy]** — sum of `CurrentMonthCredits` across all row view models, formatted N2; label derived from `DateTime.Today` at load time (e.g., "Credits Jul 2026")
+  5. **Est. Annual Credits** — sum of non-null `EstimatedAnnualCredits` across all row view models; "—" when no row has a non-null value
+- Footer panel background uses `SystemColors.ControlBrush` or equivalent to visually distinguish it from the DataGrid rows; it is outside the DataGrid's scroll viewport
+
+**Experience:**
+1. User selects a Portfolio node; WPF Summary tab loads as per P02 behaviour
+2. Application service response arrives; all row VMs are created with Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, Est. Annual % populated immediately; footer panel appears with Total Invested, Total Credits, Credits [Mon yyyy], and Est. Annual Credits
+3. Price fetches run asynchronously per row (P02 behaviour); footer Current Value updates via property-change notification as each price resolves; "Calculating…" indicator is replaced with the N2 sum once all IsLoadingPrice flags are false
+4. Rows with no credits show "—" in Last Month Credits, Last Credit Month, Last Month %; rows with undetectable frequency show "—" in Est. Annual Credits and Est. Annual %
+
+---
+
+## 7. Out of Scope
+
+**Manual frequency override**
+- Payment frequency is detected automatically from history; there is no UI or configuration for the user to override the detected frequency per asset
+
+**Broker-level credits analysis**
+- The new columns and footer apply only to the Portfolio node Summary tab; selecting a Broker node continues to show only the three aggregated totals (P02 behaviour unchanged)
+
+**Credits trend chart or history view**
+- No chart, sparkline, or history panel for credits over time is included
+
+**Sorting and filtering on new columns**
+- The new columns follow the same fixed alphabetical sort as the existing table; interactive column sorting is not added
+
+**Notification or alert when credits arrive**
+- No push notification, badge, or email is triggered when a credit is added to the data
+
+**Cross-currency credits aggregation**
+- Footer totals are in the portfolio's native currency; no cross-currency conversion is applied in the footer or the new columns
+
+**Credit frequency detection for assets with fewer than 2 credit months**
+- Assets with 0 or 1 distinct credit months in history always show "—" in Est. Annual Credits and Est. Annual %; no partial estimation is attempted
+
+---
+
+## 8. Dependency Graph
+
+| # | Feature | Priority | Dependencies |
+|---|---------|----------|--------------|
+| F01 | Credits Analysis — Service Enhancement | 1 | None |
+| F02 | Credits Analysis Columns and Footer — Web Frontend | 1 | F01 |
+| F03 | Credits Analysis Columns and Footer — WPF | 1 | F01 |
+
+### Execution Waves
+Features within the same wave can be built in parallel. A wave starts only after every feature in earlier waves is complete.
+
+- **Wave 1**: F01
+- **Wave 2**: F02, F03
+
+### Priority levels
+- **1** = Essential — product does not work without it
+- **2** = Important — significant value addition
+- **3** = Desirable — incremental improvement
+
+```mermaid
+graph TD
+  F01[Credits Analysis Service] --> F02[Web Frontend]
+  F01 --> F03[WPF Frontend]
+```
+
+---
+
+## 9. Acceptance Criteria
+
+### F01. Credits Analysis — Service Enhancement
+
+- [ ] `GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets` response includes `lastMonthCredits`, `lastCreditMonth`, `lastMonthCreditsPercent`, `creditFrequencyPerYear`, `estimatedAnnualCredits`, `estimatedAnnualPercent`, `currentMonthCredits` for every item
+- [ ] `lastMonthCredits` equals the sum of all credit `Value` fields whose date falls in the most recent credit month ≤ today; is 0 when the asset has no credits
+- [ ] `lastCreditMonth` is formatted `"YYYY-MM"`; is null when the asset has no credits
+- [ ] `lastMonthCreditsPercent` equals `lastMonthCredits / totalInvested × 100`; is null when `totalInvested` is 0 or `lastCreditMonth` is null
+- [ ] `currentMonthCredits` equals the sum of credit `Value` fields whose date falls in the current calendar month (year + month matching today); is 0 when no such credits exist
+- [ ] **Frequency detection — monthly:** an asset with credits in Jan, Feb, Mar (gaps = 1, 1) returns `creditFrequencyPerYear = 12`
+- [ ] **Frequency detection — quarterly:** an asset with credits in Jan, Apr, Jul (gaps = 3, 3) returns `creditFrequencyPerYear = 4`
+- [ ] **Frequency detection — four-month:** an asset with credits in Jan, May, Sep (gaps = 4, 4) returns `creditFrequencyPerYear = 3`
+- [ ] **Frequency detection — undetectable:** an asset with only 1 distinct credit month returns `creditFrequencyPerYear = null`; an asset with gaps averaging outside 0–5 months also returns null
+- [ ] `estimatedAnnualCredits` equals `lastMonthCredits × creditFrequencyPerYear`; is null when `creditFrequencyPerYear` is null
+- [ ] `estimatedAnnualPercent` equals `estimatedAnnualCredits / totalInvested × 100`; is null when `estimatedAnnualCredits` is null or `totalInvested` is 0
+- [ ] Credits with a future date (after today) are excluded from `lastCreditMonth` and `lastMonthCredits` calculations
+- [ ] Existing fields (`assetName`, `totalInvested`, `totalCredits`, `cashFlows`, etc.) are unchanged and pass all P02 acceptance criteria without regression
+
+### F02. Credits Analysis Columns and Footer — Web Frontend
+
+- [ ] Five new columns appear after XIRR in the web per-asset table: Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, Est. Annual %
+- [ ] A thick left border visually separates the "Last Month Credits" column from the XIRR column; no additional column is inserted between them
+- [ ] Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, and Est. Annual % are populated immediately on F01 data load, before any price fetches complete
+- [ ] An asset with no credits shows "—" in Last Month Credits, Last Credit Month, and Last Month %
+- [ ] An asset with fewer than 2 distinct credit months shows "—" in Est. Annual Credits and Est. Annual %
+- [ ] Last Credit Month displays in "MMM YYYY" format (e.g., "Jun 2026")
+- [ ] Last Month % displays as N2 with "%" suffix (e.g., "1.25%"); "—" when null
+- [ ] Est. Annual % displays as N2 with "%" suffix (e.g., "5.00%"); "—" when null
+- [ ] Footer panel is visible below the table once F01 data has loaded
+- [ ] Footer shows: Total Invested (sum), Total Credits (sum), Current Value (sum), Credits [Mon YYYY] (current month sum), Est. Annual Credits (sum of non-null values)
+- [ ] Footer "Credits" label includes the current month and year (e.g., "Credits Jul 2026") matching the current calendar month
+- [ ] Current Value footer shows "Calculating…" while price fetches are in progress and updates as prices resolve
+- [ ] Footer is not a `<tr>` inside the table; it is a separate DOM element rendered below the table
+- [ ] All existing columns (Asset Name through XIRR) and the three portfolio totals above the table are unaffected (P02 regression check)
+
+### F03. Credits Analysis Columns and Footer — WPF
+
+- [ ] Five new DataGrid columns appear after XIRR in the WPF DataGrid: Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, Est. Annual %
+- [ ] The "Last Month Credits" DataGrid column has a visually distinct thick left border separating it from XIRR
+- [ ] New columns are populated immediately when the Application service response arrives, before any price fetches complete
+- [ ] An asset with no credits shows "—" in Last Month Credits, Last Credit Month, and Last Month %
+- [ ] An asset with fewer than 2 distinct credit months shows "—" in Est. Annual Credits and Est. Annual %
+- [ ] Last Credit Month displays as "MMM yyyy" (e.g., "Jun 2026"); "—" when null
+- [ ] Footer panel is a separate XAML element below the DataGrid (not a DataGrid row)
+- [ ] WPF footer shows: Total Invested, Total Credits, Current Value, Credits [Mon yyyy] (current month), Est. Annual Credits — consistent with the web footer
+- [ ] WPF footer "Credits" label includes the current month and year (e.g., "Credits Jul 2026")
+- [ ] Current Value in the WPF footer shows "Calculating…" while any row has `IsLoadingPrice = true`; updates via property-change notification as prices resolve
+- [ ] All existing DataGrid columns (Asset Name through XIRR) and the three colour-coded totals above the DataGrid are unaffected (P02 regression check)
+
+### Cross-Feature Integration
+
+- [ ] The `lastMonthCredits`, `lastCreditMonth`, `lastMonthCreditsPercent`, `estimatedAnnualCredits`, `estimatedAnnualPercent`, and `currentMonthCredits` values returned by F01's endpoint are used without transformation in F02's column rendering
+- [ ] The same fields from F01's Application service are used without transformation in F03's row view model properties
+- [ ] The `currentMonthCredits` values from F01 are summed by F02 to produce the footer "Credits [Mon YYYY]" total, verified with a portfolio containing assets with credits in the current month and assets without
+- [ ] The `currentMonthCredits` values from F01 are summed by F03 to produce the WPF footer total, verified with the same test portfolio


### PR DESCRIPTION
## Summary

- Extends `PortfolioAssetSummaryItemDTO` with seven new credits-analysis fields: `LastMonthCredits`, `LastCreditMonth`, `LastMonthCreditsPercent`, `CreditFrequencyPerYear`, `EstimatedAnnualCredits`, `EstimatedAnnualPercent`, `CurrentMonthCredits`
- Extends `PortfolioAssetSummaryQueryService` with a `ComputeCreditsAnalysis` private static method and a payment-frequency detection algorithm (monthly / quarterly / four-month)
- No breaking changes to existing fields or endpoint routing; additive response only

## PRD

[P03 — Portfolio Credits Analysis Enhancement](docs/prd/P03-prd-portfolio-credits-analysis/prd-portfolio-credits-analysis.md)

## Test plan

- [x] 20 new unit tests covering all seven fields, four frequency-detection scenarios, null paths, future-date exclusion, and current-month matching — all pass (`130/130` in `Financial.Application.Tests`)
- [x] 1 new integration test (`GetPortfolioAssetsSummary_Returns200WithCreditsAnalysisFields`) verifying all seven fields appear in the HTTP response — passes (`28/28` in `Financial.Api.Tests`)
- [x] Full suite: `322 passed`, `3 skipped` (pre-existing Google Finance tests requiring external network), `0 failed`
- [x] All 110 pre-existing P02 tests pass without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)