### PR TITLE
fix(spec-writer): include PR id in spec output folder name

### DIFF
--- a/.claude/skills/spec-writer/SKILL.md
+++ b/.claude/skills/spec-writer/SKILL.md
@@ -14,7 +14,7 @@ Generate implementation-ready technical specifications based on the project's PR
 1. `spec.md` - Technical specification (7 sections)
 2. `plan.md` - Implementation plan (phases and steps)
 
-**Output location:** `docs/<feature-id>-<kebab-name>/spec.md` and `docs/<feature-id>-<kebab-name>/plan.md`
+**Output location:** `docs/<pr-id>-<feature-id>-<kebab-name>/spec.md` and `docs/<feature-id>-<kebab-name>/plan.md`
 - The `<kebab-name>` is derived from the feature's name in the PRD Section 6 (lowercase, spaces → hyphens, special characters removed). Example: `F03. Video Upload` → `docs/F03-video-upload/`.
 
 ---


### PR DESCRIPTION
## Summary
- The spec-writer skill's output folder naming didn't match what's actually being used in practice (e.g. `docs/P04-F05-broker-portfolio-totals-display-web-frontend/`) — it documented `docs/<feature-id>-<kebab-name>/` without the PR id prefix.
- Updates the documented output location to `docs/<pr-id>-<feature-id>-<kebab-name>/spec.md`, matching the naming convention already in use across `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)