### PR TITLE
feat(P04-F06): Broker & Portfolio Totals Display — WPF

### DIFF
--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -322,6 +322,54 @@
                                 </Grid>
                             </ScrollViewer>
                         </DataTemplate>
+                        <DataTemplate x:Key="BrokerSummaryTemplate">
+                            <Grid Margin="10">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <!-- Row 0: Total Bought & Total Sold -->
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Total Bought:" FontWeight="Bold" Margin="0,5"/>
+                                <TextBlock Grid.Row="0" Grid.Column="1"
+                                           Text="{Binding AssetDetails.TotalBought, Mode=OneWay, StringFormat=N2}"
+                                           TextAlignment="Right"
+                                           FontFamily="Consolas"
+                                           Margin="10,5"
+                                           Foreground="Green"/>
+
+                                <TextBlock Grid.Row="0" Grid.Column="2" Text="Total Sold:" FontWeight="Bold" Margin="20,5,0,5"/>
+                                <TextBlock Grid.Row="0" Grid.Column="3"
+                                           Text="{Binding AssetDetails.TotalSold, Mode=OneWay, StringFormat=N2}"
+                                           TextAlignment="Right"
+                                           FontFamily="Consolas"
+                                           Margin="10,5"
+                                           Foreground="Red"/>
+
+                                <!-- Row 1: Total Credits & Total Invested -->
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Total Credits:" FontWeight="Bold" Margin="0,5"/>
+                                <TextBlock Grid.Row="1" Grid.Column="1"
+                                           Text="{Binding AssetDetails.TotalCredits, Mode=OneWay, StringFormat=N2}"
+                                           TextAlignment="Right"
+                                           FontFamily="Consolas"
+                                           Margin="10,5"
+                                           Foreground="Blue"/>
+
+                                <TextBlock Grid.Row="1" Grid.Column="2" Text="Total Invested:" FontWeight="Bold" Margin="20,5,0,5"/>
+                                <TextBlock Grid.Row="1" Grid.Column="3"
+                                           Text="{Binding AssetDetails.TotalInvested, Mode=OneWay, StringFormat=N2}"
+                                           TextAlignment="Right"
+                                           FontFamily="Consolas"
+                                           Foreground="{Binding AssetDetails.TotalInvested, Converter={StaticResource SignedValueToBrushConverter}}"
+                                           Margin="10,5"/>
+                            </Grid>
+                        </DataTemplate>
                         <DataTemplate x:Key="PortfolioSummaryTemplate">
                             <Grid Margin="10">
                                 <Grid.RowDefinitions>
@@ -340,7 +388,11 @@
                                                FontFamily="Consolas" Foreground="Red" Margin="0,0,20,0"/>
                                     <TextBlock Text="Total Credits:" FontWeight="Bold" Margin="0,0,5,0"/>
                                     <TextBlock Text="{Binding AssetDetails.TotalCredits, Mode=OneWay, StringFormat=N2}"
-                                               FontFamily="Consolas" Foreground="Blue"/>
+                                               FontFamily="Consolas" Foreground="Blue" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Total Invested:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                    <TextBlock Text="{Binding AssetDetails.TotalInvested, Mode=OneWay, StringFormat=N2}"
+                                               FontFamily="Consolas"
+                                               Foreground="{Binding AssetDetails.TotalInvested, Converter={StaticResource SignedValueToBrushConverter}}"/>
                                 </StackPanel>
 
                                 <!-- Per-Asset DataGrid -->
@@ -571,6 +623,9 @@
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding AssetDetails.IsPortfolioView}" Value="True">
                                         <Setter Property="ContentTemplate" Value="{StaticResource PortfolioSummaryTemplate}"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding AssetDetails.IsBrokerView}" Value="True">
+                                        <Setter Property="ContentTemplate" Value="{StaticResource BrokerSummaryTemplate}"/>
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -56,6 +56,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private bool _isCreditsAggregateView;
     private bool _hasCreditsContext;
     private bool _isPortfolioView;
+    private bool _isBrokerView;
+    private decimal _totalInvested;
     private CancellationTokenSource? _rowPriceCts;
     private decimal _footerTotalInvested;
     private decimal _footerTotalCredits;
@@ -156,6 +158,18 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         private set => SetProperty(ref _isPortfolioView, value);
     }
 
