### PR TITLE
feat(P03-F03): Credits Analysis Columns and Footer — WPF

### DIFF
--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -327,6 +327,7 @@
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="*"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
 
                                 <!-- Aggregated Totals -->
@@ -473,8 +474,95 @@
                                                 </DataTemplate>
                                             </DataGridTemplateColumn.CellTemplate>
                                         </DataGridTemplateColumn>
+                                        <DataGridTextColumn Header="Last Month Credits" Binding="{Binding DisplayLastMonthCredits}" Width="Auto">
+                                            <DataGridTextColumn.CellStyle>
+                                                <Style TargetType="DataGridCell">
+                                                    <Setter Property="BorderThickness" Value="3,0,0,0"/>
+                                                    <Setter Property="BorderBrush" Value="#007ACC"/>
+                                                </Style>
+                                            </DataGridTextColumn.CellStyle>
+                                            <DataGridTextColumn.HeaderStyle>
+                                                <Style TargetType="DataGridColumnHeader">
+                                                    <Setter Property="BorderThickness" Value="3,0,0,0"/>
+                                                    <Setter Property="BorderBrush" Value="#007ACC"/>
+                                                </Style>
+                                            </DataGridTextColumn.HeaderStyle>
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                    <Setter Property="FontFamily" Value="Consolas"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Last Credit Month" Binding="{Binding LastCreditMonthDisplay}" Width="Auto">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                    <Setter Property="FontFamily" Value="Consolas"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Last Month %" Binding="{Binding DisplayLastMonthCreditsPercent}" Width="Auto">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                    <Setter Property="FontFamily" Value="Consolas"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Est. Annual Credits" Binding="{Binding DisplayEstimatedAnnualCredits}" Width="Auto">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                    <Setter Property="FontFamily" Value="Consolas"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Est. Annual %" Binding="{Binding DisplayEstimatedAnnualPercent}" Width="Auto">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                    <Setter Property="FontFamily" Value="Consolas"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
                                     </DataGrid.Columns>
                                 </DataGrid>
+                                <Border Grid.Row="2"
+                                        Background="{x:Static SystemColors.ControlBrush}"
+                                        Padding="8,6"
+                                        Margin="0,4,0,0">
+                                    <WrapPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                                            <TextBlock Text="Total Invested:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                            <TextBlock Text="{Binding AssetDetails.FooterTotalInvested, StringFormat=N2}"
+                                                       FontFamily="Consolas"/>
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                                            <TextBlock Text="Total Credits:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                            <TextBlock Text="{Binding AssetDetails.FooterTotalCredits, StringFormat=N2}"
+                                                       FontFamily="Consolas"/>
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                                            <TextBlock Text="Current Value:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                            <TextBlock Text="{Binding AssetDetails.FooterCurrentValueDisplay}"
+                                                       FontFamily="Consolas"/>
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                                            <TextBlock FontWeight="Bold" Margin="0,0,5,0">
+                                                <Run Text="{Binding AssetDetails.FooterCurrentMonthLabel}"/>
+                                                <Run Text=":"/>
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding AssetDetails.FooterCurrentMonthCredits, StringFormat=N2}"
+                                                       FontFamily="Consolas"/>
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="Est. Annual Credits:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                            <TextBlock Text="{Binding AssetDetails.FooterEstimatedAnnualCreditsDisplay}"
+                                                       FontFamily="Consolas"/>
+                                        </StackPanel>
+                                    </WrapPanel>
+                                </Border>
                             </Grid>
                         </DataTemplate>
                     </TabItem.Resources>

--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -550,7 +550,7 @@
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
                                             <TextBlock FontWeight="Bold" Margin="0,0,5,0">
-                                                <Run Text="{Binding AssetDetails.FooterCurrentMonthLabel}"/>
+                                                <Run Text="{Binding AssetDetails.FooterCurrentMonthLabel, Mode=OneWay}"/>
                                                 <Run Text=":"/>
                                             </TextBlock>
                                             <TextBlock Text="{Binding AssetDetails.FooterCurrentMonthCredits, StringFormat=N2}"

