### PR TITLE
ci: add browser smoke test job to the pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,3 +56,71 @@ jobs:
     - name: Build
       working-directory: Financial.Web
       run: npm run build
+
+  browser-smoke-test:
+    needs: [ build-and-test, web-build-test ]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24.13.0
+
+    - name: Install web dependencies
+      working-directory: Financial.Web
+      run: npm install
+
+    - name: Install Playwright browser
+      working-directory: Financial.Web
+      run: npx playwright install --with-deps chromium
+
+    - name: Build web frontend
+      working-directory: Financial.Web
+      run: |
+        echo "API_BASE_URL=/api/v1/financial" > .env
+        npm run build
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Publish API
+      run: dotnet publish Financial.Api/Financial.Api.csproj --configuration Release --output publish
+
+    - name: Embed web build into API wwwroot
+      run: |
+        mkdir -p publish/wwwroot
+        cp -r Financial.Web/dist/. publish/wwwroot/
+
+    - name: Run browser smoke test
+      env:
+        DataJsonFile: ${{ github.workspace }}/Tests/Financial.Api.Tests/TestData/data.test.json
+        ASPNETCORE_URLS: http://localhost:8080
+        SMOKE_APP_URL: http://localhost:8080
+      run: |
+        cd publish
+        dotnet Financial.Api.dll &
+        API_PID=$!
+        cd ..
+        ready=0
+        for i in $(seq 1 30); do
+          if curl -sf http://localhost:8080/api/v1/financial/health > /dev/null; then
+            ready=1
+            break
+          fi
+          sleep 1
+        done
+        if [ "$ready" -ne 1 ]; then
+          echo "API did not become healthy in time"
+          kill $API_PID
+          exit 1
+        fi
+        node Financial.Web/scripts/smoke-test.mjs
+        SMOKE_EXIT=$?
+        kill $API_PID
+        exit $SMOKE_EXIT

--- a/Financial.Web/package-lock.json
+++ b/Financial.Web/package-lock.json
@@ -27,6 +27,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^29.0.2",
+        "playwright": "^1.61.1",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4",
@@ -3604,6 +3605,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/Financial.Web/package.json
+++ b/Financial.Web/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "smoke-test": "node scripts/smoke-test.mjs"
   },
   "dependencies": {
     "react": "^19.2.4",
@@ -31,6 +32,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^29.0.2",
+    "playwright": "^1.61.1",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.4",

--- a/Financial.Web/scripts/smoke-test.mjs
+++ b/Financial.Web/scripts/smoke-test.mjs
@@ -1,0 +1,38 @@
+// Browser smoke test: loads the app against a running API and confirms
+// the tree renders with no console errors. Run via `npm run smoke-test`
+// after the API and web dev server are already up (see CI workflow).
+import { chromium } from 'playwright'
+
+const APP_URL = process.env.SMOKE_APP_URL ?? 'http://localhost:5173'
+const TIMEOUT_MS = 15000
+
+async function main() {
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+
+  const consoleErrors = []
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text())
+  })
+  page.on('pageerror', (err) => consoleErrors.push(String(err)))
+
+  await page.goto(APP_URL, { waitUntil: 'domcontentloaded' })
+
+  // Broker name from Tests/Financial.Api.Tests/TestData/data.test.json
+  await page.getByText('XPI').first().waitFor({ timeout: TIMEOUT_MS })
+
+  if (consoleErrors.length > 0) {
+    console.error('Smoke test failed: console errors detected')
+    for (const err of consoleErrors) console.error(` - ${err}`)
+    await browser.close()
+    process.exit(1)
+  }
+
+  console.log('Smoke test passed: app loaded and rendered the navigation tree with no console errors')
+  await browser.close()
+}
+
+main().catch((err) => {
+  console.error('Smoke test failed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- Adds a `browser-smoke-test` job to `.github/workflows/build.yml` that actually loads the app in a headless browser and checks it renders — closing a real gap where lint/typecheck/unit-tests/build can all pass while the app is broken at runtime.
- Builds the web frontend and publishes the API exactly the way `Dockerfile` does (web `dist/` copied into the API's `wwwroot`), so the smoke test exercises the real production wiring, not a dev-only setup.
- Boots the single published app against the checked-in fixture `Tests/Financial.Api.Tests/TestData/data.test.json` (no real personal data needed — `data/data.json` is gitignored).
- Drives it with Playwright (`Financial.Web/scripts/smoke-test.mjs`, exposed as `npm run smoke-test`): waits for the navigation tree to render (asserts on the fixture's `XPI` broker) and fails the job on any browser console error.
- Adds `playwright` as a devDependency.

## Test plan
- [x] Dry-ran the exact CI sequence locally: `npm run build` → `dotnet publish` → copy `dist` into `wwwroot` → boot from inside the publish dir → poll `/api/v1/financial/health` → run `smoke-test.mjs` — passed with no console errors
- [x] Found and fixed two issues during the dry run that would have made the job pass for the wrong reason or hang forever: (1) `/health` is actually served at `/api/v1/financial/health` (the controller group prefixes all routes, including the diagnostics controller), not `/health` at root; (2) the published app must be started from inside the publish directory or it can't find `wwwroot` (content root defaults to CWD, not the DLL's location)
- [x] `npm run lint`, `tsc -b --noEmit`, `npm test` (24 files / 299 tests) all still pass after adding the new devDependency and script

🤖 Generated with [Claude Code](https://claude.com/claude-code)