### PR TITLE
feat(P04-F07): Broker Breakdown Pie Charts — Web Frontend

### DIFF
--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -11,6 +11,7 @@ import type {
   DividendHistoryItemDto,
   DividendSummaryDto,
   PortfolioAssetSummaryItemDto,
+  PortfolioBreakdownItemDto,
   PortfolioReferenceDto,
   TransactionCreateDto,
   TransactionDeleteDto,
@@ -27,6 +28,7 @@ export interface FinancialApiClient {
   getCreditsByPortfolio: (brokerName: string, portfolioName: string) => Promise<CreditDto[]>
   getSummaryByBroker: (brokerName: string) => Promise<AggregatedSummaryDto>
   getSummaryByPortfolio: (brokerName: string, portfolioName: string) => Promise<AggregatedSummaryDto>
+  getBrokerBreakdown: (brokerName: string) => Promise<PortfolioBreakdownItemDto[]>
   addTransaction: (request: TransactionCreateDto) => Promise<AssetDetailsDto>
   updateTransaction: (request: TransactionUpdateDto) => Promise<AssetDetailsDto>
   deleteTransaction: (request: TransactionDeleteDto) => Promise<AssetDetailsDto>
@@ -108,6 +110,8 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       request<AggregatedSummaryDto>(
         `/summary/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}`,
       ),
+    getBrokerBreakdown: (brokerName) =>
+      request<PortfolioBreakdownItemDto[]>(`/summary/broker/${encodeURIComponent(brokerName)}/breakdown`),
     addTransaction: (requestBody) =>
       request<AssetDetailsDto>('/transactions', {
         method: 'POST',

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -185,6 +185,17 @@ export interface AggregatedSummaryDto {
   totalInvested: number
 }
 
+export interface AssetBreakdownItemDto {
+  assetName: string
+  totalInvested: number
+}
+
+export interface PortfolioBreakdownItemDto {
+  portfolioName: string
+  totalInvested: number
+  assets: AssetBreakdownItemDto[]
+}
+
 export interface WatchlistItemDto {
   group: string
   name: string

--- a/Financial.Web/src/components/AggregatedSummaryTab.tsx
+++ b/Financial.Web/src/components/AggregatedSummaryTab.tsx
@@ -1,6 +1,8 @@
+import BrokerBreakdownCharts from './BrokerBreakdownCharts'
 import ErrorState from './ErrorState'
 import LoadingState from './LoadingState'
 import { useAggregatedSummary } from '../hooks/useAggregatedSummary'
+import { useSelectedNode } from '../context/SelectedNodeContext'
 import './AggregatedSummaryTab.css'
 
 function formatN2(value: number): string {
@@ -16,6 +18,8 @@ function getInvestedClass(value: number): string {
 
 export default function AggregatedSummaryTab() {
   const { summary, isLoading, error, retry } = useAggregatedSummary()
+  const { selectedNode } = useSelectedNode()
+  const isBroker = selectedNode?.nodeType === 'Broker'
 
   if (isLoading) {
     return <LoadingState />
@@ -57,6 +61,7 @@ export default function AggregatedSummaryTab() {
           </span>
         </div>
       </div>
+      {isBroker && <BrokerBreakdownCharts />}
     </div>
   )
 }

--- a/Financial.Web/src/components/BrokerBreakdownCharts.css
+++ b/Financial.Web/src/components/BrokerBreakdownCharts.css
@@ -1,0 +1,40 @@
+.broker-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.broker-breakdown__chart-title {
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.broker-breakdown__empty {
+  color: var(--text-muted, #888);
+  font-size: 13px;
+  margin-top: 24px;
+}
+
+.broker-breakdown__tooltip {
+  background: #fff;
+  border: 1px solid #e1e0d9;
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-size: 12px;
+}
+
+.broker-breakdown__tooltip-name {
+  color: #52514e;
+  margin-bottom: 2px;
+}
+
+.broker-breakdown__tooltip-value {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.broker-breakdown__tooltip-percent {
+  color: #52514e;
+}

--- a/Financial.Web/src/components/BrokerBreakdownCharts.tsx
+++ b/Financial.Web/src/components/BrokerBreakdownCharts.tsx
@@ -30,6 +30,15 @@ function formatPercent(value: number): string {
 interface PieSliceDatum {
   name: string
   value: number
+  percent: number
+}
+
+function buildPieSliceData(items: { name: string; value: number }[]): PieSliceDatum[] {
+  const total = items.reduce((sum, item) => sum + item.value, 0)
+  return items.map((item) => ({
+    ...item,
+    percent: total > 0 ? item.value / total : 0,
+  }))
 }
 
 interface PieTooltipContentProps {
@@ -48,14 +57,17 @@ function PieTooltipContent({ name, value, percent }: PieTooltipContentProps) {
   )
 }
 
-// recharts' Pie tooltip payload carries `percent` at runtime, but the shared
-// TooltipPayloadEntry type doesn't declare it — narrow it safely here.
+// recharts' Pie tooltip payload entry doesn't carry `percent` itself (that's
+// only attached to the internal sector geometry, not the tooltip payload) —
+// but it does carry the original data object under `.payload`, which is where
+// our own pre-computed `percent` (see buildPieSliceData) actually surfaces.
 function readPieTooltipEntry(entry: unknown): PieTooltipContentProps {
-  const record = entry as { name?: unknown; value?: unknown; percent?: unknown }
+  const record = entry as { payload?: { name?: unknown; value?: unknown; percent?: unknown } }
+  const source = record.payload ?? {}
   return {
-    name: typeof record.name === 'string' ? record.name : '',
-    value: typeof record.value === 'number' ? record.value : 0,
-    percent: typeof record.percent === 'number' ? record.percent : 0,
+    name: typeof source.name === 'string' ? source.name : '',
+    value: typeof source.value === 'number' ? source.value : 0,
+    percent: typeof source.percent === 'number' ? source.percent : 0,
   }
 }
 
@@ -109,10 +121,9 @@ export default function BrokerBreakdownCharts() {
     return <p className="broker-breakdown__empty">No active portfolios to display</p>
   }
 
-  const portfolioData: PieSliceDatum[] = breakdown.map((portfolio) => ({
-    name: portfolio.portfolioName,
-    value: portfolio.totalInvested,
-  }))
+  const portfolioData = buildPieSliceData(
+    breakdown.map((portfolio) => ({ name: portfolio.portfolioName, value: portfolio.totalInvested })),
+  )
 
   return (
     <div className="broker-breakdown">
@@ -121,7 +132,9 @@ export default function BrokerBreakdownCharts() {
         <BreakdownPie
           key={portfolio.portfolioName}
           title={portfolio.portfolioName}
-          data={portfolio.assets.map((asset) => ({ name: asset.assetName, value: asset.totalInvested }))}
+          data={buildPieSliceData(
+            portfolio.assets.map((asset) => ({ name: asset.assetName, value: asset.totalInvested })),
+          )}
         />
       ))}
     </div>

--- a/Financial.Web/src/components/BrokerBreakdownCharts.tsx
+++ b/Financial.Web/src/components/BrokerBreakdownCharts.tsx
@@ -1,0 +1,129 @@
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts'
+import ErrorState from './ErrorState'
+import LoadingState from './LoadingState'
+import { useBrokerBreakdown } from '../hooks/useBrokerBreakdown'
+import './BrokerBreakdownCharts.css'
+
+// Validated categorical palette (fixed hue order, CVD-safe adjacency).
+const CATEGORICAL_PALETTE = [
+  '#2a78d6', // blue
+  '#1baf7a', // aqua
+  '#eda100', // yellow
+  '#008300', // green
+  '#4a3aa7', // violet
+  '#e34948', // red
+  '#e87ba4', // magenta
+  '#eb6834', // orange
+]
+
+function formatN2(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+function formatPercent(value: number): string {
+  return `${value.toFixed(1)}%`
+}
+
+interface PieSliceDatum {
+  name: string
+  value: number
+}
+
+interface PieTooltipContentProps {
+  name: string
+  value: number
+  percent: number
+}
+
+function PieTooltipContent({ name, value, percent }: PieTooltipContentProps) {
+  return (
+    <div className="broker-breakdown__tooltip">
+      <div className="broker-breakdown__tooltip-name">{name}</div>
+      <div className="broker-breakdown__tooltip-value">{formatN2(value)}</div>
+      <div className="broker-breakdown__tooltip-percent">{formatPercent(percent * 100)}</div>
+    </div>
+  )
+}
+
+// recharts' Pie tooltip payload carries `percent` at runtime, but the shared
+// TooltipPayloadEntry type doesn't declare it — narrow it safely here.
+function readPieTooltipEntry(entry: unknown): PieTooltipContentProps {
+  const record = entry as { name?: unknown; value?: unknown; percent?: unknown }
+  return {
+    name: typeof record.name === 'string' ? record.name : '',
+    value: typeof record.value === 'number' ? record.value : 0,
+    percent: typeof record.percent === 'number' ? record.percent : 0,
+  }
+}
+
+interface BreakdownPieProps {
+  title: string
+  data: PieSliceDatum[]
+}
+
+function BreakdownPie({ title, data }: BreakdownPieProps) {
+  return (
+    <div className="broker-breakdown__chart">
+      <h3 className="broker-breakdown__chart-title">{title}</h3>
+      <ResponsiveContainer width="100%" height={280}>
+        <PieChart>
+          <Pie data={data} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={90}>
+            {data.map((entry, index) => (
+              <Cell key={entry.name} fill={CATEGORICAL_PALETTE[index % CATEGORICAL_PALETTE.length]} />
+            ))}
+          </Pie>
+          <Tooltip
+            content={({ active, payload }) => {
+              if (!active || !payload || payload.length === 0) {
+                return null
+              }
+              return <PieTooltipContent {...readPieTooltipEntry(payload[0])} />
+            }}
+          />
+          <Legend />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+export default function BrokerBreakdownCharts() {
+  const { breakdown, isLoading, error, retry } = useBrokerBreakdown()
+
+  if (isLoading) {
+    return <LoadingState />
+  }
+
+  if (error) {
+    return <ErrorState message={error} onRetry={retry} />
+  }
+
+  if (!breakdown) {
+    return null
+  }
+
+  if (breakdown.length === 0) {
+    return <p className="broker-breakdown__empty">No active portfolios to display</p>
+  }
+
+  const portfolioData: PieSliceDatum[] = breakdown.map((portfolio) => ({
+    name: portfolio.portfolioName,
+    value: portfolio.totalInvested,
+  }))
+
+  return (
+    <div className="broker-breakdown">
+      <BreakdownPie title="Portfolio Breakdown" data={portfolioData} />
+      {breakdown.map((portfolio) => (
+        <BreakdownPie
+          key={portfolio.portfolioName}
+          title={portfolio.portfolioName}
+          data={portfolio.assets.map((asset) => ({ name: asset.assetName, value: asset.totalInvested }))}
+        />
+      ))}
+    </div>
+  )
+}

--- a/Financial.Web/src/components/__tests__/AggregatedSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/AggregatedSummaryTab.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react'
-import { act, createElement } from 'react'
+import { act, render, screen } from '@testing-library/react'
+import { createElement } from 'react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AggregatedSummaryData } from '../../hooks/useAggregatedSummary'

--- a/Financial.Web/src/components/__tests__/AggregatedSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/AggregatedSummaryTab.test.tsx
@@ -2,7 +2,16 @@ import { render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AggregatedSummaryData } from '../../hooks/useAggregatedSummary'
 import type { AggregatedSummaryDto } from '../../api/types'
+import { SelectedNodeProvider } from '../../context/SelectedNodeContext'
 import AggregatedSummaryTab from '../AggregatedSummaryTab'
+
+function renderComponent() {
+  return render(
+    <SelectedNodeProvider>
+      <AggregatedSummaryTab />
+    </SelectedNodeProvider>,
+  )
+}
 
 const mockRetry = vi.fn()
 
@@ -40,20 +49,20 @@ describe('AggregatedSummaryTab', () => {
 
   it('renders_loading_indicator_while_data_loads', () => {
     setMock({ isLoading: true })
-    render(<AggregatedSummaryTab />)
+    renderComponent()
     expect(screen.getByText('Loading...')).toBeInTheDocument()
   })
 
   it('renders_error_state_with_retry_on_failure', () => {
     setMock({ error: 'Unable to load summary' })
-    render(<AggregatedSummaryTab />)
+    renderComponent()
     expect(screen.getByText('Unable to load summary')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
   })
 
   it('renders_total_bought_in_green', () => {
     setMock({ summary: SUMMARY })
-    render(<AggregatedSummaryTab />)
+    renderComponent()
     const label = screen.getByText('Total Bought')
     const valueEl = label.nextElementSibling
     expect(valueEl).toHaveClass('aggregated-summary__value--green')
@@ -61,7 +70,7 @@ describe('AggregatedSummaryTab', () => {
 
   it('renders_total_sold_in_red', () => {
     setMock({ summary: SUMMARY })
-    render(<AggregatedSummaryTab />)
+    renderComponent()
     const label = screen.getByText('Total Sold')
     const valueEl = label.nextElementSibling
     expect(valueEl).toHaveClass('aggregated-summary__value--red')
@@ -69,7 +78,7 @@ describe('AggregatedSummaryTab', () => {
 
   it('renders_total_credits_in_blue', () => {
     setMock({ summary: SUMMARY })
-    render(<AggregatedSummaryTab />)
+    renderComponent()
     const label = screen.getByText('Total Credits')
     const valueEl = label.nextElementSibling
     expect(valueEl).toHaveClass('aggregated-summary__value--blue')
@@ -77,14 +86,14 @@ describe('AggregatedSummaryTab', () => {
 
   it('renders_total_invested_after_total_credits', () => {
     setMock({ summary: SUMMARY })
-    render(<AggregatedSummaryTab />)
+    renderComponent()
     const labels = screen.getAllByText(/^Total /).map((el) => el.textContent)
     expect(labels).toEqual(['Total Bought', 'Total Sold', 'Total Credits', 'Total Invested'])
   })
 
   it('renders_total_invested_in_green_when_non_negative', () => {
     setMock({ summary: { ...SUMMARY, totalInvested: 0 } })
-    render(<AggregatedSummaryTab />)
+    renderComponent()
     const label = screen.getByText('Total Invested')
     const valueEl = label.nextElementSibling
     expect(valueEl).toHaveClass('aggregated-summary__value--green')
@@ -92,7 +101,7 @@ describe('AggregatedSummaryTab', () => {
 
   it('renders_total_invested_in_red_when_negative', () => {
     setMock({ summary: { ...SUMMARY, totalInvested: -125.5 } })
-    render(<AggregatedSummaryTab />)
+    renderComponent()
     const label = screen.getByText('Total Invested')
     const valueEl = label.nextElementSibling
     expect(valueEl).toHaveClass('aggregated-summary__value--red')
@@ -107,7 +116,7 @@ describe('AggregatedSummaryTab', () => {
         totalInvested: 12220.5678,
       },
     })
-    render(<AggregatedSummaryTab />)
+    renderComponent()
     const label = screen.getByText('Total Bought')
     expect(label.nextElementSibling?.textContent).toMatch(/\d+[.,]\d{2}$/)
     const investedLabel = screen.getByText('Total Invested')
@@ -116,7 +125,7 @@ describe('AggregatedSummaryTab', () => {
 
   it('renders_zero_values_without_error', () => {
     setMock({ summary: { totalBought: 0, totalSold: 0, totalCredits: 0, totalInvested: 0 } })
-    render(<AggregatedSummaryTab />)
+    renderComponent()
     expect(screen.getByText('Total Bought')).toBeInTheDocument()
     expect(screen.getByText('Total Sold')).toBeInTheDocument()
     expect(screen.getByText('Total Credits')).toBeInTheDocument()

--- a/Financial.Web/src/components/__tests__/AggregatedSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/AggregatedSummaryTab.test.tsx
@@ -1,9 +1,15 @@
 import { render, screen } from '@testing-library/react'
+import { act, createElement } from 'react'
+import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AggregatedSummaryData } from '../../hooks/useAggregatedSummary'
-import type { AggregatedSummaryDto } from '../../api/types'
-import { SelectedNodeProvider } from '../../context/SelectedNodeContext'
+import type { AggregatedSummaryDto, SelectedNode } from '../../api/types'
+import { SelectedNodeProvider, useSelectedNode } from '../../context/SelectedNodeContext'
 import AggregatedSummaryTab from '../AggregatedSummaryTab'
+
+vi.mock('../BrokerBreakdownCharts', () => ({
+  default: () => <div data-testid="broker-breakdown-charts" />,
+}))
 
 function renderComponent() {
   return render(
@@ -11,6 +17,24 @@ function renderComponent() {
       <AggregatedSummaryTab />
     </SelectedNodeProvider>,
   )
+}
+
+function renderComponentWithNode(node: SelectedNode) {
+  let setNodeRef: ((node: SelectedNode | null) => void) | undefined
+
+  function NodeControl() {
+    const { setSelectedNode } = useSelectedNode()
+    setNodeRef = setSelectedNode
+    return null
+  }
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(SelectedNodeProvider, null, createElement(NodeControl), children)
+  }
+
+  const result = render(<AggregatedSummaryTab />, { wrapper: Wrapper })
+  act(() => setNodeRef?.(node))
+  return result
 }
 
 const mockRetry = vi.fn()
@@ -130,5 +154,17 @@ describe('AggregatedSummaryTab', () => {
     expect(screen.getByText('Total Sold')).toBeInTheDocument()
     expect(screen.getByText('Total Credits')).toBeInTheDocument()
     expect(screen.getByText('Total Invested')).toBeInTheDocument()
+  })
+
+  it('renders_broker_breakdown_charts_for_broker_node_selection', () => {
+    setMock({ summary: SUMMARY })
+    renderComponentWithNode({ nodeType: 'Broker', brokerName: 'XPI', currency: 'BRL' })
+    expect(screen.getByTestId('broker-breakdown-charts')).toBeInTheDocument()
+  })
+
+  it('does_not_render_broker_breakdown_charts_for_portfolio_node_selection', () => {
+    setMock({ summary: SUMMARY })
+    renderComponentWithNode({ nodeType: 'Portfolio', brokerName: 'XPI', portfolioName: 'Acoes' })
+    expect(screen.queryByTestId('broker-breakdown-charts')).not.toBeInTheDocument()
   })
 })

--- a/Financial.Web/src/components/__tests__/BrokerBreakdownCharts.test.tsx
+++ b/Financial.Web/src/components/__tests__/BrokerBreakdownCharts.test.tsx
@@ -21,6 +21,7 @@ vi.mock('../../hooks/useBrokerBreakdown', () => ({
 interface MockPieDatum {
   name: string
   value: number
+  percent: number
 }
 
 vi.mock('recharts', () => ({
@@ -30,7 +31,7 @@ vi.mock('recharts', () => ({
   Pie: ({ data, children }: { data: MockPieDatum[]; children?: React.ReactNode }) => (
     <div data-testid="pie">
       {data.map((d) => (
-        <span key={d.name} data-testid="pie-slice">
+        <span key={d.name} data-testid="pie-slice" data-percent={d.percent}>
           {d.name}
         </span>
       ))}
@@ -41,10 +42,24 @@ vi.mock('recharts', () => ({
   Tooltip: ({
     content,
   }: {
-    content?: (props: { active: boolean; payload: { name: string; value: number; percent: number }[] }) => React.ReactNode
+    content?: (props: {
+      active: boolean
+      payload: { name: string; value: number; payload: { name: string; value: number; percent: number } }[]
+    }) => React.ReactNode
   }) => (
     <div data-testid="tooltip">
-      {content ? content({ active: true, payload: [{ name: 'Test Slice', value: 1234.5, percent: 0.256 }] }) : null}
+      {content
+        ? content({
+            active: true,
+            payload: [
+              {
+                name: 'Test Slice',
+                value: 1234.5,
+                payload: { name: 'Test Slice', value: 1234.5, percent: 0.256 },
+              },
+            ],
+          })
+        : null}
     </div>
   ),
   Legend: () => <div data-testid="legend" />,
@@ -108,6 +123,16 @@ describe('BrokerBreakdownCharts', () => {
     expect(overviewSlices).toHaveLength(2)
     expect(overviewSlices[0].textContent).toBe('Acoes')
     expect(overviewSlices[1].textContent).toBe('FII')
+  })
+
+  it('computes_correct_percentage_per_slice', () => {
+    setMock({ breakdown: BREAKDOWN })
+    render(<BrokerBreakdownCharts />)
+    const pies = screen.getAllByTestId('pie')
+    const overviewSlices = pies[0].querySelectorAll('[data-testid="pie-slice"]')
+    const total = 38639.49 + 20000
+    expect(Number(overviewSlices[0].getAttribute('data-percent'))).toBeCloseTo(38639.49 / total, 5)
+    expect(Number(overviewSlices[1].getAttribute('data-percent'))).toBeCloseTo(20000 / total, 5)
   })
 
   it('renders_one_additional_pie_per_portfolio', () => {

--- a/Financial.Web/src/components/__tests__/BrokerBreakdownCharts.test.tsx
+++ b/Financial.Web/src/components/__tests__/BrokerBreakdownCharts.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BrokerBreakdownData } from '../../hooks/useBrokerBreakdown'
+import type { PortfolioBreakdownItemDto } from '../../api/types'
+import BrokerBreakdownCharts from '../BrokerBreakdownCharts'
+
+const mockRetry = vi.fn()
+
+const mockHookValue: BrokerBreakdownData = {
+  breakdown: null,
+  isLoading: false,
+  error: null,
+  retry: mockRetry,
+}
+
+vi.mock('../../hooks/useBrokerBreakdown', () => ({
+  useBrokerBreakdown: () => mockHookValue,
+}))
+
+interface MockPieDatum {
+  name: string
+  value: number
+}
+
+vi.mock('recharts', () => ({
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: ({ data, children }: { data: MockPieDatum[]; children?: React.ReactNode }) => (
+    <div data-testid="pie">
+      {data.map((d) => (
+        <span key={d.name} data-testid="pie-slice">
+          {d.name}
+        </span>
+      ))}
+      {children}
+    </div>
+  ),
+  Cell: () => null,
+  Tooltip: ({
+    content,
+  }: {
+    content?: (props: { active: boolean; payload: { name: string; value: number; percent: number }[] }) => React.ReactNode
+  }) => (
+    <div data-testid="tooltip">
+      {content ? content({ active: true, payload: [{ name: 'Test Slice', value: 1234.5, percent: 0.256 }] }) : null}
+    </div>
+  ),
+  Legend: () => <div data-testid="legend" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+}))
+
+function setMock(overrides: Partial<BrokerBreakdownData>) {
+  Object.assign(mockHookValue, overrides)
+}
+
+const BREAKDOWN: PortfolioBreakdownItemDto[] = [
+  {
+    portfolioName: 'Acoes',
+    totalInvested: 38639.49,
+    assets: [
+      { assetName: 'BBAS3', totalInvested: 9850.4 },
+      { assetName: 'KLBN4', totalInvested: 3737.48 },
+    ],
+  },
+  {
+    portfolioName: 'FII',
+    totalInvested: 20000,
+    assets: [{ assetName: 'MXRF11', totalInvested: 20000 }],
+  },
+]
+
+describe('BrokerBreakdownCharts', () => {
+  beforeEach(() => {
+    mockRetry.mockReset()
+    Object.assign(mockHookValue, { breakdown: null, isLoading: false, error: null })
+  })
+
+  it('renders_loading_state_independently_of_totals', () => {
+    setMock({ isLoading: true })
+    render(<BrokerBreakdownCharts />)
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('renders_error_state_with_retry_on_failure', () => {
+    setMock({ error: 'Unable to load breakdown' })
+    render(<BrokerBreakdownCharts />)
+    expect(screen.getByText('Unable to load breakdown')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('renders_empty_state_when_breakdown_is_empty_array', () => {
+    setMock({ breakdown: [] })
+    render(<BrokerBreakdownCharts />)
+    expect(screen.getByText('No active portfolios to display')).toBeInTheDocument()
+    expect(screen.queryAllByTestId('pie-chart')).toHaveLength(0)
+  })
+
+  it('renders_portfolio_breakdown_pie_with_one_slice_per_portfolio', () => {
+    setMock({ breakdown: BREAKDOWN })
+    render(<BrokerBreakdownCharts />)
+    expect(screen.getByText('Portfolio Breakdown')).toBeInTheDocument()
+    const pies = screen.getAllByTestId('pie')
+    const overviewSlices = pies[0].querySelectorAll('[data-testid="pie-slice"]')
+    expect(overviewSlices).toHaveLength(2)
+    expect(overviewSlices[0].textContent).toBe('Acoes')
+    expect(overviewSlices[1].textContent).toBe('FII')
+  })
+
+  it('renders_one_additional_pie_per_portfolio', () => {
+    setMock({ breakdown: BREAKDOWN })
+    render(<BrokerBreakdownCharts />)
+    expect(screen.getByRole('heading', { name: 'Acoes' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'FII' })).toBeInTheDocument()
+    const pieCharts = screen.getAllByTestId('pie-chart')
+    expect(pieCharts).toHaveLength(3)
+  })
+
+  it('renders_tooltip_content_with_name_value_and_formatted_percentage', () => {
+    setMock({ breakdown: BREAKDOWN })
+    render(<BrokerBreakdownCharts />)
+    expect(screen.getAllByText('Test Slice').length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/1,234\.50|1234[.,]50/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText('25.6%').length).toBeGreaterThan(0)
+  })
+
+  it('renders_nothing_extra_when_breakdown_is_null', () => {
+    setMock({ breakdown: null })
+    const { container } = render(<BrokerBreakdownCharts />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
@@ -3,7 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AggregatedSummaryData } from '../../hooks/useAggregatedSummary'
 import type { PortfolioAssetSummaryData, RowPriceState } from '../../hooks/usePortfolioAssetSummary'
 import type { AggregatedSummaryDto, PortfolioAssetSummaryItemDto } from '../../api/types'
+import { SelectedNodeProvider } from '../../context/SelectedNodeContext'
 import PortfolioSummaryTab from '../PortfolioSummaryTab'
+
+function renderComponent() {
+  return render(
+    <SelectedNodeProvider>
+      <PortfolioSummaryTab />
+    </SelectedNodeProvider>,
+  )
+}
 
 const mockAggregatedRetry = vi.fn()
 const mockPortfolioRetry = vi.fn()
@@ -97,34 +106,34 @@ describe('PortfolioSummaryTab', () => {
 
   it('renders_loading_state_in_totals_section_while_aggregated_summary_loads', () => {
     setAggregatedMock({ isLoading: true })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText('Loading...')).toBeInTheDocument()
   })
 
   it('renders_error_state_in_totals_section_on_aggregated_summary_failure', () => {
     setAggregatedMock({ error: 'Unable to load summary' })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText('Unable to load summary')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
   })
 
   it('renders_total_invested_for_portfolio_node_selection', () => {
     setAggregatedMock({ summary: SUMMARY })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const labels = screen.getAllByText(/^Total (Bought|Sold|Credits|Invested)$/, { selector: 'span.aggregated-summary__label' })
     expect(labels.map((el) => el.textContent)).toEqual(['Total Bought', 'Total Sold', 'Total Credits', 'Total Invested'])
   })
 
   it('renders_loading_state_in_table_section_while_items_load', () => {
     setPortfolioMock({ isLoading: true })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText('Loading...')).toBeInTheDocument()
   })
 
   it('renders_error_state_in_table_section_on_items_fetch_failure', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ error: 'Unable to load portfolio assets' })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText('Unable to load portfolio assets')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
     expect(screen.getByText('Total Bought')).toBeInTheDocument()
@@ -133,7 +142,7 @@ describe('PortfolioSummaryTab', () => {
   it('renders_table_with_correct_column_headers', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText('Asset Name')).toBeInTheDocument()
     expect(screen.getByText('First Investment')).toBeInTheDocument()
     expect(screen.getByText('Quantity')).toBeInTheDocument()
@@ -150,7 +159,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, totalCredits: 75.5 }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [IDLE_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText('ALZR11')).toBeInTheDocument()
     expect(screen.getByText('01/03/2021')).toBeInTheDocument()
     expect(screen.getByText(/23\.4%/)).toBeInTheDocument()
@@ -161,7 +170,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, totalCredits: 75.5 }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText(/75[.,]50/)).toBeInTheDocument()
     const loadingCells = screen.getAllByText('...')
     expect(loadingCells.length).toBeGreaterThanOrEqual(1)
@@ -170,7 +179,7 @@ describe('PortfolioSummaryTab', () => {
   it('renders_per_cell_loading_indicator_while_price_loads', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const loadingCells = screen.getAllByText('...')
     expect(loadingCells).toHaveLength(4)
   })
@@ -179,7 +188,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText(/262[.,]50/)).toBeInTheDocument()
   })
 
@@ -188,7 +197,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     // Both % Profit and % Profit w/ Credits show 5.00% when totalCredits is 0
     const profitElements = screen.getAllByText(/5[.,]00%/)
     expect(profitElements.length).toBeGreaterThanOrEqual(1)
@@ -207,7 +216,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText(/10[.,]00%/)).toBeInTheDocument()
   })
 
@@ -216,7 +225,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText(/12[.,]34%/)).toBeInTheDocument()
     expect(xirrMock).toHaveBeenCalledWith(
       expect.arrayContaining([expect.objectContaining({ amount: 262.5 })]),
@@ -226,7 +235,7 @@ describe('PortfolioSummaryTab', () => {
   it('renders_dash_in_current_value_and_price_dependent_columns_on_price_failure', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [FAILED_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const dashes = screen.getAllByText('—')
     expect(dashes.length).toBeGreaterThanOrEqual(4)
   })
@@ -236,7 +245,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const dashes = screen.getAllByText('—')
     expect(dashes.length).toBeGreaterThanOrEqual(2) // % Profit and % Profit w/ Credits
     expect(screen.getByText(/262[.,]50/)).toBeInTheDocument()
@@ -248,7 +257,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const dashes = screen.getAllByText('—')
     expect(dashes.length).toBeGreaterThanOrEqual(1)
   })
@@ -258,7 +267,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const dashes = screen.getAllByText('—')
     expect(dashes.length).toBeGreaterThanOrEqual(1)
   })
@@ -268,7 +277,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const profitEl = document.querySelector('.portfolio-summary__profit--green')
     expect(profitEl).toBeInTheDocument()
   })
@@ -278,7 +287,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const profitEl = document.querySelector('.portfolio-summary__profit--red')
     expect(profitEl).toBeInTheDocument()
   })
@@ -295,7 +304,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const greenEls = document.querySelectorAll('.portfolio-summary__profit--green')
     expect(greenEls.length).toBeGreaterThanOrEqual(1)
   })
@@ -312,7 +321,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const redEls = document.querySelectorAll('.portfolio-summary__profit--red')
     expect(redEls.length).toBeGreaterThanOrEqual(1)
   })
@@ -322,7 +331,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const greenEls = document.querySelectorAll('.portfolio-summary__profit--green')
     expect(greenEls.length).toBeGreaterThanOrEqual(1)
   })
@@ -332,7 +341,7 @@ describe('PortfolioSummaryTab', () => {
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const redEls = document.querySelectorAll('.portfolio-summary__profit--red')
     expect(redEls.length).toBeGreaterThanOrEqual(1)
   })
@@ -341,14 +350,14 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, firstInvestmentDate: null }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [IDLE_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.queryByText('01/03/2021')).not.toBeInTheDocument()
   })
 
   it('totals_section_is_unaffected_when_table_section_errors', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ error: 'F01 fetch failed' })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText('Total Bought')).toBeInTheDocument()
     expect(screen.getByText('Total Sold')).toBeInTheDocument()
     expect(screen.getByText('Total Credits')).toBeInTheDocument()
@@ -360,7 +369,7 @@ describe('PortfolioSummaryTab', () => {
   it('renders_five_new_column_headers_after_xirr', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText('Last Month Credits')).toBeInTheDocument()
     expect(screen.getByText('Last Credit Month')).toBeInTheDocument()
     expect(screen.getByText('Last Month %')).toBeInTheDocument()
@@ -372,7 +381,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 12.50, lastCreditMonth: '2026-06' }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText(/12[.,]50/)).toBeInTheDocument()
   })
 
@@ -380,7 +389,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 0, lastCreditMonth: null }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const dashes = screen.getAllByText('—')
     expect(dashes.length).toBeGreaterThanOrEqual(1)
   })
@@ -389,7 +398,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 12.50, lastCreditMonth: '2026-06' }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText('Jun 2026')).toBeInTheDocument()
   })
 
@@ -397,7 +406,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastCreditMonth: null }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const dashes = screen.getAllByText('—')
     expect(dashes.length).toBeGreaterThanOrEqual(1)
   })
@@ -406,7 +415,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 12.50, lastCreditMonth: '2026-06', lastMonthCreditsPercent: 1.25 }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText(/1[.,]25%/)).toBeInTheDocument()
   })
 
@@ -414,7 +423,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCreditsPercent: null }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const dashes = screen.getAllByText('—')
     expect(dashes.length).toBeGreaterThanOrEqual(1)
   })
@@ -423,7 +432,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 12.50, lastCreditMonth: '2026-06', estimatedAnnualCredits: 150.00 }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText(/150[.,]00/)).toBeInTheDocument()
   })
 
@@ -431,7 +440,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, estimatedAnnualCredits: null }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const dashes = screen.getAllByText('—')
     expect(dashes.length).toBeGreaterThanOrEqual(1)
   })
@@ -440,7 +449,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, lastMonthCredits: 12.50, lastCreditMonth: '2026-06', estimatedAnnualCredits: 150.00, estimatedAnnualPercent: 6.00 }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByText(/6[.,]00%/)).toBeInTheDocument()
   })
 
@@ -448,7 +457,7 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, estimatedAnnualPercent: null }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const dashes = screen.getAllByText('—')
     expect(dashes.length).toBeGreaterThanOrEqual(1)
   })
@@ -456,7 +465,7 @@ describe('PortfolioSummaryTab', () => {
   it('renders_credits_separator_class_on_last_month_credits_header', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     const header = screen.getByText('Last Month Credits')
     expect(header).toHaveClass('portfolio-summary__credits-separator')
   })
@@ -468,7 +477,7 @@ describe('PortfolioSummaryTab', () => {
     const item2: PortfolioAssetSummaryItemDto = { ...ITEM_1, assetName: 'MXRF11', totalInvested: 2000, totalCredits: 0 }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item1, item2], rowPrices: [LOADING_ROW_PRICE, LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByDisplayValue(/3[,.]000[.,]00/)).toBeInTheDocument()
   })
 
@@ -477,7 +486,7 @@ describe('PortfolioSummaryTab', () => {
     const item2: PortfolioAssetSummaryItemDto = { ...ITEM_1, assetName: 'MXRF11', totalCredits: 75, totalInvested: 2000 }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item1, item2], rowPrices: [LOADING_ROW_PRICE, LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByDisplayValue(/125[.,]00/)).toBeInTheDocument()
   })
 