--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -549,10 +549,8 @@
                                                        FontFamily="Consolas"/>
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
-                                            <TextBlock FontWeight="Bold" Margin="0,0,5,0">
-                                                <Run Text="{Binding AssetDetails.FooterCurrentMonthLabel, Mode=OneWay}"/>
-                                                <Run Text=":"/>
-                                            </TextBlock>
+                                            <TextBlock Text="{Binding AssetDetails.FooterCurrentMonthLabel, StringFormat='{}{0}:'}"
+                                                       FontWeight="Bold" Margin="0,0,5,0"/>
                                             <TextBlock Text="{Binding AssetDetails.FooterCurrentMonthCredits, StringFormat=N2}"
                                                        FontFamily="Consolas"/>
                                         </StackPanel>

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -3,6 +3,8 @@ using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using OxyPlot;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
 using System.Windows;
 
 namespace Financial.Presentation.App.ViewModels;
@@ -54,6 +56,12 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private bool _hasCreditsContext;
     private bool _isPortfolioView;
     private CancellationTokenSource? _rowPriceCts;
+    private decimal _footerTotalInvested;
+    private decimal _footerTotalCredits;
+    private decimal _footerCurrentMonthCredits;
+    private string _footerCurrentMonthLabel = string.Empty;
+    private string _footerEstimatedAnnualCreditsDisplay = "—";
+    private readonly List<(PortfolioAssetSummaryRowViewModel Row, PropertyChangedEventHandler Handler)> _rowSubscriptions = new();
     private TransactionDTO? _selectedTransaction;
     private CreditDTO? _selectedCredit;
     private IReadOnlyList<CreditsMonthTypeTotals> _creditsChartMonths = Array.Empty<CreditsMonthTypeTotals>();
@@ -148,6 +156,23 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     }
 
     public ObservableCollection<PortfolioAssetSummaryRowViewModel> PortfolioAssetSummaryRows { get; } = new();
+
+    public decimal FooterTotalInvested { get => _footerTotalInvested; private set => SetProperty(ref _footerTotalInvested, value); }
+    public decimal FooterTotalCredits { get => _footerTotalCredits; private set => SetProperty(ref _footerTotalCredits, value); }
+    public decimal FooterCurrentMonthCredits { get => _footerCurrentMonthCredits; private set => SetProperty(ref _footerCurrentMonthCredits, value); }
+    public string FooterCurrentMonthLabel { get => _footerCurrentMonthLabel; private set => SetProperty(ref _footerCurrentMonthLabel, value); }
+    public string FooterEstimatedAnnualCreditsDisplay { get => _footerEstimatedAnnualCreditsDisplay; private set => SetProperty(ref _footerEstimatedAnnualCreditsDisplay, value); }
+
+    public string FooterCurrentValueDisplay
+    {
+        get
+        {
+            if (!PortfolioAssetSummaryRows.Any() || PortfolioAssetSummaryRows.Any(r => r.IsLoadingPrice))
+                return "Calculating…";
+            return PortfolioAssetSummaryRows.Sum(r => r.CurrentValue ?? 0m).ToString("N2");
+        }
+    }
+
     public ObservableCollection<TransactionDTO> Transactions { get; } = new();
     public ObservableCollection<CreditDTO> Credits { get; } = new();
     public ObservableCollection<KeyValuePair<string, decimal>> CreditsByMonthChart { get; } = new();
@@ -226,6 +251,19 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         foreach (var item in assetItems)
             PortfolioAssetSummaryRows.Add(new PortfolioAssetSummaryRowViewModel(item));
 
