### PR TITLE
feat(P04-F08): Broker Breakdown Pie Charts — WPF

### DIFF
--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -323,52 +323,102 @@
                             </ScrollViewer>
                         </DataTemplate>
                         <DataTemplate x:Key="BrokerSummaryTemplate">
-                            <Grid Margin="10">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
+                            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                <Grid Margin="10">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
 
-                                <!-- Row 0: Total Bought & Total Sold -->
-                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Total Bought:" FontWeight="Bold" Margin="0,5"/>
-                                <TextBlock Grid.Row="0" Grid.Column="1"
-                                           Text="{Binding AssetDetails.TotalBought, Mode=OneWay, StringFormat=N2}"
-                                           TextAlignment="Right"
-                                           FontFamily="Consolas"
-                                           Margin="10,5"
-                                           Foreground="Green"/>
+                                    <!-- Row 0: Total Bought & Total Sold -->
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Total Bought:" FontWeight="Bold" Margin="0,5"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="1"
+                                               Text="{Binding AssetDetails.TotalBought, Mode=OneWay, StringFormat=N2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Margin="10,5"
+                                               Foreground="Green"/>
 
-                                <TextBlock Grid.Row="0" Grid.Column="2" Text="Total Sold:" FontWeight="Bold" Margin="20,5,0,5"/>
-                                <TextBlock Grid.Row="0" Grid.Column="3"
-                                           Text="{Binding AssetDetails.TotalSold, Mode=OneWay, StringFormat=N2}"
-                                           TextAlignment="Right"
-                                           FontFamily="Consolas"
-                                           Margin="10,5"
-                                           Foreground="Red"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="2" Text="Total Sold:" FontWeight="Bold" Margin="20,5,0,5"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="3"
+                                               Text="{Binding AssetDetails.TotalSold, Mode=OneWay, StringFormat=N2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Margin="10,5"
+                                               Foreground="Red"/>
 
-                                <!-- Row 1: Total Credits & Total Invested -->
-                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Total Credits:" FontWeight="Bold" Margin="0,5"/>
-                                <TextBlock Grid.Row="1" Grid.Column="1"
-                                           Text="{Binding AssetDetails.TotalCredits, Mode=OneWay, StringFormat=N2}"
-                                           TextAlignment="Right"
-                                           FontFamily="Consolas"
-                                           Margin="10,5"
-                                           Foreground="Blue"/>
+                                    <!-- Row 1: Total Credits & Total Invested -->
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Total Credits:" FontWeight="Bold" Margin="0,5"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="1"
+                                               Text="{Binding AssetDetails.TotalCredits, Mode=OneWay, StringFormat=N2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Margin="10,5"
+                                               Foreground="Blue"/>
 
-                                <TextBlock Grid.Row="1" Grid.Column="2" Text="Total Invested:" FontWeight="Bold" Margin="20,5,0,5"/>
-                                <TextBlock Grid.Row="1" Grid.Column="3"
-                                           Text="{Binding AssetDetails.TotalInvested, Mode=OneWay, StringFormat=N2}"
-                                           TextAlignment="Right"
-                                           FontFamily="Consolas"
-                                           Foreground="{Binding AssetDetails.TotalInvested, Converter={StaticResource SignedValueToBrushConverter}}"
-                                           Margin="10,5"/>
-                            </Grid>
+                                    <TextBlock Grid.Row="1" Grid.Column="2" Text="Total Invested:" FontWeight="Bold" Margin="20,5,0,5"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="3"
+                                               Text="{Binding AssetDetails.TotalInvested, Mode=OneWay, StringFormat=N2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Foreground="{Binding AssetDetails.TotalInvested, Converter={StaticResource SignedValueToBrushConverter}}"
+                                               Margin="10,5"/>
+
+                                    <!-- Row 2: Breakdown loading indicator -->
+                                    <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="4"
+                                               Text="Loading breakdown..."
+                                               Margin="0,15,0,5"
+                                               Visibility="{Binding AssetDetails.IsBreakdownLoading, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+                                    <!-- Row 3: Breakdown inline error -->
+                                    <TextBlock Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="4"
+                                               Text="{Binding AssetDetails.BreakdownError}"
+                                               Foreground="DarkRed"
+                                               Margin="0,15,0,5"
+                                               Visibility="{Binding AssetDetails.HasBreakdownError, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+                                    <!-- Row 4: Breakdown empty state -->
+                                    <TextBlock Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="4"
+                                               Text="No active portfolios to display"
+                                               Foreground="Gray"
+                                               Margin="0,15,0,5"
+                                               Visibility="{Binding AssetDetails.ShowBreakdownEmptyState, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+                                    <!-- Row 5: Overall portfolio breakdown pie -->
+                                    <StackPanel Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="4"
+                                                Margin="0,15,0,0"
+                                                Visibility="{Binding AssetDetails.HasBreakdownData, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        <TextBlock Text="Portfolio Breakdown" FontWeight="Bold" Margin="0,0,0,5"/>
+                                        <oxy:PlotView Model="{Binding AssetDetails.OverallBreakdownPlotModel}" Height="260" Background="Transparent"/>
+                                    </StackPanel>
+
+                                    <!-- Row 6: Per-portfolio asset breakdown pies -->
+                                    <ItemsControl Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="4"
+                                                  Margin="0,15,0,0"
+                                                  ItemsSource="{Binding AssetDetails.PortfolioBreakdownPieItems}"
+                                                  Visibility="{Binding AssetDetails.HasBreakdownData, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <StackPanel Margin="0,0,0,15">
+                                                    <TextBlock Text="{Binding PortfolioName}" FontWeight="Bold" Margin="0,0,0,5"/>
+                                                    <oxy:PlotView Model="{Binding PlotModel}" Height="260" Background="Transparent"/>
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </Grid>
+                            </ScrollViewer>
                         </DataTemplate>
                         <DataTemplate x:Key="PortfolioSummaryTemplate">
                             <Grid Margin="10">

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -406,14 +406,14 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         TotalInvested = summary.TotalInvested;
     }
 
