### PR TITLE
feat(F01): Aggregated Totals Enhancement — Application Layer

### DIFF
--- a/Financial.Application/DTOs/AggregatedSummaryDTO.cs
+++ b/Financial.Application/DTOs/AggregatedSummaryDTO.cs
@@ -5,4 +5,5 @@ public sealed class AggregatedSummaryDTO
     public decimal TotalBought { get; init; }
     public decimal TotalSold { get; init; }
     public decimal TotalCredits { get; init; }
+    public decimal TotalInvested { get; init; }
 }

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -172,6 +172,6 @@ internal static class NavigationMapper
         };
     }
 
-    private static bool IsEncerradas(string? name) =>
+    internal static bool IsEncerradas(string? name) =>
         string.Equals(name?.Trim(), EncerradasName, StringComparison.CurrentCultureIgnoreCase);
 }

--- a/Financial.Application/Services/SummaryQueryService.cs
+++ b/Financial.Application/Services/SummaryQueryService.cs
@@ -17,7 +17,15 @@ public sealed class SummaryQueryService : ISummaryQueryService
         if (string.IsNullOrWhiteSpace(brokerName))
             return new AggregatedSummaryDTO();
 
-        var assets = _repository.GetAssetsByBroker(brokerName).Where(a => a.Active);
+        var broker = _repository.GetBrokerList().FirstOrDefault(b => b.Name == brokerName);
+        if (broker is null)
+            return new AggregatedSummaryDTO();
+
+        var assets = broker.Portfolios
+            .Where(p => !NavigationMapper.IsEncerradas(p.Name))
+            .SelectMany(p => p.Assets)
+            .Where(a => a.Active);
+
         return Aggregate(assets);
     }
 
@@ -47,6 +55,7 @@ public sealed class SummaryQueryService : ISummaryQueryService
             TotalBought = totalBought,
             TotalSold = totalSold,
             TotalCredits = totalCredits,
+            TotalInvested = totalBought - totalSold,
         };
     }
 }

--- a/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
@@ -100,6 +100,7 @@ public class SummaryEndpointsTests
         dto!.TotalBought.Should().BeGreaterThanOrEqualTo(0m);
         dto.TotalSold.Should().BeGreaterThanOrEqualTo(0m);
         dto.TotalCredits.Should().BeGreaterThanOrEqualTo(0m);
+        dto.TotalInvested.Should().Be(dto.TotalBought - dto.TotalSold);
     }
 
     [Fact]
@@ -117,5 +118,6 @@ public class SummaryEndpointsTests
         dto!.TotalBought.Should().BeGreaterThanOrEqualTo(0m);
         dto.TotalSold.Should().BeGreaterThanOrEqualTo(0m);
         dto.TotalCredits.Should().BeGreaterThanOrEqualTo(0m);
+        dto.TotalInvested.Should().Be(dto.TotalBought - dto.TotalSold);
     }
 }

--- a/Tests/Financial.Application.Tests/Services/SummaryQueryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/SummaryQueryServiceTests.cs
@@ -23,7 +23,7 @@ public class SummaryQueryServiceTests
         var asset = MakeAsset();
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 15m, 0m));
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 20m, 0m));
-        _repository.AssetsByBroker = [asset];
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", asset)];
 
         var result = CreateService().GetBrokerSummary("XPI");
 
@@ -36,7 +36,7 @@ public class SummaryQueryServiceTests
         var asset = MakeAsset();
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 20m, 10m, 0m));
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 12m, 0m));
-        _repository.AssetsByBroker = [asset];
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", asset)];
 
         var result = CreateService().GetBrokerSummary("XPI");
 
@@ -50,7 +50,7 @@ public class SummaryQueryServiceTests
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
         asset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 30m));
         asset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Rent, 15m));
-        _repository.AssetsByBroker = [asset];
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", asset)];
 
         var result = CreateService().GetBrokerSummary("XPI");
 
@@ -67,7 +67,7 @@ public class SummaryQueryServiceTests
         var inactiveAsset = MakeZeroQuantityAsset();
         inactiveAsset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 100m));
 
-        _repository.AssetsByBroker = [activeAsset, inactiveAsset];
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", activeAsset, inactiveAsset)];
 
         var result = CreateService().GetBrokerSummary("XPI");
 
@@ -79,7 +79,7 @@ public class SummaryQueryServiceTests
     [Fact]
     public void GetBrokerSummary_ReturnsZerosForBrokerWithNoActiveAssets()
     {
-        _repository.AssetsByBroker = [MakeZeroQuantityAsset()];
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", MakeZeroQuantityAsset())];
 
         var result = CreateService().GetBrokerSummary("XPI");
 
@@ -87,6 +87,85 @@ public class SummaryQueryServiceTests
         result.TotalBought.Should().Be(0m);
         result.TotalSold.Should().Be(0m);
         result.TotalCredits.Should().Be(0m);
+        result.TotalInvested.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetBrokerSummary_ReturnsZerosForUnknownBrokerName()
+    {
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", MakeAsset())];
+
+        var result = CreateService().GetBrokerSummary("UNKNOWN");
+
+        using var _ = new AssertionScope();
+        result.TotalBought.Should().Be(0m);
+        result.TotalSold.Should().Be(0m);
+        result.TotalCredits.Should().Be(0m);
+        result.TotalInvested.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetBrokerSummary_ExcludesEncerradasPortfolio()
+    {
+        var defaultAsset = MakeAsset("DEFAULT", "DEF");
+        defaultAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+
+        var encerradasAsset = MakeAsset("CLOSED", "CLO");
+        encerradasAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 100m, 5m, 0m));
+
+        var broker = Broker.Create("XPI", "BRL");
+        broker.AddPortfolio("Default").AddAsset(defaultAsset);
+        broker.AddPortfolio("Encerradas").AddAsset(encerradasAsset);
+        _repository.Brokers = [broker];
+
+        var result = CreateService().GetBrokerSummary("XPI");
+
+        result.TotalBought.Should().Be(100m);
+    }
+
+    [Theory]
+    [InlineData("Encerradas")]
+    [InlineData("encerradas")]
+    [InlineData("ENCERRADAS")]
+    [InlineData(" Encerradas ")]
+    public void GetBrokerSummary_ExcludesEncerradasPortfolio_CaseInsensitive(string portfolioName)
+    {
+        var encerradasAsset = MakeAsset("CLOSED", "CLO");
+        encerradasAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 100m, 5m, 0m));
+
+        var broker = Broker.Create("XPI", "BRL");
+        broker.AddPortfolio(portfolioName).AddAsset(encerradasAsset);
+        _repository.Brokers = [broker];
+
+        var result = CreateService().GetBrokerSummary("XPI");
+
+        result.TotalBought.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetBrokerSummary_TotalInvested_EqualsBoughtMinusSold()
+    {
+        var asset = MakeAsset();
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 30m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 12m, 10m, 0m));
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", asset)];
+
+        var result = CreateService().GetBrokerSummary("XPI");
+
+        result.TotalInvested.Should().Be(180m);
+    }
+
+    [Fact]
+    public void GetBrokerSummary_TotalInvested_CanBeNegative()
+    {
+        var asset = MakeAsset();
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 50m, 0m));
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", asset)];
+
+        var result = CreateService().GetBrokerSummary("XPI");
+
+        result.TotalInvested.Should().Be(-150m);
     }
 
     [Theory]
@@ -101,6 +180,7 @@ public class SummaryQueryServiceTests
         result.TotalBought.Should().Be(0m);
         result.TotalSold.Should().Be(0m);
         result.TotalCredits.Should().Be(0m);
+        result.TotalInvested.Should().Be(0m);
     }
 
     [Fact]
@@ -172,6 +252,19 @@ public class SummaryQueryServiceTests
         result.TotalCredits.Should().Be(0m);
     }
 
+    [Fact]
+    public void GetPortfolioSummary_TotalInvested_EqualsBoughtMinusSold()
+    {
+        var asset = MakeAsset();
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 20m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 10m, 0m));
+        _repository.AssetsByBrokerPortfolio = [asset];
+
+        var result = CreateService().GetPortfolioSummary("XPI", "Default");
+
+        result.TotalInvested.Should().Be(150m);
+    }
+
     [Theory]
     [InlineData(null, "Default")]
     [InlineData("", "Default")]