@@ -487,7 +496,7 @@ describe('PortfolioSummaryTab', () => {
     try {
       setAggregatedMock({ summary: SUMMARY })
       setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
-      render(<PortfolioSummaryTab />)
+      renderComponent()
       expect(screen.getByText('Credits Jul 2026')).toBeInTheDocument()
     } finally {
       vi.useRealTimers()
@@ -499,7 +508,7 @@ describe('PortfolioSummaryTab', () => {
     const item2: PortfolioAssetSummaryItemDto = { ...ITEM_1, assetName: 'MXRF11', currentMonthCredits: 20, totalInvested: 2000 }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item1, item2], rowPrices: [LOADING_ROW_PRICE, LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByDisplayValue(/30[.,]00/)).toBeInTheDocument()
   })
 
@@ -508,7 +517,7 @@ describe('PortfolioSummaryTab', () => {
     const item2: PortfolioAssetSummaryItemDto = { ...ITEM_1, assetName: 'MXRF11', estimatedAnnualCredits: null, totalInvested: 2000 }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item1, item2], rowPrices: [LOADING_ROW_PRICE, LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByDisplayValue(/600[.,]00/)).toBeInTheDocument()
   })
 
@@ -516,14 +525,14 @@ describe('PortfolioSummaryTab', () => {
     const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, estimatedAnnualCredits: null }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByDisplayValue('—')).toBeInTheDocument()
   })
 
   it('renders_footer_current_value_as_calculating_when_all_prices_pending', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByDisplayValue('Calculating…')).toBeInTheDocument()
   })
 