-    public void LoadBrokerBreakdown(string brokerName)
+    public Task LoadBrokerBreakdown(string brokerName)
     {
         CancelAndResetBreakdownFetch();
         IsBreakdownLoading = true;
 
         _breakdownCts = new CancellationTokenSource();
         var token = _breakdownCts.Token;
-        Task.Run(() =>
+        return Task.Run(() =>
         {
             try
             {

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -184,14 +184,33 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public bool IsBreakdownLoading
     {
         get => _isBreakdownLoading;
-        private set => SetProperty(ref _isBreakdownLoading, value);
+        private set
+        {
+            if (SetProperty(ref _isBreakdownLoading, value))
+            {
+                OnPropertyChanged(nameof(ShowBreakdownEmptyState));
+                OnPropertyChanged(nameof(HasBreakdownData));
+            }
+        }
     }
 
     public string? BreakdownError
     {
         get => _breakdownError;
-        private set => SetProperty(ref _breakdownError, value);
+        private set
+        {
+            if (SetProperty(ref _breakdownError, value))
+            {
+                OnPropertyChanged(nameof(HasBreakdownError));
+                OnPropertyChanged(nameof(ShowBreakdownEmptyState));
+                OnPropertyChanged(nameof(HasBreakdownData));
+            }
+        }
     }
+
+    public bool HasBreakdownError => BreakdownError != null;
+    public bool ShowBreakdownEmptyState => !IsBreakdownLoading && BreakdownError == null && PortfolioBreakdownPieItems.Count == 0;
+    public bool HasBreakdownData => !IsBreakdownLoading && BreakdownError == null && PortfolioBreakdownPieItems.Count > 0;
 
     public ObservableCollection<PortfolioBreakdownPieItem> PortfolioBreakdownPieItems { get; } = new();
 
@@ -553,6 +572,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         BreakdownError = null;
         OverallBreakdownPlotModel = null;
         PortfolioBreakdownPieItems.Clear();
+        OnPropertyChanged(nameof(ShowBreakdownEmptyState));
+        OnPropertyChanged(nameof(HasBreakdownData));
     }
 
     private void SubscribeToRowPriceChanges(PortfolioAssetSummaryRowViewModel row)

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -549,18 +549,39 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
 
     private void ApplyBrokerBreakdown(IReadOnlyList<PortfolioBreakdownItemDTO> breakdown)
     {
-        OverallBreakdownPlotModel = BrokerBreakdownChartBuilder.Build(
+        var overallModel = BrokerBreakdownChartBuilder.Build(
             breakdown.Select(p => (p.PortfolioName, p.TotalInvested)).ToList());
 
-        PortfolioBreakdownPieItems.Clear();
-        foreach (var portfolio in breakdown)
-        {
-            var plotModel = BrokerBreakdownChartBuilder.Build(
-                portfolio.Assets.Select(a => (a.AssetName, a.TotalInvested)).ToList());
-            PortfolioBreakdownPieItems.Add(new PortfolioBreakdownPieItem(portfolio.PortfolioName, plotModel));
-        }
+        var items = breakdown
+            .Select(portfolio =>
+            {
+                var plotModel = BrokerBreakdownChartBuilder.Build(
+                    portfolio.Assets.Select(a => (a.AssetName, a.TotalInvested)).ToList());
+                return new PortfolioBreakdownPieItem(portfolio.PortfolioName, plotModel);
+            })
+            .ToList();
 
+        // ObservableCollection structural changes (unlike plain property changes) must
+        // happen on the thread that owns the bound CollectionView, or WPF throws
+        // NotSupportedException — this method runs on a background thread (Task.Run).
+        RunOnUIThread(() =>
+        {
+            PortfolioBreakdownPieItems.Clear();
+            foreach (var item in items)
+                PortfolioBreakdownPieItems.Add(item);
+        });
+
+        OverallBreakdownPlotModel = overallModel;
         IsBreakdownLoading = false;
+    }
+
+    private static void RunOnUIThread(Action action)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess())
+            action();
+        else
+            dispatcher.Invoke(action);
     }
 
     private void CancelAndResetBreakdownFetch()

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -15,6 +15,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private readonly ITransactionService _transactionService;
     private readonly ICreditService _creditService;
     private readonly IAssetPriceService _assetPriceService;
+    private readonly IBrokerBreakdownQueryService _brokerBreakdownQueryService;
     private readonly TodayInfoTracker _todayInfo;
     private readonly TransactionActions _transactionActions;
     private readonly CreditActions _creditActions;
@@ -58,6 +59,10 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private bool _isPortfolioView;
     private bool _isBrokerView;
     private decimal _totalInvested;
+    private PlotModel? _overallBreakdownPlotModel;
+    private bool _isBreakdownLoading;
+    private string? _breakdownError;
+    private CancellationTokenSource? _breakdownCts;
     private CancellationTokenSource? _rowPriceCts;
     private decimal _footerTotalInvested;
     private decimal _footerTotalCredits;
@@ -170,6 +175,26 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         private set => SetProperty(ref _totalInvested, value);
     }
 
+    public PlotModel? OverallBreakdownPlotModel
+    {
+        get => _overallBreakdownPlotModel;
+        private set => SetProperty(ref _overallBreakdownPlotModel, value);
+    }
+
+    public bool IsBreakdownLoading
+    {
+        get => _isBreakdownLoading;
+        private set => SetProperty(ref _isBreakdownLoading, value);
+    }
+
+    public string? BreakdownError
+    {
+        get => _breakdownError;
+        private set => SetProperty(ref _breakdownError, value);
+    }
+
+    public ObservableCollection<PortfolioBreakdownPieItem> PortfolioBreakdownPieItems { get; } = new();
+
     public ObservableCollection<PortfolioAssetSummaryRowViewModel> PortfolioAssetSummaryRows { get; } = new();
 
     public decimal FooterTotalInvested { get => _footerTotalInvested; private set => SetProperty(ref _footerTotalInvested, value); }
@@ -220,11 +245,13 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public AssetDetailsViewModel(
         ITransactionService transactionService,
         ICreditService creditService,
-        IAssetPriceService assetPriceService)
+        IAssetPriceService assetPriceService,
+        IBrokerBreakdownQueryService brokerBreakdownQueryService)
     {
         _transactionService = transactionService ?? throw new ArgumentNullException(nameof(transactionService));
         _creditService = creditService ?? throw new ArgumentNullException(nameof(creditService));
         _assetPriceService = assetPriceService ?? throw new ArgumentNullException(nameof(assetPriceService));
+        _brokerBreakdownQueryService = brokerBreakdownQueryService ?? throw new ArgumentNullException(nameof(brokerBreakdownQueryService));
         _todayInfo = new TodayInfoTracker(ApplyTodayInfo, ResetTodayInfo, UpdateCommandStates);
         _transactionActions = new TransactionActions(
             _transactionService,
@@ -290,6 +317,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     {
         IsPortfolioView = false;
         IsBrokerView = false;
+        CancelAndResetBreakdownFetch();
         var assetKey = BuildAssetKey(details.BrokerName, details.PortfolioName, details.Name);
         _todayInfo.UpdateAssetKey(assetKey);
 
@@ -339,6 +367,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         IsPortfolioView = false;
         IsBrokerView = false;
         TotalInvested = 0m;
+        CancelAndResetBreakdownFetch();
         ClearAssetContext();
         Credits.Clear();
         CreditsByMonthChart.Clear();
@@ -356,6 +385,30 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         LoadAggregateCredits(BuildBrokerKey(brokerName), summary, credits);
         IsBrokerView = true;
         TotalInvested = summary.TotalInvested;
+    }
+
+    public void LoadBrokerBreakdown(string brokerName)
+    {
+        CancelAndResetBreakdownFetch();
+        IsBreakdownLoading = true;
+
+        _breakdownCts = new CancellationTokenSource();
+        var token = _breakdownCts.Token;
+        Task.Run(() =>
+        {
+            try
+            {
+                var breakdown = _brokerBreakdownQueryService.GetBrokerBreakdown(brokerName);
+                if (token.IsCancellationRequested) return;
+                ApplyBrokerBreakdown(breakdown);
+            }
+            catch
+            {
+                if (token.IsCancellationRequested) return;
+                BreakdownError = "Unable to load breakdown";
+                IsBreakdownLoading = false;
+            }
+        }, token);
     }
 
     public void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
@@ -425,6 +478,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     {
         IsPortfolioView = false;
         IsBrokerView = false;
+        CancelAndResetBreakdownFetch();
         ClearAssetContext();
         TotalBought = summary.TotalBought;
         TotalSold = summary.TotalSold;
@@ -472,6 +526,33 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         _rowPriceCts?.Cancel();
         _rowPriceCts?.Dispose();
         _rowPriceCts = null;
+    }
+
+    private void ApplyBrokerBreakdown(IReadOnlyList<PortfolioBreakdownItemDTO> breakdown)
+    {
+        OverallBreakdownPlotModel = BrokerBreakdownChartBuilder.Build(
+            breakdown.Select(p => (p.PortfolioName, p.TotalInvested)).ToList());
+
+        PortfolioBreakdownPieItems.Clear();
+        foreach (var portfolio in breakdown)
+        {
+            var plotModel = BrokerBreakdownChartBuilder.Build(
+                portfolio.Assets.Select(a => (a.AssetName, a.TotalInvested)).ToList());
+            PortfolioBreakdownPieItems.Add(new PortfolioBreakdownPieItem(portfolio.PortfolioName, plotModel));
+        }
+
+        IsBreakdownLoading = false;
+    }
+
+    private void CancelAndResetBreakdownFetch()
+    {
+        _breakdownCts?.Cancel();
+        _breakdownCts?.Dispose();
+        _breakdownCts = null;
+        IsBreakdownLoading = false;
+        BreakdownError = null;
+        OverallBreakdownPlotModel = null;
+        PortfolioBreakdownPieItems.Clear();
     }
 
     private void SubscribeToRowPriceChanges(PortfolioAssetSummaryRowViewModel row)

--- a/Financial.App/ViewModels/BrokerBreakdownChartBuilder.cs
+++ b/Financial.App/ViewModels/BrokerBreakdownChartBuilder.cs
@@ -1,0 +1,46 @@
+using OxyPlot;
+using OxyPlot.Series;
+
+namespace Financial.Presentation.App.ViewModels;
+
+internal static class BrokerBreakdownChartBuilder
+{
+    // Same validated categorical palette used by the web equivalent (F07),
+    // for cross-platform visual consistency.
+    private static readonly OxyColor[] Palette =
+    [
+        OxyColor.Parse("#2a78d6"), // blue
+        OxyColor.Parse("#1baf7a"), // aqua
+        OxyColor.Parse("#eda100"), // yellow
+        OxyColor.Parse("#008300"), // green
+        OxyColor.Parse("#4a3aa7"), // violet
+        OxyColor.Parse("#e34948"), // red
+        OxyColor.Parse("#e87ba4"), // magenta
+        OxyColor.Parse("#eb6834"), // orange
+    ];
+
+    public static PlotModel Build(IReadOnlyList<(string Name, decimal Value)> slices)
+    {
+        var model = new PlotModel();
+
+        if (slices.Count == 0)
+            return model;
+
+        var series = new PieSeries
+        {
+            StrokeThickness = 1.0,
+            AngleSpan = 360,
+            StartAngle = 0,
+            TrackerFormatString = "{1}\n{2:N2}\n{3:P1}",
+        };
+
+        for (var i = 0; i < slices.Count; i++)
+        {
+            var (name, value) = slices[i];
+            series.Slices.Add(new PieSlice(name, (double)value) { Fill = Palette[i % Palette.Length] });
+        }
+
+        model.Series.Add(series);
+        return model;
+    }
+}

--- a/Financial.App/ViewModels/IAssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/IAssetDetailsViewModel.cs
@@ -8,7 +8,7 @@ public interface IAssetDetailsViewModel
     bool IsBrokerView { get; }
     void LoadAssetDetails(AssetDetailsDTO details);
     void LoadBrokerSummary(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
-    void LoadBrokerBreakdown(string brokerName);
+    Task LoadBrokerBreakdown(string brokerName);
     void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
     void LoadPortfolioSummary(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits, IReadOnlyList<PortfolioAssetSummaryItemDTO> assetItems);
     void Clear();

--- a/Financial.App/ViewModels/IAssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/IAssetDetailsViewModel.cs
@@ -8,6 +8,7 @@ public interface IAssetDetailsViewModel
     bool IsBrokerView { get; }
     void LoadAssetDetails(AssetDetailsDTO details);
     void LoadBrokerSummary(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
+    void LoadBrokerBreakdown(string brokerName);
     void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
     void LoadPortfolioSummary(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits, IReadOnlyList<PortfolioAssetSummaryItemDTO> assetItems);
     void Clear();

--- a/Financial.App/ViewModels/MainNavigationViewModel.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModel.cs
@@ -14,7 +14,8 @@ public class MainNavigationViewModel : MainNavigationViewModelBase<AssetDetailsV
         IPortfolioAssetSummaryQueryService portfolioAssetSummaryQueryService,
         ITransactionService transactionService,
         ICreditService creditService,
-        IAssetPriceService assetPriceService)
+        IAssetPriceService assetPriceService,
+        IBrokerBreakdownQueryService brokerBreakdownQueryService)
         : base(
             navigationService ?? throw new ArgumentNullException(nameof(navigationService)),
             creditQueryService ?? throw new ArgumentNullException(nameof(creditQueryService)),
@@ -23,7 +24,8 @@ public class MainNavigationViewModel : MainNavigationViewModelBase<AssetDetailsV
             new AssetDetailsViewModel(
                 transactionService ?? throw new ArgumentNullException(nameof(transactionService)),
                 creditService ?? throw new ArgumentNullException(nameof(creditService)),
-                assetPriceService ?? throw new ArgumentNullException(nameof(assetPriceService))))
+                assetPriceService ?? throw new ArgumentNullException(nameof(assetPriceService)),
+                brokerBreakdownQueryService ?? throw new ArgumentNullException(nameof(brokerBreakdownQueryService))))
     {
     }
 }