+        FooterTotalInvested = assetItems.Sum(i => i.TotalInvested);
+        FooterTotalCredits = assetItems.Sum(i => i.TotalCredits);
+        FooterCurrentMonthCredits = assetItems.Sum(i => i.CurrentMonthCredits);
+        FooterCurrentMonthLabel = "Credits " + DateTime.Today.ToString("MMM yyyy", CultureInfo.InvariantCulture);
+        var withEstimated = assetItems.Where(i => i.EstimatedAnnualCredits.HasValue).ToList();
+        FooterEstimatedAnnualCreditsDisplay = withEstimated.Any()
+            ? withEstimated.Sum(i => i.EstimatedAnnualCredits!.Value).ToString("N2")
+            : "—";
+
+        foreach (var row in PortfolioAssetSummaryRows)
+            SubscribeToRowPriceChanges(row);
+        OnPropertyChanged(nameof(FooterCurrentValueDisplay));
+
         var rows = PortfolioAssetSummaryRows.ToList();
         _rowPriceCts = new CancellationTokenSource();
         var token = _rowPriceCts.Token;
@@ -275,6 +313,12 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     {
         CancelAndResetRowPriceFetch();
         PortfolioAssetSummaryRows.Clear();
+        FooterTotalInvested = 0m;
+        FooterTotalCredits = 0m;
+        FooterCurrentMonthCredits = 0m;
+        FooterCurrentMonthLabel = string.Empty;
+        FooterEstimatedAnnualCreditsDisplay = "—";
+        OnPropertyChanged(nameof(FooterCurrentValueDisplay));
         IsPortfolioView = false;
         ClearAssetContext();
         Credits.Clear();
@@ -402,9 +446,29 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
 
     private void CancelAndResetRowPriceFetch()
     {
+        UnsubscribeFromRowPriceChanges();
         _rowPriceCts?.Cancel();
         _rowPriceCts?.Dispose();
         _rowPriceCts = null;
+    }
+
+    private void SubscribeToRowPriceChanges(PortfolioAssetSummaryRowViewModel row)
+    {
+        void Handler(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName is nameof(PortfolioAssetSummaryRowViewModel.IsLoadingPrice)
+                or nameof(PortfolioAssetSummaryRowViewModel.CurrentValue))
+                OnPropertyChanged(nameof(FooterCurrentValueDisplay));
+        }
+        row.PropertyChanged += Handler;
+        _rowSubscriptions.Add((row, Handler));
+    }
+
+    private void UnsubscribeFromRowPriceChanges()
+    {
+        foreach (var (row, handler) in _rowSubscriptions)
+            row.PropertyChanged -= handler;
+        _rowSubscriptions.Clear();
     }
 
     private void ClearAssetContext()

--- a/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
+++ b/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using System.Globalization;
 
 namespace Financial.Presentation.App.ViewModels;
 
@@ -23,6 +24,12 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
     public decimal PortfolioWeight { get; }
     public decimal TotalCredits { get; }
     public IReadOnlyList<AssetCashFlowDTO> CashFlows { get; }
+    public decimal LastMonthCredits { get; }
+    public string? LastCreditMonth { get; }
+    public decimal? LastMonthCreditsPercent { get; }
+    public decimal? EstimatedAnnualCredits { get; }
+    public decimal? EstimatedAnnualPercent { get; }
+    public decimal CurrentMonthCredits { get; }
 
     public bool IsLoadingPrice => _isLoadingPrice;
     public bool PriceFetchFailed => _priceFetchFailed;
@@ -38,6 +45,24 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
     public string DisplayTotalInvested => TotalInvested.ToString("N2");
     public string DisplayPortfolioWeight => $"{PortfolioWeight:F1}%";
     public string DisplayTotalCredits => TotalCredits.ToString("N2");
+
+    public string DisplayLastMonthCredits =>
+        LastCreditMonth is null ? "—" : LastMonthCredits.ToString("N2");
+
+    public string LastCreditMonthDisplay =>
+        LastCreditMonth is null
+            ? "—"
+            : DateTime.ParseExact(LastCreditMonth, "yyyy-MM", CultureInfo.InvariantCulture)
+                      .ToString("MMM yyyy", CultureInfo.InvariantCulture);
+
+    public string DisplayLastMonthCreditsPercent =>
+        LastMonthCreditsPercent.HasValue ? $"{LastMonthCreditsPercent.Value:F2}%" : "—";
+
+    public string DisplayEstimatedAnnualCredits =>
+        EstimatedAnnualCredits.HasValue ? EstimatedAnnualCredits.Value.ToString("N2") : "—";
+
+    public string DisplayEstimatedAnnualPercent =>
+        EstimatedAnnualPercent.HasValue ? $"{EstimatedAnnualPercent.Value:F2}%" : "—";
 
     public string DisplayCurrentValue =>
         _isLoadingPrice || _priceFetchFailed ? "—" : _currentValue?.ToString("N2") ?? "—";