+    public bool IsBrokerView
+    {
+        get => _isBrokerView;
+        private set => SetProperty(ref _isBrokerView, value);
+    }
+
+    public decimal TotalInvested
+    {
+        get => _totalInvested;
+        private set => SetProperty(ref _totalInvested, value);
+    }
+
     public ObservableCollection<PortfolioAssetSummaryRowViewModel> PortfolioAssetSummaryRows { get; } = new();
 
     public decimal FooterTotalInvested { get => _footerTotalInvested; private set => SetProperty(ref _footerTotalInvested, value); }
@@ -247,6 +261,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         CancelAndResetRowPriceFetch();
         LoadAggregateCredits(BuildPortfolioKey(brokerName, portfolioName), summary, credits);
         IsPortfolioView = true;
+        TotalInvested = summary.TotalInvested;
 
         PortfolioAssetSummaryRows.Clear();
         foreach (var item in assetItems)
@@ -274,6 +289,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public void LoadAssetDetails(AssetDetailsDTO details)
     {
         IsPortfolioView = false;
+        IsBrokerView = false;
         var assetKey = BuildAssetKey(details.BrokerName, details.PortfolioName, details.Name);
         _todayInfo.UpdateAssetKey(assetKey);
 
@@ -321,6 +337,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         FooterEstimatedAnnualCreditsDisplay = "—";
         OnPropertyChanged(nameof(FooterCurrentValueDisplay));
         IsPortfolioView = false;
+        IsBrokerView = false;
+        TotalInvested = 0m;
         ClearAssetContext();
         Credits.Clear();
         CreditsByMonthChart.Clear();
@@ -333,9 +351,11 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         UpdateCommandStates();
     }
 