--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -292,5 +292,6 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
         var summary = _summaryQueryService.GetBrokerSummary(brokerName);
         var credits = _creditQueryService.GetCreditsByBroker(brokerName);
         AssetDetails.LoadBrokerSummary(brokerName, summary, credits);
+        AssetDetails.LoadBrokerBreakdown(brokerName);
     }
 }

--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -292,6 +292,6 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
         var summary = _summaryQueryService.GetBrokerSummary(brokerName);
         var credits = _creditQueryService.GetCreditsByBroker(brokerName);
         AssetDetails.LoadBrokerSummary(brokerName, summary, credits);
-        AssetDetails.LoadBrokerBreakdown(brokerName);
+        _ = AssetDetails.LoadBrokerBreakdown(brokerName);
     }
 }

--- a/Financial.App/ViewModels/PortfolioBreakdownPieItem.cs
+++ b/Financial.App/ViewModels/PortfolioBreakdownPieItem.cs
@@ -1,0 +1,5 @@
+using OxyPlot;
+
+namespace Financial.Presentation.App.ViewModels;
+
+public sealed record PortfolioBreakdownPieItem(string PortfolioName, PlotModel PlotModel);

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
@@ -7,8 +7,6 @@ namespace Financial.Presentation.Tests.ViewModels;
 
 public class AssetDetailsViewModelBrokerSummaryTests
 {
-    private static readonly TimeSpan AsyncWaitTimeout = TimeSpan.FromSeconds(2);
-
     private static AssetDetailsViewModel BuildViewModel(IBrokerBreakdownQueryService? brokerBreakdownQueryService = null)
     {
         return new AssetDetailsViewModel(
@@ -152,12 +150,12 @@ public class AssetDetailsViewModelBrokerSummaryTests
     {
         var stub = new StubBrokerBreakdownQueryService();
         var vm = BuildViewModel(stub);
-        vm.LoadBrokerBreakdown("XPI");
+        _ = vm.LoadBrokerBreakdown("XPI");
         vm.IsBreakdownLoading.Should().BeTrue();
     }
 
     [Fact]
-    public void LoadBrokerBreakdown_PopulatesOverallBreakdownPlotModel_OnSuccess()
+    public async Task LoadBrokerBreakdown_PopulatesOverallBreakdownPlotModel_OnSuccess()
     {
         var stub = new StubBrokerBreakdownQueryService
         {
@@ -168,15 +166,14 @@ public class AssetDetailsViewModelBrokerSummaryTests
             ],
         };
         var vm = BuildViewModel(stub);
-        vm.LoadBrokerBreakdown("XPI");
-        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+        await vm.LoadBrokerBreakdown("XPI");
 
         vm.OverallBreakdownPlotModel.Should().NotBeNull();
         vm.OverallBreakdownPlotModel!.Series.Should().HaveCount(1);
     }
 
     [Fact]
-    public void LoadBrokerBreakdown_PopulatesPortfolioBreakdownPieItems_OnSuccess()
+    public async Task LoadBrokerBreakdown_PopulatesPortfolioBreakdownPieItems_OnSuccess()
     {
         var stub = new StubBrokerBreakdownQueryService
         {
@@ -197,8 +194,7 @@ public class AssetDetailsViewModelBrokerSummaryTests
             ],
         };
         var vm = BuildViewModel(stub);
-        vm.LoadBrokerBreakdown("XPI");
-        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+        await vm.LoadBrokerBreakdown("XPI");
 
         vm.PortfolioBreakdownPieItems.Should().HaveCount(2);
         vm.PortfolioBreakdownPieItems[0].PortfolioName.Should().Be("Acoes");
@@ -207,37 +203,34 @@ public class AssetDetailsViewModelBrokerSummaryTests
     }
 
     [Fact]
-    public void LoadBrokerBreakdown_SetsIsBreakdownLoadingFalse_OnSuccess()
+    public async Task LoadBrokerBreakdown_SetsIsBreakdownLoadingFalse_OnSuccess()
     {
         var stub = new StubBrokerBreakdownQueryService { Breakdown = [] };
         var vm = BuildViewModel(stub);
-        vm.LoadBrokerBreakdown("XPI");
-        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+        await vm.LoadBrokerBreakdown("XPI");
         vm.IsBreakdownLoading.Should().BeFalse();
     }
 
     [Fact]
-    public void LoadBrokerBreakdown_SetsBreakdownError_OnFailure()
+    public async Task LoadBrokerBreakdown_SetsBreakdownError_OnFailure()
     {
         var stub = new StubBrokerBreakdownQueryService { ExceptionToThrow = new InvalidOperationException("boom") };
         var vm = BuildViewModel(stub);
-        vm.LoadBrokerBreakdown("XPI");
-        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+        await vm.LoadBrokerBreakdown("XPI");
 
         vm.BreakdownError.Should().NotBeNull();
         vm.IsBreakdownLoading.Should().BeFalse();
     }
 
     [Fact]
-    public void Clear_AfterLoadBrokerBreakdown_ResetsBreakdownState()
+    public async Task Clear_AfterLoadBrokerBreakdown_ResetsBreakdownState()
     {
         var stub = new StubBrokerBreakdownQueryService
         {
             Breakdown = [new PortfolioBreakdownItemDTO { PortfolioName = "Acoes", TotalInvested = 1000m, Assets = [] }],
         };
         var vm = BuildViewModel(stub);
-        vm.LoadBrokerBreakdown("XPI");
-        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+        await vm.LoadBrokerBreakdown("XPI");
 
         vm.Clear();
 
@@ -248,15 +241,14 @@ public class AssetDetailsViewModelBrokerSummaryTests
     }
 
     [Fact]
-    public void LoadAssetDetails_AfterLoadBrokerBreakdown_ResetsBreakdownState()
+    public async Task LoadAssetDetails_AfterLoadBrokerBreakdown_ResetsBreakdownState()
     {
         var stub = new StubBrokerBreakdownQueryService
         {
             Breakdown = [new PortfolioBreakdownItemDTO { PortfolioName = "Acoes", TotalInvested = 1000m, Assets = [] }],
         };
         var vm = BuildViewModel(stub);
-        vm.LoadBrokerBreakdown("XPI");
-        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+        await vm.LoadBrokerBreakdown("XPI");
 
         vm.LoadAssetDetails(new AssetDetailsDTO
         {

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
@@ -7,12 +7,15 @@ namespace Financial.Presentation.Tests.ViewModels;
 
 public class AssetDetailsViewModelBrokerSummaryTests
 {
-    private static AssetDetailsViewModel BuildViewModel()
+    private static readonly TimeSpan AsyncWaitTimeout = TimeSpan.FromSeconds(2);
+
+    private static AssetDetailsViewModel BuildViewModel(IBrokerBreakdownQueryService? brokerBreakdownQueryService = null)
     {
         return new AssetDetailsViewModel(
             new StubTransactionService(),
             new StubCreditService(),
-            new StubAssetPriceService());
+            new StubAssetPriceService(),
+            brokerBreakdownQueryService ?? new StubBrokerBreakdownQueryService());
     }
 
     [Fact]
@@ -142,6 +145,146 @@ public class AssetDetailsViewModelBrokerSummaryTests
         vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), []);
         vm.IsPortfolioView.Should().BeFalse();
         vm.IsBrokerView.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LoadBrokerBreakdown_SetsIsBreakdownLoadingTrue_Synchronously()
+    {
+        var stub = new StubBrokerBreakdownQueryService();
+        var vm = BuildViewModel(stub);
+        vm.LoadBrokerBreakdown("XPI");
+        vm.IsBreakdownLoading.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LoadBrokerBreakdown_PopulatesOverallBreakdownPlotModel_OnSuccess()
+    {
+        var stub = new StubBrokerBreakdownQueryService
+        {
+            Breakdown =
+            [
+                new PortfolioBreakdownItemDTO { PortfolioName = "Acoes", TotalInvested = 1000m, Assets = [] },
+                new PortfolioBreakdownItemDTO { PortfolioName = "FII", TotalInvested = 2000m, Assets = [] },
+            ],
+        };
+        var vm = BuildViewModel(stub);
+        vm.LoadBrokerBreakdown("XPI");
+        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+
+        vm.OverallBreakdownPlotModel.Should().NotBeNull();
+        vm.OverallBreakdownPlotModel!.Series.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void LoadBrokerBreakdown_PopulatesPortfolioBreakdownPieItems_OnSuccess()
+    {
+        var stub = new StubBrokerBreakdownQueryService
+        {
+            Breakdown =
+            [
+                new PortfolioBreakdownItemDTO
+                {
+                    PortfolioName = "Acoes",
+                    TotalInvested = 1000m,
+                    Assets = [new AssetBreakdownItemDTO { AssetName = "BBAS3", TotalInvested = 1000m }],
+                },
+                new PortfolioBreakdownItemDTO
+                {
+                    PortfolioName = "FII",
+                    TotalInvested = 2000m,
+                    Assets = [new AssetBreakdownItemDTO { AssetName = "MXRF11", TotalInvested = 2000m }],
+                },
+            ],
+        };
+        var vm = BuildViewModel(stub);
+        vm.LoadBrokerBreakdown("XPI");
+        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+
+        vm.PortfolioBreakdownPieItems.Should().HaveCount(2);
+        vm.PortfolioBreakdownPieItems[0].PortfolioName.Should().Be("Acoes");
+        vm.PortfolioBreakdownPieItems[0].PlotModel.Should().NotBeNull();
+        vm.PortfolioBreakdownPieItems[1].PortfolioName.Should().Be("FII");
+    }
+
+    [Fact]
+    public void LoadBrokerBreakdown_SetsIsBreakdownLoadingFalse_OnSuccess()
+    {
+        var stub = new StubBrokerBreakdownQueryService { Breakdown = [] };
+        var vm = BuildViewModel(stub);
+        vm.LoadBrokerBreakdown("XPI");
+        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+        vm.IsBreakdownLoading.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LoadBrokerBreakdown_SetsBreakdownError_OnFailure()
+    {
+        var stub = new StubBrokerBreakdownQueryService { ExceptionToThrow = new InvalidOperationException("boom") };
+        var vm = BuildViewModel(stub);
+        vm.LoadBrokerBreakdown("XPI");
+        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+
+        vm.BreakdownError.Should().NotBeNull();
+        vm.IsBreakdownLoading.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Clear_AfterLoadBrokerBreakdown_ResetsBreakdownState()
+    {
+        var stub = new StubBrokerBreakdownQueryService
+        {
+            Breakdown = [new PortfolioBreakdownItemDTO { PortfolioName = "Acoes", TotalInvested = 1000m, Assets = [] }],
+        };
+        var vm = BuildViewModel(stub);
+        vm.LoadBrokerBreakdown("XPI");
+        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+
+        vm.Clear();
+
+        vm.OverallBreakdownPlotModel.Should().BeNull();
+        vm.PortfolioBreakdownPieItems.Should().BeEmpty();
+        vm.IsBreakdownLoading.Should().BeFalse();
+        vm.BreakdownError.Should().BeNull();
+    }
+
+    [Fact]
+    public void LoadAssetDetails_AfterLoadBrokerBreakdown_ResetsBreakdownState()
+    {
+        var stub = new StubBrokerBreakdownQueryService
+        {
+            Breakdown = [new PortfolioBreakdownItemDTO { PortfolioName = "Acoes", TotalInvested = 1000m, Assets = [] }],
+        };
+        var vm = BuildViewModel(stub);
+        vm.LoadBrokerBreakdown("XPI");
+        SpinWait.SpinUntil(() => !vm.IsBreakdownLoading, AsyncWaitTimeout);
+
+        vm.LoadAssetDetails(new AssetDetailsDTO
+        {
+            Name = "Asset A", BrokerName = "XPI", PortfolioName = "Portfolio",
+            Ticker = "T", ISIN = "", Exchange = "LSE",
+            Country = Financial.Domain.Entities.CountryCode.Unknown,
+            LocalTypeCode = "", Class = Financial.Domain.Entities.GlobalAssetClass.Unknown,
+            Quantity = 0m, AveragePrice = 0m, IsActive = true,
+            TotalBought = 0m, TotalSold = 0m, TotalCredits = 0m,
+            Transactions = [], Credits = []
+        });
+
+        vm.OverallBreakdownPlotModel.Should().BeNull();
+        vm.PortfolioBreakdownPieItems.Should().BeEmpty();
+    }
+
+    private sealed class StubBrokerBreakdownQueryService : IBrokerBreakdownQueryService
+    {
+        public IReadOnlyList<PortfolioBreakdownItemDTO> Breakdown { get; set; } = [];
+        public Exception? ExceptionToThrow { get; set; }
+        public string? LastBrokerName { get; private set; }
+
+        public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName)
+        {
+            LastBrokerName = brokerName;
+            if (ExceptionToThrow != null) throw ExceptionToThrow;
+            return Breakdown;
+        }
     }
 
     private sealed class StubAssetPriceService : IAssetPriceService

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
@@ -12,7 +12,8 @@ public class AssetDetailsViewModelPortfolioSummaryTests
         return new AssetDetailsViewModel(
             new StubTransactionService(),
             new StubCreditService(),
-            priceService ?? new NeverResolvingPriceService());
+            priceService ?? new NeverResolvingPriceService(),
+            new StubBrokerBreakdownQueryService());
     }
 
     private static IReadOnlyList<PortfolioAssetSummaryItemDTO> BuildItems(int count = 2)
@@ -267,6 +268,11 @@ public class AssetDetailsViewModelPortfolioSummaryTests
         vm.FooterCurrentMonthCredits.Should().Be(0m);
         vm.FooterCurrentMonthLabel.Should().Be(string.Empty);
         vm.FooterEstimatedAnnualCreditsDisplay.Should().Be("—");
+    }
+
+    private sealed class StubBrokerBreakdownQueryService : IBrokerBreakdownQueryService
+    {
+        public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName) => [];
     }
 
     private sealed class NeverResolvingPriceService : IAssetPriceService

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -82,6 +82,20 @@ public class MainNavigationViewModelBaseTests
     }
 
     [Fact]