@@ -187,6 +280,7 @@ public class SummaryQueryServiceTests
         result.TotalBought.Should().Be(0m);
         result.TotalSold.Should().Be(0m);
         result.TotalCredits.Should().Be(0m);
+        result.TotalInvested.Should().Be(0m);
     }
 
     private SummaryQueryService CreateService() => new(_repository);
@@ -202,14 +296,26 @@ public class SummaryQueryServiceTests
         return asset;
     }
 
+    private static Broker MakeBrokerWithAssets(string brokerName, string portfolioName, params Asset[] assets)
+    {
+        var broker = Broker.Create(brokerName, "BRL");
+        var portfolio = broker.AddPortfolio(portfolioName);
+        foreach (var asset in assets)
+        {
+            portfolio.AddAsset(asset);
+        }
+        return broker;
+    }
+
     private sealed class StubRepository : IRepository
     {
         public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
         public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
+        public IEnumerable<Broker> Brokers { get; set; } = [];
 
         public IEnumerable<Asset> GetAssetsByBroker(string name) => AssetsByBroker;
         public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => AssetsByBrokerPortfolio;
-        public IEnumerable<Broker> GetBrokerList() => [];
+        public IEnumerable<Broker> GetBrokerList() => Brokers;
         public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => null;
         public Task SaveChangesAsync() => Task.CompletedTask;
     }

--- a/docs/F01-aggregated-totals-enhancement-application-layer/plan.md
+++ b/docs/F01-aggregated-totals-enhancement-application-layer/plan.md
@@ -1,0 +1,31 @@
+# Implementation Plan: F01 — Aggregated Totals Enhancement — Application Layer
+
+**Prerequisites:**
+- No new libraries or environment configuration required
+- Existing `Financial.Application`, `Financial.Application.Tests`, and `Financial.Api.Tests` projects build and pass before starting
+
+---
+
+### Stage 1: Data Shape and Shared Helper
+
+**1. AggregatedSummaryDTO** - Add the new `TotalInvested` property to the DTO, following the existing properties' style, so both existing endpoints can return it once the service populates it.
+
+**2. NavigationMapper visibility** - Widen `IsEncerradas` from `private` to `internal` so it can be reused outside `NavigationMapper` without duplicating the comparison logic.
+
+---
+
+### Stage 2: Service Logic
+
+**3. GetBrokerSummary rewrite** - Change the broker-level aggregation to source data from the broker/portfolio/asset tree instead of the flat asset list, excluding the Encerradas portfolio before applying the existing active-asset filter, per the spec's chosen data-access approach.
+
+**4. GetPortfolioSummary and Aggregate update** - Leave the portfolio-level data source unchanged; update the shared aggregation helper so both methods populate `TotalInvested` on the returned DTO.
+
+---
+
+### Stage 3: Test Coverage
+
+**5. Unit test fixture rewrite** - Update the `SummaryQueryService` test double to support building a broker/portfolio/asset graph, and adapt all existing broker-level tests to the new fixture shape without changing their original assertions.
+
+**6. New unit tests** - Add coverage for Encerradas exclusion (including case-insensitivity), an unknown broker name, and `TotalInvested` computation (including the negative case) at both broker and portfolio scope.
+
+**7. Integration test updates** - Extend the existing HTTP-level summary endpoint tests to assert the new `totalInvested` field is present and correctly computed in the live response.