@@ -69,6 +94,12 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
         PortfolioWeight = dto.PortfolioWeight;
         TotalCredits = dto.TotalCredits;
         CashFlows = dto.CashFlows;
+        LastMonthCredits = dto.LastMonthCredits;
+        LastCreditMonth = dto.LastCreditMonth;
+        LastMonthCreditsPercent = dto.LastMonthCreditsPercent;
+        EstimatedAnnualCredits = dto.EstimatedAnnualCredits;
+        EstimatedAnnualPercent = dto.EstimatedAnnualPercent;
+        CurrentMonthCredits = dto.CurrentMonthCredits;
     }
 
     public void ApplyPrice(decimal price)

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
@@ -30,6 +30,30 @@ public class AssetDetailsViewModelPortfolioSummaryTests
         }).ToList();
     }
 
+    private static PortfolioAssetSummaryItemDTO BuildItem(
+        string assetName = "Asset",
+        decimal currentQuantity = 10m,
+        decimal totalInvested = 1000m,
+        decimal totalCredits = 0m,
+        decimal currentMonthCredits = 0m,
+        decimal? estimatedAnnualCredits = null)
+    {
+        return new PortfolioAssetSummaryItemDTO
+        {
+            AssetName = assetName,
+            Ticker = "T",
+            Exchange = "LSE",
+            CurrentQuantity = currentQuantity,
+            TotalBought = totalInvested,
+            TotalSold = 0m,
+            TotalInvested = totalInvested,
+            PortfolioWeight = 50m,
+            TotalCredits = totalCredits,
+            CurrentMonthCredits = currentMonthCredits,
+            EstimatedAnnualCredits = estimatedAnnualCredits
+        };
+    }
+
     [Fact]
     public void LoadPortfolioSummary_SetsIsPortfolioViewTrue()
     {
@@ -120,6 +144,101 @@ public class AssetDetailsViewModelPortfolioSummaryTests
             Transactions = [], Credits = []
         });
         vm.IsPortfolioView.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_SetsFooterTotalInvested_SumOfRows()