+    public void SelectingBrokerNode_CallsLoadBrokerBreakdownOnDetailsViewModel()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var brokerNode = BuildBrokerNode("XPI");
+        vm.SelectedNode = brokerNode;
+
+        spy.WasBrokerBreakdownLoaded.Should().BeTrue();
+        spy.LastBrokerBreakdownName.Should().Be("XPI");
+    }
+
+    [Fact]
     public void SelectingPortfolioNode_WhenMissingMetadata_ClearsDetails()
     {
         var summaryService = new StubSummaryQueryService();
@@ -234,10 +248,11 @@ public class MainNavigationViewModelBaseTests
             WasBrokerSummaryLoaded = true;
         }
 
-        public void LoadBrokerBreakdown(string brokerName)
+        public Task LoadBrokerBreakdown(string brokerName)
         {
             LastBrokerBreakdownName = brokerName;
             WasBrokerBreakdownLoaded = true;
+            return Task.CompletedTask;
         }
 
         public void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits) { }

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -221,6 +221,8 @@ public class MainNavigationViewModelBaseTests
         public bool WasCleared { get; private set; }
         public bool WasPortfolioSummaryLoaded { get; private set; }
         public bool WasBrokerSummaryLoaded { get; private set; }
+        public string? LastBrokerBreakdownName { get; private set; }
+        public bool WasBrokerBreakdownLoaded { get; private set; }
         public bool IsPortfolioView => false;
         public bool IsBrokerView => false;
 