-    public void LoadBrokerCredits(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
+    public void LoadBrokerSummary(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
     {
         LoadAggregateCredits(BuildBrokerKey(brokerName), summary, credits);
+        IsBrokerView = true;
+        TotalInvested = summary.TotalInvested;
     }
 
     public void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
@@ -404,6 +424,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private void LoadAggregateCredits(string contextKey, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
     {
         IsPortfolioView = false;
+        IsBrokerView = false;
         ClearAssetContext();
         TotalBought = summary.TotalBought;
         TotalSold = summary.TotalSold;

--- a/Financial.App/ViewModels/IAssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/IAssetDetailsViewModel.cs
@@ -5,8 +5,9 @@ namespace Financial.Presentation.App.ViewModels;
 public interface IAssetDetailsViewModel
 {
     bool IsPortfolioView { get; }
+    bool IsBrokerView { get; }
     void LoadAssetDetails(AssetDetailsDTO details);
-    void LoadBrokerCredits(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
+    void LoadBrokerSummary(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
     void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
     void LoadPortfolioSummary(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits, IReadOnlyList<PortfolioAssetSummaryItemDTO> assetItems);
     void Clear();

--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -291,6 +291,6 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
 
         var summary = _summaryQueryService.GetBrokerSummary(brokerName);
         var credits = _creditQueryService.GetCreditsByBroker(brokerName);
-        AssetDetails.LoadBrokerCredits(brokerName, summary, credits);
+        AssetDetails.LoadBrokerSummary(brokerName, summary, credits);
     }
 }

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
@@ -1,0 +1,166 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class AssetDetailsViewModelBrokerSummaryTests
+{
+    private static AssetDetailsViewModel BuildViewModel()
+    {
+        return new AssetDetailsViewModel(
+            new StubTransactionService(),
+            new StubCreditService(),
+            new StubAssetPriceService());
+    }
+
+    [Fact]
+    public void LoadBrokerSummary_SetsIsBrokerViewTrue()
+    {
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), []);
+        vm.IsBrokerView.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LoadBrokerSummary_SetsAggregatedTotals()
+    {
+        var vm = BuildViewModel();
+        var summary = new AggregatedSummaryDTO { TotalBought = 20000m, TotalSold = 9000m };
+        vm.LoadBrokerSummary("XPI", summary, []);
+        vm.TotalBought.Should().Be(20000m);
+        vm.TotalSold.Should().Be(9000m);
+    }
+
+    [Fact]
+    public void LoadBrokerSummary_SetsTotalInvested()
+    {
+        var vm = BuildViewModel();
+        var summary = new AggregatedSummaryDTO { TotalBought = 20000m, TotalSold = 9000m, TotalInvested = 11000m };
+        vm.LoadBrokerSummary("XPI", summary, []);
+        vm.TotalInvested.Should().Be(11000m);
+    }
+
+    [Fact]
+    public void LoadBrokerSummary_SetsNegativeTotalInvested()
+    {
+        var vm = BuildViewModel();
+        var summary = new AggregatedSummaryDTO { TotalBought = 1000m, TotalSold = 5000m, TotalInvested = -4000m };
+        vm.LoadBrokerSummary("XPI", summary, []);
+        vm.TotalInvested.Should().Be(-4000m);
+    }
+
+    [Fact]
+    public void LoadBrokerSummary_LoadsCreditsForCreditsTab()
+    {
+        var vm = BuildViewModel();
+        var credits = new List<CreditDTO>
+        {
+            new() { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Dividend", Value = 100m },
+            new() { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Interest", Value = 50m }
+        };
+        vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), credits);
+        vm.Credits.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void LoadBrokerSummary_ClearsAssetSpecificFields()
+    {
+        var vm = BuildViewModel();
+        vm.LoadAssetDetails(new AssetDetailsDTO
+        {
+            Name = "Asset A", BrokerName = "XPI", PortfolioName = "Portfolio",
+            Ticker = "T", ISIN = "US1234567890", Exchange = "LSE",
+            Country = Financial.Domain.Entities.CountryCode.Unknown,
+            LocalTypeCode = "", Class = Financial.Domain.Entities.GlobalAssetClass.Unknown,
+            Quantity = 10m, AveragePrice = 50m, IsActive = true,
+            TotalBought = 500m, TotalSold = 0m, TotalCredits = 0m,
+            Transactions = [], Credits = []
+        });
+
+        vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), []);
+
+        vm.AssetName.Should().BeEmpty();
+        vm.ISIN.Should().BeEmpty();
+        vm.Quantity.Should().Be(0m);
+        vm.AveragePrice.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Clear_AfterLoadBrokerSummary_SetsIsBrokerViewFalse()
+    {
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), []);
+        vm.Clear();
+        vm.IsBrokerView.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Clear_AfterLoadBrokerSummary_ResetsTotalInvested()
+    {
+        var vm = BuildViewModel();
+        var summary = new AggregatedSummaryDTO { TotalBought = 20000m, TotalSold = 9000m, TotalInvested = 11000m };
+        vm.LoadBrokerSummary("XPI", summary, []);
+        vm.Clear();
+        vm.TotalInvested.Should().Be(0m);
+    }
+
+    [Fact]
+    public void LoadAssetDetails_AfterBrokerSummary_SetsIsBrokerViewFalse()
+    {
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), []);
+        vm.LoadAssetDetails(new AssetDetailsDTO
+        {
+            Name = "Asset A", BrokerName = "XPI", PortfolioName = "Portfolio",
+            Ticker = "T", ISIN = "", Exchange = "LSE",
+            Country = Financial.Domain.Entities.CountryCode.Unknown,
+            LocalTypeCode = "", Class = Financial.Domain.Entities.GlobalAssetClass.Unknown,
+            Quantity = 0m, AveragePrice = 0m, IsActive = true,
+            TotalBought = 0m, TotalSold = 0m, TotalCredits = 0m,
+            Transactions = [], Credits = []
+        });
+        vm.IsBrokerView.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_AfterBrokerSummary_SetsIsBrokerViewFalse()
+    {
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), []);
+        vm.LoadPortfolioSummary("XPI", "Portfolio", new AggregatedSummaryDTO(), [], []);
+        vm.IsBrokerView.Should().BeFalse();
+        vm.IsPortfolioView.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LoadBrokerSummary_AfterPortfolioSummary_SetsIsPortfolioViewFalse()
+    {
+        var vm = BuildViewModel();
+        vm.LoadPortfolioSummary("XPI", "Portfolio", new AggregatedSummaryDTO(), [], []);
+        vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), []);
+        vm.IsPortfolioView.Should().BeFalse();
+        vm.IsBrokerView.Should().BeTrue();
+    }
+
+    private sealed class StubAssetPriceService : IAssetPriceService
+    {
+        public AssetPriceDTO GetCurrentPrice(AssetPriceRequestDTO request) =>
+            new() { Exchange = request.Exchange, Ticker = request.Ticker, Price = 0m };
+    }
+
+    private sealed class StubTransactionService : ITransactionService
+    {
+        public Task<AssetDetailsDTO?> AddTransactionAsync(TransactionCreateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> UpdateTransactionAsync(TransactionUpdateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> DeleteTransactionAsync(TransactionDeleteDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+    }
+
+    private sealed class StubCreditService : ICreditService
+    {
+        public Task<AssetDetailsDTO?> AddCreditAsync(CreditCreateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> UpdateCreditAsync(CreditUpdateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> DeleteCreditAsync(CreditDeleteDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+    }
+}

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
@@ -90,6 +90,24 @@ public class AssetDetailsViewModelPortfolioSummaryTests
     }
 
     [Fact]
+    public void LoadPortfolioSummary_SetsTotalInvested()
+    {
+        var vm = BuildViewModel();
+        var summary = new AggregatedSummaryDTO { TotalBought = 10000m, TotalSold = 2000m, TotalInvested = 8000m };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", summary, [], BuildItems());
+        vm.TotalInvested.Should().Be(8000m);
+    }
+
+    [Fact]
+    public void LoadPortfolioSummary_SetsNegativeTotalInvested()
+    {
+        var vm = BuildViewModel();
+        var summary = new AggregatedSummaryDTO { TotalBought = 1000m, TotalSold = 3000m, TotalInvested = -2000m };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", summary, [], BuildItems());
+        vm.TotalInvested.Should().Be(-2000m);
+    }
+
+    [Fact]
     public void LoadPortfolioSummary_LoadsCreditsForCreditsTab()
     {
         var vm = BuildViewModel();
@@ -126,6 +144,16 @@ public class AssetDetailsViewModelPortfolioSummaryTests
         vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], BuildItems());
         vm.Clear();
         vm.IsPortfolioView.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Clear_AfterLoadPortfolioSummary_ResetsTotalInvested()
+    {
+        var vm = BuildViewModel();
+        var summary = new AggregatedSummaryDTO { TotalBought = 10000m, TotalSold = 2000m, TotalInvested = 8000m };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", summary, [], BuildItems());
+        vm.Clear();
+        vm.TotalInvested.Should().Be(0m);
     }
 
     [Fact]

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -206,13 +206,16 @@ public class MainNavigationViewModelBaseTests
         public IReadOnlyList<PortfolioAssetSummaryItemDTO>? LastPortfolioAssetItems { get; private set; }
         public bool WasCleared { get; private set; }
         public bool WasPortfolioSummaryLoaded { get; private set; }
+        public bool WasBrokerSummaryLoaded { get; private set; }
         public bool IsPortfolioView => false;
+        public bool IsBrokerView => false;
 
         public void LoadAssetDetails(AssetDetailsDTO details) { }
 
-        public void LoadBrokerCredits(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
+        public void LoadBrokerSummary(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
         {
             LastBrokerSummary = summary;
+            WasBrokerSummaryLoaded = true;
         }
 
         public void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits) { }

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -68,6 +68,20 @@ public class MainNavigationViewModelBaseTests
     }
 
     [Fact]
+    public void SelectingBrokerNode_CallsLoadBrokerSummaryOnDetailsViewModel()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var brokerNode = BuildBrokerNode("XPI");
+        vm.SelectedNode = brokerNode;
+
+        spy.WasBrokerSummaryLoaded.Should().BeTrue();
+        spy.LastBrokerSummary.Should().NotBeNull();
+    }
+
+    [Fact]
     public void SelectingPortfolioNode_WhenMissingMetadata_ClearsDetails()
     {
         var summaryService = new StubSummaryQueryService();

--- a/docs/P04-F06-broker-portfolio-totals-display-wpf/plan.md
+++ b/docs/P04-F06-broker-portfolio-totals-display-wpf/plan.md
@@ -1,0 +1,25 @@
+# Implementation Plan: Broker & Portfolio Totals Display — WPF
+
+**Prerequisites:**
+- F01 (Aggregated Totals Enhancement — Application Layer) already merged to `main`; `TotalInvested` is already returned by `ISummaryQueryService.GetBrokerSummary`/`GetPortfolioSummary`
+- No new tools, libraries, or environment variables required
+
+### Stage 1: ViewModel and Interface
+
+**1. AssetDetailsViewModel view state and totals** - Add `IsBrokerView` and `TotalInvested` properties to `AssetDetailsViewModel`, mirroring the existing `IsPortfolioView` pattern. Add a new `LoadBrokerSummary` method that populates Credits-tab state, sets `IsBrokerView`, and sets `TotalInvested` from the summary DTO, replacing the existing `LoadBrokerCredits` method. Extend `LoadPortfolioSummary` to also set `TotalInvested`, and ensure `Clear()`, `LoadAssetDetails`, and the shared credits-loading helper correctly reset the new Broker view state. Reference the spec's Component Overview for exact reset points.
+
+**2. IAssetDetailsViewModel contract update** - Update the interface to expose `IsBrokerView` and `LoadBrokerSummary`, removing the now-unused `LoadBrokerCredits` member. Reference the spec's Technical Decisions for the rationale on what does and doesn't belong on the interface.
+
+### Stage 2: WPF Template
+
+**3. BrokerSummaryTemplate** - Add a new DataTemplate showing only the four colour-coded totals (Total Bought, Total Sold, Total Credits, Total Invested) in a 2×2 grid layout, with no asset-specific fields and no DataGrid. Reference the spec's Technical Decisions for the chosen layout and colour-coding approach.
+
+**4. Template selection and PortfolioSummaryTemplate extension** - Wire up template selection so Broker node selection renders the new template instead of falling back to the asset template, and extend the existing Portfolio totals display with the fourth Total Invested field using the same colour rule. Reference the spec's Component Overview for the exact binding and trigger pattern to mirror.
+
+### Stage 3: Routing and Tests
+
+**5. Broker node dispatch** - Update the Broker node selection routing to call the new `LoadBrokerSummary` method instead of the old `LoadBrokerCredits` method, with no change to how the summary and credits data are fetched.
+
+**6. ViewModel test coverage** - Add a new test file covering `LoadBrokerSummary`'s behaviour (view state, totals, Credits-tab population, asset-field clearing, and reset behaviour on `Clear()`/node-switching), and extend the existing Portfolio summary test file with `TotalInvested` coverage. Reference the spec's Testing Strategy for the full list of test functions.
+
+**7. Routing test coverage** - Update the existing Broker-dispatch test double to implement the new interface method, and confirm existing Broker-selection routing tests still pass unchanged.

--- a/docs/P04-F06-broker-portfolio-totals-display-wpf/spec.md
+++ b/docs/P04-F06-broker-portfolio-totals-display-wpf/spec.md
@@ -1,0 +1,106 @@
+# F06. Broker & Portfolio Totals Display — WPF
+
+## 1. Technical Overview
+
+**What:** Fix the WPF Broker-node display bug (it currently falls back to `AssetSummaryTemplate`, showing meaningless zeroed asset fields) by introducing a dedicated `BrokerSummaryTemplate` with only four colour-coded totals: Total Bought, Total Sold, Total Credits, Total Invested. Also extend the existing `PortfolioSummaryTemplate` with the same fourth total, **Total Invested**.
+
+**Why:** The backend (F01, already merged to `main`) already computes and returns `TotalInvested` in `AggregatedSummaryDTO` for both broker and portfolio scope via `ISummaryQueryService`. The WPF desktop app never adopted a dedicated Broker template — `AssetDetailsViewModel`'s Broker-loading path (`LoadBrokerCredits` → `LoadAggregateCredits`) only ever set `IsPortfolioView = false`, leaving `AssetSummaryTemplate` as the active (wrong) template for Broker selection. This is the same display-layer catch-up already done for the web frontend in F05, now mirrored for WPF.
+
+**Scope:**
+- Included: new `BrokerSummaryTemplate` DataTemplate; new `IsBrokerView` and `TotalInvested` properties on `AssetDetailsViewModel`; new `LoadBrokerSummary` method replacing `LoadBrokerCredits`; extending `PortfolioSummaryTemplate` and `LoadPortfolioSummary` with `TotalInvested`; updating `MainNavigationViewModelBase`'s Broker dispatch; unit test coverage.
+- Excluded: any backend change (F01 already complete); Credits tab and Transactions tab behaviour for Broker/Portfolio selection (unchanged, addressed by other features in this PRD); pie charts (F08) and the Transactions monthly chart (F10) — out of scope for this feature.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.App/Components/NavigationView.xaml` — new `BrokerSummaryTemplate`, extended `PortfolioSummaryTemplate`, new `DataTrigger`
+- `Financial.App/ViewModels/AssetDetailsViewModel.cs` — new properties, new/modified methods
+- `Financial.App/ViewModels/IAssetDetailsViewModel.cs` — interface update
+- `Financial.App/ViewModels/MainNavigationViewModelBase.cs` — Broker dispatch call site
+- `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs` — new
+- `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs` — extended
+- `Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs` — `SpyAssetDetailsViewModel` updated
+
+```mermaid
+graph TD
+    A[User selects Broker or Portfolio node] --> B[MainNavigationViewModelBase]
+    B --> C["ISummaryQueryService.GetBrokerSummary / GetPortfolioSummary"]
+    C --> D["AggregatedSummaryDTO (TotalInvested already populated by F01)"]
+    D --> E[AssetDetailsViewModel]
+    E --> F["LoadBrokerSummary sets IsBrokerView=true, TotalInvested"]
+    E --> G["LoadPortfolioSummary sets IsPortfolioView=true, TotalInvested"]
+    F --> H["BrokerSummaryTemplate (new, 2x2 grid, 4 totals only)"]
+    G --> I["PortfolioSummaryTemplate (existing, +4th total)"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|------------------|-------------------------|-----------|
+| `BrokerSummaryTemplate` layout | 2×2 `Grid` (Total Bought/Total Sold on row 0, Total Credits/Total Invested on row 1), mirroring `AssetSummaryTemplate`'s existing Grid.Row/Grid.Column label-value pair pattern | Single horizontal `StackPanel` row (extending `PortfolioSummaryTemplate`'s 3-item row pattern to 4 items) | The StackPanel approach is less code (copy an existing row), but the Broker tab has nothing else below it (no DataGrid), so a single thin horizontal line would look sparse as the tab's only content. The 2×2 grid also keeps the WPF and Web (F05) implementations visually consistent for the same screen |
+| `LoadBrokerCredits` interface method | Removed from `IAssetDetailsViewModel` and `AssetDetailsViewModel`, replaced by `LoadBrokerSummary` | Keep `LoadBrokerCredits` as dead code, add `LoadBrokerSummary` alongside it | The PRD explicitly says the broker-loading path "is replaced with" a new method. Its only production call site (`MainNavigationViewModelBase`'s Broker dispatch) is being updated to call the new method, so nothing else references the old one. (Note: `LoadPortfolioCredits` is a pre-existing, already-unused interface method left over from before `LoadPortfolioSummary` existed — this feature does not touch it, since cleaning up unrelated dead code is out of scope) |
+| `IsBrokerView` on the interface | Added to `IAssetDetailsViewModel` alongside `LoadBrokerSummary`, mirroring how `IsPortfolioView` is already exposed there | Keep it only on the concrete `AssetDetailsViewModel` (like `TotalBought`/`TotalCredits`/etc., which XAML binds to via runtime reflection without needing the interface) | `IsPortfolioView` is already on the interface even though only XAML binds to it, establishing the precedent that view-state booleans (not raw totals) are interface members. Following it keeps `IsBrokerView` discoverable and testable the same way |
+| `TotalInvested` on the interface | NOT added to `IAssetDetailsViewModel` — stays a concrete `AssetDetailsViewModel` property only | Add it to the interface for symmetry with `IsBrokerView` | Matches the existing precedent: `TotalBought`, `TotalSold`, `TotalCredits` are not on the interface either (XAML binds to the concrete instance via `{Binding AssetDetails.TotalBought}` at runtime; tests construct the concrete `AssetDetailsViewModel` directly, never through the interface, to assert on totals) |
+
+## 4. Component Overview
+
+**Frontend (WPF):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|---------------|---------|------------------------|
+| `Financial.App/Components/NavigationView.xaml` | Modified | Template selection + rendering | Add `BrokerSummaryTemplate` (`x:Key`, sibling of `AssetSummaryTemplate`/`PortfolioSummaryTemplate` in `TabItem.Resources`) with a 2×2 `Grid` of 4 colour-coded totals; append a 4th `TextBlock` pair (Total Invested) to `PortfolioSummaryTemplate`'s existing totals `StackPanel`; add a second `DataTrigger` on `AssetDetails.IsBrokerView` to the `ContentControl.Style.Triggers` block, selecting `BrokerSummaryTemplate` |
+| `Financial.App/ViewModels/AssetDetailsViewModel.cs` | Modified | View state | Add `_isBrokerView`/`IsBrokerView` (mirrors `_isPortfolioView`/`IsPortfolioView`) and `_totalInvested`/`TotalInvested` backing field + property; add `LoadBrokerSummary(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)` calling `LoadAggregateCredits` then setting `IsBrokerView = true` and `TotalInvested = summary.TotalInvested`; remove `LoadBrokerCredits`; extend `LoadPortfolioSummary` to set `TotalInvested = summary.TotalInvested`; extend `LoadAggregateCredits` to reset `IsBrokerView = false` at its start (mirroring its existing `IsPortfolioView = false` reset); extend `LoadAssetDetails` and `Clear()` to reset `IsBrokerView = false` and `TotalInvested = 0m` |
+| `Financial.App/ViewModels/IAssetDetailsViewModel.cs` | Modified | Contract | Add `bool IsBrokerView { get; }` and `void LoadBrokerSummary(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)`; remove `void LoadBrokerCredits(...)` |
+| `Financial.App/ViewModels/MainNavigationViewModelBase.cs` | Modified | Node-selection routing | In the private `LoadBrokerCredits(TreeNodeViewModel brokerNode)` method (Broker dispatch, called from `LoadSelectionDetails`), change the call from `AssetDetails.LoadBrokerCredits(brokerName, summary, credits)` to `AssetDetails.LoadBrokerSummary(brokerName, summary, credits)`. No change to how `summary`/`credits` are fetched |
+
+**Backend:** None — `TotalInvested` is already implemented and returned by F01 (merged to `main`). No API contract, service, or data model changes required.
+
+## 5. API Contracts
+
+Not applicable — no new or modified endpoint. `ISummaryQueryService.GetBrokerSummary`/`GetPortfolioSummary` already return `TotalInvested` on `AggregatedSummaryDTO` (delivered by F01); this feature only adds the WPF display layer that consumes the value already present in the DTO.
+
+## 6. Data Model
+
+Not applicable — no database changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|-----------------|
+| `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs` (new) | Unit | `AssetDetailsViewModel.LoadBrokerSummary` | Sets `IsBrokerView`, totals (incl. `TotalInvested`), populates Credits-tab state, clears asset-specific fields, resets correctly on `Clear()`/`LoadAssetDetails`/`LoadPortfolioSummary` |
+| `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs` (extended) | Unit | `AssetDetailsViewModel.LoadPortfolioSummary` | `TotalInvested` set from `summary.TotalInvested`; reset to 0 on `Clear()` |
+| `Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs` (extended) | Unit | `MainNavigationViewModelBase` Broker dispatch | `SpyAssetDetailsViewModel` implements `LoadBrokerSummary` instead of `LoadBrokerCredits`; existing Broker-selection routing tests continue to pass unchanged |
+
+**Test Functions:**
+
+| Test Function | Description | Assertions |
+|----------------|--------------|-------------|
+| `LoadBrokerSummary_SetsIsBrokerViewTrue` | Calling `LoadBrokerSummary` | `vm.IsBrokerView` is `true` |
+| `LoadBrokerSummary_SetsAggregatedTotals` | `TotalBought`/`TotalSold` from `summary` | Match the DTO's values |
+| `LoadBrokerSummary_SetsTotalInvested` | `TotalInvested` from `summary.TotalInvested` | Matches the DTO's value, including a negative value case |
+| `LoadBrokerSummary_LoadsCreditsForCreditsTab` | Credits-tab state still populated (regression: Credits tab must keep working) | `vm.Credits.Count` matches input |
+| `LoadBrokerSummary_ClearsAssetSpecificFields` | Asset-specific fields (Quantity, ISIN, etc.) are zeroed/empty | Mirrors `ClearAssetContext` behaviour already exercised by the Portfolio path |
+| `Clear_AfterLoadBrokerSummary_SetsIsBrokerViewFalse` | `Clear()` resets Broker view state | `vm.IsBrokerView` is `false` |
+| `Clear_AfterLoadBrokerSummary_ResetsTotalInvested` | `Clear()` resets `TotalInvested` | `vm.TotalInvested` is `0m` |
+| `LoadAssetDetails_AfterBrokerSummary_SetsIsBrokerViewFalse` | Selecting an Asset node after a Broker node (regression: Asset view unaffected) | `vm.IsBrokerView` is `false` |
+| `LoadPortfolioSummary_AfterBrokerSummary_SetsIsBrokerViewFalse` | Selecting a Portfolio node after a Broker node (mutual exclusivity) | `vm.IsBrokerView` is `false`, `vm.IsPortfolioView` is `true` |
+| `LoadPortfolioSummary_SetsTotalInvested` (added to existing file) | `TotalInvested` from `summary.TotalInvested` for Portfolio scope | Matches the DTO's value |
+| `Clear_AfterLoadPortfolioSummary_ResetsTotalInvested` (added to existing file) | `Clear()` resets Portfolio `TotalInvested` | `vm.TotalInvested` is `0m` |
+
+**Acceptance tests (PRD Section 9, F06):**
+- Selecting a Broker node in WPF shows only 4 colour-coded totals and no asset-specific fields → covered by `LoadBrokerSummary_SetsIsBrokerViewTrue` + `LoadBrokerSummary_ClearsAssetSpecificFields` (template selection itself is XAML `DataTrigger`, not directly unit-testable — verified via manual/smoke check)
+- Selecting a Portfolio node in WPF shows the existing per-asset DataGrid plus 4 totals including Total Invested → covered by `LoadPortfolioSummary_SetsTotalInvested`
+- Selecting an Asset node in WPF is unaffected (regression) → covered by `LoadAssetDetails_AfterBrokerSummary_SetsIsBrokerViewFalse`
+- Total Invested is styled green when `>= 0` and red when `< 0` → XAML-level (`SignedValueToBrushConverter` binding), verified via manual/smoke check, not unit-testable
+
+**Cross-feature integration tests (PRD Section 9):**
+- `totalInvested` computed by F01 for Broker scope is displayed without transformation in F06's fourth total → covered by `LoadBrokerSummary_SetsTotalInvested`
+- `totalInvested` computed by F01 for Portfolio scope is displayed without transformation in F06's fourth total for Portfolio selection → covered by `LoadPortfolioSummary_SetsTotalInvested`
+
+## Assumptions and Decisions (from interview)
+
+- **2×2 Grid layout** for `BrokerSummaryTemplate`, matching the layout just chosen for the equivalent Web feature (F05), rather than extending the simpler horizontal `StackPanel` pattern — confirmed with the user since the Broker tab has no other content below the totals.
+- **`LoadBrokerCredits` is removed**, not left as dead code, since the PRD explicitly describes it as "replaced" and its only production caller is updated in this same feature.
+- **`IsBrokerView` is added to `IAssetDetailsViewModel`** (mirroring `IsPortfolioView`); **`TotalInvested` is not** (mirroring `TotalBought`/`TotalSold`/`TotalCredits`, which are also absent from the interface).


### PR DESCRIPTION
## Summary
- Fixes the WPF Broker-node display bug: selecting a Broker node used to fall back to the individual-asset layout (`AssetSummaryTemplate`), showing meaningless zeroed fields (Quantity, ISIN, Country, Current Value section, etc.). A new `BrokerSummaryTemplate` now shows only the four colour-coded totals.
- Adds **Total Invested** (green when `>= 0`, red when `< 0`, via the existing `SignedValueToBrushConverter`) to both the new Broker template and the existing `PortfolioSummaryTemplate`.
- Frontend-only: the backend (F01, already on `main`) already returns `TotalInvested` in `AggregatedSummaryDTO`.
- `LoadBrokerCredits` was replaced with `LoadBrokerSummary` on `AssetDetailsViewModel`/`IAssetDetailsViewModel` (its only caller and test double updated in the same commit, since removing an interface member is atomic in C# and can't be split across separately-buildable commits — see Deviations below).

## Deviations from plan.md
- The plan's Stage 3 ("Routing and Tests") assumed the interface change alone could be its own buildable commit. In practice, removing `LoadBrokerCredits` from `IAssetDetailsViewModel` breaks the build until its only call site (`MainNavigationViewModelBase`) and test double (`SpyAssetDetailsViewModel`) are updated too — so those were folded into Phase 1 instead of Phase 3, keeping every commit green.

## Test plan
- [x] `dotnet build` — 0 errors, only pre-existing unrelated warnings
- [x] `dotnet test` — 415/418 passing (3 pre-existing skipped manual tests, unrelated to this change), including 12 new `AssetDetailsViewModelBrokerSummaryTests` and extended `AssetDetailsViewModelPortfolioSummaryTests`/`MainNavigationViewModelBaseTests`
- [x] Web frontend suite (`tsc`, `eslint`, `vitest`) — untouched by this feature, still green (303/303) as a full-repo sanity check
- [x] Manual smoke test: launched the actual WPF app against real local data and screenshotted all three node types —
  - **Broker node (XPI)**: renders only the 4 totals in a 2x2 grid (Total Bought 263,225.29 green / Total Sold 4,706.55 red / Total Credits 12,650.45 blue / Total Invested 258,518.74 green), no asset-specific fields — bug confirmed fixed
  - **Portfolio node (Acoes)**: existing per-asset DataGrid intact, plus all 4 totals including Total Invested
  - **Asset node (BBAS3)**: unaffected — Quantity, Average Price, ISIN, Country, Current Value section all still render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)