+    {
+        var vm = BuildViewModel();
+        var items = new[] { BuildItem(totalInvested: 1000m), BuildItem(totalInvested: 2000m) };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], items);
+        vm.FooterTotalInvested.Should().Be(3000m);
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_SetsFooterTotalCredits_SumOfRows()
+    {
+        var vm = BuildViewModel();
+        var items = new[] { BuildItem(totalCredits: 50m), BuildItem(totalCredits: 75m) };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], items);
+        vm.FooterTotalCredits.Should().Be(125m);
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_SetsFooterCurrentMonthCredits_SumOfRows()
+    {
+        var vm = BuildViewModel();
+        var items = new[] { BuildItem(currentMonthCredits: 10m), BuildItem(currentMonthCredits: 20m) };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], items);
+        vm.FooterCurrentMonthCredits.Should().Be(30m);
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_SetsFooterCurrentMonthLabel_IncludesCreditsAndMonthYear()
+    {
+        var vm = BuildViewModel();
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], BuildItems(1));
+        vm.FooterCurrentMonthLabel.Should().StartWith("Credits ");
+        vm.FooterCurrentMonthLabel.Should().MatchRegex(@"Credits [A-Z][a-z]{2} \d{4}");
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_SetsFooterEstimatedAnnualCreditsDisplay_SumOfNonNull()
+    {
+        var vm = BuildViewModel();
+        var items = new[] { BuildItem(estimatedAnnualCredits: 600m), BuildItem(estimatedAnnualCredits: null) };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], items);
+        vm.FooterEstimatedAnnualCreditsDisplay.Should().Be("600.00");
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_SetsFooterEstimatedAnnualCreditsDisplay_DashWhenAllNull()
+    {
+        var vm = BuildViewModel();
+        var items = new[] { BuildItem(estimatedAnnualCredits: null), BuildItem(estimatedAnnualCredits: null) };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], items);
+        vm.FooterEstimatedAnnualCreditsDisplay.Should().Be("—");
+    }
+
+    [Fact]
+    public void FooterCurrentValueDisplay_WhenAnyRowIsLoading_ReturnsCalculating()
+    {
+        var vm = BuildViewModel(new NeverResolvingPriceService());
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], BuildItems(2));
+        vm.FooterCurrentValueDisplay.Should().Be("Calculating…");
+    }
+
+    [Fact]
+    public void FooterCurrentValueDisplay_WhenAllPricesResolved_ReturnsSumN2()
+    {
+        var vm = BuildViewModel(new NeverResolvingPriceService());
+        var items = new[]
+        {
+            BuildItem(currentQuantity: 5m),
+            BuildItem(currentQuantity: 2m)
+        };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], items);
+
+        vm.PortfolioAssetSummaryRows[0].ApplyPrice(10m);  // CV = 50
+        vm.PortfolioAssetSummaryRows[1].ApplyPrice(20m);  // CV = 40
+
+        vm.FooterCurrentValueDisplay.Should().Be("90.00");
+    }
+
+    [Fact]
+    public void Clear_AfterLoadPortfolioSummary_ResetsFooterProperties()
+    {
+        var vm = BuildViewModel();
+        var items = new[] { BuildItem(totalInvested: 1000m, totalCredits: 50m, currentMonthCredits: 10m, estimatedAnnualCredits: 600m) };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], items);
+
+        vm.Clear();
+
+        vm.FooterTotalInvested.Should().Be(0m);
+        vm.FooterTotalCredits.Should().Be(0m);
+        vm.FooterCurrentMonthCredits.Should().Be(0m);
+        vm.FooterCurrentMonthLabel.Should().Be(string.Empty);
+        vm.FooterEstimatedAnnualCreditsDisplay.Should().Be("—");
     }
 
     private sealed class NeverResolvingPriceService : IAssetPriceService

--- a/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
@@ -12,7 +12,13 @@ public class PortfolioAssetSummaryRowViewModelTests
         decimal portfolioWeight = 0m,
         decimal totalCredits = 0m,
         DateTime? firstInvestmentDate = null,
-        IReadOnlyList<AssetCashFlowDTO>? cashFlows = null)
+        IReadOnlyList<AssetCashFlowDTO>? cashFlows = null,
+        decimal lastMonthCredits = 0m,
+        string? lastCreditMonth = null,
+        decimal? lastMonthCreditsPercent = null,
+        decimal? estimatedAnnualCredits = null,
+        decimal? estimatedAnnualPercent = null,
+        decimal currentMonthCredits = 0m)
     {
         var dto = new PortfolioAssetSummaryItemDTO
         {
@@ -26,7 +32,13 @@ public class PortfolioAssetSummaryRowViewModelTests
             TotalInvested = totalInvested,
             PortfolioWeight = portfolioWeight,
             TotalCredits = totalCredits,
-            CashFlows = cashFlows ?? []
+            CashFlows = cashFlows ?? [],
+            LastMonthCredits = lastMonthCredits,
+            LastCreditMonth = lastCreditMonth,
+            LastMonthCreditsPercent = lastMonthCreditsPercent,
+            EstimatedAnnualCredits = estimatedAnnualCredits,
+            EstimatedAnnualPercent = estimatedAnnualPercent,
+            CurrentMonthCredits = currentMonthCredits
         };
         return new PortfolioAssetSummaryRowViewModel(dto);
     }
@@ -356,5 +368,75 @@ public class PortfolioAssetSummaryRowViewModelTests
         raised.Should().Contain(nameof(row.DisplayXirr));
         raised.Should().Contain(nameof(row.PriceFetchFailed));
         raised.Should().Contain(nameof(row.IsLoadingPrice));