@@ -230,6 +232,12 @@ public class MainNavigationViewModelBaseTests
         {
             LastBrokerSummary = summary;
             WasBrokerSummaryLoaded = true;
+        }
+
+        public void LoadBrokerBreakdown(string brokerName)
+        {
+            LastBrokerBreakdownName = brokerName;
+            WasBrokerBreakdownLoaded = true;
         }
 
         public void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits) { }

--- a/docs/P04-F08-broker-breakdown-pie-charts-wpf/plan.md
+++ b/docs/P04-F08-broker-breakdown-pie-charts-wpf/plan.md
@@ -1,0 +1,36 @@
+# Implementation Plan: Broker Breakdown Pie Charts — WPF
+
+**Prerequisites:**
+- F02 (Broker Portfolio & Asset Breakdown Service — Application Layer) already merged to `main`; `IBrokerBreakdownQueryService` is already implemented and registered in DI
+- F06 (Broker & Portfolio Totals Display — WPF) already merged to `main`; `BrokerSummaryTemplate` and `IsBrokerView` already exist
+- `OxyPlot.Wpf` is already a project dependency; `PieSeries`/`PieSlice` are available but not yet used anywhere in the codebase
+
+### Stage 1: Chart Builder and Pie Data Types
+
+**1. BrokerBreakdownChartBuilder** - Add a new static class that builds an OxyPlot `PlotModel` containing a single pie series from a list of named values, using a shared categorical colour palette and a tracker format string showing name, value, and percentage. Reference the spec's Technical Decisions for the palette and tracker format.
+
+**2. PortfolioBreakdownPieItem** - Add a small immutable record pairing a portfolio's name with its built pie `PlotModel`, used to back the per-portfolio pies collection.
+
+### Stage 2: ViewModel Async Loading
+
+**3. AssetDetailsViewModel breakdown state and async load** - Add the new constructor dependency, the overall and per-portfolio pie properties, loading/error state, and a `LoadBrokerBreakdown` method that fetches and builds the chart data on a background task, following the existing async-fetch pattern already used for per-row price fetching. Reference the spec's Technical Decisions for why this service is owned directly by the view model rather than passed through the navigation view model base.
+
+**4. Reset behavior** - Ensure breakdown state is correctly cleared and any in-flight fetch is cancelled whenever the view model clears or switches away from Broker view, mirroring the existing reset points for other Broker-scoped state.
+
+**5. IAssetDetailsViewModel contract update** - Add the new load method to the interface.
+
+### Stage 3: Dispatch and DI Wiring
+
+**6. Broker node dispatch** - Call the new load method alongside the existing broker summary load when a Broker node is selected, with no change to how the existing totals and credits data are fetched.
+
+**7. Constructor wiring** - Add the new service dependency to the concrete navigation view model's constructor and pass it through to the asset details view model, relying on existing dependency injection registration.
+
+### Stage 4: WPF Template
+
+**8. BrokerSummaryTemplate breakdown UI** - Extend the template with a scrollable container, a loading indicator, an inline error message, an empty-state message, the overall breakdown pie, and an items control rendering one pie per eligible portfolio. Reference the spec's Component Overview for the exact layout and binding structure.
+
+### Stage 5: Tests
+
+**9. ViewModel test coverage** - Extend the existing Broker summary test file with coverage for the new load method's loading state, successful population of both pie properties, error handling, and reset behavior on clear and node switching. Reference the spec's Testing Strategy for the full list of test functions.
+
+**10. Routing test coverage** - Extend the routing test double and its tests to confirm the new load method is called with the correct broker name on Broker node selection.