@@ -533,7 +542,7 @@ describe('PortfolioSummaryTab', () => {
     const resolvedPrice: RowPriceState = { isLoading: false, currentPrice: 10, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item1, item2], rowPrices: [resolvedPrice, LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByDisplayValue(/50[.,]00 \*/)).toBeInTheDocument()
     expect(screen.getByText('excludes assets with pending prices')).toBeInTheDocument()
   })
@@ -545,7 +554,7 @@ describe('PortfolioSummaryTab', () => {
     const price2: RowPriceState = { isLoading: false, currentPrice: 5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item1, item2], rowPrices: [price1, price2] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(screen.getByDisplayValue(/100[.,]00/)).toBeInTheDocument()
     expect(screen.queryByText('excludes assets with pending prices')).not.toBeInTheDocument()
   })
@@ -553,7 +562,7 @@ describe('PortfolioSummaryTab', () => {
   it('footer_panel_is_not_inside_table_element', () => {
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
-    render(<PortfolioSummaryTab />)
+    renderComponent()
     expect(document.querySelector('.portfolio-summary__footer')).not.toBeNull()
     expect(document.querySelector('table tfoot')).toBeNull()
   })

--- a/Financial.Web/src/hooks/useBrokerBreakdown.test.ts
+++ b/Financial.Web/src/hooks/useBrokerBreakdown.test.ts
@@ -1,0 +1,158 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { createElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FinancialApiClient } from '../api/financialApiClient'
+import type { PortfolioBreakdownItemDto, SelectedNode } from '../api/types'
+import { SelectedNodeProvider, useSelectedNode } from '../context/SelectedNodeContext'
+import { useBrokerBreakdown } from './useBrokerBreakdown'
+
+const getBrokerBreakdownMock = vi.fn<FinancialApiClient['getBrokerBreakdown']>()
+
+vi.mock('../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getBrokerBreakdown: getBrokerBreakdownMock,
+  }),
+}))
+
+const BROKER_NODE: SelectedNode = {
+  nodeType: 'Broker',
+  brokerName: 'XPI',
+  currency: 'BRL',
+}
+
+const PORTFOLIO_NODE: SelectedNode = {
+  nodeType: 'Portfolio',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+}
+
+const ASSET_NODE: SelectedNode = {
+  nodeType: 'Asset',
+  brokerName: 'XPI',
+  portfolioName: 'Acoes',
+  assetName: 'KLBN4',
+  ticker: 'KLBN4',
+  exchange: 'BVMF',
+}
+
+const BREAKDOWN_DTO: PortfolioBreakdownItemDto[] = [
+  {
+    portfolioName: 'Acoes',
+    totalInvested: 38639.49,
+    assets: [
+      { assetName: 'BBAS3', totalInvested: 9850.4 },
+      { assetName: 'KLBN4', totalInvested: 3737.48 },
+    ],
+  },
+]
+
+function createWrapper() {
+  let setNodeRef: ((node: SelectedNode | null) => void) | undefined
+
+  function NodeControl() {
+    const { setSelectedNode } = useSelectedNode()
+    setNodeRef = setSelectedNode
+    return null
+  }
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(SelectedNodeProvider, null, createElement(NodeControl), children)
+  }
+
+  return {
+    wrapper: Wrapper,
+    setNode: (node: SelectedNode | null) => act(() => { setNodeRef?.(node) }),
+  }
+}
+
+describe('useBrokerBreakdown', () => {
+  beforeEach(() => {
+    getBrokerBreakdownMock.mockReset()
+  })
+
+  it('calls_getBrokerBreakdown_on_broker_node_selection', async () => {
+    getBrokerBreakdownMock.mockResolvedValue(BREAKDOWN_DTO)
+    const { wrapper, setNode } = createWrapper()
+    renderHook(() => useBrokerBreakdown(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => {
+      expect(getBrokerBreakdownMock).toHaveBeenCalledWith('XPI')
+    })
+  })
+
+  it('does_not_fetch_on_portfolio_node_selection', async () => {
+    const { wrapper, setNode } = createWrapper()
+    renderHook(() => useBrokerBreakdown(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await act(async () => {})
+    expect(getBrokerBreakdownMock).not.toHaveBeenCalled()
+  })
+
+  it('does_not_fetch_on_asset_node_selection', async () => {
+    const { wrapper, setNode } = createWrapper()
+    renderHook(() => useBrokerBreakdown(), { wrapper })
+    setNode(ASSET_NODE)
+    await act(async () => {})
+    expect(getBrokerBreakdownMock).not.toHaveBeenCalled()
+  })
+
+  it('sets_isLoading_true_while_fetch_is_in_progress', async () => {
+    getBrokerBreakdownMock.mockReturnValue(new Promise(() => {}))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useBrokerBreakdown(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.isLoading).toBe(true))
+  })
+
+  it('populates_breakdown_on_successful_fetch', async () => {
+    getBrokerBreakdownMock.mockResolvedValue(BREAKDOWN_DTO)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useBrokerBreakdown(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.breakdown).not.toBeNull())
+    expect(result.current.breakdown).toEqual(BREAKDOWN_DTO)
+  })
+
+  it('sets_error_on_fetch_failure', async () => {
+    getBrokerBreakdownMock.mockRejectedValue(new Error('Network error'))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useBrokerBreakdown(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.error).toBe('Network error'))
+    expect(result.current.breakdown).toBeNull()
+  })
+
+  it('retry_re_triggers_fetch', async () => {
+    getBrokerBreakdownMock.mockRejectedValueOnce(new Error('Fail'))
+    getBrokerBreakdownMock.mockResolvedValue(BREAKDOWN_DTO)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useBrokerBreakdown(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.error).toBe('Fail'))
+
+    act(() => result.current.retry())
+    await waitFor(() => expect(result.current.breakdown).not.toBeNull())
+    expect(getBrokerBreakdownMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('resets_state_on_node_change_to_non_broker', async () => {
+    getBrokerBreakdownMock.mockResolvedValue(BREAKDOWN_DTO)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useBrokerBreakdown(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.breakdown).not.toBeNull())
+
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() => expect(result.current.breakdown).toBeNull())
+  })
+
+  it('does_not_fetch_when_no_node_selected', async () => {
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useBrokerBreakdown(), { wrapper })
+    setNode(null)
+    await act(async () => {})
+    expect(getBrokerBreakdownMock).not.toHaveBeenCalled()
+    expect(result.current.breakdown).toBeNull()
+  })
+})

