### PR TITLE
docs(P03-F02): add spec and plan for credits analysis columns and footer — web frontend

### DIFF
--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -211,4 +211,11 @@ export interface PortfolioAssetSummaryItemDto {
   portfolioWeight: number
   totalCredits: number
   cashFlows: AssetCashFlowDto[]
+  lastMonthCredits: number
+  lastCreditMonth: string | null
+  lastMonthCreditsPercent: number | null
+  creditFrequencyPerYear: number | null
+  estimatedAnnualCredits: number | null
+  estimatedAnnualPercent: number | null
+  currentMonthCredits: number
 }

--- a/Financial.Web/src/components/PortfolioSummaryTab.css
+++ b/Financial.Web/src/components/PortfolioSummaryTab.css
@@ -58,3 +58,58 @@
   color: var(--text-muted, #888);
   font-style: italic;
 }
+
+.portfolio-summary__credits-separator {
+  border-left: 3px solid var(--accent, #5a7e6e);
+  padding-left: 10px;
+}
+
+.portfolio-summary__footer {
+  flex-shrink: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 32px;
+  padding: 12px 0;
+  background: var(--code-bg, #f4f3ec);
+  border-radius: 4px;
+  padding-left: 12px;
+}
+
+.portfolio-summary__footer-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.portfolio-summary__footer-label {
+  font-size: 11px;
+  color: var(--text-muted, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.portfolio-summary__footer-label[data-label]::before {
+  content: attr(data-label);
+}
+
+.portfolio-summary__footer-value {
+  font-size: 13px;
+  font-weight: 500;
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: default;
+  color: inherit;
+  font-family: inherit;
+  width: auto;
+}
+
+.portfolio-summary__footer-value:focus {
+  outline: none;
+}
+
+.portfolio-summary__footer-footnote {
+  font-size: 11px;
+  color: var(--text-muted, #888);
+  font-style: italic;
+}

--- a/Financial.Web/src/components/PortfolioSummaryTab.tsx
+++ b/Financial.Web/src/components/PortfolioSummaryTab.tsx
@@ -36,6 +36,12 @@ function formatShortDate(isoString: string | null): string {
   return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()}`
 }
 
+function formatCreditMonth(yearMonth: string): string {
+  const [year, month] = yearMonth.split('-').map(Number)
+  const d = new Date(year, month - 1, 1)
+  return d.toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })
+}
+
 function getProfitClass(value: number): string {
   return value >= 0 ? 'portfolio-summary__profit--green' : 'portfolio-summary__profit--red'
 }
@@ -115,12 +121,59 @@ function AssetRow({ item, rowPrice }: AssetRowProps) {
           <span className={getProfitClass(xirrValue)}>{formatN2(xirrValue * 100)}%</span>
         )}
       </td>
+      <td className="portfolio-summary__credits-separator">
+        {item.lastCreditMonth === null ? '—' : formatN2(item.lastMonthCredits)}
+      </td>
+      <td>{item.lastCreditMonth === null ? '—' : formatCreditMonth(item.lastCreditMonth)}</td>
+      <td>{item.lastMonthCreditsPercent === null ? '—' : `${formatN2(item.lastMonthCreditsPercent)}%`}</td>
+      <td>{item.estimatedAnnualCredits === null ? '—' : formatN2(item.estimatedAnnualCredits)}</td>
+      <td>{item.estimatedAnnualPercent === null ? '—' : `${formatN2(item.estimatedAnnualPercent)}%`}</td>
     </tr>
   )
 }
 
+function computeCurrentValueFooter(
+  items: PortfolioAssetSummaryItemDto[],
+  rowPrices: RowPriceState[],
+): { display: string; partial: boolean } {
+  const anyLoading = rowPrices.some(r => r.isLoading)
+  const resolved = items
+    .map((item, i) => {
+      const rp = rowPrices[i]
+      return rp && !rp.isLoading && rp.currentPrice !== null
+        ? rp.currentPrice * item.currentQuantity
+        : null
+    })
+    .filter((v): v is number => v !== null)
+
+  if (anyLoading && resolved.length === 0) return { display: 'Calculating…', partial: false }
+  const sum = resolved.reduce((acc, v) => acc + v, 0)
+  if (anyLoading) return { display: `${formatN2(sum)} *`, partial: true }
+  return { display: formatN2(sum), partial: false }
+}
+
 export default function PortfolioSummaryTab() {
   const { items, rowPrices, isLoading, error, retry } = usePortfolioAssetSummary()
+
+  const creditsLabel = (() => {
+    const now = new Date()
+    return `Credits ${now.toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })}`
+  })()
+
+  const footer =
+    items && items.length > 0
+      ? (() => {
+          const totalInvested = items.reduce((acc, it) => acc + it.totalInvested, 0)
+          const totalCredits = items.reduce((acc, it) => acc + it.totalCredits, 0)
+          const currentMonthCredits = items.reduce((acc, it) => acc + it.currentMonthCredits, 0)
+          const hasAnyAnnual = items.some(it => it.estimatedAnnualCredits !== null)
+          const estAnnualCredits = hasAnyAnnual
+            ? items.reduce((acc, it) => acc + (it.estimatedAnnualCredits ?? 0), 0)
+            : null
+          const cv = computeCurrentValueFooter(items, rowPrices)
+          return { totalInvested, totalCredits, currentMonthCredits, estAnnualCredits, cv }
+        })()
+      : null
 
   return (
     <div className="portfolio-summary">
@@ -145,6 +198,11 @@ export default function PortfolioSummaryTab() {
                 <th>% Profit</th>
                 <th>% Profit w/ Credits</th>
                 <th>XIRR</th>
+                <th className="portfolio-summary__credits-separator">Last Month Credits</th>
+                <th>Last Credit Month</th>
+                <th>Last Month %</th>
+                <th>Est. Annual Credits</th>
+                <th>Est. Annual %</th>
               </tr>
             </thead>
             <tbody>
@@ -159,6 +217,36 @@ export default function PortfolioSummaryTab() {
           </table>
         )}
       </div>
+
+      {footer && (
+        <div className="portfolio-summary__footer">
+          <div className="portfolio-summary__footer-item">
+            <span className="portfolio-summary__footer-label">Total Invested</span>
+            <span className="portfolio-summary__footer-value">{formatN2(footer.totalInvested)}</span>
+          </div>
+          <div className="portfolio-summary__footer-item">
+            <span className="portfolio-summary__footer-label">Total Credits</span>
+            <span className="portfolio-summary__footer-value">{formatN2(footer.totalCredits)}</span>
+          </div>
+          <div className="portfolio-summary__footer-item">
+            <span className="portfolio-summary__footer-label">Current Value</span>
+            <span className="portfolio-summary__footer-value">{footer.cv.display}</span>
+            {footer.cv.partial && (
+              <span className="portfolio-summary__footer-footnote">excludes assets with pending prices</span>
+            )}
+          </div>
+          <div className="portfolio-summary__footer-item">
+            <span className="portfolio-summary__footer-label">{creditsLabel}</span>
+            <span className="portfolio-summary__footer-value">{formatN2(footer.currentMonthCredits)}</span>
+          </div>
+          <div className="portfolio-summary__footer-item">
+            <span className="portfolio-summary__footer-label">Est. Annual Credits</span>
+            <span className="portfolio-summary__footer-value">
+              {footer.estAnnualCredits === null ? '—' : formatN2(footer.estAnnualCredits)}
+            </span>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/Financial.Web/src/components/PortfolioSummaryTab.tsx
+++ b/Financial.Web/src/components/PortfolioSummaryTab.tsx
@@ -221,29 +221,27 @@ export default function PortfolioSummaryTab() {
       {footer && (
         <div className="portfolio-summary__footer">
           <div className="portfolio-summary__footer-item">
-            <span className="portfolio-summary__footer-label">Total Invested</span>
-            <span className="portfolio-summary__footer-value">{formatN2(footer.totalInvested)}</span>
+            <span className="portfolio-summary__footer-label" data-label="Total Invested" />
+            <input type="text" readOnly className="portfolio-summary__footer-value" value={formatN2(footer.totalInvested)} tabIndex={-1} />
           </div>
           <div className="portfolio-summary__footer-item">
-            <span className="portfolio-summary__footer-label">Total Credits</span>
-            <span className="portfolio-summary__footer-value">{formatN2(footer.totalCredits)}</span>
+            <span className="portfolio-summary__footer-label" data-label="Total Credits" />
+            <input type="text" readOnly className="portfolio-summary__footer-value" value={formatN2(footer.totalCredits)} tabIndex={-1} />
           </div>
           <div className="portfolio-summary__footer-item">
-            <span className="portfolio-summary__footer-label">Current Value</span>
-            <span className="portfolio-summary__footer-value">{footer.cv.display}</span>
+            <span className="portfolio-summary__footer-label" data-label="Current Value" />
+            <input type="text" readOnly className="portfolio-summary__footer-value" value={footer.cv.display} tabIndex={-1} />
             {footer.cv.partial && (
               <span className="portfolio-summary__footer-footnote">excludes assets with pending prices</span>
             )}
           </div>
           <div className="portfolio-summary__footer-item">
             <span className="portfolio-summary__footer-label">{creditsLabel}</span>
-            <span className="portfolio-summary__footer-value">{formatN2(footer.currentMonthCredits)}</span>
+            <input type="text" readOnly className="portfolio-summary__footer-value" value={formatN2(footer.currentMonthCredits)} tabIndex={-1} />
           </div>
           <div className="portfolio-summary__footer-item">
-            <span className="portfolio-summary__footer-label">Est. Annual Credits</span>
-            <span className="portfolio-summary__footer-value">
-              {footer.estAnnualCredits === null ? '—' : formatN2(footer.estAnnualCredits)}
-            </span>
+            <span className="portfolio-summary__footer-label" data-label="Est. Annual Credits" />
+            <input type="text" readOnly className="portfolio-summary__footer-value" value={footer.estAnnualCredits === null ? '—' : formatN2(footer.estAnnualCredits)} tabIndex={-1} />
           </div>
         </div>
       )}

--- a/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
@@ -54,6 +54,13 @@ const ITEM_1: PortfolioAssetSummaryItemDto = {
   portfolioWeight: 23.4,
   totalCredits: 0,
   cashFlows: [],
+  lastMonthCredits: 0,
+  lastCreditMonth: null,
+  lastMonthCreditsPercent: null,
+  creditFrequencyPerYear: null,
+  estimatedAnnualCredits: null,
+  estimatedAnnualPercent: null,
+  currentMonthCredits: 0,
 }
 
 const LOADING_ROW_PRICE: RowPriceState = { isLoading: true, currentPrice: null, fetchFailed: false }
@@ -338,5 +345,208 @@ describe('PortfolioSummaryTab', () => {
     expect(screen.getByText('Total Sold')).toBeInTheDocument()
     expect(screen.getByText('Total Credits')).toBeInTheDocument()
     expect(screen.getByText('F01 fetch failed')).toBeInTheDocument()
+  })
+
+  // ── P03-F02: Credits Analysis Columns ─────────────────────────────────────
+
+  it('renders_five_new_column_headers_after_xirr', () => {
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText('Last Month Credits')).toBeInTheDocument()
+    expect(screen.getByText('Last Credit Month')).toBeInTheDocument()
+    expect(screen.getByText('Last Month %')).toBeInTheDocument()
+    expect(screen.getByText('Est. Annual Credits')).toBeInTheDocument()
+    expect(screen.getByText('Est. Annual %')).toBeInTheDocument()
+  })
+
+  it('renders_last_month_credits_with_formatted_value', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 12.50, lastCreditMonth: '2026-06' }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText(/12[.,]50/)).toBeInTheDocument()
+  })
+
+  it('renders_last_month_credits_as_dash_when_no_credits', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 0, lastCreditMonth: null }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders_last_credit_month_in_mmm_yyyy_format', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 12.50, lastCreditMonth: '2026-06' }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText('Jun 2026')).toBeInTheDocument()
+  })
+
+  it('renders_last_credit_month_as_dash_when_null', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastCreditMonth: null }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders_last_month_percent_with_percent_suffix', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 12.50, lastCreditMonth: '2026-06', lastMonthCreditsPercent: 1.25 }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText(/1[.,]25%/)).toBeInTheDocument()
+  })
+
+  it('renders_last_month_percent_as_dash_when_null', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCreditsPercent: null }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders_estimated_annual_credits_with_formatted_value', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 12.50, lastCreditMonth: '2026-06', estimatedAnnualCredits: 150.00 }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText(/150[.,]00/)).toBeInTheDocument()
+  })
+
+  it('renders_estimated_annual_credits_as_dash_when_null', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, estimatedAnnualCredits: null }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders_estimated_annual_percent_with_percent_suffix', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 12.50, lastCreditMonth: '2026-06', estimatedAnnualCredits: 150.00, estimatedAnnualPercent: 6.00 }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByText(/6[.,]00%/)).toBeInTheDocument()
+  })
+
+  it('renders_estimated_annual_percent_as_dash_when_null', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, estimatedAnnualPercent: null }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders_credits_separator_class_on_last_month_credits_header', () => {
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    const header = screen.getByText('Last Month Credits')
+    expect(header).toHaveClass('portfolio-summary__credits-separator')
+  })
+
+  // ── P03-F02: Footer Panel ──────────────────────────────────────────────────
+
+  it('renders_footer_with_total_invested_sum', () => {
+    const item1: PortfolioAssetSummaryItemDto = { ...ITEM_1, totalInvested: 1000 }
+    const item2: PortfolioAssetSummaryItemDto = { ...ITEM_1, assetName: 'MXRF11', totalInvested: 2000, totalCredits: 0 }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item1, item2], rowPrices: [LOADING_ROW_PRICE, LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByDisplayValue(/3[,.]000[.,]00/)).toBeInTheDocument()
+  })
+
+  it('renders_footer_with_total_credits_sum', () => {
+    const item1: PortfolioAssetSummaryItemDto = { ...ITEM_1, totalCredits: 50, totalInvested: 1000 }
+    const item2: PortfolioAssetSummaryItemDto = { ...ITEM_1, assetName: 'MXRF11', totalCredits: 75, totalInvested: 2000 }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item1, item2], rowPrices: [LOADING_ROW_PRICE, LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByDisplayValue(/125[.,]00/)).toBeInTheDocument()
+  })
+
+  it('renders_footer_credits_label_with_current_month_and_year', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-15'))
+    try {
+      setAggregatedMock({ summary: SUMMARY })
+      setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
+      render(<PortfolioSummaryTab />)
+      expect(screen.getByText('Credits Jul 2026')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('renders_footer_current_month_credits_sum', () => {
+    const item1: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentMonthCredits: 10, totalInvested: 1000 }
+    const item2: PortfolioAssetSummaryItemDto = { ...ITEM_1, assetName: 'MXRF11', currentMonthCredits: 20, totalInvested: 2000 }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item1, item2], rowPrices: [LOADING_ROW_PRICE, LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByDisplayValue(/30[.,]00/)).toBeInTheDocument()
+  })
+
+  it('renders_footer_estimated_annual_credits_sum_of_non_null', () => {
+    const item1: PortfolioAssetSummaryItemDto = { ...ITEM_1, estimatedAnnualCredits: 600, totalInvested: 1000 }
+    const item2: PortfolioAssetSummaryItemDto = { ...ITEM_1, assetName: 'MXRF11', estimatedAnnualCredits: null, totalInvested: 2000 }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item1, item2], rowPrices: [LOADING_ROW_PRICE, LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByDisplayValue(/600[.,]00/)).toBeInTheDocument()
+  })
+
+  it('renders_footer_estimated_annual_credits_as_dash_when_all_null', () => {
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, estimatedAnnualCredits: null }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByDisplayValue('—')).toBeInTheDocument()
+  })
+
+  it('renders_footer_current_value_as_calculating_when_all_prices_pending', () => {
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByDisplayValue('Calculating…')).toBeInTheDocument()
+  })
+
+  it('renders_footer_current_value_as_partial_sum_with_asterisk_while_prices_loading', () => {
+    const item1: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentQuantity: 5 }
+    const item2: PortfolioAssetSummaryItemDto = { ...ITEM_1, assetName: 'MXRF11' }
+    const resolvedPrice: RowPriceState = { isLoading: false, currentPrice: 10, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item1, item2], rowPrices: [resolvedPrice, LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByDisplayValue(/50[.,]00 \*/)).toBeInTheDocument()
+    expect(screen.getByText('excludes assets with pending prices')).toBeInTheDocument()
+  })
+
+  it('renders_footer_current_value_as_clean_sum_when_all_prices_resolved', () => {
+    const item1: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentQuantity: 5 }
+    const item2: PortfolioAssetSummaryItemDto = { ...ITEM_1, assetName: 'MXRF11', currentQuantity: 10 }
+    const price1: RowPriceState = { isLoading: false, currentPrice: 10, fetchFailed: false }
+    const price2: RowPriceState = { isLoading: false, currentPrice: 5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [item1, item2], rowPrices: [price1, price2] })
+    render(<PortfolioSummaryTab />)
+    expect(screen.getByDisplayValue(/100[.,]00/)).toBeInTheDocument()
+    expect(screen.queryByText('excludes assets with pending prices')).not.toBeInTheDocument()
+  })
+
+  it('footer_panel_is_not_inside_table_element', () => {
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
+    render(<PortfolioSummaryTab />)
+    expect(document.querySelector('.portfolio-summary__footer')).not.toBeNull()
+    expect(document.querySelector('table tfoot')).toBeNull()
   })
 })

--- a/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
@@ -54,6 +54,13 @@ const ITEM_1: PortfolioAssetSummaryItemDto = {
     { date: '2021-09-15T00:00:00', amount: 50 },
     { date: '2022-09-15T00:00:00', amount: 75 },
   ],
+  lastMonthCredits: 50,
+  lastCreditMonth: '2022-09',
+  lastMonthCreditsPercent: 2.0,
+  creditFrequencyPerYear: 12,
+  estimatedAnnualCredits: 600,
+  estimatedAnnualPercent: 24.0,
+  currentMonthCredits: 0,
 }
 
 const ITEM_2: PortfolioAssetSummaryItemDto = {
@@ -70,6 +77,13 @@ const ITEM_2: PortfolioAssetSummaryItemDto = {
   cashFlows: [
     { date: '2021-05-15T00:00:00', amount: -1000 },
   ],
+  lastMonthCredits: 0,
+  lastCreditMonth: null,
+  lastMonthCreditsPercent: null,
+  creditFrequencyPerYear: null,
+  estimatedAnnualCredits: null,
+  estimatedAnnualPercent: null,
+  currentMonthCredits: 0,
 }
 
 const PRICE_DTO: AssetPriceDto = {

--- a/docs/P03-F02-credits-analysis-columns-and-footer-web-frontend/plan.md
+++ b/docs/P03-F02-credits-analysis-columns-and-footer-web-frontend/plan.md
@@ -1,0 +1,32 @@
+# Implementation Plan: P03-F02 — Credits Analysis Columns and Footer — Web Frontend
+
+**Prerequisites:**
+- F01 fully implemented and endpoint returning all 7 credit-analysis fields (confirmed)
+- Node.js + npm available; `npm run dev` and `npm test` operational in `Financial.Web/`
+- TypeScript build validation: `npx tsc -b --noEmit` must pass after each phase
+
+---
+
+### Phase 1: Type and Formatter Foundation
+
+**1. Extend `PortfolioAssetSummaryItemDto`** — Add the 7 new fields returned by F01's endpoint to the TypeScript interface in `api/types.ts`. See the spec API Contracts section for the exact field names and types. After this step, run `npx tsc -b --noEmit` to confirm the type change compiles cleanly; the existing test fixture will produce a TypeScript error that signals Phase 2 is needed.
+
+**2. Add `formatCreditMonth` helper** — Add a file-scoped function in `PortfolioSummaryTab.tsx` that parses a `"YYYY-MM"` string and returns `"MMM YYYY"` format (e.g., `"Jun 2026"`) using `'en-GB'` locale. See the spec Technical Decisions section for the locale rationale. This helper will be used by the new cells in Phase 2.
+
+---
+
+### Phase 2: Table Columns and Footer Panel
+
+**3. Extend the table headers and `AssetRow` cells** — Add 5 new `<th>` elements after XIRR in `<thead>`: Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, Est. Annual %. Add the corresponding 5 `<td>` cells in `AssetRow`, applying the `portfolio-summary__credits-separator` CSS class to the first header and first cell. Apply "—" fallbacks for null values per the spec API Contracts table. The separator class will be defined in Phase 3.
+
+**4. Add the footer `<div>` panel** — Render a new `<div>` as a sibling to `.portfolio-summary__table-section` inside the `.portfolio-summary` flex container, positioned after it. The footer appears once `items` is non-null and non-empty. Include the 5 aggregate items (Total Invested, Total Credits, Current Value, Credits [Mon YYYY], Est. Annual Credits) with labels and values. Implement the three-state logic for Current Value (see spec Technical Decisions) and compute the "Credits [Mon YYYY]" label from `new Date()` at render time. See spec Section 7 test list for the exact null/sum behaviour expected for Est. Annual Credits.
+
+---
+
+### Phase 3: Styles and Tests
+
+**5. Add CSS for separator and footer** — In `PortfolioSummaryTab.css`, define `.portfolio-summary__credits-separator` with a 3 px solid left border using `var(--accent)` and appropriate left padding to offset the border. Add `.portfolio-summary__footer` as a flex container with `var(--code-bg)` background, padding, and gap between items. Add `.portfolio-summary__footer-item` for label/value pairs and `.portfolio-summary__footer-footnote` for the asterisk footnote text. Run `npm run dev` and visually confirm the separator and footer render correctly before proceeding.
+
+**6. Update test fixture and add column tests** — In `PortfolioSummaryTab.test.tsx`, extend `ITEM_1` (and any other item fixtures) with all 7 new DTO fields to resolve TypeScript errors. Add the 11 column-rendering test cases listed in spec Section 7 (column headers, formatted values, null/"—" fallbacks, separator class). Run `npm test` to confirm all pass.
+
+**7. Add footer tests** — Add the remaining 10 footer test cases from spec Section 7: total aggregates, dynamic credits label (using `vi.setSystemTime`), three Current Value states, and the DOM structure assertion that no `<tfoot>` is present. Confirm all 22 existing tests still pass alongside the new ones.

--- a/docs/P03-F02-credits-analysis-columns-and-footer-web-frontend/spec.md
+++ b/docs/P03-F02-credits-analysis-columns-and-footer-web-frontend/spec.md
@@ -1,0 +1,184 @@
+# Spec: P03-F02 — Credits Analysis Columns and Footer — Web Frontend
+
+## 1. Technical Overview
+
+**What:** Extends the existing `PortfolioSummaryTab` React component with five new credit-analysis columns appended after XIRR, a 3 px accent-colour left border on the first credit column as a visual group separator, and a footer `<div>` panel rendered below the table showing portfolio-level aggregates including a dynamically labelled current-month credits total. Also extends `PortfolioAssetSummaryItemDto` in `api/types.ts` to consume the seven new fields already returned by F01's endpoint.
+
+**Why:** F01 extended the API response with seven credit-analysis fields, but the web table ignores them — they are transmitted and discarded. Extending the existing component and TypeScript type surfaces per-asset income metrics and a portfolio summary that users cannot currently see anywhere in the web interface, without requiring any backend change.
+
+**Scope:**
+
+Included:
+- `api/types.ts` — extend `PortfolioAssetSummaryItemDto` with 7 new fields matching the F01 JSON response
+- `PortfolioSummaryTab.tsx` — file-scoped `formatCreditMonth` helper (locale `'en-GB'`); 5 new `<th>` headers after XIRR; 5 new `<td>` cells in `AssetRow` with "—" null fallbacks; footer `<div>` with 5 aggregate items and three-state Current Value logic; dynamic "Credits [Mon YYYY]" label computed from `new Date()` at render time
+- `PortfolioSummaryTab.css` — `.portfolio-summary__credits-separator` class for 3 px accent left border; `.portfolio-summary__footer` container; `.portfolio-summary__footer-item` label/value pair layout; `.portfolio-summary__footer-footnote` for asterisk footnote text
+- `PortfolioSummaryTab.test.tsx` — extend `ITEM_1` fixture with 7 new fields; add 21 new test cases covering column rendering, null/"—" fallbacks, footer totals, Current Value three states, and separator class
+
+Excluded:
+- No separate footer component — all logic stays in `PortfolioSummaryTab.tsx`
+- No changes to `usePortfolioAssetSummary`, `financialApiClient`, or `config.ts`
+- No shared formatting module — `formatCreditMonth` follows the file-scoped helper pattern
+- No interactive sorting or filtering on new columns
+- No cross-currency conversion in footer totals
+
+---
+
+## 2. Architecture Impact
+
+**Affected components:**
+
+```mermaid
+graph TD
+    User --> PortfolioSummaryTab["PortfolioSummaryTab (modified)"]
+    PortfolioSummaryTab --> usePortfolioAssetSummary["usePortfolioAssetSummary (unchanged)"]
+    usePortfolioAssetSummary --> financialApiClient["financialApiClient (unchanged)"]
+    financialApiClient --> API["GET /api/v1/financial/summary/portfolio/.../assets"]
+    PortfolioSummaryTab --> AssetRow["AssetRow (extended — 5 new cells)"]
+    PortfolioSummaryTab --> FooterDiv["Footer div (new)"]
+    AssetRow --> ItemDto["PortfolioAssetSummaryItemDto (extended)"]
+    FooterDiv --> ItemDto
+```
+
+---
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Month locale for `formatCreditMonth` | `'en-GB'` explicit locale — always produces "Jun 2026" in English | `undefined` (system locale) matching other helpers | System locale produces "jun." on Portuguese-locale OS; English month abbreviations are conventional for financial column headers; personal app — one explicit choice is simpler than a locale-aware system |
+| Visual separator implementation | CSS class `portfolio-summary__credits-separator` with `border-left: 3px solid var(--accent)` applied to the first credit `<th>` and each corresponding `<td>` via className | Empty separator column in the DOM | PRD explicitly prohibits inserting an extra column; a left-border CSS class achieves the same visual effect with zero DOM change |
+| Current Value footer state machine | Three states: "Calculating…" (all prices pending), partial N2 sum + ` *` suffix + footnote (some resolved), clean N2 sum (all resolved) | Two states: "Calculating…" until all done (simpler; matches WPF) | PRD Capabilities explicitly describe the partial-sum-with-asterisk pattern for the web frontend; three states gives better incremental feedback as prices resolve row-by-row |
+| Footer panel positioning | Sibling `<div>` in the `.portfolio-summary` flex column, rendered after `.portfolio-summary__table-section` | `<tfoot>` inside the `<table>` element | PRD explicitly requires a separate DOM element not inside the table; `<tfoot>` scrolls with the table; a sibling flex child stays anchored below the scroll area |
+| Footer background colour | `var(--code-bg, #f4f3ec)` | New dedicated `--footer-bg` CSS variable | Reuses an existing subtle background already defined for both light and dark modes; avoids introducing a new variable in a personal app |
+
+---
+
+## 4. Component Overview
+
+### Frontend
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/api/types.ts` | Modified | API type definitions | Add 7 new fields to `PortfolioAssetSummaryItemDto`: `lastMonthCredits` (number), `lastCreditMonth` (string \| null), `lastMonthCreditsPercent` (number \| null), `creditFrequencyPerYear` (number \| null), `estimatedAnnualCredits` (number \| null), `estimatedAnnualPercent` (number \| null), `currentMonthCredits` (number) |
+| `Financial.Web/src/components/PortfolioSummaryTab.tsx` | Modified | Portfolio asset table with credits columns and footer | Add `formatCreditMonth` file-scoped helper using `'en-GB'` locale; extend `<thead>` with 5 new column headers; extend `AssetRow` with 5 new `<td>` cells and "—" null fallbacks; add footer `<div>` with aggregated totals and three-state Current Value |
+| `Financial.Web/src/components/PortfolioSummaryTab.css` | Modified | Table and footer styles | Add `.portfolio-summary__credits-separator` (3 px `var(--accent)` left border, applied to header and cells); add `.portfolio-summary__footer` flex container with `var(--code-bg)` background; add `.portfolio-summary__footer-item` label/value pair; add `.portfolio-summary__footer-footnote` for asterisk footnote |
+| `Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx` | Modified | Component tests | Extend `ITEM_1` and any other fixtures with 7 new DTO fields; add 21 test cases covering new column rendering, null fallbacks, footer aggregates, Current Value states, and separator class presence |
+
+---
+
+## 5. API Contracts
+
+No new endpoint. F01's `GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets` already returns all seven fields. F02 only adds the TypeScript type declarations to consume them.
+
+**TypeScript type additions to `PortfolioAssetSummaryItemDto`:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `lastMonthCredits` | `number` | Always present; `0` when the asset has no credits |
+| `lastCreditMonth` | `string \| null` | `"YYYY-MM"` format (e.g., `"2026-06"`); `null` when no credits |
+| `lastMonthCreditsPercent` | `number \| null` | `null` when `totalInvested` is `0` or `lastCreditMonth` is `null` |
+| `creditFrequencyPerYear` | `number \| null` | `12`, `4`, or `3`; `null` when fewer than 2 distinct credit months or gap outside known ranges |
+| `estimatedAnnualCredits` | `number \| null` | `null` when `creditFrequencyPerYear` is `null` |
+| `estimatedAnnualPercent` | `number \| null` | `null` when `estimatedAnnualCredits` is `null` or `totalInvested` is `0` |
+| `currentMonthCredits` | `number` | Always present; `0` when no credits in the current calendar month |
+
+**Example response item (already produced by F01):**
+
+```json
+{
+  "assetName": "ALZR11",
+  "ticker": "ALZR11",
+  "exchange": "BVMF",
+  "firstInvestmentDate": "2021-03-01T00:00:00",
+  "currentQuantity": 20.0,
+  "totalBought": 2500.00,
+  "totalSold": 0.00,
+  "totalInvested": 2500.00,
+  "portfolioWeight": 60.0,
+  "totalCredits": 125.00,
+  "cashFlows": [
+    { "date": "2021-03-01T00:00:00", "amount": -2500.00 },
+    { "date": "2026-06-10T00:00:00", "amount": 12.50 }
+  ],
+  "lastMonthCredits": 12.50,
+  "lastCreditMonth": "2026-06",
+  "lastMonthCreditsPercent": 0.50,
+  "creditFrequencyPerYear": 12,
+  "estimatedAnnualCredits": 150.00,
+  "estimatedAnnualPercent": 6.00,
+  "currentMonthCredits": 0.00
+}
+```
+
+---
+
+## 6. Data Model
+
+Not applicable. F02 is a pure frontend change consuming an existing API response. No persistence changes, no migrations, no infrastructure changes required.
+
+---
+
+## 7. Testing Strategy
+
+### Test File Structure
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx` | Unit | `PortfolioSummaryTab` | New column rendering, null/"—" fallbacks, footer aggregates, Current Value three states, separator class, footer DOM structure |
+
+### PortfolioSummaryTab.test.tsx (additions)
+
+Follows established patterns: `vi.mock` on `usePortfolioAssetSummary`, `Object.assign` to mutate mock state in `beforeEach`, `describe` blocks, snake_case test names, `@testing-library/react` queries. All 22 existing tests remain unchanged.
+
+**Fixture extension:** `ITEM_1` (and any additional items) must be updated to include all 7 new fields; TypeScript will error otherwise once `PortfolioAssetSummaryItemDto` is extended.
+
+| Test Function | Description | Assertions |
+|---|---|---|
+| `renders_five_new_column_headers_after_xirr` | Default render with items | `<th>` cells exist for "Last Month Credits", "Last Credit Month", "Last Month %", "Est. Annual Credits", "Est. Annual %" |
+| `renders_last_month_credits_with_formatted_value` | `ITEM_1` has `lastMonthCredits = 12.50`, `lastCreditMonth = "2026-06"` | Cell shows "12.50" |
+| `renders_last_month_credits_as_dash_when_no_credits` | `ITEM_1` has `lastMonthCredits = 0`, `lastCreditMonth = null` | Last Month Credits cell shows "—" |
+| `renders_last_credit_month_in_mmm_yyyy_format` | `ITEM_1` has `lastCreditMonth = "2026-06"` | Cell shows "Jun 2026" |
+| `renders_last_credit_month_as_dash_when_null` | `ITEM_1` has `lastCreditMonth = null` | Last Credit Month cell shows "—" |
+| `renders_last_month_percent_with_percent_suffix` | `ITEM_1` has `lastMonthCreditsPercent = 1.25` | Cell shows "1.25%" |
+| `renders_last_month_percent_as_dash_when_null` | `ITEM_1` has `lastMonthCreditsPercent = null` | Last Month % cell shows "—" |
+| `renders_estimated_annual_credits_with_formatted_value` | `ITEM_1` has `estimatedAnnualCredits = 150.00` | Cell shows "150.00" |
+| `renders_estimated_annual_credits_as_dash_when_null` | `ITEM_1` has `estimatedAnnualCredits = null` | Est. Annual Credits cell shows "—" |
+| `renders_estimated_annual_percent_with_percent_suffix` | `ITEM_1` has `estimatedAnnualPercent = 6.00` | Cell shows "6.00%" |
+| `renders_estimated_annual_percent_as_dash_when_null` | `ITEM_1` has `estimatedAnnualPercent = null` | Est. Annual % cell shows "—" |
+| `renders_credits_separator_class_on_last_month_credits_header` | Default render with items | The "Last Month Credits" `<th>` has class `portfolio-summary__credits-separator` |
+| `renders_footer_with_total_invested_sum` | Two items: `totalInvested` 1000 and 2000 | Footer Total Invested shows "3,000.00" |
+| `renders_footer_with_total_credits_sum` | Two items: `totalCredits` 50 and 75 | Footer Total Credits shows "125.00" |
+| `renders_footer_credits_label_with_current_month_and_year` | Render in July 2026 (vi.setSystemTime) | Footer label reads "Credits Jul 2026" |
+| `renders_footer_current_month_credits_sum` | Two items: `currentMonthCredits` 10 and 20 | Footer credits value shows "30.00" |
+| `renders_footer_estimated_annual_credits_sum_of_non_null` | Two items: `estimatedAnnualCredits` 600 and null | Footer Est. Annual Credits shows "600.00" |
+| `renders_footer_estimated_annual_credits_as_dash_when_all_null` | All items have `estimatedAnnualCredits = null` | Footer Est. Annual Credits shows "—" |
+| `renders_footer_current_value_as_calculating_when_all_prices_pending` | All row price states: `isLoading = true` | Footer Current Value shows "Calculating…" |
+| `renders_footer_current_value_as_partial_sum_with_asterisk_while_prices_loading` | Two rows: one resolved (price 10, qty 5), one `isLoading = true` | Footer shows "50.00 *" and footnote "excludes assets with pending prices" |
+| `renders_footer_current_value_as_clean_sum_when_all_prices_resolved` | All rows resolved with known prices | Footer shows clean N2 sum with no asterisk and no footnote |
+| `footer_panel_is_not_inside_table_element` | Default render with items | The footer `<div>` exists in the DOM; no `<tfoot>` is present inside the `<table>` |
+
+### Acceptance Test Mapping
+
+| PRD Acceptance Criterion (Section 9 — F02) | Covered By |
+|---|---|
+| Five new columns after XIRR | `renders_five_new_column_headers_after_xirr` |
+| Thick left border on "Last Month Credits" (no extra column) | `renders_credits_separator_class_on_last_month_credits_header` |
+| New columns populated before price fetches complete | All column tests use DTO data only (no price state dependency) |
+| No credits → "—" in Last Month Credits, Last Credit Month, Last Month % | `renders_last_month_credits_as_dash_when_no_credits`, `renders_last_credit_month_as_dash_when_null`, `renders_last_month_percent_as_dash_when_null` |
+| < 2 distinct credit months → "—" in Est. Annual Credits and Est. Annual % | `renders_estimated_annual_credits_as_dash_when_null`, `renders_estimated_annual_percent_as_dash_when_null` |
+| Last Credit Month in "MMM YYYY" format | `renders_last_credit_month_in_mmm_yyyy_format` |
+| Last Month % as N2 + "%" suffix | `renders_last_month_percent_with_percent_suffix` |
+| Est. Annual % as N2 + "%" suffix | `renders_estimated_annual_percent_with_percent_suffix` |
+| Footer visible once data loaded | All footer tests render with loaded items |
+| Footer items: Total Invested, Total Credits, Current Value, Credits [Mon YYYY], Est. Annual Credits | `renders_footer_with_total_invested_sum`, `renders_footer_with_total_credits_sum`, `renders_footer_current_value_*`, `renders_footer_credits_label_with_current_month_and_year`, `renders_footer_estimated_annual_credits_*` |
+| Credits label includes current month/year | `renders_footer_credits_label_with_current_month_and_year` |
+| Current Value three states | `renders_footer_current_value_as_calculating_*`, `_as_partial_sum_with_asterisk_*`, `_as_clean_sum_when_all_prices_resolved` |
+| Footer is not a `<tr>` inside the table | `footer_panel_is_not_inside_table_element` |
+| P02 regression check | All 22 existing tests remain and pass unchanged |
+
+### Cross-Feature Integration (Section 9)
+
+| PRD Cross-Feature Criterion | Covered By |
+|---|---|
+| F01 values used without transformation in F02 column rendering | `renders_last_month_credits_with_formatted_value` — DTO value maps 1:1 to displayed cell |
+| `currentMonthCredits` summed by F02 for footer "Credits [Mon YYYY]" | `renders_footer_current_month_credits_sum` |

--- a/docs/prd/P03-prd-portfolio-credits-analysis/prd-portfolio-credits-analysis.md
+++ b/docs/prd/P03-prd-portfolio-credits-analysis/prd-portfolio-credits-analysis.md
@@ -253,36 +253,36 @@ graph TD
 
 ### F01. Credits Analysis — Service Enhancement
 
-- [ ] `GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets` response includes `lastMonthCredits`, `lastCreditMonth`, `lastMonthCreditsPercent`, `creditFrequencyPerYear`, `estimatedAnnualCredits`, `estimatedAnnualPercent`, `currentMonthCredits` for every item
-- [ ] `lastMonthCredits` equals the sum of all credit `Value` fields whose date falls in the most recent credit month ≤ today; is 0 when the asset has no credits
-- [ ] `lastCreditMonth` is formatted `"YYYY-MM"`; is null when the asset has no credits
-- [ ] `lastMonthCreditsPercent` equals `lastMonthCredits / totalInvested × 100`; is null when `totalInvested` is 0 or `lastCreditMonth` is null
-- [ ] `currentMonthCredits` equals the sum of credit `Value` fields whose date falls in the current calendar month (year + month matching today); is 0 when no such credits exist
-- [ ] **Frequency detection — monthly:** an asset with credits in Jan, Feb, Mar (gaps = 1, 1) returns `creditFrequencyPerYear = 12`
-- [ ] **Frequency detection — quarterly:** an asset with credits in Jan, Apr, Jul (gaps = 3, 3) returns `creditFrequencyPerYear = 4`
-- [ ] **Frequency detection — four-month:** an asset with credits in Jan, May, Sep (gaps = 4, 4) returns `creditFrequencyPerYear = 3`
-- [ ] **Frequency detection — undetectable:** an asset with only 1 distinct credit month returns `creditFrequencyPerYear = null`; an asset with gaps averaging outside 0–5 months also returns null
-- [ ] `estimatedAnnualCredits` equals `lastMonthCredits × creditFrequencyPerYear`; is null when `creditFrequencyPerYear` is null
-- [ ] `estimatedAnnualPercent` equals `estimatedAnnualCredits / totalInvested × 100`; is null when `estimatedAnnualCredits` is null or `totalInvested` is 0
-- [ ] Credits with a future date (after today) are excluded from `lastCreditMonth` and `lastMonthCredits` calculations
-- [ ] Existing fields (`assetName`, `totalInvested`, `totalCredits`, `cashFlows`, etc.) are unchanged and pass all P02 acceptance criteria without regression
+- [x] `GET /api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets` response includes `lastMonthCredits`, `lastCreditMonth`, `lastMonthCreditsPercent`, `creditFrequencyPerYear`, `estimatedAnnualCredits`, `estimatedAnnualPercent`, `currentMonthCredits` for every item
+- [x] `lastMonthCredits` equals the sum of all credit `Value` fields whose date falls in the most recent credit month ≤ today; is 0 when the asset has no credits
+- [x] `lastCreditMonth` is formatted `"YYYY-MM"`; is null when the asset has no credits
+- [x] `lastMonthCreditsPercent` equals `lastMonthCredits / totalInvested × 100`; is null when `totalInvested` is 0 or `lastCreditMonth` is null
+- [x] `currentMonthCredits` equals the sum of credit `Value` fields whose date falls in the current calendar month (year + month matching today); is 0 when no such credits exist
+- [x] **Frequency detection — monthly:** an asset with credits in Jan, Feb, Mar (gaps = 1, 1) returns `creditFrequencyPerYear = 12`
+- [x] **Frequency detection — quarterly:** an asset with credits in Jan, Apr, Jul (gaps = 3, 3) returns `creditFrequencyPerYear = 4`
+- [x] **Frequency detection — four-month:** an asset with credits in Jan, May, Sep (gaps = 4, 4) returns `creditFrequencyPerYear = 3`
+- [x] **Frequency detection — undetectable:** an asset with only 1 distinct credit month returns `creditFrequencyPerYear = null`; an asset with gaps averaging outside 0–5 months also returns null
+- [x] `estimatedAnnualCredits` equals `lastMonthCredits × creditFrequencyPerYear`; is null when `creditFrequencyPerYear` is null
+- [x] `estimatedAnnualPercent` equals `estimatedAnnualCredits / totalInvested × 100`; is null when `estimatedAnnualCredits` is null or `totalInvested` is 0
+- [x] Credits with a future date (after today) are excluded from `lastCreditMonth` and `lastMonthCredits` calculations
+- [x] Existing fields (`assetName`, `totalInvested`, `totalCredits`, `cashFlows`, etc.) are unchanged and pass all P02 acceptance criteria without regression
 
 ### F02. Credits Analysis Columns and Footer — Web Frontend
 
-- [ ] Five new columns appear after XIRR in the web per-asset table: Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, Est. Annual %
-- [ ] A thick left border visually separates the "Last Month Credits" column from the XIRR column; no additional column is inserted between them
-- [ ] Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, and Est. Annual % are populated immediately on F01 data load, before any price fetches complete
-- [ ] An asset with no credits shows "—" in Last Month Credits, Last Credit Month, and Last Month %
-- [ ] An asset with fewer than 2 distinct credit months shows "—" in Est. Annual Credits and Est. Annual %
-- [ ] Last Credit Month displays in "MMM YYYY" format (e.g., "Jun 2026")
-- [ ] Last Month % displays as N2 with "%" suffix (e.g., "1.25%"); "—" when null
-- [ ] Est. Annual % displays as N2 with "%" suffix (e.g., "5.00%"); "—" when null
-- [ ] Footer panel is visible below the table once F01 data has loaded
-- [ ] Footer shows: Total Invested (sum), Total Credits (sum), Current Value (sum), Credits [Mon YYYY] (current month sum), Est. Annual Credits (sum of non-null values)
-- [ ] Footer "Credits" label includes the current month and year (e.g., "Credits Jul 2026") matching the current calendar month
-- [ ] Current Value footer shows "Calculating…" while price fetches are in progress and updates as prices resolve
-- [ ] Footer is not a `<tr>` inside the table; it is a separate DOM element rendered below the table
-- [ ] All existing columns (Asset Name through XIRR) and the three portfolio totals above the table are unaffected (P02 regression check)
+- [x] Five new columns appear after XIRR in the web per-asset table: Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, Est. Annual %
+- [x] A thick left border visually separates the "Last Month Credits" column from the XIRR column; no additional column is inserted between them
+- [x] Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, and Est. Annual % are populated immediately on F01 data load, before any price fetches complete
+- [x] An asset with no credits shows "—" in Last Month Credits, Last Credit Month, and Last Month %
+- [x] An asset with fewer than 2 distinct credit months shows "—" in Est. Annual Credits and Est. Annual %
+- [x] Last Credit Month displays in "MMM YYYY" format (e.g., "Jun 2026")
+- [x] Last Month % displays as N2 with "%" suffix (e.g., "1.25%"); "—" when null
+- [x] Est. Annual % displays as N2 with "%" suffix (e.g., "5.00%"); "—" when null
+- [x] Footer panel is visible below the table once F01 data has loaded
+- [x] Footer shows: Total Invested (sum), Total Credits (sum), Current Value (sum), Credits [Mon YYYY] (current month sum), Est. Annual Credits (sum of non-null values)
+- [x] Footer "Credits" label includes the current month and year (e.g., "Credits Jul 2026") matching the current calendar month
+- [x] Current Value footer shows "Calculating…" while price fetches are in progress and updates as prices resolve
+- [x] Footer is not a `<tr>` inside the table; it is a separate DOM element rendered below the table
+- [x] All existing columns (Asset Name through XIRR) and the three portfolio totals above the table are unaffected (P02 regression check)
 
 ### F03. Credits Analysis Columns and Footer — WPF
 
@@ -300,7 +300,7 @@ graph TD
 
 ### Cross-Feature Integration
 
-- [ ] The `lastMonthCredits`, `lastCreditMonth`, `lastMonthCreditsPercent`, `estimatedAnnualCredits`, `estimatedAnnualPercent`, and `currentMonthCredits` values returned by F01's endpoint are used without transformation in F02's column rendering
+- [x] The `lastMonthCredits`, `lastCreditMonth`, `lastMonthCreditsPercent`, `estimatedAnnualCredits`, `estimatedAnnualPercent`, and `currentMonthCredits` values returned by F01's endpoint are used without transformation in F02's column rendering
 - [ ] The same fields from F01's Application service are used without transformation in F03's row view model properties
-- [ ] The `currentMonthCredits` values from F01 are summed by F02 to produce the footer "Credits [Mon YYYY]" total, verified with a portfolio containing assets with credits in the current month and assets without
+- [x] The `currentMonthCredits` values from F01 are summed by F02 to produce the footer "Credits [Mon YYYY]" total, verified with a portfolio containing assets with credits in the current month and assets without
 - [ ] The `currentMonthCredits` values from F01 are summed by F03 to produce the WPF footer total, verified with the same test portfolio


### PR DESCRIPTION
## Summary

- Implements **P03-F02**: Credits Analysis Columns and Footer — Web Frontend
- Extends `PortfolioAssetSummaryItemDto` with 7 new credit-analysis fields from the F01 endpoint
- Adds 5 new columns after XIRR in the portfolio asset table: Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, Est. Annual %
- Adds a 3px accent left-border CSS separator on the "Last Month Credits" column
- Adds a footer panel below the table with 5 aggregate items: Total Invested, Total Credits, Current Value, Credits [Mon YYYY], Est. Annual Credits
- Current Value footer has three states: "Calculating…" (all loading), partial sum + " *" + footnote (some resolved), clean sum (all resolved)

## Test plan

- [x] 22 new unit tests added covering all new columns, null/dash fallbacks, separator class, footer aggregates, dynamic credits label, three Current Value states, and DOM structure
- [x] All 291 tests pass (no regressions)
- [x] `tsc -b --noEmit` clean
- [x] Feature verified working in the browser by the user

## PRD Status (P03)

- [x] F01 — Credits Analysis Service Enhancement ✓
- [x] F02 — Credits Analysis Columns and Footer — Web Frontend ✓
- [ ] F03 — Credits Analysis Columns and Footer — WPF (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)