--- a/docs/F01-aggregated-totals-enhancement-application-layer/spec.md
+++ b/docs/F01-aggregated-totals-enhancement-application-layer/spec.md
@@ -1,0 +1,181 @@
+# Spec: F01 — Aggregated Totals Enhancement — Application Layer
+
+## 1. Technical Overview
+
+**What:** Adds a `TotalInvested` field (`TotalBought − TotalSold`) to `AggregatedSummaryDTO`, returned by both the existing broker-level and portfolio-level summary endpoints. Also corrects `SummaryQueryService.GetBrokerSummary` so that broker-level totals (`TotalBought`, `TotalSold`, `TotalCredits`, and the new `TotalInvested`) exclude all transactions and credits belonging to assets in the "Encerradas" portfolio, in addition to the existing exclusion of inactive assets (`Quantity == 0`).
+
+**Why:** `AggregatedSummaryDTO` currently exposes only the three raw sums; both frontends would otherwise have to duplicate the `TotalBought − TotalSold` subtraction themselves (Web and WPF, in F05/F06). More importantly, `GetBrokerSummary` today aggregates via `IRepository.GetAssetsByBroker(brokerName)`, which flattens every portfolio's assets into one list with no portfolio identity — so a broker's fully-closed "Encerradas" portfolio silently inflates the broker's totals with historical, no-longer-relevant capital. `NavigationMapper` already defines this exact exclusion rule (`IsEncerradas`, used by `NavigationService` for tree ordering); this feature reuses it here instead of re-deriving the concept.
+
+**Scope:**
+
+Included:
+- `TotalInvested` property on `AggregatedSummaryDTO`
+- `SummaryQueryService.GetBrokerSummary` rewritten to source data from `IRepository.GetBrokerList()` (broker → portfolio → asset tree) instead of the flat `GetAssetsByBroker`, filtering out the Encerradas portfolio before filtering active assets
+- `SummaryQueryService.GetPortfolioSummary` unchanged aggregation source (`GetAssetsByBrokerPortfolio`); only gains `TotalInvested` in its returned DTO
+- `NavigationMapper.IsEncerradas` visibility changed from `private` to `internal` so `SummaryQueryService` can reuse it
+- Unit test rewrite for `GetBrokerSummary` (new stub shape) and new tests for Encerradas exclusion, unknown broker, and `TotalInvested` computation
+- Integration test updates asserting `totalInvested` in both endpoints' JSON responses
+
+Excluded:
+- Any change to `IRepository.GetAssetsByBroker`'s existing flat-list contract (still used unchanged by `CreditQueryService`)
+- Any change to `CreditQueryService`'s broker-level credit aggregation (Credits tab breakdown is a separate, unrelated data path not scoped by this PRD)
+- Any Presentation-layer (Web or WPF) display change — covered by F05 and F06
+- The Broker/Portfolio breakdown pie-chart data (covered by F02)
+- Excluding Encerradas from `GetPortfolioSummary` — not applicable; a direct Portfolio selection is never filtered against itself
+
+---
+
+## 2. Architecture Impact
+
+**Affected components:**
+
+```mermaid
+graph TD
+    Controller["SummaryController (unchanged)"] --> Service["SummaryQueryService (modified)"]
+    Service --> BrokerList["IRepository.GetBrokerList() (existing, now used here)"]
+    Service --> AssetsByPortfolio["IRepository.GetAssetsByBrokerPortfolio() (unchanged)"]
+    Service --> Mapper["NavigationMapper.IsEncerradas (visibility widened) + CalculateTotals (unchanged)"]
+    Service --> DTO["AggregatedSummaryDTO (modified: +TotalInvested)"]
+```
+
+---
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Broker-scope data source for Encerradas filtering | Reuse `IRepository.GetBrokerList()`, which already returns the full `Broker → Portfolio → Asset` tree, exactly as `NavigationService` already does for the same Encerradas concept | Add a new `IRepository.GetPortfoliosByBroker(brokerName)` method, exposing `JSONRepository`'s existing private helper | `GetBrokerList()` returns more data than strictly needed (the whole broker graph, not just portfolio names), but this is a personal-scale, in-memory dataset — the cost is negligible. Avoids growing `IRepository` for a need only one caller has today, and keeps the Encerradas-exclusion logic sourced from the exact same repository call already trusted for that purpose |
+| Encerradas check reuse | Widen `NavigationMapper.IsEncerradas` from `private` to `internal`, called directly from `SummaryQueryService` (same assembly) | Duplicate the case-insensitive, trimmed name comparison inline in `SummaryQueryService` | A second copy of the same string-comparison rule would drift if the Encerradas matching logic ever changes (e.g., to support multiple archive-portfolio names); one internal helper keeps a single source of truth |
+| Where `TotalInvested` is computed | Computed once in `SummaryQueryService.Aggregate`, carried on `AggregatedSummaryDTO` | Compute `TotalBought − TotalSold` independently in each frontend (Web component, WPF ViewModel) | Guarantees Web (F05) and WPF (F06) never diverge in sign or rounding; the DTO now carries one derived value alongside its two raw sums, a small increase in DTO responsibility for a meaningful reduction in duplicated logic |
+
+---
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Application/DTOs/AggregatedSummaryDTO.cs` | Modified | Aggregated totals response shape | Add `TotalInvested` (`decimal`, `init`-only), following the existing three properties' style |
+| `Financial.Application/Services/NavigationMapper.cs` | Modified | Shared navigation/aggregation helpers | Change `IsEncerradas` from `private static` to `internal static`; no behavioural change to the method itself |
+| `Financial.Application/Services/SummaryQueryService.cs` | Modified | Broker/Portfolio totals aggregation | `GetBrokerSummary`: look up the broker via `_repository.GetBrokerList().FirstOrDefault(b => b.Name == brokerName)`, return a zero-filled DTO when not found, otherwise flatten `broker.Portfolios.Where(p => !NavigationMapper.IsEncerradas(p.Name)).SelectMany(p => p.Assets)` before the existing `.Where(a => a.Active)` filter; `GetPortfolioSummary` keeps its existing `GetAssetsByBrokerPortfolio` source unchanged; `Aggregate` gains `TotalInvested = totalBought - totalSold` in the returned DTO |
+| `Tests/Financial.Application.Tests/Services/SummaryQueryServiceTests.cs` | Modified | Unit tests for `SummaryQueryService` | `StubRepository` gains a `Brokers` property (`IEnumerable<Broker>`) backing `GetBrokerList()`; all existing `GetBrokerSummary_*` tests rewritten to build a `Broker`/`Portfolio`/`Asset` graph instead of a flat asset list; new tests added for Encerradas exclusion, unknown broker name, and `TotalInvested` on both broker and portfolio scope |
+| `Tests/Financial.Api.Tests/SummaryEndpointsTests.cs` | Modified | HTTP integration tests for summary endpoints | Extend `GetBrokerSummary_Returns200WithDto` and `GetPortfolioSummary_Returns200WithDto` to assert `TotalInvested` equals `TotalBought − TotalSold` on the deserialized response |
+
+---
+
+## 5. API Contracts
+
+No new endpoints. Both existing endpoints gain one additional response field.
+
+### `GET /summary/broker/{brokerName}` (modified response)
+
+- **Method:** GET
+- **Path:** `/api/v1/financial/summary/broker/{brokerName}`
+- **Authentication:** None (matches existing endpoint)
+
+**Response (Success - 200):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalBought` | `decimal` | Unchanged: sum of Buy transaction totals across active, non-Encerradas assets |
+| `totalSold` | `decimal` | Unchanged: sum of Sell transaction totals across active, non-Encerradas assets |
+| `totalCredits` | `decimal` | Unchanged: sum of credit values across active, non-Encerradas assets |
+| `totalInvested` | `decimal` | **New.** `totalBought − totalSold`; may be negative |
+
+**Response Example:**
+```json
+{
+  "totalBought": 15250.00,
+  "totalSold": 3200.00,
+  "totalCredits": 480.50,
+  "totalInvested": 12050.00
+}
+```
+
+**Error Codes:**
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| N/A | 400 | Returned by ASP.NET routing when `brokerName` is whitespace-only after URL decoding (unchanged existing behaviour) |
+
+### `GET /summary/portfolio/{brokerName}/{portfolioName}` (modified response)
+
+- **Method:** GET
+- **Path:** `/api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}`
+- **Authentication:** None (matches existing endpoint)
+
+**Response (Success - 200):** same shape as above, computed only from the given portfolio's active assets (no Encerradas check applied — the selected portfolio may itself be Encerradas, in which case it is aggregated unfiltered, consistent with today's behaviour).
+
+**Response Example:**
+```json
+{
+  "totalBought": 4500.00,
+  "totalSold": 4500.00,
+  "totalCredits": 125.00,
+  "totalInvested": 0.00
+}
+```
+
+---
+
+## 6. Data Model
+
+Not applicable. No persistence schema changes; `TotalInvested` is a computed, in-memory value derived at query time from `Asset.Transactions`, exactly like the three existing totals.
+
+---
+
+## 7. Testing Strategy
+
+### Test File Structure
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Tests/Financial.Application.Tests/Services/SummaryQueryServiceTests.cs` | Unit | `SummaryQueryService` | All existing broker/portfolio aggregation behaviour (rewired to new stub shape) plus Encerradas exclusion, unknown broker, and `TotalInvested` computation |
+| `Tests/Financial.Api.Tests/SummaryEndpointsTests.cs` | Integration | `GET /summary/broker/{brokerName}`, `GET /summary/portfolio/{brokerName}/{portfolioName}` | `totalInvested` present and correctly computed in the live HTTP response |
+
+### SummaryQueryServiceTests.cs
+
+`StubRepository` is extended with a `Brokers` property (`IEnumerable<Broker>`, default `[]`) backing `GetBrokerList()`. All `GetBrokerSummary_*` tests are rewritten to build the fixture via `Broker.Create(...)`, `broker.AddPortfolio(...)`, and `portfolio.AddAsset(...)` instead of assigning `AssetsByBroker` directly. `GetPortfolioSummary_*` tests are unchanged (still use `AssetsByBrokerPortfolio`) except for new `TotalInvested` assertions.
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `GetBrokerSummary_ReturnsSumOfBuyTransactions` (rewritten) | Broker with one portfolio containing the existing fixture asset | `TotalBought` unchanged from current expected value |
+| `GetBrokerSummary_ReturnsSumOfSellTransactions` (rewritten) | Same pattern | `TotalSold` unchanged from current expected value |
+| `GetBrokerSummary_ReturnsSumOfCredits` (rewritten) | Same pattern | `TotalCredits` unchanged from current expected value |
+| `GetBrokerSummary_ExcludesInactiveAssets` (rewritten) | Portfolio contains one active and one zero-quantity asset | `TotalBought`/`TotalCredits` reflect only the active asset (regression, existing behaviour preserved) |
+| `GetBrokerSummary_ReturnsZerosForBrokerWithNoActiveAssets` (rewritten) | Portfolio contains only a zero-quantity asset | All totals, including `TotalInvested`, are 0 |
+| `GetBrokerSummary_ReturnsZerosOnNullOrWhitespaceBrokerName` (unchanged assertions, `Theory` retained) | `null`/`""`/`"   "` broker name | All totals, including `TotalInvested`, are 0; `GetBrokerList()` is never queried |
+| `GetBrokerSummary_ReturnsZerosForUnknownBrokerName` (new) | `Brokers` contains brokers, but none match the requested name | All totals are 0, no exception thrown |
+| `GetBrokerSummary_ExcludesEncerradasPortfolio` (new) | Broker has two portfolios: "Default" (active asset, bought 100) and "Encerradas" (active asset, bought 500) | `TotalBought` is 100; the Encerradas asset's amounts are excluded entirely |
+| `GetBrokerSummary_ExcludesEncerradasPortfolio_CaseInsensitive` (new) | Portfolio named `"encerradas"` (lowercase) | Still excluded, matching `IsEncerradas`'s case-insensitive comparison |
+| `GetBrokerSummary_TotalInvested_EqualsBoughtMinusSold` (new) | Bought 300, sold 120 across included assets | `TotalInvested` equals 180 |
+| `GetBrokerSummary_TotalInvested_CanBeNegative` (new) | Sold exceeds bought for the scope | `TotalInvested` is negative, no clamping applied |
+| `GetPortfolioSummary_TotalInvested_EqualsBoughtMinusSold` (new) | Bought 200, sold 50 | `TotalInvested` equals 150 |
+| `GetPortfolioSummary_ReturnsZerosOnNullOrWhitespaceInput` (existing, extended) | Existing `Theory` cases | `TotalInvested` is also asserted to be 0 |
+
+### SummaryEndpointsTests.cs
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `GetBrokerSummary_Returns200WithDto` (extended) | Existing call to `/summary/broker/XPI` | Adds: `dto.TotalInvested.Should().Be(dto.TotalBought - dto.TotalSold)` |
+| `GetPortfolioSummary_Returns200WithDto` (extended) | Existing call to `/summary/portfolio/XPI/Default` | Adds: `dto.TotalInvested.Should().Be(dto.TotalBought - dto.TotalSold)` |
+
+### Acceptance Test Mapping
+
+| PRD Acceptance Criterion (Section 9 — F01) | Covered By |
+|---------------------------------------------|------------|
+| `GET /summary/broker/{brokerName}` includes `totalInvested` equal to `totalBought − totalSold` | `GetBrokerSummary_Returns200WithDto` + `GetBrokerSummary_TotalInvested_EqualsBoughtMinusSold` |
+| `GET /summary/portfolio/{brokerName}/{portfolioName}` includes `totalInvested` equal to `totalBought − totalSold` | `GetPortfolioSummary_Returns200WithDto` + `GetPortfolioSummary_TotalInvested_EqualsBoughtMinusSold` |
+| Broker-level totals exclude Encerradas portfolio | `GetBrokerSummary_ExcludesEncerradasPortfolio` + `GetBrokerSummary_ExcludesEncerradasPortfolio_CaseInsensitive` |
+| Broker/Portfolio totals continue to exclude `Quantity == 0` assets | `GetBrokerSummary_ExcludesInactiveAssets` (regression) + existing `GetPortfolioSummary_ExcludesInactiveAssets` (unchanged) |
+| Selecting Encerradas directly still returns unfiltered totals | Implicit: `GetPortfolioSummary` source and logic are untouched by this feature; no new filter is added to it |
+| Broker with zero eligible portfolios returns 0 totals, not an error | `GetBrokerSummary_ReturnsZerosForBrokerWithNoActiveAssets` + `GetBrokerSummary_ReturnsZerosForUnknownBrokerName` |
+| Existing HTTP 400 behaviour unchanged | No changes to `SummaryController`; existing whitespace-routing behaviour is untouched |
+
+### Cross-Feature Integration Tests
+
+| PRD Section 9 — Cross-Feature Criterion | Covered By |
+|------------------------------------------|------------|
+| `totalInvested` computed by F01 for Broker scope is displayed without transformation in F05's and F06's fourth total | Not directly testable from F01 (F05/F06 do not exist yet); `GetBrokerSummary_Returns200WithDto`'s exact-value assertion is the contract F05/F06 will consume unmodified |
+| `totalInvested` computed by F01 for Portfolio scope is displayed without transformation in F05's and F06's fourth total | Same as above, via `GetPortfolioSummary_Returns200WithDto` |

--- a/docs/prd/P04-prd-broker-level-view-improvements/prd-broker-level-view-improvements.md
+++ b/docs/prd/P04-prd-broker-level-view-improvements/prd-broker-level-view-improvements.md
@@ -1,0 +1,493 @@
+# Broker-Level View Improvements
+
+## 1. Executive Summary
+
+Broker-Level View Improvements extends the Financial application's Broker Summary and Transactions views, in both the WPF desktop application and the React web application, with corrected totals, visual portfolio/asset breakdowns, and a monthly investment trend chart. Today, selecting a Broker node shows only three aggregate totals (Total Bought, Total Sold, Total Credits) in the web app, but in WPF it incorrectly falls back to the individual-asset layout, displaying a cluttered set of zeroed, meaningless fields (Quantity, ISIN, Country, Current Value section, and more). Neither platform currently shows a net "Total Invested" figure, nor any visual breakdown of how a broker's capital is distributed across its portfolios and assets.
+
+This feature set fixes the WPF layout bug, adds a Total Invested total (Total Bought − Total Sold) at both Broker and Portfolio levels, and introduces pie chart visualizations on the Broker Summary screen: one chart showing each active portfolio's share of the broker's total invested capital, and one additional chart per portfolio showing its own assets' share within that portfolio. The "Encerradas" (closed) portfolio and any fully-sold asset (zero quantity) are excluded from all of these totals and charts, since they no longer represent live capital allocation.
+
+Separately, the Transactions tab — currently available only for individual assets — is extended to Broker and Portfolio levels and gains a new monthly investment chart (Bought − Sold per calendar month), rendered as bars by default with an optional line view, filterable by six time periods (This Month, Last 3 Months, Last 6 Months, Last 12 Months, YTD, All Time). This same expanded period-filter set is also applied to the existing Credits tab chart for consistency across the two features.
+
+---
+
+## 2. Problem and Opportunity
+
+### The Problem
+
+**Misleading WPF Broker-level display**
+- Selecting a Broker node in WPF reuses the individual-asset layout, showing Quantity (0.00000000), Average Price (0.00), ISIN, Country, Local Type, Asset Class, a Current Value section with a Refresh button, and a Status field — none of which have any meaning at the broker level
+- The three real aggregate totals (Total Bought, Total Sold, Total Credits) are visually buried among this irrelevant clutter, making the Broker Summary screen harder to read than the Portfolio Summary screen, which was already fixed for this exact problem in a prior feature
+
+**No net investment figure**
+- Total Bought and Total Sold are shown side by side, but the user must mentally subtract them to know how much capital is actually still deployed; there is no single "Total Invested" number at either Broker or Portfolio level
+
+**No visual breakdown of capital allocation**
+- Reviewing how capital is distributed across portfolios, or across assets within a portfolio, requires manually reading and comparing individual numbers in a table; there is no chart that shows relative weight at a glance
+- Historical/closed activity (the Encerradas portfolio, fully-sold assets) has no way to be excluded from view when the user only cares about live capital allocation
+
+**No visibility into investment pace over time**
+- The Transactions tab shows only a flat list of individual Buy/Sell rows for a single asset; there is no way to see how much net capital was deployed per month, whether spending is accelerating or slowing, or to view this at the Broker or Portfolio level at all (the tab does not support those node types today)
+
+### The Opportunity
+
+Each problem maps to a concrete deliverable:
+- Misleading WPF display → F06 replaces the individual-asset fallback with a dedicated Broker totals-only layout, mirroring the fix already applied to the Portfolio level
+- No net investment figure → F01 introduces a Total Invested total, surfaced in both UIs by F05 (Web) and F06 (WPF)
+- No visual breakdown → F02 computes an Encerradas-and-inactive-asset-excluded breakdown of portfolios and assets by Total Invested; F07 (Web) and F08 (WPF) render it as pie charts on the Broker Summary screen
+- No investment-pace visibility → F03 provides aggregated transaction data for Broker and Portfolio scopes; F09 (Web) and F10 (WPF) render the monthly Bought-minus-Sold chart with period filtering, extending the Transactions tab beyond its current Asset-only scope; F04 extends the period-filter options (adding YTD) consistently across both the Credits and Transactions charts
+
+---
+
+## 3. Target Audience
+
+### Primary Users
+
+**Personal Investor**
+- Manages a multi-broker portfolio spanning UK (GBP) and Brazil (BRL) markets with assets across equities, real estate funds, ETFs, and fixed income
+- Maintains a "Encerradas" portfolio to archive positions that have been fully exited, and wants broker-level views to reflect only live, active capital allocation by default
+- Uses both the WPF desktop application and the React web application interchangeably and expects consistent totals, charts, and behavior across both interfaces
+- Wants to understand, at a glance, how much of their capital sits in each portfolio and each asset, and how their monthly investment pace has trended over time
+
+---
+
+## 4. Objectives
+
+**Correct the WPF Broker-level display** to show only relevant aggregate information
+- Metric: Selecting a Broker node in WPF shows zero asset-specific fields (Quantity, ISIN, Country, Local Type, Asset Class, Current Value section, Status); only the four totals are visible
+
+**Provide an accurate, consistent net investment figure** at both Broker and Portfolio levels
+- Metric: Total Invested (`Total Bought − Total Sold`) is displayed alongside the existing three totals in 100% of Broker and Portfolio selections, in both UIs, and always equals `Total Bought − Total Sold` for that scope
+
+**Exclude closed/inactive capital from broker-level totals and charts**
+- Metric: Total Bought, Total Sold, Total Credits, and Total Invested at the Broker level never include transactions or credits belonging to the Encerradas portfolio or to any asset with zero quantity, verified by automated tests
+
+**Deliver an at-a-glance visual breakdown of capital allocation**
+- Metric: Selecting a Broker node renders one portfolio-breakdown pie chart and one asset-breakdown pie chart per eligible portfolio within 3 seconds, in both UIs
+
+**Surface monthly investment pace with flexible time filtering**
+- Metric: The Transactions tab renders a monthly Bought-minus-Sold chart for Asset, Portfolio, and Broker selections, supporting 6 period filters and a Bar/Line display toggle, in both UIs
+
+---
+
+## 5. User Stories
+
+### F01. Aggregated Totals Enhancement — Application Layer
+
+- As the system, I want to compute Total Invested as Total Bought minus Total Sold at both Broker and Portfolio scope so that both frontends can display it without duplicating the subtraction logic
+- As the system, I want Broker-level totals to exclude the Encerradas portfolio so that closed/archived capital never inflates the live broker view
+- As the system, I want Broker and Portfolio totals to continue excluding assets with zero quantity so that fully-exited positions do not distort current totals
+
+### F02. Broker Portfolio & Asset Breakdown Service — Application Layer
+
+- As the system, I want to compute each eligible portfolio's share of a broker's Total Invested so that the web and WPF frontends can render a portfolio breakdown pie chart without recomputing aggregation logic
+- As the system, I want to compute each eligible asset's share of its portfolio's Total Invested so that both frontends can render a per-portfolio asset breakdown pie chart
+- As the system, I want to exclude the Encerradas portfolio and non-positive Total Invested slices from the breakdown so that both frontends receive only chart-ready, meaningful data
+
+### F03. Broker & Portfolio Transactions Aggregation Service — Application Layer
+
+- As the system, I want to return the combined list of Buy/Sell transactions for every asset under a given broker so that frontends can compute a broker-level monthly investment chart
+- As the system, I want to return the combined list of Buy/Sell transactions for every asset under a given portfolio so that frontends can compute a portfolio-level monthly investment chart
+
+### F04. Chart Period Filter — YTD Extension
+
+- As a user, I want a "Year to Date" period option on the Credits tab chart so that I can see this calendar year's activity without manually approximating it with "Last 12 Months"
+- As a user, I want the Transactions tab's new monthly chart to offer the same period options as the Credits tab (This Month, Last 3 Months, Last 6 Months, Last 12 Months, YTD, All Time) so that I have a consistent filtering experience across both charts
+
+### F05. Broker & Portfolio Totals Display — Web Frontend
+
+- As a user, I want to see a Total Invested figure alongside Total Bought, Total Sold, and Total Credits when I select a Broker or Portfolio node so that I know my net deployed capital without doing mental math
+- As a user, I want Total Invested to be colour-coded (green when non-negative, red when negative) so that I can tell at a glance whether a scope has net positive or net negative deployed capital
+
+### F06. Broker & Portfolio Totals Display — WPF
+
+- As a user, I want selecting a Broker node in WPF to show only the four aggregate totals, with no leftover asset-specific fields, so that the screen is as clean as the Portfolio-level view
+- As a user, I want to see Total Invested alongside Total Bought, Total Sold, and Total Credits for both Broker and Portfolio selections in WPF so that the desktop app matches the web app's information
+
+### F07. Broker Breakdown Pie Charts — Web Frontend
+
+- As a user, I want to see a pie chart showing each of my active portfolios' share of my broker's total invested capital so that I can quickly see where my money is concentrated
+- As a user, I want to see a separate pie chart for each portfolio showing its assets' relative weight so that I can review composition without opening each portfolio individually
+- As a user, I want to hover a pie slice to see its exact name, value, and percentage so that I can get precise figures without leaving the broker screen
+- As a user, I want the Encerradas portfolio and any fully-exited position to be excluded from these charts so that closed capital doesn't distort my view of active allocation
+
+### F08. Broker Breakdown Pie Charts — WPF
+
+- As a user, I want the same portfolio and per-portfolio asset breakdown pie charts available in WPF as in the web app so that both interfaces show consistent visual information
+- As a user, I want to hover a pie slice in WPF to see its name, value, and percentage so that I have the same detail available as in the web app
+
+### F09. Transactions Monthly Investment Chart — Web Frontend
+
+- As a user, I want to see a chart of my net monthly investment (Bought minus Sold) so that I can see whether my investment pace is increasing or decreasing over time
+- As a user, I want to select a Broker or Portfolio node and still see a Transactions view (previously unavailable) showing this monthly chart so that I'm not limited to reviewing investment pace one asset at a time
+- As a user, I want to filter the chart by This Month, Last 3 Months, Last 6 Months, Last 12 Months, YTD, or All Time so that I can focus on the timeframe I care about
+- As a user, I want to switch the chart between bar and line display, with bars shown by default, so that I can pick the visual style I find clearest
+
+### F10. Transactions Monthly Investment Chart — WPF
+
+- As a user, I want the same monthly investment chart, period filters, and Bar/Line toggle available in WPF as in the web app so that both interfaces offer the same investment-pace insight
+- As a user, I want selecting a Broker or Portfolio node in WPF to show this chart instead of the current "transactions only available for individual assets" message so that the desktop app matches the web app's capability
+
+---
+
+## 6. Functionalities
+
+### F01. Aggregated Totals Enhancement — Application Layer
+
+**Provides:**
+- Total Invested figure and Encerradas/inactive-asset-excluded Total Bought, Total Sold, and Total Credits, for both Broker and Portfolio scope (used by F05, F06)
+
+**Capabilities:**
+- `AggregatedSummaryDTO` gains a new property `TotalInvested` (decimal), computed as `TotalBought − TotalSold`, at both Broker and Portfolio scope
+- `SummaryQueryService.GetBrokerSummary` is modified to exclude all assets belonging to the portfolio whose name matches the existing `IsEncerradas` check (case-insensitive, trimmed match against "Encerradas"), in addition to the existing exclusion of assets where `Active` is `false` (`Quantity == 0`)
+- `SummaryQueryService.GetPortfolioSummary` continues to exclude only inactive assets (`Active == false`); no portfolio-level exclusion applies here since a single portfolio selection is never the Encerradas portfolio's siblings — if the selected portfolio IS Encerradas itself, its own totals are still computed and displayed unfiltered (Encerradas exclusion only applies when aggregating a broker's set of portfolios, not when Encerradas is the direct selection)
+- `TotalInvested` can be negative (e.g., partial sells exceeding the remaining position's cost basis); no clamping is applied at this layer — display-layer colour coding is handled by F05/F06
+- Returns `TotalInvested = 0` when both `TotalBought` and `TotalSold` are 0 (no transactions in scope)
+
+**Experience:**
+- No new endpoint; existing `GET /summary/broker/{brokerName}` and `GET /summary/portfolio/{brokerName}/{portfolioName}` responses gain the `totalInvested` field
+- Endpoint response time is unaffected (same in-memory aggregation, no new I/O)
+
+**Error Handling:**
+- If a broker has zero eligible portfolios after Encerradas exclusion (e.g., a broker that only ever had a single, now-fully-closed portfolio), `GetBrokerSummary` returns all totals as 0 rather than throwing
+- Existing HTTP 400 behaviour for a null/whitespace `brokerName` or `portfolioName` is unchanged
+
+---
+
+### F02. Broker Portfolio & Asset Breakdown Service — Application Layer
+
+**Consumes:**
+- F01: the same active-asset and Encerradas-exclusion rules
+
+**Provides:**
+- Broker breakdown: eligible portfolios with their Total Invested value, and each eligible portfolio's eligible assets with their own Total Invested value (used by F07, F08)
+
+**Capabilities:**
+- New endpoint `GET /summary/broker/{brokerName}/breakdown` returning a `BrokerBreakdownDTO`: a list of `PortfolioBreakdownItemDTO { PortfolioName, TotalInvested, Assets: List<AssetBreakdownItemDTO { AssetName, TotalInvested }> }`
+- The Encerradas portfolio is always excluded from the returned list
+- Within each remaining portfolio, only assets with `Active == true` (`Quantity > 0`) and individual `TotalInvested > 0` are included in that portfolio's `Assets` list
+- A portfolio's `TotalInvested` in the response equals the sum of its included assets' `TotalInvested` (i.e., the sum of only the positive-slice assets, not the portfolio's raw net which could include a negative-invested asset) — this keeps a portfolio's top-level slice size consistent with the sum of its own asset breakdown slices
+- A portfolio is included in the response only if it has at least one included asset (i.e., its computed `TotalInvested > 0`); portfolios with no qualifying assets are omitted entirely, not returned with an empty `Assets` list
+- Portfolios and assets within each portfolio are returned sorted alphabetically by name
+- Returns an empty list (`[]`) when the broker has no eligible portfolios (valid response, not an error)
+- Returns HTTP 400 when `brokerName` is null or whitespace
+
+**Experience:**
+- Endpoint responds within 200 ms (in-memory aggregation, no external calls)
+- Percentage calculation (slice ÷ sum of sibling slices in the same chart) is left to the frontend, consistent with how `PortfolioWeight` is computed client-side elsewhere; the endpoint returns raw `TotalInvested` values only
+
+---
+
+### F03. Broker & Portfolio Transactions Aggregation Service — Application Layer
+
+**Provides:**
+- Combined Buy/Sell transaction list (asset name, date, transaction type, total price) for a broker or portfolio scope (used by F09, F10)
+
+**Capabilities:**
+- New endpoint `GET /transactions/broker/{brokerName}` returning a flat, date-ascending list of `TransactionSummaryItemDTO { AssetName, Date, Type ("Buy"|"Sell"), TotalPrice }` covering every transaction of every asset under the given broker, across all of its portfolios (including Encerradas — no exclusion is applied here, since this is raw historical transaction history, not a live-capital total)
+- New endpoint `GET /transactions/portfolio/{brokerName}/{portfolioName}` returning the same shape, scoped to a single portfolio's assets
+- No date-range filtering is applied server-side; the full history is returned in one call and period filtering (F04) happens client-side, consistent with the existing Credits tab pattern where the full credit history is fetched once
+- Returns an empty list (`[]`) when the scope has no transactions (valid response, not an error)
+- Returns HTTP 400 when `brokerName` (or `brokerName`/`portfolioName`) is null or whitespace
+
+**Experience:**
+- Endpoint responds within 300 ms for typical personal-portfolio transaction volumes (in-memory aggregation, no external calls)
+
+---
+
+### F04. Chart Period Filter — YTD Extension
+
+**Provides:**
+- Period filter option set and date-range computation rules: This Month, Last 3 Months, Last 6 Months, Last 12 Months, YTD, All Time (used by F09, F10)
+
+**Capabilities:**
+- The existing Credits tab period filter (web `FILTER_OPTIONS`, WPF `CreditsFilter` enum) is extended from 5 to 6 options; the existing "Last Year" option is relabelled "Last 12 Months" with unchanged date-range behaviour, the existing "All" option is relabelled "All Time" with unchanged behaviour, and a new "YTD" option is added
+- Date-range rules: **This Month** = 1st day of the current calendar month through today; **Last 3 Months** / **Last 6 Months** / **Last 12 Months** = rolling window of that many months ending today (inclusive); **YTD** = January 1st of the current year through today; **All Time** = entire available history, no lower bound
+- The same six-option set and date-range rules are reused, not reimplemented, by the new Transactions monthly chart (F09, F10) — both charts share one canonical definition per platform (a shared TypeScript type/util on web, a shared enum/helper on WPF)
+- Existing Credits chart behaviour (Stacked/Grouped toggle, chart type, colours) is otherwise unchanged by this feature
+
+**Experience:**
+- Changing the period filter re-renders the affected chart(s) immediately using already-fetched data; no new network request is triggered by a filter change (data for the full history is already in memory)
+
+---
+
+### F05. Broker & Portfolio Totals Display — Web Frontend
+
+**Consumes:**
+- F01: Total Invested (Broker and Portfolio scope)
+
+**Capabilities:**
+- `AggregatedSummaryTab` (rendered for Broker node selection) adds a fourth total, **Total Invested**, after the existing Total Bought, Total Sold, and Total Credits, in that fixed order
+- The totals section reused inside `PortfolioSummaryTab` (rendered for Portfolio node selection) receives the same fourth total, in the same position
+- `Total Invested` is formatted N2 with the scope's currency symbol, consistent with the other three totals
+- `Total Invested` is styled green when `≥ 0` and red when `< 0`, using the same colour classes already applied to `% Profit` elsewhere in the app
+- No other change to `AggregatedSummaryTab` or `PortfolioSummaryTab`'s existing loading/error behaviour
+
+**Experience:**
+- `Total Invested` appears at the same time as the other three totals, since all four come from the same API response; there is no separate loading state for it
+
+---
+
+### F06. Broker & Portfolio Totals Display — WPF
+
+**Consumes:**
+- F01: Total Invested (Broker and Portfolio scope)
+
+**Capabilities:**
+- New `BrokerSummaryTemplate` `DataTemplate` in `NavigationView.xaml`, selected via a new `IsBrokerView` boolean on `AssetDetailsViewModel`, shown when a Broker node is selected; it contains ONLY four colour-coded total labels: Total Bought (green), Total Sold (red), Total Credits (blue), Total Invested (green when `≥ 0`, red when `< 0`) — no DataGrid, no asset-specific fields of any kind
+- `AssetDetailsViewModel`'s existing broker-loading path (currently `LoadBrokerCredits` → `LoadAggregateCredits`, which calls `ClearAssetContext()` and leaves the `AssetSummaryTemplate` active) is replaced with a new `LoadBrokerSummary` method that sets `IsBrokerView = true`, `IsPortfolioView = false`, and populates the four totals directly, without touching or referencing any asset-specific field
+- The existing `PortfolioSummaryTemplate` (Portfolio node selection) is extended with a fourth total label, **Total Invested**, alongside its existing Total Bought/Sold/Credits totals, using the same colour rule as above
+- Selecting an Asset node continues to set `IsBrokerView = false` and `IsPortfolioView = false`, showing the unchanged `AssetSummaryTemplate`
+- The Credits tab and Transactions tab behaviour for Broker node selection is unchanged by this feature (addressed separately by F04/F08/F10)
+
+**Experience:**
+1. User selects a Broker node
+2. `NavigationView.xaml` switches to `BrokerSummaryTemplate` via `DataTrigger` on `IsBrokerView = True`
+3. The four totals populate synchronously from `IPortfolioAssetSummaryQueryService`/`ISummaryQueryService`'s existing broker summary call, now including `TotalInvested`
+4. Selecting a different node (Portfolio, Asset, or clearing selection) resets `IsBrokerView` to `false`
+
+---
+
+### F07. Broker Breakdown Pie Charts — Web Frontend
+
+**Consumes:**
+- F02: eligible portfolios with Total Invested, and each eligible portfolio's eligible assets with Total Invested
+
+**Capabilities:**
+- New `BrokerBreakdownCharts` component renders below the four totals in `AggregatedSummaryTab`, only for Broker node selection
+- Renders one `recharts` `PieChart` titled "Portfolio Breakdown": one slice per eligible portfolio, sized by `TotalInvested`, percentage computed as `portfolio.TotalInvested / sum(all eligible portfolios' TotalInvested) × 100`
+- Renders one additional `recharts` `PieChart` per eligible portfolio, titled with the portfolio's name: one slice per eligible asset in that portfolio, sized by `TotalInvested`, percentage computed as `asset.TotalInvested / sum(that portfolio's eligible assets' TotalInvested) × 100`
+- Each pie uses a categorical colour palette (a fixed set of distinct hues, repeating if the slice count exceeds the palette size); the same palette instance is not required to assign identical colours to the same portfolio/asset across separate pies
+- Hovering a slice shows a tooltip with the portfolio/asset name, its `TotalInvested` value formatted N2 with currency, and its percentage formatted with one decimal place (e.g. `23.4%`)
+- Slices are not clickable; no navigation occurs on click or hover
+- When F02 returns an empty list (zero eligible portfolios), the component renders a text empty-state ("No active portfolios to display") instead of an empty chart area
+- Selecting a Portfolio or Asset node does not render this component (no per-node pie chart outside the Broker screen)
+
+**Experience:**
+1. User selects a Broker node; the four totals render immediately from the existing summary call
+2. `BrokerBreakdownCharts` independently fetches from `GET /summary/broker/{brokerName}/breakdown`, showing a loading indicator in its own section while the totals above remain interactive
+3. On success, the "Portfolio Breakdown" pie renders first, followed by one pie per eligible portfolio, in the same alphabetical order returned by F02
+4. On failure, the breakdown section shows an `ErrorState` with a Retry button; the totals section above is unaffected
+
+---
+
+### F08. Broker Breakdown Pie Charts — WPF
+
+**Consumes:**
+- F02: eligible portfolios with Total Invested, and each eligible portfolio's eligible assets with Total Invested
+
+**Capabilities:**
+- `BrokerSummaryTemplate` (introduced in F06) is extended with an `ItemsControl` bound to a new `PortfolioBreakdownPieViewModel` collection on `AssetDetailsViewModel`, plus one top-level `OverallBreakdownPieViewModel`
+- Each pie is rendered using `OxyPlot.Wpf`'s `PieSeries`, one `PieSlice` per portfolio (top pie) or per asset (per-portfolio pie), with the same sizing and percentage rules as F07
+- Hovering a slice shows OxyPlot's built-in tracker (`TrackerFormatString`) displaying name, `TotalInvested` value (N2, currency), and percentage (one decimal place)
+- No slice click behaviour is wired; the DataGrid pattern of read-only, non-interactive rows used elsewhere in the app is followed here for consistency
+- When the breakdown service returns zero eligible portfolios, a `TextBlock` empty-state message is shown in place of the pie charts
+
+**Experience:**
+1. User selects a Broker node; `BrokerSummaryTemplate` shows the four totals immediately
+2. `IPortfolioAssetSummaryQueryService` (or a new dedicated breakdown service interface) is called asynchronously; while pending, the breakdown area shows a loading indicator
+3. On success, the overall pie and each portfolio's asset pie render in alphabetical order
+4. On failure, the breakdown area shows an inline error message; the four totals remain visible and unaffected
+
+---
+
+### F09. Transactions Monthly Investment Chart — Web Frontend
+
+**Consumes:**
+- F03: combined transaction list for Broker/Portfolio scope
+- F04: period filter option set and date-range rules
+
+**Capabilities:**
+- `TransactionsTab` is extended to handle Broker and Portfolio node selection: instead of the current "Transactions are only available for individual assets" placeholder, it fetches from `GET /transactions/broker/{brokerName}` or `GET /transactions/portfolio/{brokerName}/{portfolioName}` (F03) and renders ONLY the new monthly investment chart — no combined transaction table at these two levels
+- For Asset node selection, the existing transaction table is retained unchanged, and the same monthly investment chart is added above it, computed client-side from the asset's already-loaded transaction list (no new fetch for this case)
+- Monthly aggregation: transactions are grouped by calendar month; each month's plotted value = `sum(Buy.TotalPrice) − sum(Sell.TotalPrice)` for that month; months within the selected period range with zero transactions still appear on the chart with a value of 0, so the timeline has no gaps
+- Chart is rendered with `recharts`, reusing the `BarChart`/`LineChart` components already used by `CreditsTab`; X-axis = month label (`MMM yyyy`), Y-axis = net invested amount (currency, N2 on hover)
+- A Bar/Line toggle control (mirroring `CreditsTab`'s existing Stacked/Grouped toggle button styling) switches the chart type; default on load is Bar
+- The six period-filter buttons from F04 (This Month, Last 3 Months, Last 6 Months, Last 12 Months, YTD, All Time) filter which months are plotted; default selected period on load is **Last 12 Months**
+- Months with a negative net value (Sold > Bought that month) render as bars/points extending below the zero axis, using a single neutral series colour (no green/red sign colouring, since the bar's position below/above zero already conveys sign)
+
+**Experience:**
+1. User selects a Broker, Portfolio, or Asset node
+2. For Broker/Portfolio: `TransactionsTab` shows a loading indicator, then renders the chart with filter buttons and Bar/Line toggle above it (no table)
+3. For Asset: the existing table loads as today, with the new chart and its controls appearing above the table
+4. Changing the period filter or the Bar/Line toggle re-renders the chart instantly from already-fetched data, no new network call
+5. If the F03 fetch fails (Broker/Portfolio scope), an `ErrorState` with Retry is shown in place of the chart
+
+---
+
+### F10. Transactions Monthly Investment Chart — WPF
+
+**Consumes:**
+- F03: combined transaction list for Broker/Portfolio scope
+- F04: period filter option set and date-range rules
+
+**Capabilities:**
+- `AssetDetailsViewModel` gains `LoadBrokerTransactions` and `LoadPortfolioTransactions` methods, invoked by `MainNavigationViewModelBase` on Broker/Portfolio node selection, replacing the current placeholder text shown in the Transactions tab for those node types
+- A new `TransactionsChartBuilder` (mirroring the existing `CreditsChartBuilder`) builds an `OxyPlot.PlotModel` from the monthly-aggregated net-invested series, using the same grouping and zero-fill rules as F09
+- A `ChartTypeModes` collection (Bar/Line) mirrors the existing `CreditsTypeModes` (Stacked/Grouped) binding pattern; default selection is Bar
+- The `CreditsFilters` binding pattern (F04) is reused for the Transactions chart's own period selection, independent from the Credits tab's currently-selected period
+- For Asset node selection, the existing `Transactions` collection and DataGrid remain unchanged, with the same chart added above it, built from the already-loaded `Transactions` collection
+
+**Experience:**
+1. User selects a Broker, Portfolio, or Asset node
+2. For Broker/Portfolio: the Transactions tab shows the chart, period filter buttons, and Bar/Line toggle, with no DataGrid
+3. For Asset: the existing DataGrid remains, with the chart and its controls above it
+4. Changing period or chart type updates the `PlotModel` synchronously from in-memory data
+5. Selecting a different node rebuilds the chart for the new scope
+
+---
+
+## 7. Out of Scope
+
+**Pie charts outside the Broker screen**
+- No dedicated pie chart is added to a Portfolio's own Summary tab or an Asset's Summary tab; the per-portfolio asset breakdown pie (F07/F08) is shown only on the Broker screen, alongside all its sibling portfolios' pies
+
+**Combined transaction table at Broker/Portfolio level**
+- Broker and Portfolio Transactions views show only the monthly chart; a full list of every underlying transaction across assets is not included in this release
+
+**Encerradas exclusion configurability**
+- The "Encerradas" portfolio name remains a fixed constant, consistent with existing code; there is no settings UI to rename it or to mark other portfolios as excluded
+
+**Chart export or sharing**
+- Pie charts and the monthly investment chart cannot be exported as an image, PDF, or CSV in this release
+
+**Slice or bar click navigation**
+- Clicking a pie slice or a chart bar/point does not navigate to the corresponding portfolio/asset/month; all new charts are read-only visualizations, consistent with the existing per-asset table's read-only rows
+
+**Currency conversion across charts**
+- All totals and charts display amounts in the broker/portfolio's native currency as stored in transactions; no cross-currency aggregation or conversion is introduced
+
+**Real-time or live-updating charts**
+- Charts reflect data as of the moment they were fetched; there is no polling, websocket, or auto-refresh behaviour
+
+**New chart types for the Credits tab**
+- F04 only adds the YTD period option and relabels two existing options; the Credits tab's existing Stacked/Grouped bar chart type is not changed
+
+**Manual data refresh controls**
+- None of the new charts include a manual Refresh button; they load automatically on node selection, consistent with how Total Invested and the breakdown data are fetched
+
+---
+
+## 8. Dependency Graph
+
+| # | Feature | Priority | Dependencies |
+|---|---------|----------|--------------|
+| F01 | Aggregated Totals Enhancement — Application Layer | 1 | None |
+| F02 | Broker Portfolio & Asset Breakdown Service — Application Layer | 2 | None |
+| F03 | Broker & Portfolio Transactions Aggregation Service — Application Layer | 2 | None |
+| F04 | Chart Period Filter — YTD Extension | 2 | None |
+| F05 | Broker & Portfolio Totals Display — Web Frontend | 1 | F01 |
+| F06 | Broker & Portfolio Totals Display — WPF | 1 | F01 |
+| F07 | Broker Breakdown Pie Charts — Web Frontend | 2 | F02 |
+| F08 | Broker Breakdown Pie Charts — WPF | 2 | F02 |
+| F09 | Transactions Monthly Investment Chart — Web Frontend | 2 | F03, F04 |
+| F10 | Transactions Monthly Investment Chart — WPF | 2 | F03, F04 |
+
+### Execution Waves
+Features within the same wave can be built in parallel. A wave starts only after every feature in earlier waves is complete.
+
+- **Wave 1**: F01, F02, F03, F04
+- **Wave 2**: F05, F06, F07, F08, F09, F10
+
+### Priority levels
+- **1** = Essential — product does not work without it
+- **2** = Important — significant value addition
+- **3** = Desirable — incremental improvement
+
+```mermaid
+graph TD
+  F01[Totals Enhancement] --> F05[Web Totals Display]
+  F01 --> F06[WPF Totals Display]
+  F02[Breakdown Service] --> F07[Web Pie Charts]
+  F02 --> F08[WPF Pie Charts]
+  F03[Transactions Aggregation] --> F09[Web Monthly Chart]
+  F03 --> F10[WPF Monthly Chart]
+  F04[Period Filter YTD] --> F09
+  F04 --> F10
+```
+
+---
+
+## 9. Acceptance Criteria
+
+### F01. Aggregated Totals Enhancement — Application Layer
+- [ ] `GET /summary/broker/{brokerName}` response includes `totalInvested`, equal to `totalBought − totalSold`
+- [ ] `GET /summary/portfolio/{brokerName}/{portfolioName}` response includes `totalInvested`, equal to `totalBought − totalSold`
+- [ ] Broker-level totals exclude all transactions and credits from assets in the Encerradas portfolio
+- [ ] Broker-level and Portfolio-level totals continue to exclude assets with `Quantity == 0`
+- [ ] Selecting the Encerradas portfolio directly still returns its own unfiltered totals
+- [ ] A broker with zero eligible portfolios after exclusion returns all totals as 0, not an error
+- [ ] Existing HTTP 400 behaviour for missing/whitespace names is unchanged
+
+### F02. Broker Portfolio & Asset Breakdown Service — Application Layer
+- [ ] `GET /summary/broker/{brokerName}/breakdown` returns HTTP 200 with a list of portfolios, each with `portfolioName`, `totalInvested`, and an `assets` array
+- [ ] The Encerradas portfolio never appears in the response
+- [ ] Assets with `Quantity == 0` or `totalInvested <= 0` never appear in a portfolio's `assets` array
+- [ ] A portfolio's `totalInvested` equals the sum of its included assets' `totalInvested`
+- [ ] A portfolio with zero qualifying assets is omitted entirely from the response
+- [ ] Portfolios and assets are sorted alphabetically by name
+- [ ] Returns `[]` with HTTP 200 when the broker has no eligible portfolios
+- [ ] Returns HTTP 400 when `brokerName` is null or whitespace
+
+### F03. Broker & Portfolio Transactions Aggregation Service — Application Layer
+- [ ] `GET /transactions/broker/{brokerName}` returns every transaction (Buy and Sell) for every asset under the broker, across all portfolios including Encerradas
+- [ ] `GET /transactions/portfolio/{brokerName}/{portfolioName}` returns every transaction for every asset under that portfolio only
+- [ ] Both endpoints return results sorted ascending by date
+- [ ] Returns `[]` with HTTP 200 when the scope has no transactions
+- [ ] Returns HTTP 400 when required route parameters are null or whitespace
+
+### F04. Chart Period Filter — YTD Extension
+- [ ] Credits tab (web and WPF) offers exactly 6 period options: This Month, Last 3 Months, Last 6 Months, Last 12 Months, YTD, All Time
+- [ ] Selecting YTD filters to transactions/credits dated January 1st of the current year through today
+- [ ] The relabelled "Last 12 Months" and "All Time" options produce identical date ranges to the previous "Last Year" and "All" options
+- [ ] Changing the period filter does not trigger a new network request (filtering happens on already-fetched data)
+
+### F05. Broker & Portfolio Totals Display — Web Frontend
+- [ ] Selecting a Broker node shows 4 totals in order: Total Bought, Total Sold, Total Credits, Total Invested
+- [ ] Selecting a Portfolio node shows the same 4 totals in the same order
+- [ ] Total Invested is styled green when `>= 0` and red when `< 0`
+- [ ] Total Invested value matches `totalBought − totalSold` from the API response exactly
+
+### F06. Broker & Portfolio Totals Display — WPF
+- [ ] Selecting a Broker node in WPF shows only 4 colour-coded totals (Total Bought, Total Sold, Total Credits, Total Invested) and no Quantity, Average Price, ISIN, Country, Local Type, Asset Class, Current Value section, or Status fields
+- [ ] Selecting a Portfolio node in WPF shows the existing per-asset DataGrid plus 4 totals including Total Invested
+- [ ] Selecting an Asset node in WPF is unaffected (regression check): all asset-specific fields still render as before
+- [ ] Total Invested is styled green when `>= 0` and red when `< 0`
+
+### F07. Broker Breakdown Pie Charts — Web Frontend
+- [ ] Selecting a Broker node renders a "Portfolio Breakdown" pie chart below the 4 totals, with one slice per eligible portfolio
+- [ ] One additional pie chart renders per eligible portfolio, showing that portfolio's eligible assets
+- [ ] Hovering a slice shows its name, Total Invested value, and percentage
+- [ ] The Encerradas portfolio and any asset with `totalInvested <= 0` never appear as a slice
+- [ ] Selecting a Portfolio or Asset node does not render this component (regression check)
+- [ ] Zero eligible portfolios renders an empty-state message instead of an empty chart
+- [ ] A failed breakdown fetch shows an `ErrorState` with Retry; the 4 totals above remain visible and functional
+
+### F08. Broker Breakdown Pie Charts — WPF
+- [ ] Selecting a Broker node in WPF renders the overall portfolio breakdown pie and one pie per eligible portfolio
+- [ ] Hovering a slice in WPF shows its name, value, and percentage via OxyPlot's tracker
+- [ ] Zero eligible portfolios shows an empty-state message
+- [ ] A failed breakdown fetch shows an inline error; the 4 totals remain visible
+
+### F09. Transactions Monthly Investment Chart — Web Frontend
+- [ ] Selecting a Broker or Portfolio node in the Transactions tab shows the monthly chart instead of the previous placeholder message, with no transaction table
+- [ ] Selecting an Asset node shows the existing transaction table plus the new chart above it
+- [ ] Each month's plotted value equals `sum(Buy.totalPrice) − sum(Sell.totalPrice)` for that month
+- [ ] Months with no transactions within the selected period still appear on the chart with a value of 0
+- [ ] The chart defaults to Bar display; toggling to Line re-renders the same data as a line
+- [ ] The 6 period filter buttons correctly narrow the plotted months; default period on load is Last 12 Months
+- [ ] A failed Broker/Portfolio transaction fetch shows an `ErrorState` with Retry
+
+### F10. Transactions Monthly Investment Chart — WPF
+- [ ] Selecting a Broker or Portfolio node in WPF's Transactions tab shows the monthly chart with no DataGrid
+- [ ] Selecting an Asset node shows the existing DataGrid plus the new chart above it
+- [ ] Chart values and zero-fill behaviour match the web frontend's computation for the same underlying data
+- [ ] Bar is the default chart type; toggling to Line updates the `PlotModel` accordingly
+- [ ] All 6 period filters are available and correctly filter the plotted months
+
+### Cross-Feature Integration
+- [ ] `totalInvested` computed by F01 for Broker scope is displayed without transformation in F05's and F06's fourth total
+- [ ] `totalInvested` computed by F01 for Portfolio scope is displayed without transformation in F05's and F06's fourth total for Portfolio selection
+- [ ] Portfolio and asset `totalInvested` values from F02's breakdown endpoint are used without transformation to size and label slices in F07 and F08
+- [ ] The Encerradas exclusion and non-positive-slice omission rules defined in F02 are reflected exactly in what F07 and F08 render (no additional or missing slices)
+- [ ] The transaction list returned by F03 for a Broker or Portfolio scope is used without transformation by F09 and F10 to compute each month's net-invested value
+- [ ] The period options and date-range rules defined by F04 are applied identically by F09 and F10 when filtering the monthly chart, and continue to be applied identically by the existing Credits chart


### PR DESCRIPTION
## Summary
- Adds `TotalInvested` (`TotalBought - TotalSold`) to `AggregatedSummaryDTO`, returned by both `GET /summary/broker/{brokerName}` and `GET /summary/portfolio/{brokerName}/{portfolioName}`.
- Fixes `GetBrokerSummary` to exclude the "Encerradas" portfolio from broker-level totals (it previously leaked into Total Bought/Sold/Credits via the flattened asset list), reusing the existing `NavigationMapper.IsEncerradas` check already used for tree ordering.
- Part of the P04 Broker-Level View Improvements PRD (F01 of 10).

## Test plan
- [x] `dotnet build` on the full solution — 0 errors
- [x] `Financial.Application.Tests` — 139 passed (includes new Encerradas exclusion, unknown-broker, and TotalInvested coverage)
- [x] `Financial.Api.Tests` — 28 passed (integration tests assert `totalInvested` on both live endpoints)
- [x] Full suite across all 5 test projects (Api/Application/Domain/Infrastructure/Presentation) — 355 passed, 0 failed, 3 pre-existing unrelated skips

Spec/plan: `docs/F01-aggregated-totals-enhancement-application-layer/`
PRD: `docs/prd/P04-prd-broker-level-view-improvements/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)