--- a/Financial.Web/src/hooks/useBrokerBreakdown.ts
+++ b/Financial.Web/src/hooks/useBrokerBreakdown.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react'
+import { createFinancialApiClient } from '../api/financialApiClient'
+import type { PortfolioBreakdownItemDto } from '../api/types'
+import { useSelectedNode } from '../context/SelectedNodeContext'
+
+interface BrokerBreakdownState {
+  breakdown: PortfolioBreakdownItemDto[] | null
+  isLoading: boolean
+  error: string | null
+  retryCount: number
+}
+
+type BrokerBreakdownAction =
+  | { type: 'RESET' }
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; payload: PortfolioBreakdownItemDto[] }
+  | { type: 'FETCH_ERROR'; payload: string }
+  | { type: 'RETRY' }
+
+const INITIAL_STATE: BrokerBreakdownState = {
+  breakdown: null,
+  isLoading: false,
+  error: null,
+  retryCount: 0,
+}
+
+function reducer(state: BrokerBreakdownState, action: BrokerBreakdownAction): BrokerBreakdownState {
+  switch (action.type) {
+    case 'RESET':
+      return INITIAL_STATE
+    case 'FETCH_START':
+      return { ...state, isLoading: true, error: null, breakdown: null }
+    case 'FETCH_SUCCESS':
+      return { ...state, isLoading: false, breakdown: action.payload }
+    case 'FETCH_ERROR':
+      return { ...state, isLoading: false, error: action.payload }
+    case 'RETRY':
+      return { ...state, retryCount: state.retryCount + 1 }
+    default:
+      return state
+  }
+}
+
+export interface BrokerBreakdownData {
+  breakdown: PortfolioBreakdownItemDto[] | null
+  isLoading: boolean
+  error: string | null
+  retry: () => void
+}
+
+export function useBrokerBreakdown(): BrokerBreakdownData {
+  const { selectedNode } = useSelectedNode()
+  const apiClient = useMemo(() => createFinancialApiClient(), [])
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  const isBroker = selectedNode?.nodeType === 'Broker'
+
+  useEffect(() => {
+    if (!isBroker || !selectedNode) {
+      dispatch({ type: 'RESET' })
+      return
+    }
+
+    dispatch({ type: 'FETCH_START' })
+
+    void apiClient
+      .getBrokerBreakdown(selectedNode.brokerName)
+      .then((result) => dispatch({ type: 'FETCH_SUCCESS', payload: result }))
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'FETCH_ERROR',
+          payload: err instanceof Error ? err.message : 'Unable to load breakdown',
+        })
+      })
+  }, [selectedNode, isBroker, apiClient, state.retryCount])
+
+  const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
+
+  return {
+    breakdown: state.breakdown,
+    isLoading: state.isLoading,
+    error: state.error,
+    retry,
+  }
+}