--- a/docs/P04-F08-broker-breakdown-pie-charts-wpf/spec.md
+++ b/docs/P04-F08-broker-breakdown-pie-charts-wpf/spec.md
@@ -1,0 +1,112 @@
+# F08. Broker Breakdown Pie Charts — WPF
+
+## 1. Technical Overview
+
+**What:** Extend the existing `BrokerSummaryTemplate` (added by F06, already merged) with the same portfolio/asset capital-allocation pie charts already delivered on the web (F07, already merged): one overall "Portfolio Breakdown" pie (one slice per eligible portfolio) plus one additional pie per eligible portfolio (one slice per eligible asset), using `OxyPlot.Wpf`'s `PieSeries`.
+
+**Why:** F02 already computes and returns the Encerradas-and-inactive-excluded breakdown (`IBrokerBreakdownQueryService.GetBrokerBreakdown`), and F07 already proved the visual design (validated categorical palette, tooltip content, empty/error/loading states) on the web. This feature is the WPF display layer consuming the same already-available data, so both platforms show consistent visual information as the PRD requires.
+
+**Scope:**
+- Included: a new static `BrokerBreakdownChartBuilder` producing `OxyPlot.PlotModel`s from breakdown DTOs; new async-loading state and pie data on `AssetDetailsViewModel`; wiring into `BrokerSummaryTemplate` (overall pie + `ItemsControl` of per-portfolio pies); loading/empty/inline-error states; unit test coverage.
+- Excluded: any backend change (F02 already complete); the web equivalent (F07, already merged); the Transactions monthly chart (F10) — out of scope for this feature.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.App/ViewModels/BrokerBreakdownChartBuilder.cs` — new static class
+- `Financial.App/ViewModels/PortfolioBreakdownPieItem.cs` — new immutable record
+- `Financial.App/ViewModels/AssetDetailsViewModel.cs` — new constructor dependency, properties, and `LoadBrokerBreakdown` method
+- `Financial.App/ViewModels/IAssetDetailsViewModel.cs` — interface update
+- `Financial.App/ViewModels/MainNavigationViewModelBase.cs` — dispatch calls the new method
+- `Financial.App/ViewModels/MainNavigationViewModel.cs` — new constructor parameter, passed directly into `AssetDetailsViewModel` (see Technical Decisions)
+- `Financial.App/Components/NavigationView.xaml` — `BrokerSummaryTemplate` extended with the pie charts
+- `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs` — extended
+- `Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs` — `SpyAssetDetailsViewModel`/stub updated
+
+```mermaid
+graph TD
+    A[User selects Broker node] --> B[MainNavigationViewModelBase.LoadBrokerCredits]
+    B --> C["AssetDetails.LoadBrokerSummary (sync, unchanged)"]
+    B --> D["AssetDetails.LoadBrokerBreakdown (new, async)"]
+    D --> E["IBrokerBreakdownQueryService.GetBrokerBreakdown (F02, already on main)"]
+    E --> F[BrokerBreakdownChartBuilder]
+    F --> G["OverallBreakdownPlotModel (PlotModel?)"]
+    F --> H["PortfolioBreakdownPieItems (ObservableCollection of records)"]
+    G --> I["BrokerSummaryTemplate: oxy:PlotView"]
+    H --> J["BrokerSummaryTemplate: ItemsControl of oxy:PlotView"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|------------------|-------------------------|-----------|
+| `IBrokerBreakdownQueryService` ownership | Injected directly into `AssetDetailsViewModel`'s constructor (4th parameter), exactly like `IAssetPriceService` already is — not threaded through `MainNavigationViewModelBase` like `ISummaryQueryService`/`ICreditQueryService`/`IPortfolioAssetSummaryQueryService` | Inject into `MainNavigationViewModelBase`, fetch synchronously in `LoadBrokerCredits` like the other three services, then pass the DTO into a sync `Load*` method | `MainNavigationViewModelBase`'s three existing services are all used for *synchronous* pre-fetch-then-pass-DTO calls. `IAssetPriceService` is the only existing precedent for a service that `AssetDetailsViewModel` owns and calls *asynchronously in the background* (see `FetchRowPricesAsync`) — since the PRD explicitly wants the breakdown fetched asynchronously with its own independent loading state (unlike the synchronous totals/credits fetch), it belongs with the async-service precedent, not the sync one |
+| Async fetch mechanics | `Task.Run(() => _brokerBreakdownQueryService.GetBrokerBreakdown(brokerName))` wrapped in a `CancellationTokenSource` (new `_breakdownCts` field), mirroring `FetchRowPricesAsync`'s exact pattern (`Task.Run` + cancellation check before applying results) | `async`/`await` with `Task.Run` only at the service-call boundary | `GetBrokerBreakdown` is a synchronous method (no async overload exists); `Task.Run` is the same mechanism already used for `_assetPriceService.GetCurrentPrice` (also synchronous), so this keeps the codebase's one async-wrapping idiom consistent rather than introducing a second one |
+| Per-portfolio pie data shape | `PortfolioBreakdownPieItem` — an immutable `sealed record(string PortfolioName, PlotModel PlotModel)`, held in an `ObservableCollection<PortfolioBreakdownPieItem>`, confirmed with the user | Two new `ObservableObject`-derived view-model classes (`OverallBreakdownPieViewModel`, `PortfolioBreakdownPieViewModel`) as the PRD's wording literally names them | Neither the overall pie nor any per-portfolio pie mutates after the initial load (unlike `PortfolioAssetSummaryRowViewModel`, which genuinely needs property-change notification for its async per-row price fetch) — an `ObservableObject` wrapper would add `INotifyPropertyChanged` machinery with nothing to notify. A record is the leaner, equally-bindable choice for static, build-once-per-load data |
+| Overall pie property shape | A single nullable `PlotModel? OverallBreakdownPlotModel` property (private setter), mirroring the existing `CreditsPlotModel` pattern exactly | A dedicated `OverallBreakdownPieViewModel` wrapper class | Same reasoning as above — `CreditsPlotModel` already establishes "bare nullable `PlotModel?` property" as this ViewModel's convention for a single chart; no wrapper is needed when there's only one chart and nothing else to bind alongside it |
+| Categorical palette | The same 8 validated hex values used by F07's web pie charts (`OxyColor.FromRgb`/`OxyColor.Parse` equivalents of `#2a78d6`, `#1baf7a`, `#eda100`, `#008300`, `#4a3aa7`, `#e34948`, `#e87ba4`, `#eb6834`), assigned by slice index and cycling | A WPF-specific palette (e.g. reusing `CreditsChartBuilder`'s blue gradient approach) | The PRD's own goal is visual consistency between web and WPF for the *same* screen; reusing F07's exact validated hues (rather than deriving new ones) is the only way to actually achieve that |
+| Tooltip content | OxyPlot's built-in tracker via `PieSeries.TrackerFormatString = "{1}\n{2:N2}\n{3:P1}"` (label, N2 value, 1-decimal percentage — `{3}` is OxyPlot's own built-in fraction-of-total, unlike recharts which required manual computation in F07) | A custom `TrackerFormatString` matching F07's tooltip layout more literally | `PieSeries` already computes and exposes the slice's fraction of the series total to its own tracker format string (unlike recharts' Tooltip payload, which does not carry it) — no manual percentage computation is needed on the WPF side, unlike the fix that was required for F07 |
+| Error retry | No retry button — an inline error message only, matching the PRD's WPF Experience wording ("shows an inline error message") which, unlike F07's Web spec, does not mention a retry action for this platform | Add a retry button/command for parity with F07's web `ErrorState` + Retry | The PRD is specific and different between the two platforms here (F07's Experience explicitly says "with a Retry button"; F08's Experience does not) — treated as an intentional platform difference, not an oversight, and documented as an assumption below |
+
+## 4. Component Overview
+
+**Frontend (WPF):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|---------------|---------|------------------------|
+| `Financial.App/ViewModels/BrokerBreakdownChartBuilder.cs` | New | Chart construction | `internal static class` with `Build(IReadOnlyList<(string Name, decimal Value)> slices) : PlotModel`, mirroring `CreditsChartBuilder`'s static-builder shape; constructs a `PieSeries` with one `PieSlice` per input, assigns colours from the shared palette by index, sets `TrackerFormatString`; returns an empty `PlotModel` (no series) when `slices` is empty, letting the empty-state check happen at the ViewModel/XAML level |
+| `Financial.App/ViewModels/PortfolioBreakdownPieItem.cs` | New | Per-portfolio pie data | `public sealed record PortfolioBreakdownPieItem(string PortfolioName, PlotModel PlotModel)` |
+| `Financial.App/ViewModels/AssetDetailsViewModel.cs` | Modified | View state + async load | Add 4th constructor parameter `IBrokerBreakdownQueryService brokerBreakdownQueryService`; add `PlotModel? OverallBreakdownPlotModel`, `ObservableCollection<PortfolioBreakdownPieItem> PortfolioBreakdownPieItems`, `bool IsBreakdownLoading`, `string? BreakdownError` properties; add `public void LoadBrokerBreakdown(string brokerName)` following `FetchRowPricesAsync`'s `Task.Run`+`CancellationTokenSource` pattern (new `_breakdownCts` field); reset all breakdown state (cancel pending fetch, clear collection/plot/error, `IsBreakdownLoading = false`) in `Clear()` and in `LoadAggregateCredits`/`LoadAssetDetails` (i.e., whenever switching away from Broker view) |
+| `Financial.App/ViewModels/IAssetDetailsViewModel.cs` | Modified | Contract | Add `void LoadBrokerBreakdown(string brokerName)` (state properties are read-only outputs, not called via the interface by any C# caller, so — mirroring `TotalInvested`'s precedent from F06 — they are not added to the interface, only the method is) |
+| `Financial.App/ViewModels/MainNavigationViewModelBase.cs` | Modified | Dispatch | In the private `LoadBrokerCredits(TreeNodeViewModel brokerNode)` method, add `AssetDetails.LoadBrokerBreakdown(brokerName);` immediately after the existing `AssetDetails.LoadBrokerSummary(...)` call. No constructor change needed here (see Technical Decisions) |
+| `Financial.App/ViewModels/MainNavigationViewModel.cs` | Modified | DI wiring | Add `IBrokerBreakdownQueryService brokerBreakdownQueryService` constructor parameter, passed directly into `new AssetDetailsViewModel(...)`. No DI registration change needed — `IBrokerBreakdownQueryService` is already registered by `AddFinancialApplication()` (F02), and `MainNavigationViewModel` is already resolved via `services.AddTransient<MainNavigationViewModel>()`, which resolves new constructor parameters automatically |
+| `Financial.App/Components/NavigationView.xaml` | Modified | Rendering | Wrap `BrokerSummaryTemplate`'s content in a `ScrollViewer` (it currently isn't scrollable, unlike `AssetSummaryTemplate`, and a broker with several portfolios could exceed viewport height); add, below the existing 2-row totals grid: a loading `TextBlock` (`Visibility` bound to `IsBreakdownLoading` via `BoolToVisibilityConverter`), an inline error `TextBlock` (bound to `BreakdownError`, visible when non-null), an empty-state `TextBlock` ("No active portfolios to display", visible when not loading, no error, and `PortfolioBreakdownPieItems.Count == 0`), an `oxy:PlotView Model="{Binding AssetDetails.OverallBreakdownPlotModel}"`, and an `ItemsControl ItemsSource="{Binding AssetDetails.PortfolioBreakdownPieItems}"` whose `ItemTemplate` shows the portfolio name (`TextBlock Text="{Binding PortfolioName}"`) above an `oxy:PlotView Model="{Binding PlotModel}"` |
+
+**Backend:** None — `IBrokerBreakdownQueryService.GetBrokerBreakdown` is already implemented and registered (F02, merged to `main`). No API contract, service, or data model changes required.
+
+## 5. API Contracts
+
+Not applicable — no new or modified endpoint or service interface. `IBrokerBreakdownQueryService.GetBrokerBreakdown(string brokerName) : IReadOnlyList<PortfolioBreakdownItemDTO>` (F02) is called directly in-process (no HTTP boundary in the WPF app); this feature only adds the async-loading wrapper and chart construction that consume its already-defined return shape (`PortfolioName`, `TotalInvested`, `Assets: IReadOnlyList<AssetBreakdownItemDTO> { AssetName, TotalInvested }`).
+
+## 6. Data Model
+
+Not applicable — no database changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|-----------------|
+| `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs` (extended) | Unit | `AssetDetailsViewModel.LoadBrokerBreakdown` | Sets loading state, populates overall/per-portfolio pie data on success, sets error on failure, resets on `Clear()`/node switching, cancels a stale in-flight fetch on rapid re-load |
+| `Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs` (extended) | Unit | `MainNavigationViewModelBase` Broker dispatch | `LoadBrokerBreakdown` is called with the correct broker name alongside `LoadBrokerSummary` on Broker node selection |
+
+**Test Functions:**
+
+| Test Function | Description | Assertions |
+|----------------|--------------|-------------|
+| `LoadBrokerBreakdown_SetsIsBreakdownLoadingTrue_Synchronously` | Calling `LoadBrokerBreakdown` before the background task completes | `vm.IsBreakdownLoading` is `true` immediately (synchronous state change, before any `await`/poll) |
+| `LoadBrokerBreakdown_PopulatesOverallBreakdownPlotModel_OnSuccess` | Stub service returns 2+ portfolios | After the background task completes, `vm.OverallBreakdownPlotModel` is non-null with one series |
+| `LoadBrokerBreakdown_PopulatesPortfolioBreakdownPieItems_OnSuccess` | Stub service returns 2 portfolios with assets | `vm.PortfolioBreakdownPieItems.Count` equals 2, each item's `PortfolioName` matches, each `PlotModel` is non-null |
+| `LoadBrokerBreakdown_SetsIsBreakdownLoadingFalse_OnSuccess` | After successful completion | `vm.IsBreakdownLoading` is `false` |
+| `LoadBrokerBreakdown_SetsBreakdownError_OnFailure` | Stub service throws | `vm.BreakdownError` is non-null, `vm.IsBreakdownLoading` is `false` |
+| `Clear_AfterLoadBrokerBreakdown_ResetsBreakdownState` | `Clear()` called after a successful load | `OverallBreakdownPlotModel` is `null`, `PortfolioBreakdownPieItems` is empty, `IsBreakdownLoading` is `false`, `BreakdownError` is `null` |
+| `LoadAssetDetails_AfterLoadBrokerBreakdown_ResetsBreakdownState` | Selecting an Asset node after a Broker node (regression check) | Breakdown state resets the same way as `Clear()` |
+| `SelectingBrokerNode_CallsLoadBrokerBreakdownOnDetailsViewModel` (in `MainNavigationViewModelBaseTests.cs`) | Broker node selected via the routing dispatch | Spy's `LastBrokerBreakdownName` (or equivalent) equals the selected broker's name |
+
+**Acceptance tests (PRD Section 9, F08):**
+- Selecting a Broker node in WPF renders the overall portfolio breakdown pie and one pie per eligible portfolio → covered by `LoadBrokerBreakdown_PopulatesOverallBreakdownPlotModel_OnSuccess` + `LoadBrokerBreakdown_PopulatesPortfolioBreakdownPieItems_OnSuccess` (template/`ItemsControl` rendering itself is XAML data-binding, not directly unit-testable — verified via manual/smoke check)
+- Hovering a slice in WPF shows its name, value, and percentage via OxyPlot's tracker → `TrackerFormatString` is set on every constructed `PieSeries`; OxyPlot's own tracker rendering is a third-party concern, verified via manual/smoke check
+- Zero eligible portfolios shows an empty-state message → the empty-state `TextBlock`'s visibility binding is XAML-level; the underlying condition (`PortfolioBreakdownPieItems.Count == 0`) is exercised by a success test with an empty stub result, verified via manual/smoke check for the visual empty-state itself
+- A failed breakdown fetch shows an inline error; the 4 totals remain visible and unaffected → `LoadBrokerBreakdown_SetsBreakdownError_OnFailure` (isolation from totals is by construction: separate method, separate state, `LoadBrokerSummary` is unaffected by `LoadBrokerBreakdown`'s outcome)
+
+**Cross-feature integration tests (PRD Section 9):**
+- Portfolio and asset `totalInvested` values from F02's breakdown endpoint are used without transformation to size and label slices in F07 and F08 → covered by `LoadBrokerBreakdown_PopulatesPortfolioBreakdownPieItems_OnSuccess` (values passed straight into `BrokerBreakdownChartBuilder.Build`, no transformation)
+- The Encerradas exclusion and non-positive-slice omission rules defined in F02 are reflected exactly in what F07 and F08 render → satisfied by construction: F08 renders `IBrokerBreakdownQueryService`'s response verbatim, with no client-side re-filtering (same principle already established in F07's spec)
+
+## Assumptions and Decisions (from interview)
+
+- **Simplified pie data shape**: confirmed with the user — the overall pie reuses the existing bare-`PlotModel?`-property convention (`CreditsPlotModel`'s precedent), and per-portfolio pies use a lightweight immutable record rather than the two `ObservableObject`-derived classes the PRD's wording literally names, since none of this data mutates after the initial load.
+- **`IBrokerBreakdownQueryService` is injected directly into `AssetDetailsViewModel`**, not threaded through `MainNavigationViewModelBase`, following the `IAssetPriceService`/`FetchRowPricesAsync` async-ownership precedent rather than the synchronous three-service precedent.
+- **No retry button for the WPF error state** — the PRD's Experience wording differs between F07 (Web, explicit "Retry button") and F08 (WPF, "inline error message" only); treated as an intentional platform difference rather than applying web parity by default.
+- **Colour palette reused verbatim from F07** (same 8 hex values) to achieve the PRD's stated cross-platform visual-consistency goal.


### PR DESCRIPTION
## Summary
- Extends `BrokerSummaryTemplate` (F06, already on `main`) with the same portfolio/asset capital-allocation pie charts already shipped on the web (F07, already on `main`): an overall "Portfolio Breakdown" pie plus one additional pie per eligible portfolio, using `OxyPlot.Wpf`'s `PieSeries` — the first use of OxyPlot pie charts in this codebase.
- Consumes F02's already-implemented `IBrokerBreakdownQueryService.GetBrokerBreakdown` (no backend changes).
- Reuses F07's exact validated 8-hue categorical palette for cross-platform visual consistency, and OxyPlot's built-in tracker (`TrackerFormatString`) for hover name/value/percentage — no manual percentage computation needed (unlike F07's web fix, since `PieSeries` computes the slice fraction natively).
- Loading indicator, inline error message (no retry, per the PRD's WPF-specific wording), and empty-state message, all independent of the 4 totals above.
- `IBrokerBreakdownQueryService` is injected directly into `AssetDetailsViewModel` (like `IAssetPriceService`) rather than through `MainNavigationViewModelBase`, since the fetch needs its own async loading state — see the spec's Technical Decisions for the reasoning.

## Regression found and fixed during live smoke testing
Mocked/stubbed unit tests all passed, but manually driving the real app (Step 6.4 of the implementation workflow) caught a real crash: selecting a Broker node threw `System.NotSupportedException` ("This type of CollectionView does not support changes to its SourceCollection from a thread different from the Dispatcher thread"). The existing codebase precedent (`FetchRowPricesAsync`) only ever mutates *plain properties* from a background thread, which WPF tolerates — but `ObservableCollection<T>.Clear()`/`.Add()` (a *structural* change) requires the UI thread, or WPF throws. Fixed by building the chart data off-thread as before, then marshaling only the collection mutation onto the UI thread via `Dispatcher.Invoke` (bypassed safely in unit tests, where there's no live `Application`). Verified live afterward — XPI's 3-portfolio, 16-asset breakdown now renders correctly with no crash.

Also found and fixed, before the above: async test flakiness from `SpinWait`-based polling under full-suite thread-pool contention — fixed by making `LoadBrokerBreakdown` return the awaitable `Task` (mirroring `EnsureTodayInfoLoadedAsync`'s existing pattern in this same class) instead of polling a timeout.

## Test plan
- [x] `dotnet build` — 0 errors, only pre-existing unrelated warnings
- [x] `dotnet test` — 415/418 passing (3 pre-existing skipped manual tests, unrelated), including 19 tests directly mapped to this feature, verified fresh across 3 consecutive full-suite runs with zero flakiness
- [x] Web frontend suite (`tsc`, `eslint`, `vitest`) — untouched by this feature, still green (322/322) as a full-repo sanity check
- [x] Manual smoke test: launched the actual WPF app against real local data —
  - **Broker node (XPI)**: renders the overview pie (3 portfolios: Fundos Investimento 60%, FII 25%, Acoes 15%) plus 3 per-portfolio pies (Acoes: 4 assets, FII: 9 assets — correctly cycling the 8-hue palette, Fundos Investimento: 3 assets), all matching F07's web percentages exactly; Encerradas (38 assets, visible in the tree) correctly excluded from every chart
  - **Portfolio node (Acoes)**: unaffected — existing DataGrid + 4 totals render as before, no breakdown UI leaks in (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)