+    }
+
+    [Fact]
+    public void DisplayLastMonthCredits_WhenLastCreditMonthIsNotNull_FormatsN2()
+    {
+        var row = BuildRow(lastMonthCredits: 12.50m, lastCreditMonth: "2026-06");
+        row.DisplayLastMonthCredits.Should().Be("12.50");
+    }
+
+    [Fact]
+    public void DisplayLastMonthCredits_WhenLastCreditMonthIsNull_ReturnsDash()
+    {
+        var row = BuildRow(lastCreditMonth: null);
+        row.DisplayLastMonthCredits.Should().Be("—");
+    }
+
+    [Fact]
+    public void LastCreditMonthDisplay_WhenNotNull_FormatsAsMMMYyyy()
+    {
+        var row = BuildRow(lastCreditMonth: "2026-06");
+        row.LastCreditMonthDisplay.Should().Be("Jun 2026");
+    }
+
+    [Fact]
+    public void LastCreditMonthDisplay_WhenNull_ReturnsDash()
+    {
+        var row = BuildRow(lastCreditMonth: null);
+        row.LastCreditMonthDisplay.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayLastMonthCreditsPercent_WhenNotNull_FormatsF2Percent()
+    {
+        var row = BuildRow(lastMonthCreditsPercent: 1.25m);
+        row.DisplayLastMonthCreditsPercent.Should().Be("1.25%");
+    }
+
+    [Fact]
+    public void DisplayLastMonthCreditsPercent_WhenNull_ReturnsDash()
+    {
+        var row = BuildRow(lastMonthCreditsPercent: null);
+        row.DisplayLastMonthCreditsPercent.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayEstimatedAnnualCredits_WhenNotNull_FormatsN2()
+    {
+        var row = BuildRow(estimatedAnnualCredits: 150.00m);
+        row.DisplayEstimatedAnnualCredits.Should().Be("150.00");
+    }
+
+    [Fact]
+    public void DisplayEstimatedAnnualCredits_WhenNull_ReturnsDash()
+    {
+        var row = BuildRow(estimatedAnnualCredits: null);
+        row.DisplayEstimatedAnnualCredits.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayEstimatedAnnualPercent_WhenNotNull_FormatsF2Percent()
+    {
+        var row = BuildRow(estimatedAnnualPercent: 6.00m);
+        row.DisplayEstimatedAnnualPercent.Should().Be("6.00%");
+    }
+
+    [Fact]
+    public void DisplayEstimatedAnnualPercent_WhenNull_ReturnsDash()
+    {
+        var row = BuildRow(estimatedAnnualPercent: null);
+        row.DisplayEstimatedAnnualPercent.Should().Be("—");
     }
 }


### PR DESCRIPTION
## Summary

- Adds five credit-analysis DataGrid columns after XIRR in the WPF `PortfolioSummaryTemplate` (Last Month Credits, Last Credit Month, Last Month %, Est. Annual Credits, Est. Annual %) with a 3 px `#007ACC` left border on the first column as a visual group separator
- Adds reactive footer panel below the DataGrid with five portfolio-level aggregates: Total Invested, Total Credits, Current Value (live via `PropertyChanged` subscriptions), Credits [Mon yyyy] (current-month, dynamically labelled), and Est. Annual Credits
- Extends `PortfolioAssetSummaryRowViewModel` with 6 DTO-sourced properties and 5 display strings (with "—" null guards); extends `AssetDetailsViewModel` with footer properties, `_rowSubscriptions` lifecycle, and footer reset on `Clear()`

## Test plan

- [x] 10 new row VM tests — all `Display*` properties and null/"—" guard conditions
- [x] 9 new footer tests — population from row data, `FooterCurrentValueDisplay` two states, `Clear()` reset
- [x] Full suite: 341 tests, 0 failures across all projects
- [x] `Run.Text` TwoWay binding crash fixed — replaced with `TextBlock + StringFormat`; rule documented in project memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)