--- a/docs/P04-F07-broker-breakdown-pie-charts-web-frontend/plan.md
+++ b/docs/P04-F07-broker-breakdown-pie-charts-web-frontend/plan.md
@@ -1,0 +1,31 @@
+# Implementation Plan: Broker Breakdown Pie Charts — Web Frontend
+
+**Prerequisites:**
+- F02 (Broker Portfolio & Asset Breakdown Service — Application Layer) already merged to `main`; `GET /summary/broker/{brokerName}/breakdown` is already implemented and returns the fully filtered, sorted breakdown
+- `recharts` is already a project dependency (used by `CreditsTab`)
+
+### Stage 1: Type Contract and API Client
+
+**1. Breakdown DTO types** - Add the frontend types mirroring the backend's portfolio/asset breakdown DTOs, matching the shape already returned by the breakdown endpoint.
+
+**2. API client method** - Add a client method for fetching a broker's breakdown, following the existing broker/portfolio summary method pattern.
+
+### Stage 2: Data Hook
+
+**3. useBrokerBreakdown hook** - Add a new hook that fetches the breakdown only when a Broker node is selected, exposing loading, error, retry, and the fetched data, mirroring the existing aggregated-summary hook's reducer shape but without the Portfolio-scope fetch path.
+
+### Stage 3: Component and Integration
+
+**4. BrokerBreakdownCharts component** - Add the new component that renders its own independent loading and error (with retry) states, an empty-state message when there are no eligible portfolios, and otherwise the overview "Portfolio Breakdown" pie chart followed by one pie chart per eligible portfolio. Reference the spec's Technical Decisions for the palette, tooltip, and legend approach.
+
+**5. Percentage computation and tooltip content** - Compute each slice's percentage of its chart's total client-side and render it together with the slice name and formatted value in a custom tooltip, per the spec's Technical Decisions.
+
+**6. Integration into AggregatedSummaryTab** - Render the new component below the existing totals grid, only when the selected node is a Broker, leaving Portfolio and Asset selection behavior unchanged.
+
+### Stage 4: Tests
+
+**7. useBrokerBreakdown test coverage** - Add unit tests covering fetch gating by node type, loading/success/error/retry states, and reset behavior on node change. Reference the spec's Testing Strategy for the full list of test functions.
+
+**8. BrokerBreakdownCharts test coverage** - Add unit tests covering the overview and per-portfolio pies, percentage computation, the empty state, the error/retry state, and the independent loading state, mocking `recharts` per the project's existing pattern.
+
+**9. AggregatedSummaryTab integration test** - Extend the existing test file to confirm the new component renders only for Broker node selection and not for Portfolio selection.

--- a/docs/P04-F07-broker-breakdown-pie-charts-web-frontend/spec.md
+++ b/docs/P04-F07-broker-breakdown-pie-charts-web-frontend/spec.md
@@ -1,0 +1,138 @@
+# F07. Broker Breakdown Pie Charts — Web Frontend
+
+## 1. Technical Overview
+
+**What:** Add a new `BrokerBreakdownCharts` component, rendered below the four totals in `AggregatedSummaryTab`, shown only for Broker node selection. It independently fetches `GET /summary/broker/{brokerName}/breakdown` (already implemented by F02, merged to `main`) and renders one `recharts` pie chart titled "Portfolio Breakdown" (one slice per eligible portfolio) plus one additional pie chart per eligible portfolio (one slice per eligible asset in that portfolio).
+
+**Why:** F02 already computes and returns the Encerradas-and-inactive-asset-excluded breakdown data (`IReadOnlyList<PortfolioBreakdownItemDTO>`) via `GET /summary/broker/{brokerName}/breakdown`, but nothing in the frontend consumes it yet. This feature is the display layer that turns that already-available data into the visual capital-allocation breakdown described in the PRD.
+
+**Scope:**
+- Included: new `BrokerBreakdownCharts` component and its own independent loading/error/empty states; new `useBrokerBreakdown` hook; new `getBrokerBreakdown` API client method and `PortfolioBreakdownItemDto`/`AssetBreakdownItemDto` types; hover tooltips (name, N2 value, 1-decimal percentage); a categorical colour palette; per-chart legend; unit test coverage.
+- Excluded: any backend change (F02 already complete); the WPF equivalent (F08, separate feature); the Transactions monthly chart (F09) — out of scope for this feature.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/api/types.ts` — new `PortfolioBreakdownItemDto`/`AssetBreakdownItemDto` types
+- `Financial.Web/src/api/financialApiClient.ts` — new `getBrokerBreakdown` method
+- `Financial.Web/src/hooks/useBrokerBreakdown.ts` — new hook, mirrors `useAggregatedSummary`'s reducer/fetch pattern but only fetches for Broker selection
+- `Financial.Web/src/components/BrokerBreakdownCharts.tsx` — new component
+- `Financial.Web/src/components/BrokerBreakdownCharts.css` — new stylesheet
+- `Financial.Web/src/components/AggregatedSummaryTab.tsx` — conditionally renders `BrokerBreakdownCharts` for Broker selection
+- `Financial.Web/src/hooks/useBrokerBreakdown.test.ts` — new
+- `Financial.Web/src/components/__tests__/BrokerBreakdownCharts.test.tsx` — new
+- `Financial.Web/src/components/__tests__/AggregatedSummaryTab.test.tsx` — extended
+
+```mermaid
+graph TD
+    A[User selects Broker node] --> B[AggregatedSummaryTab]
+    B --> C[Totals grid — existing, unchanged]
+    B --> D[BrokerBreakdownCharts]
+    D --> E[useBrokerBreakdown hook]
+    E --> F["GET /summary/broker/{brokerName}/breakdown"]
+    F --> G["PortfolioBreakdownItemDto[] (F02, already on main)"]
+    G --> D
+    D --> H["Portfolio Breakdown pie (1 slice per portfolio)"]
+    D --> I["Per-portfolio pie x N (1 slice per asset)"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|------------------|-------------------------|-----------|
+| Categorical palette | Adopt the 8-hue validated reference palette from the project's dataviz methodology (`#2a78d6` blue, `#1baf7a` aqua, `#eda100` yellow, `#008300` green, `#4a3aa7` violet, `#e34948` red, `#e87ba4` magenta, `#eb6834` orange), assigned by slice index and cycling (`palette[i % palette.length]`) per the PRD's "repeating if the slice count exceeds the palette size" | Hand-pick colours matching the app's existing green/red/blue financial semantics | The existing green/red/blue are reserved for signed financial meaning (bought/sold/credits) — reusing them as arbitrary categorical identity would create false meaning. The reference palette is pre-validated for CVD-safe adjacency (worst adjacent ΔE 24.2, well clear of the ≥12 target), so no ad-hoc colour picking is needed. **Known trade-off:** the PRD's explicit "repeat when slices exceed the palette" (some portfolios have 9+ assets, confirmed live in F06) means colour identity alone is not reliable past 8 slices — the legend (below) and hover tooltip are the required relief channels, not an optional nicety |
+| Legend | Every pie chart renders its own legend (portfolio/asset name + colour swatch), confirmed with the user | Tooltip-only, no legend | The reference palette's own guidance requires a legend for ≥2 categorical series so identity isn't hover-only; given some portfolios have many assets, a legend is the accessible default over relying solely on hover |
+| Tooltip content | Custom `content` render function passed to recharts' `Tooltip` (not the stock `formatter` prop used by `CreditsTab`), computing `percentage = slice.totalInvested / sum(siblings' totalInvested) × 100` per slice and rendering name + N2 value + 1-decimal percentage together | Stock `Tooltip formatter` prop (as used in `CreditsTab`) | `formatter` only reformats a single value; the PRD requires three related figures (name, value, percentage) shown together per slice, which needs a custom content renderer, not a single-value formatter |
+| Colour assignment stability | Index-based (`palette[i % palette.length]`) per chart, independently for each pie — no shared name→colour map across charts | Deterministic colour per portfolio/asset name (e.g. hash-based), stable across all charts on the page | The PRD explicitly states "the same palette instance is not required to assign identical colours to the same portfolio/asset across separate pies," so the simpler index-based approach is sufficient and avoids an unnecessary hashing/mapping layer |
+| Percentage computation location | Computed client-side per chart from the already-fetched `totalInvested` values (matches F02's own design: "Percentage calculation... is left to the frontend, consistent with how `PortfolioWeight` is computed client-side elsewhere") | Have the backend return a pre-computed percentage field | Explicitly directed by F02's spec; no endpoint change needed |
+| Palette location | Defined as a local `const` array directly in `BrokerBreakdownCharts.tsx`, mirroring `CreditsTab.tsx`'s existing `DIVIDEND_COLOR`/`RENT_COLOR` local-constant convention | A shared `utils/categoricalPalette.ts` module | Only one component uses it today; extracting a shared module before a second consumer exists is premature abstraction |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|---------------|---------|------------------------|
+| `Financial.Web/src/api/types.ts` | Modified | Type contracts | Add `AssetBreakdownItemDto { assetName: string; totalInvested: number }` and `PortfolioBreakdownItemDto { portfolioName: string; totalInvested: number; assets: AssetBreakdownItemDto[] }`, mirroring `AssetBreakdownItemDTO`/`PortfolioBreakdownItemDTO` field-for-field |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | API client | Add `getBrokerBreakdown: (brokerName: string) => Promise<PortfolioBreakdownItemDto[]>` to the interface and its `request<PortfolioBreakdownItemDto[]>(\`/summary/broker/${encodeURIComponent(brokerName)}/breakdown\`)` implementation, mirroring `getSummaryByBroker`'s pattern |
+| `Financial.Web/src/hooks/useBrokerBreakdown.ts` | New | Data fetching | Reducer with `RESET \| FETCH_START \| FETCH_SUCCESS \| FETCH_ERROR \| RETRY` actions, mirroring `useAggregatedSummary`'s shape; fetches only when `selectedNode?.nodeType === 'Broker'` (unlike `useAggregatedSummary`, does NOT fetch for Portfolio); resets to empty state for any other node type; exposes `{ breakdown: PortfolioBreakdownItemDto[] | null; isLoading; error; retry }` |
+| `Financial.Web/src/components/BrokerBreakdownCharts.tsx` | New | Rendering | Renders `LoadingState`/`ErrorState` (with retry) from `useBrokerBreakdown()`; when `breakdown` is an empty array, renders the text empty-state "No active portfolios to display"; otherwise renders the "Portfolio Breakdown" `PieChart` (one slice per portfolio, sized by `totalInvested`) followed by one `PieChart` per portfolio (titled with the portfolio's name, one slice per asset), in the array's existing order (already alphabetical per F02); each pie has its own custom tooltip content and legend; defines the local categorical palette constant |
+| `Financial.Web/src/components/BrokerBreakdownCharts.css` | New | Layout | Stacks the overview pie and per-portfolio pies vertically with spacing; each pie section gets a title (portfolio name, or "Portfolio Breakdown" for the overview) above the chart |
+| `Financial.Web/src/components/AggregatedSummaryTab.tsx` | Modified | Integration | Add `const { selectedNode } = useSelectedNode()` and render `{selectedNode?.nodeType === 'Broker' && <BrokerBreakdownCharts />}` after the existing totals grid, inside the same outer `<div className="aggregated-summary">` |
+
+**Backend:** None — `GET /summary/broker/{brokerName}/breakdown` is already implemented and returns the fully Encerradas-and-inactive-excluded, alphabetically-sorted breakdown (F02, merged to `main`). No API contract, service, or data model changes required.
+
+## 5. API Contracts
+
+Not applicable — no new or modified endpoint. `GET /summary/broker/{brokerName}/breakdown` (implemented by F02) already returns the shape this feature consumes:
+
+**Response Example (200 OK):**
+```json
+[
+  {
+    "portfolioName": "Acoes",
+    "totalInvested": 38639.49,
+    "assets": [
+      { "assetName": "BBAS3", "totalInvested": 9850.40 },
+      { "assetName": "KLBN4", "totalInvested": 3737.48 },
+      { "assetName": "TAEE3", "totalInvested": 21914.97 },
+      { "assetName": "TASA4", "totalInvested": 3136.64 }
+    ]
+  }
+]
+```
+
+Empty response (`[]`, HTTP 200) is a valid, expected shape (broker with zero eligible portfolios) — not an error.
+
+## 6. Data Model
+
+Not applicable — no database changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|-----------------|
+| `Financial.Web/src/hooks/useBrokerBreakdown.test.ts` | Unit | `useBrokerBreakdown` | Fetches only for Broker node selection, loading/success/error/retry states, resets on node change to non-Broker |
+| `Financial.Web/src/components/__tests__/BrokerBreakdownCharts.test.tsx` | Unit | `BrokerBreakdownCharts` | Renders overview + per-portfolio pies, empty state, error+retry state, loading state, correct slice/percentage data passed to recharts (mocked) |
+| `Financial.Web/src/components/__tests__/AggregatedSummaryTab.test.tsx` (extended) | Unit | `AggregatedSummaryTab` | Renders `BrokerBreakdownCharts` only for Broker node selection, not for Portfolio |
+
+**Test Functions:**
+
+| Test Function | Description | Assertions |
+|----------------|--------------|-------------|
+| `calls_getBrokerBreakdown_on_broker_node_selection` | Broker node selected | `getBrokerBreakdown` called with the broker name |
+| `does_not_fetch_on_portfolio_node_selection` | Portfolio node selected | `getBrokerBreakdown` never called |
+| `does_not_fetch_on_asset_node_selection` | Asset node selected | `getBrokerBreakdown` never called |
+| `sets_isLoading_true_while_fetch_is_in_progress` | Fetch pending | `isLoading` is `true` |
+| `populates_breakdown_on_successful_fetch` | Fetch resolves | `breakdown` matches the resolved array |
+| `sets_error_on_fetch_failure` | Fetch rejects | `error` is set, `breakdown` stays `null` |
+| `retry_re_triggers_fetch` | `retry()` called after failure | `getBrokerBreakdown` called again, success clears the error |
+| `resets_state_on_node_change_to_non_broker` | Node changes from Broker to Portfolio/Asset/null | `breakdown` resets to `null` |
+| `renders_portfolio_breakdown_pie_with_one_slice_per_portfolio` | 2+ portfolios in response | Pie chart (mocked) receives one data entry per portfolio |
+| `renders_one_additional_pie_per_portfolio` | 2 portfolios, each with assets | 2 additional per-portfolio pie charts render, titled with each portfolio's name |
+| `computes_correct_percentage_per_slice` | Known `totalInvested` values | Tooltip content receives `percentage` computed as `slice / sum(siblings) × 100`, matching PRD's formula |
+| `renders_empty_state_when_breakdown_is_empty_array` | `breakdown: []` | Text "No active portfolios to display" renders; no chart elements render |
+| `renders_error_state_with_retry_on_failure` | `error` set | `ErrorState` renders with retry button; totals section (parent) is unaffected (verified in the `AggregatedSummaryTab` test) |
+| `renders_loading_state_independently_of_totals` | `isLoading: true` on the breakdown hook while totals hook is idle | Loading indicator shows only in the breakdown section |
+
+**Acceptance tests (PRD Section 9, F07):**
+- Selecting a Broker node renders a "Portfolio Breakdown" pie chart below the 4 totals, one slice per eligible portfolio → `renders_portfolio_breakdown_pie_with_one_slice_per_portfolio`
+- One additional pie chart renders per eligible portfolio → `renders_one_additional_pie_per_portfolio`
+- Hovering a slice shows its name, Total Invested value, and percentage → `computes_correct_percentage_per_slice` (percentage logic; tooltip rendering itself is recharts-internal, verified by passing the correct computed data into the mocked `Tooltip`/`content` prop)
+- The Encerradas portfolio and any asset with `totalInvested <= 0` never appear as a slice → not re-tested here; already covered by F02's own test suite (this feature renders F02's response verbatim, per the Technical Decisions table — no client-side filtering is applied or needed)
+- Selecting a Portfolio or Asset node does not render this component (regression check) → covered by the extended `AggregatedSummaryTab.test.tsx`
+- Zero eligible portfolios renders an empty-state message → `renders_empty_state_when_breakdown_is_empty_array`
+- A failed breakdown fetch shows an `ErrorState` with Retry; the 4 totals above remain visible and functional → `renders_error_state_with_retry_on_failure` (breakdown fetch failure is isolated to `useBrokerBreakdown`, entirely independent of `useAggregatedSummary`)
+
+**Cross-feature integration tests (PRD Section 9):**
+- Portfolio and asset `totalInvested` values from F02's breakdown endpoint are used without transformation to size and label slices → `renders_portfolio_breakdown_pie_with_one_slice_per_portfolio` + `renders_one_additional_pie_per_portfolio`
+- The Encerradas exclusion and non-positive-slice omission rules defined in F02 are reflected exactly in what F07 renders (no additional or missing slices) → satisfied by construction: F07 renders the F02 response array directly with no client-side filtering
+
+## Assumptions and Decisions (from interview)
+
+- **Legend per chart**: every pie (overview and per-portfolio) renders its own legend, confirmed with the user over a tooltip-only alternative, given some portfolios have many assets (9+ observed live) and the palette repeats past 8 slices.
+- **Categorical palette**: the 8-hue validated reference palette (see Technical Decisions) is adopted directly since the app has no existing categorical palette and its existing green/red/blue colours are reserved for signed financial totals, not generic category identity.
+- **Custom tooltip content** (not the stock `formatter` prop `CreditsTab` uses) is required because the PRD's tooltip must show three related figures (name, N2 value, 1-decimal percentage) together, not a single reformatted value.
+- **No client-side re-filtering or re-sorting**: F07 trusts F02's response as-is (already Encerradas-excluded, non-positive-slice-omitted, alphabetically sorted) — this is a decision, not just an assumption, since it keeps the exclusion/sorting rules defined in exactly one place (F02).


### PR DESCRIPTION
## Summary
- Adds `BrokerBreakdownCharts`, rendered below the 4 totals in `AggregatedSummaryTab` only for Broker node selection: one "Portfolio Breakdown" pie (one slice per eligible portfolio) plus one additional pie per portfolio (one slice per eligible asset).
- Consumes F02's already-implemented `GET /summary/broker/{brokerName}/breakdown` (no backend changes).
- Uses a validated 8-hue categorical palette (from the project's dataviz methodology), a custom tooltip (name / N2 value / 1-decimal percentage), and a legend per chart.
- Loading/error(+retry)/empty states are independent of the totals section above.

## Bug found and fixed during live smoke testing
Mocked unit tests all passed, but manually driving the real app against real data (Step 6.4 of the implementation workflow) surfaced a real bug: recharts' `Pie` component computes `percent` for its internal sector geometry but **does not** forward it on the `Tooltip` payload entry — every tooltip showed **0.0%** regardless of actual share. Fixed by pre-computing `percent = value / sum(siblings)` into each chart's own data array (matching the spec's original Technical Decision) and reading it back from the payload's nested `.payload.percent`, where recharts does forward the original data object. Verified live afterward — tooltips now show correct percentages (e.g. 14.9%).

## Test plan
- [x] `tsc -b --noEmit` — no errors
- [x] `npm run lint` — no errors
- [x] `npm test` — 322/322 passing (26 files), including 29 tests directly mapped to this feature's acceptance criteria
- [x] `npm run build` — production build succeeds
- [x] `dotnet build` / `dotnet test` — untouched, still green (415/418, 3 pre-existing skips) as a full-repo sanity check
- [x] Manual smoke test (Playwright against local dev server + real API + real data): selecting Broker "XPI" renders 4 pie charts (overview + Acoes/FII/Fundos Investimento), correctly excludes the Encerradas portfolio, correctly cycles the 8-hue palette on FII's 9-asset chart, and shows accurate hover tooltips — no console errors

## Deviations
- `PortfolioSummaryTab.test.tsx` needed updating (not listed in spec's Component Overview) — `AggregatedSummaryTab` now calls `useSelectedNode()` directly, which `PortfolioSummaryTab`'s tests exercise transitively by rendering `AggregatedSummaryTab` internally, so both test files needed a `SelectedNodeProvider` wrapper they didn't need before.
- The hook's test file (`useBrokerBreakdown.test.ts`) was written alongside its implementation in the same commit rather than deferred to the later "tests" phase, since there was no reason to leave new production code temporarily untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)