### PR TITLE
feat(P04-F09): Transactions Monthly Investment Chart — Web Frontend

### DIFF
--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -15,6 +15,7 @@ import type {
   PortfolioReferenceDto,
   TransactionCreateDto,
   TransactionDeleteDto,
+  TransactionSummaryItemDto,
   TransactionUpdateDto,
   TreeNodeDto,
   WatchlistItemDto,
@@ -29,6 +30,8 @@ export interface FinancialApiClient {
   getSummaryByBroker: (brokerName: string) => Promise<AggregatedSummaryDto>
   getSummaryByPortfolio: (brokerName: string, portfolioName: string) => Promise<AggregatedSummaryDto>
   getBrokerBreakdown: (brokerName: string) => Promise<PortfolioBreakdownItemDto[]>
+  getTransactionsByBroker: (brokerName: string) => Promise<TransactionSummaryItemDto[]>
+  getTransactionsByPortfolio: (brokerName: string, portfolioName: string) => Promise<TransactionSummaryItemDto[]>
   addTransaction: (request: TransactionCreateDto) => Promise<AssetDetailsDto>
   updateTransaction: (request: TransactionUpdateDto) => Promise<AssetDetailsDto>
   deleteTransaction: (request: TransactionDeleteDto) => Promise<AssetDetailsDto>
@@ -112,6 +115,12 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       ),
     getBrokerBreakdown: (brokerName) =>
       request<PortfolioBreakdownItemDto[]>(`/summary/broker/${encodeURIComponent(brokerName)}/breakdown`),
+    getTransactionsByBroker: (brokerName) =>
+      request<TransactionSummaryItemDto[]>(`/transactions/broker/${encodeURIComponent(brokerName)}`),
+    getTransactionsByPortfolio: (brokerName, portfolioName) =>
+      request<TransactionSummaryItemDto[]>(
+        `/transactions/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}`,
+      ),
     addTransaction: (requestBody) =>
       request<AssetDetailsDto>('/transactions', {
         method: 'POST',

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -63,6 +63,13 @@ export interface TransactionDto {
   totalPrice: number
 }
 
+export interface TransactionSummaryItemDto {
+  assetName: string
+  date: string
+  type: string
+  totalPrice: number
+}
+
 export interface CreditDto {
   id: string
   date: string

--- a/Financial.Web/src/components/TransactionsTab.css
+++ b/Financial.Web/src/components/TransactionsTab.css
@@ -5,10 +5,100 @@
   overflow: hidden;
 }
 
-.transactions-tab__placeholder {
-  padding: 24px;
+.transactions-tab__controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 6px 16px;
+  border-bottom: 1px solid var(--border, #e5e4e7);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.transactions-tab__filters {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.transactions-tab__filter-btn {
+  font-size: 12px;
+  padding: 2px 8px;
+  cursor: pointer;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  color: #007acc;
+  text-decoration: underline;
+}
+
+.transactions-tab__filter-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
+}
+
+.transactions-tab__filter-btn--active {
+  color: var(--text-h, #08060d);
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.transactions-tab__modes {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.transactions-tab__mode-label {
+  font-size: 12px;
   color: var(--text-muted, #888);
+  margin-right: 4px;
+}
+
+.transactions-tab__mode-btn {
+  font-size: 12px;
+  padding: 2px 8px;
+  cursor: pointer;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  color: #007acc;
+  text-decoration: underline;
+}
+
+.transactions-tab__mode-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
+}
+
+.transactions-tab__mode-btn--active {
+  color: var(--text-h, #08060d);
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.transactions-tab__chart-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  padding: 8px 0;
+}
+
+.transactions-tab__chart-panel--compact {
+  flex: none;
+  height: 260px;
+}
+
+.transactions-tab__chart-title {
   font-size: 13px;
+  font-weight: bold;
+  text-align: center;
+  margin: 0 0 8px;
+  color: var(--text-h, #08060d);
+}
+
+.transactions-tab__chart-container {
+  flex: 1;
+  min-height: 0;
 }
 
 .transactions-tab__toolbar {

--- a/Financial.Web/src/components/TransactionsTab.tsx
+++ b/Financial.Web/src/components/TransactionsTab.tsx
@@ -1,9 +1,24 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
 import type { TransactionDto } from '../api/types'
 import ErrorState from './ErrorState'
 import LoadingState from './LoadingState'
-import type { TransactionFormField } from '../hooks/useTransactions'
+import type { ChartDisplayMode, TransactionFormField, TransactionMonthBucket } from '../hooks/useTransactions'
 import { useTransactions } from '../hooks/useTransactions'
+import { PERIOD_FILTER_OPTIONS } from '../utils/periodFilter'
+import type { PeriodFilterOption } from '../utils/periodFilter'
 import './TransactionsTab.css'
+
+const CHART_COLOR = '#6b7280'
 
 function formatN2(value: number): string {
   return new Intl.NumberFormat(undefined, {
@@ -181,12 +196,97 @@ function InlineForm({
   )
 }
 
+interface TransactionsChartProps {
+  chartData: TransactionMonthBucket[]
+  selectedFilter: PeriodFilterOption
+  selectedChartMode: ChartDisplayMode
+  setFilter: (filter: PeriodFilterOption) => void
+  setChartMode: (mode: ChartDisplayMode) => void
+  compact?: boolean
+}
+
+function TransactionsChart({
+  chartData,
+  selectedFilter,
+  selectedChartMode,
+  setFilter,
+  setChartMode,
+  compact,
+}: TransactionsChartProps) {
+  return (
+    <div
+      className={`transactions-tab__chart-panel${compact ? ' transactions-tab__chart-panel--compact' : ''}`}
+    >
+      <div className="transactions-tab__controls">
+        <div className="transactions-tab__filters">
+          {PERIOD_FILTER_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className={`transactions-tab__filter-btn${selectedFilter === opt.value ? ' transactions-tab__filter-btn--active' : ''}`}
+              onClick={() => setFilter(opt.value)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <div className="transactions-tab__modes">
+          <span className="transactions-tab__mode-label">View:</span>
+          {(['Bar', 'Line'] as ChartDisplayMode[]).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              className={`transactions-tab__mode-btn${selectedChartMode === mode ? ' transactions-tab__mode-btn--active' : ''}`}
+              onClick={() => setChartMode(mode)}
+            >
+              {mode}
+            </button>
+          ))}
+        </div>
+      </div>
+      <p className="transactions-tab__chart-title">Net Invested by Month</p>
+      <div className="transactions-tab__chart-container">
+        <ResponsiveContainer width="100%" height="100%">
+          {selectedChartMode === 'Bar' ? (
+            <BarChart data={chartData} margin={{ top: 8, right: 16, left: 8, bottom: 8 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+              <YAxis tickFormatter={formatN2} tick={{ fontSize: 11 }} width={70} />
+              <Tooltip formatter={(v) => (typeof v === 'number' ? formatN2(v) : v)} />
+              <Bar dataKey="netInvested" fill={CHART_COLOR} />
+            </BarChart>
+          ) : (
+            <LineChart data={chartData} margin={{ top: 8, right: 16, left: 8, bottom: 8 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+              <YAxis tickFormatter={formatN2} tick={{ fontSize: 11 }} width={70} />
+              <Tooltip formatter={(v) => (typeof v === 'number' ? formatN2(v) : v)} />
+              <Line
+                type="monotone"
+                dataKey="netInvested"
+                stroke={CHART_COLOR}
+                strokeWidth={2}
+                dot={{ r: 3 }}
+              />
+            </LineChart>
+          )}
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}
+
 export default function TransactionsTab() {
   const {
     isLoading,
     error,
     retry,
     transactions,
+    chartData,
+    selectedFilter,
+    selectedChartMode,
+    setFilter,
+    setChartMode,
     isFormVisible,
     editingId,
     formDate,
@@ -216,14 +316,29 @@ export default function TransactionsTab() {
 
   if (nodeType !== 'Asset') {
     return (
-      <p className="transactions-tab__placeholder">
-        Transactions are only available for individual assets
-      </p>
+      <div className="transactions-tab">
+        <TransactionsChart
+          chartData={chartData}
+          selectedFilter={selectedFilter}
+          selectedChartMode={selectedChartMode}
+          setFilter={setFilter}
+          setChartMode={setChartMode}
+        />
+      </div>
     )
   }
 
   return (
     <div className="transactions-tab">
+      <TransactionsChart
+        chartData={chartData}
+        selectedFilter={selectedFilter}
+        selectedChartMode={selectedChartMode}
+        setFilter={setFilter}
+        setChartMode={setChartMode}
+        compact
+      />
+
       <div className="transactions-tab__toolbar">
         <button className="transactions-tab__new-btn" type="button" onClick={showNewForm}>
           New

--- a/Financial.Web/src/components/__tests__/DetailPanel.test.tsx
+++ b/Financial.Web/src/components/__tests__/DetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import DetailPanel from '../DetailPanel'
 import { SelectedNodeProvider, useSelectedNode } from '../../context/SelectedNodeContext'
@@ -10,6 +10,8 @@ const getCurrentPriceMock = vi.fn()
 const getSummaryByBrokerMock = vi.fn()
 const getSummaryByPortfolioMock = vi.fn()
 const getPortfolioAssetsSummaryMock = vi.fn()
+const getTransactionsByBrokerMock = vi.fn().mockResolvedValue([])
+const getTransactionsByPortfolioMock = vi.fn().mockResolvedValue([])
 
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
@@ -18,6 +20,8 @@ vi.mock('../../api/financialApiClient', () => ({
     getSummaryByBroker: getSummaryByBrokerMock,
     getSummaryByPortfolio: getSummaryByPortfolioMock,
     getPortfolioAssetsSummary: getPortfolioAssetsSummaryMock,
+    getTransactionsByBroker: getTransactionsByBrokerMock,
+    getTransactionsByPortfolio: getTransactionsByPortfolioMock,
   }),
 }))
 
@@ -184,18 +188,26 @@ describe('DetailPanel', () => {
     expect(screen.queryByText('Transactions are only available for individual assets')).not.toBeInTheDocument()
   })
 
-  it('renders_transactions_message_for_broker_node', () => {
+  it('renders_transactions_message_for_broker_node', async () => {
     renderPanel(brokerNode)
     act(() => screen.getByTestId('setter').click())
     fireEvent.click(screen.getByRole('button', { name: 'Transactions' }))
-    expect(screen.getByText('Transactions are only available for individual assets')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        screen.getByText('Transactions are only available for individual assets'),
+      ).toBeInTheDocument(),
+    )
   })
 
-  it('renders_transactions_message_for_portfolio_node', () => {
+  it('renders_transactions_message_for_portfolio_node', async () => {
     renderPanel(portfolioNode)
     act(() => screen.getByTestId('setter').click())
     fireEvent.click(screen.getByRole('button', { name: 'Transactions' }))
-    expect(screen.getByText('Transactions are only available for individual assets')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        screen.getByText('Transactions are only available for individual assets'),
+      ).toBeInTheDocument(),
+    )
   })
 
   it('active tab resets to Summary on selectedNode change', () => {

--- a/Financial.Web/src/components/__tests__/DetailPanel.test.tsx
+++ b/Financial.Web/src/components/__tests__/DetailPanel.test.tsx
@@ -188,26 +188,24 @@ describe('DetailPanel', () => {
     expect(screen.queryByText('Transactions are only available for individual assets')).not.toBeInTheDocument()
   })
 
-  it('renders_transactions_message_for_broker_node', async () => {
+  it('renders_transactions_chart_for_broker_node', async () => {
     renderPanel(brokerNode)
     act(() => screen.getByTestId('setter').click())
     fireEvent.click(screen.getByRole('button', { name: 'Transactions' }))
     await waitFor(() =>
-      expect(
-        screen.getByText('Transactions are only available for individual assets'),
-      ).toBeInTheDocument(),
+      expect(screen.getByText('Net Invested by Month')).toBeInTheDocument(),
     )
+    expect(document.querySelector('table')).not.toBeInTheDocument()
   })
 
-  it('renders_transactions_message_for_portfolio_node', async () => {
+  it('renders_transactions_chart_for_portfolio_node', async () => {
     renderPanel(portfolioNode)
     act(() => screen.getByTestId('setter').click())
     fireEvent.click(screen.getByRole('button', { name: 'Transactions' }))
     await waitFor(() =>
-      expect(
-        screen.getByText('Transactions are only available for individual assets'),
-      ).toBeInTheDocument(),
+      expect(screen.getByText('Net Invested by Month')).toBeInTheDocument(),
     )
+    expect(document.querySelector('table')).not.toBeInTheDocument()
   })
 
   it('active tab resets to Summary on selectedNode change', () => {

--- a/Financial.Web/src/components/__tests__/TransactionsTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/TransactionsTab.test.tsx
@@ -1,8 +1,23 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { TransactionsData } from '../../hooks/useTransactions'
+import type { ReactNode } from 'react'
+import type { TransactionMonthBucket, TransactionsData } from '../../hooks/useTransactions'
 import type { TransactionDto } from '../../api/types'
 import TransactionsTab from '../TransactionsTab'
+
+vi.mock('recharts', () => ({
+  BarChart: ({ children }: { children: ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+  LineChart: ({ children }: { children: ReactNode }) => <div data-testid="line-chart">{children}</div>,
+  Bar: () => null,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+}))
 
 const mockShowNewForm = vi.fn()
 const mockShowEditForm = vi.fn()
@@ -31,6 +46,11 @@ const TRANSACTION_SELL: TransactionDto = {
   fees: 1.0,
   totalPrice: 251.0,
 }
+
+const CHART_DATA: TransactionMonthBucket[] = [
+  { month: 'Jan 2024', netInvested: 0 },
+  { month: 'Feb 2024', netInvested: 169.5 },
+]
 
 const mockSetFilter = vi.fn()
 const mockSetChartMode = vi.fn()
@@ -100,12 +120,61 @@ describe('TransactionsTab', () => {
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
   })
 
-  it('renders_placeholder_for_non_asset', () => {
-    setMock({ nodeType: 'Portfolio' })
+  it('renders_chart_only_for_broker_node_selection', () => {
+    setMock({ nodeType: 'Broker', chartData: CHART_DATA })
     render(<TransactionsTab />)
-    expect(
-      screen.getByText('Transactions are only available for individual assets'),
-    ).toBeInTheDocument()
+    expect(screen.getByText('Net Invested by Month')).toBeInTheDocument()
+    expect(document.querySelector('table')).not.toBeInTheDocument()
+  })
+
+  it('renders_chart_only_for_portfolio_node_selection', () => {
+    setMock({ nodeType: 'Portfolio', chartData: CHART_DATA })
+    render(<TransactionsTab />)
+    expect(screen.getByText('Net Invested by Month')).toBeInTheDocument()
+    expect(document.querySelector('table')).not.toBeInTheDocument()
+  })
+
+  it('renders_chart_above_table_for_asset_node_selection', () => {
+    setMock({ nodeType: 'Asset', chartData: CHART_DATA, transactions: [TRANSACTION_BUY] })
+    render(<TransactionsTab />)
+    expect(screen.getByText('Net Invested by Month')).toBeInTheDocument()
+    expect(document.querySelector('table')).toBeInTheDocument()
+    expect(screen.getByText('15/03/2024')).toBeInTheDocument()
+  })
+
+  it('renders_six_period_filter_buttons', () => {
+    render(<TransactionsTab />)
+    expect(screen.getByRole('button', { name: 'This month' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Last 3 months' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Last 6 months' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Last 12 months' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'YTD' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'All time' })).toBeInTheDocument()
+  })
+
+  it('renders_bar_line_toggle_defaulting_to_bar', () => {
+    render(<TransactionsTab />)
+    expect(screen.getByRole('button', { name: 'Bar' })).toHaveClass('transactions-tab__mode-btn--active')
+    expect(screen.getByRole('button', { name: 'Line' })).not.toHaveClass('transactions-tab__mode-btn--active')
+  })
+
+  it('clicking_line_toggle_calls_setChartMode', () => {
+    render(<TransactionsTab />)
+    fireEvent.click(screen.getByRole('button', { name: 'Line' }))
+    expect(mockSetChartMode).toHaveBeenCalledWith('Line')
+  })
+
+  it('clicking_filter_button_calls_setFilter', () => {
+    render(<TransactionsTab />)
+    fireEvent.click(screen.getByRole('button', { name: 'YTD' }))
+    expect(mockSetFilter).toHaveBeenCalledWith('ytd')
+  })
+
+  it('renders_error_state_with_retry_on_broker_portfolio_fetch_failure', () => {
+    setMock({ nodeType: 'Broker', error: 'Unable to load transactions' })
+    render(<TransactionsTab />)
+    expect(screen.getByText('Unable to load transactions')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
   })
 
   it('renders_table_with_correct_columns', () => {

--- a/Financial.Web/src/components/__tests__/TransactionsTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/TransactionsTab.test.tsx
@@ -32,12 +32,20 @@ const TRANSACTION_SELL: TransactionDto = {
   totalPrice: 251.0,
 }
 
+const mockSetFilter = vi.fn()
+const mockSetChartMode = vi.fn()
+
 const DEFAULT_HOOK: TransactionsData = {
   asset: null,
   isLoading: false,
   error: null,
   retry: mockRetry,
   transactions: [],
+  chartData: [],
+  selectedFilter: 'last-12-months',
+  selectedChartMode: 'Bar',
+  setFilter: mockSetFilter,
+  setChartMode: mockSetChartMode,
   isFormVisible: false,
   editingId: null,
   formDate: '',

--- a/Financial.Web/src/hooks/useTransactions.test.ts
+++ b/Financial.Web/src/hooks/useTransactions.test.ts
@@ -3,14 +3,16 @@ import type { ReactNode } from 'react'
 import { createElement } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FinancialApiClient } from '../api/financialApiClient'
-import type { AssetDetailsDto, SelectedNode, TransactionDto } from '../api/types'
+import type { AssetDetailsDto, SelectedNode, TransactionDto, TransactionSummaryItemDto } from '../api/types'
 import { SelectedNodeProvider, useSelectedNode } from '../context/SelectedNodeContext'
-import { useTransactions } from './useTransactions'
+import { buildMonthlyNetInvested, useTransactions } from './useTransactions'
 
 const getAssetDetailsMock = vi.fn<FinancialApiClient['getAssetDetails']>()
 const addTransactionMock = vi.fn<FinancialApiClient['addTransaction']>()
 const updateTransactionMock = vi.fn<FinancialApiClient['updateTransaction']>()
 const deleteTransactionMock = vi.fn<FinancialApiClient['deleteTransaction']>()
+const getTransactionsByBrokerMock = vi.fn<FinancialApiClient['getTransactionsByBroker']>()
+const getTransactionsByPortfolioMock = vi.fn<FinancialApiClient['getTransactionsByPortfolio']>()
 
 vi.mock('../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
@@ -18,6 +20,8 @@ vi.mock('../api/financialApiClient', () => ({
     addTransaction: addTransactionMock,
     updateTransaction: updateTransactionMock,
     deleteTransaction: deleteTransactionMock,
+    getTransactionsByBroker: getTransactionsByBrokerMock,
+    getTransactionsByPortfolio: getTransactionsByPortfolioMock,
   }),
 }))
 
@@ -37,6 +41,25 @@ const PORTFOLIO_NODE: SelectedNode = {
   nodeType: 'Portfolio',
   brokerName: 'XPI',
   portfolioName: 'Acoes',
+}
+
+const BROKER_NODE: SelectedNode = {
+  nodeType: 'Broker',
+  brokerName: 'XPI',
+}
+
+const SUMMARY_ITEM_A: TransactionSummaryItemDto = {
+  assetName: 'KLBN4',
+  date: '2024-03-15T00:00:00',
+  type: 'Buy',
+  totalPrice: 420.5,
+}
+
+const SUMMARY_ITEM_B: TransactionSummaryItemDto = {
+  assetName: 'PETR4',
+  date: '2024-01-10T00:00:00',
+  type: 'Sell',
+  totalPrice: 251.0,
 }
 
 const TRANSACTION_A: TransactionDto = {
@@ -107,6 +130,8 @@ describe('useTransactions', () => {
     addTransactionMock.mockReset()
     updateTransactionMock.mockReset()
     deleteTransactionMock.mockReset()
+    getTransactionsByBrokerMock.mockReset().mockResolvedValue([])
+    getTransactionsByPortfolioMock.mockReset().mockResolvedValue([])
     vi.mocked(window.confirm).mockReturnValue(true)
   })
 
@@ -342,4 +367,93 @@ describe('useTransactions', () => {
     await waitFor(() => expect(result.current.deleteError).toBe('Delete failed'))
     expect(result.current.asset).toEqual(ASSET_DETAILS)
   })
+
+  it('fetches_transactions_on_broker_selection', async () => {
+    getTransactionsByBrokerMock.mockResolvedValue([SUMMARY_ITEM_A, SUMMARY_ITEM_B])
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(getTransactionsByBrokerMock).toHaveBeenCalledWith('XPI'))
+    await waitFor(() => expect(result.current.chartData.length).toBeGreaterThan(0))
+  })
+
+  it('fetches_transactions_on_portfolio_selection', async () => {
+    getTransactionsByPortfolioMock.mockResolvedValue([SUMMARY_ITEM_A])
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() =>
+      expect(getTransactionsByPortfolioMock).toHaveBeenCalledWith('XPI', 'Acoes'),
+    )
+    await waitFor(() => expect(result.current.chartData.length).toBeGreaterThan(0))
+  })
+
+  it('transactions_fetch_error_sets_error_state', async () => {
+    getTransactionsByBrokerMock.mockRejectedValue(new Error('Network error'))
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.error).toBe('Network error'))
+  })
+
+  it('set_filter_and_mode_persist_per_node_selection', async () => {
+    getTransactionsByBrokerMock.mockResolvedValue([SUMMARY_ITEM_A])
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useTransactions(), { wrapper })
+
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.selectedFilter).toBe('last-12-months'))
+    act(() => result.current.setFilter('ytd'))
+    act(() => result.current.setChartMode('Line'))
+    expect(result.current.selectedFilter).toBe('ytd')
+    expect(result.current.selectedChartMode).toBe('Line')
+
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.asset).not.toBeNull())
+    expect(result.current.selectedFilter).toBe('last-12-months')
+    expect(result.current.selectedChartMode).toBe('Bar')
+
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(result.current.selectedFilter).toBe('ytd'))
+    expect(result.current.selectedChartMode).toBe('Line')
+  })
 })
+
+describe('buildMonthlyNetInvested', () => {
+  it('zero_fills_months_with_no_transactions_across_selected_period', () => {
+    const referenceDate = new Date(2024, 2, 15)
+    const buckets = buildMonthlyNetInvested([SUMMARY_ITEM_A], 'last-12-months', referenceDate)
+    expect(buckets.length).toBe(12)
+    const marchBucket = buckets.find((b) => b.month === formatMonth(referenceDate))
+    expect(marchBucket?.netInvested).toBe(420.5)
+    const emptyMonths = buckets.filter((b) => b.netInvested === 0)
+    expect(emptyMonths.length).toBe(11)
+  })
+
+  it('nets_buy_minus_sell_within_the_same_month', () => {
+    const referenceDate = new Date(2024, 0, 31)
+    const buckets = buildMonthlyNetInvested(
+      [
+        { date: '2024-01-05', type: 'Buy', totalPrice: 500 },
+        { date: '2024-01-20', type: 'Sell', totalPrice: 200 },
+      ],
+      'ytd',
+      referenceDate,
+    )
+    expect(buckets.length).toBe(1)
+    expect(buckets[0].netInvested).toBe(300)
+  })
+
+  it('works_identically_for_broker_summary_shape_and_asset_transaction_shape', () => {
+    const referenceDate = new Date(2024, 2, 31)
+    const summaryResult = buildMonthlyNetInvested([SUMMARY_ITEM_A], 'ytd', referenceDate)
+    const assetResult = buildMonthlyNetInvested([TRANSACTION_A], 'ytd', referenceDate)
+    expect(summaryResult).toEqual(assetResult)
+    expect(summaryResult.some((b) => b.netInvested === 420.5)).toBe(true)
+  })
+})
+
+function formatMonth(date: Date): string {
+  return date.toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })
+}

--- a/Financial.Web/src/hooks/useTransactions.ts
+++ b/Financial.Web/src/hooks/useTransactions.ts
@@ -1,15 +1,92 @@
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { createFinancialApiClient } from '../api/financialApiClient'
-import type { AssetDetailsDto, TransactionDto } from '../api/types'
+import type { AssetDetailsDto, TransactionDto, TransactionSummaryItemDto } from '../api/types'
 import { useSelectedNode } from '../context/SelectedNodeContext'
+import { buildSelectionKey } from './useCredits'
+import type { PeriodFilterOption } from '../utils/periodFilter'
+import { getPeriodFilterStartDate } from '../utils/periodFilter'
 
 export type TransactionFormField = 'formDate' | 'formType' | 'formQuantity' | 'formUnitPrice' | 'formFees'
+export type ChartDisplayMode = 'Bar' | 'Line'
+
+export interface TransactionMonthBucket {
+  month: string
+  netInvested: number
+}
+
+interface MinimalTransaction {
+  date: string
+  type: string
+  totalPrice: number
+}
+
+interface PersistedChartPrefs {
+  filter: PeriodFilterOption
+  mode: ChartDisplayMode
+}
+
+const DEFAULT_FILTER: PeriodFilterOption = 'last-12-months'
+const DEFAULT_CHART_MODE: ChartDisplayMode = 'Bar'
+
+function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1)
+}
+
+function addMonths(date: Date, count: number): Date {
+  return new Date(date.getFullYear(), date.getMonth() + count, 1)
+}
+
+function formatMonthLabel(date: Date): string {
+  return date.toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })
+}
+
+function monthKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
+}
+
+export function buildMonthlyNetInvested(
+  transactions: MinimalTransaction[],
+  filter: PeriodFilterOption,
+  referenceDate: Date = new Date(),
+): TransactionMonthBucket[] {
+  const netByMonth = new Map<string, number>()
+  for (const t of transactions) {
+    const key = monthKey(new Date(t.date))
+    const delta = t.type === 'Buy' ? t.totalPrice : -t.totalPrice
+    netByMonth.set(key, (netByMonth.get(key) ?? 0) + delta)
+  }
+
+  const periodStart = getPeriodFilterStartDate(filter, referenceDate)
+  let rangeStart: Date
+  if (periodStart) {
+    rangeStart = startOfMonth(periodStart)
+  } else if (transactions.length > 0) {
+    const earliest = transactions.reduce(
+      (min, t) => (new Date(t.date) < min ? new Date(t.date) : min),
+      new Date(transactions[0].date),
+    )
+    rangeStart = startOfMonth(earliest)
+  } else {
+    rangeStart = startOfMonth(referenceDate)
+  }
+
+  const rangeEnd = startOfMonth(referenceDate)
+  const buckets: TransactionMonthBucket[] = []
+  for (let cursor = rangeStart; cursor <= rangeEnd; cursor = addMonths(cursor, 1)) {
+    buckets.push({ month: formatMonthLabel(cursor), netInvested: netByMonth.get(monthKey(cursor)) ?? 0 })
+  }
+  return buckets
+}
 
 interface TransactionsState {
   asset: AssetDetailsDto | null
+  brokerPortfolioTransactions: TransactionSummaryItemDto[]
   isLoading: boolean
   error: string | null
   retryCount: number
+  selectedFilter: PeriodFilterOption
+  selectedChartMode: ChartDisplayMode
+  filterPersistence: Map<string, PersistedChartPrefs>
   isFormVisible: boolean
   editingId: string | null
   formDate: string
@@ -24,10 +101,13 @@ interface TransactionsState {
 
 type TransactionsAction =
   | { type: 'RESET' }
-  | { type: 'FETCH_START' }
+  | { type: 'FETCH_START'; payload: { key: string } }
   | { type: 'FETCH_SUCCESS'; payload: AssetDetailsDto }
+  | { type: 'FETCH_TRANSACTIONS_SUCCESS'; payload: TransactionSummaryItemDto[] }
   | { type: 'FETCH_ERROR'; payload: string }
   | { type: 'RETRY' }
+  | { type: 'SET_FILTER'; payload: { filter: PeriodFilterOption; key: string } }
+  | { type: 'SET_CHART_MODE'; payload: { mode: ChartDisplayMode; key: string } }
   | { type: 'SHOW_NEW_FORM' }
   | { type: 'SHOW_EDIT_FORM'; payload: TransactionDto }
   | { type: 'CANCEL_FORM' }
@@ -52,9 +132,13 @@ const BLANK_FORM = {
 
 const INITIAL_STATE: TransactionsState = {
   asset: null,
+  brokerPortfolioTransactions: [],
   isLoading: false,
   error: null,
   retryCount: 0,
+  selectedFilter: DEFAULT_FILTER,
+  selectedChartMode: DEFAULT_CHART_MODE,
+  filterPersistence: new Map(),
   ...BLANK_FORM,
   deleteError: null,
 }
@@ -66,15 +150,36 @@ function toInputDate(isoString: string): string {
 function reducer(state: TransactionsState, action: TransactionsAction): TransactionsState {
   switch (action.type) {
     case 'RESET':
-      return INITIAL_STATE
-    case 'FETCH_START':
-      return { ...INITIAL_STATE, isLoading: true, retryCount: state.retryCount }
+      return { ...INITIAL_STATE, filterPersistence: state.filterPersistence }
+    case 'FETCH_START': {
+      const prefs = state.filterPersistence.get(action.payload.key)
+      return {
+        ...INITIAL_STATE,
+        isLoading: true,
+        retryCount: state.retryCount,
+        filterPersistence: state.filterPersistence,
+        selectedFilter: prefs?.filter ?? DEFAULT_FILTER,
+        selectedChartMode: prefs?.mode ?? DEFAULT_CHART_MODE,
+      }
+    }
     case 'FETCH_SUCCESS':
       return { ...state, isLoading: false, asset: action.payload }
+    case 'FETCH_TRANSACTIONS_SUCCESS':
+      return { ...state, isLoading: false, brokerPortfolioTransactions: action.payload }
     case 'FETCH_ERROR':
       return { ...state, isLoading: false, error: action.payload }
     case 'RETRY':
       return { ...state, retryCount: state.retryCount + 1, error: null }
+    case 'SET_FILTER': {
+      const newMap = new Map(state.filterPersistence)
+      newMap.set(action.payload.key, { filter: action.payload.filter, mode: state.selectedChartMode })
+      return { ...state, selectedFilter: action.payload.filter, filterPersistence: newMap }
+    }
+    case 'SET_CHART_MODE': {
+      const newMap = new Map(state.filterPersistence)
+      newMap.set(action.payload.key, { filter: state.selectedFilter, mode: action.payload.mode })
+      return { ...state, selectedChartMode: action.payload.mode, filterPersistence: newMap }
+    }
     case 'SHOW_NEW_FORM':
       return {
         ...state,
@@ -128,6 +233,11 @@ export interface TransactionsData {
   error: string | null
   retry: () => void
   transactions: TransactionDto[]
+  chartData: TransactionMonthBucket[]
+  selectedFilter: PeriodFilterOption
+  selectedChartMode: ChartDisplayMode
+  setFilter: (filter: PeriodFilterOption) => void
+  setChartMode: (mode: ChartDisplayMode) => void
   isFormVisible: boolean
   editingId: string | null
   formDate: string
@@ -152,36 +262,52 @@ export function useTransactions(): TransactionsData {
   const apiClient = useMemo(() => createFinancialApiClient(), [])
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
 
-  const isAsset =
-    selectedNode?.nodeType === 'Asset' &&
-    !!selectedNode.portfolioName &&
-    !!selectedNode.assetName
-
   useEffect(() => {
-    if (!isAsset || !selectedNode) {
+    if (!selectedNode) {
       dispatch({ type: 'RESET' })
       return
     }
 
-    const { brokerName, portfolioName, assetName } = selectedNode
+    const { nodeType, brokerName, portfolioName, assetName } = selectedNode
+    const key = buildSelectionKey(selectedNode)
 
-    if (!portfolioName || !assetName) {
-      dispatch({ type: 'RESET' })
-      return
-    }
-
-    dispatch({ type: 'FETCH_START' })
-
-    void apiClient
-      .getAssetDetails(brokerName, portfolioName, assetName)
-      .then((result) => dispatch({ type: 'FETCH_SUCCESS', payload: result }))
-      .catch((err: unknown) => {
-        dispatch({
-          type: 'FETCH_ERROR',
-          payload: err instanceof Error ? err.message : 'Unable to load asset details',
+    if (nodeType === 'Asset' && portfolioName && assetName) {
+      dispatch({ type: 'FETCH_START', payload: { key } })
+      void apiClient
+        .getAssetDetails(brokerName, portfolioName, assetName)
+        .then((result) => dispatch({ type: 'FETCH_SUCCESS', payload: result }))
+        .catch((err: unknown) => {
+          dispatch({
+            type: 'FETCH_ERROR',
+            payload: err instanceof Error ? err.message : 'Unable to load asset details',
+          })
         })
-      })
-  }, [selectedNode, isAsset, apiClient, state.retryCount])
+    } else if (nodeType === 'Broker') {
+      dispatch({ type: 'FETCH_START', payload: { key } })
+      void apiClient
+        .getTransactionsByBroker(brokerName)
+        .then((result) => dispatch({ type: 'FETCH_TRANSACTIONS_SUCCESS', payload: result }))
+        .catch((err: unknown) => {
+          dispatch({
+            type: 'FETCH_ERROR',
+            payload: err instanceof Error ? err.message : 'Unable to load transactions',
+          })
+        })
+    } else if (nodeType === 'Portfolio' && portfolioName) {
+      dispatch({ type: 'FETCH_START', payload: { key } })
+      void apiClient
+        .getTransactionsByPortfolio(brokerName, portfolioName)
+        .then((result) => dispatch({ type: 'FETCH_TRANSACTIONS_SUCCESS', payload: result }))
+        .catch((err: unknown) => {
+          dispatch({
+            type: 'FETCH_ERROR',
+            payload: err instanceof Error ? err.message : 'Unable to load transactions',
+          })
+        })
+    } else {
+      dispatch({ type: 'RESET' })
+    }
+  }, [selectedNode, apiClient, state.retryCount])
 
   const transactions = useMemo(() => {
     if (!state.asset) return []
@@ -190,7 +316,33 @@ export function useTransactions(): TransactionsData {
     )
   }, [state.asset])
 
+  const transactionsForChart = useMemo(() => {
+    if (selectedNode?.nodeType === 'Asset') return state.asset?.transactions ?? []
+    return state.brokerPortfolioTransactions
+  }, [selectedNode, state.asset, state.brokerPortfolioTransactions])
+
+  const chartData = useMemo(
+    () => buildMonthlyNetInvested(transactionsForChart, state.selectedFilter, new Date()),
+    [transactionsForChart, state.selectedFilter],
+  )
+
   const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
+
+  const setFilter = useCallback(
+    (filter: PeriodFilterOption) => {
+      if (!selectedNode) return
+      dispatch({ type: 'SET_FILTER', payload: { filter, key: buildSelectionKey(selectedNode) } })
+    },
+    [selectedNode],
+  )
+
+  const setChartMode = useCallback(
+    (mode: ChartDisplayMode) => {
+      if (!selectedNode) return
+      dispatch({ type: 'SET_CHART_MODE', payload: { mode, key: buildSelectionKey(selectedNode) } })
+    },
+    [selectedNode],
+  )
 
   const showNewForm = useCallback(() => dispatch({ type: 'SHOW_NEW_FORM' }), [])
 
@@ -284,6 +436,11 @@ export function useTransactions(): TransactionsData {
     error: state.error,
     retry,
     transactions,
+    chartData,
+    selectedFilter: state.selectedFilter,
+    selectedChartMode: state.selectedChartMode,
+    setFilter,
+    setChartMode,
     isFormVisible: state.isFormVisible,
     editingId: state.editingId,
     formDate: state.formDate,

--- a/docs/P04-F09-transactions-monthly-investment-chart-web-frontend/plan.md
+++ b/docs/P04-F09-transactions-monthly-investment-chart-web-frontend/plan.md
@@ -1,0 +1,32 @@
+# Implementation Plan: Transactions Monthly Investment Chart — Web Frontend
+
+**Prerequisites:**
+- F03 (Broker & Portfolio Transactions Aggregation Service — Application Layer) already merged to `main`; both transaction endpoints are already implemented
+- F04 (Chart Period Filter — YTD Extension) already merged to `main`; the shared `utils/periodFilter.ts` module is already implemented and in use by the Credits chart
+- `recharts` is already a project dependency; `BarChart` is already used by `CreditsTab`, `LineChart` is not yet used anywhere and will be introduced by this feature
+
+### Stage 1: Type Contract and API Client
+
+**1. Transaction summary DTO type and client methods** - Add the frontend type mirroring the backend's combined transaction DTO, and the two client methods for fetching a broker's or portfolio's combined transaction list, following the existing broker/portfolio credits method pattern.
+
+### Stage 2: Hook Extension
+
+**2. Broker/Portfolio fetch branching** - Extend the existing transactions hook to also fetch the combined transaction list for Broker and Portfolio node selection, alongside its existing Asset-scope fetch, following the node-type branching pattern already established by the credits hook.
+
+**3. Chart filter and mode state** - Add period-filter and Bar/Line chart-mode state to the hook, persisted per node selection, mirroring the credits hook's existing filter/mode persistence mechanism. Reference the spec's Technical Decisions for the persistence approach.
+
+**4. Zero-filling monthly aggregation** - Add the aggregation function that computes each month's net-invested value (Buy total minus Sell total) across the selected period's full date range, including months with no transactions, working identically against either the Asset-scope or Broker/Portfolio-scope transaction list without any data conversion step. Reference the spec's Technical Decisions for the zero-fill algorithm.
+
+### Stage 3: Component
+
+**5. TransactionsChart rendering** - Add the chart sub-component with period-filter buttons, a Bar/Line toggle, and the recharts bar/line rendering, mirroring the credits chart's existing toolbar and panel structure with a single neutral series colour. Reference the spec's Technical Decisions for the colour choice and toggle naming.
+
+**6. TransactionsTab integration** - Replace the current Broker/Portfolio placeholder with the chart, and add the chart above the existing table for Asset selection, with no change to the table's existing behavior. Reference the spec's Component Overview for the exact rendering structure per node type.
+
+**7. Styling** - Add the chart, filter button, and mode toggle styles, following the existing credits tab's visual pattern.
+
+### Stage 4: Tests
+
+**8. Hook test coverage** - Extend the existing transactions hook test file with coverage for the new fetch branching, filter/mode persistence, and the zero-filling aggregation's correctness. Reference the spec's Testing Strategy for the full list of test functions.
+
+**9. Component test coverage** - Extend the existing transactions tab test file with coverage confirming the chart-only rendering for Broker/Portfolio, the chart-plus-table rendering for Asset, the period filter buttons, the Bar/Line toggle, and the error state, mocking `recharts` per the project's existing pattern.

--- a/docs/P04-F09-transactions-monthly-investment-chart-web-frontend/spec.md
+++ b/docs/P04-F09-transactions-monthly-investment-chart-web-frontend/spec.md
@@ -1,0 +1,128 @@
+# F09. Transactions Monthly Investment Chart — Web Frontend
+
+## 1. Technical Overview
+
+**What:** Extend `TransactionsTab` to render a monthly net-invested chart (`sum(Buy.totalPrice) − sum(Sell.totalPrice)` per calendar month, zero-filled for gap months) for Broker, Portfolio, and Asset node selection. For Broker/Portfolio (currently a placeholder message), the chart becomes the *only* content — no transaction table. For Asset, the existing transaction table is unchanged and the chart is added above it, computed from the asset's already-loaded transaction list. A Bar/Line toggle (default Bar) and the six F04 period-filter buttons (default Last 12 Months) control the chart, both persisted per node selection, mirroring `CreditsTab`'s existing UX.
+
+**Why:** F03 already exposes the combined Buy/Sell transaction list for Broker and Portfolio scope (`GET /transactions/broker/{brokerName}`, `GET /transactions/portfolio/{brokerName}/{portfolioName}`), and F04 already defines the canonical six-option period filter shared with the Credits chart. This feature is the display layer wiring both together into `TransactionsTab`, following the exact architectural pattern `useCredits`/`CreditsTab` already established for "fetch by node type + period-filter + monthly-aggregate + persist per node."
+
+**Scope:**
+- Included: extending `useTransactions` with Broker/Portfolio fetch branches, period-filter and chart-mode state (persisted per node selection), a zero-filling monthly aggregation function; a new `TransactionsChart` rendering (Bar/Line toggle, recharts `BarChart`/`LineChart`); replacing the Broker/Portfolio placeholder; adding the chart above the existing Asset table; new API client method and DTO type; unit test coverage.
+- Excluded: any backend change (F03/F04 already complete); the WPF equivalent (F10, separate feature) — out of scope for this feature.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/api/types.ts` — new `TransactionSummaryItemDto` type
+- `Financial.Web/src/api/financialApiClient.ts` — new `getTransactionsByBroker`/`getTransactionsByPortfolio` methods
+- `Financial.Web/src/hooks/useTransactions.ts` — extended with Broker/Portfolio fetch, chart-mode/filter state, zero-filling aggregation
+- `Financial.Web/src/components/TransactionsTab.tsx` — renders the chart for all three node types; replaces the placeholder
+- `Financial.Web/src/components/TransactionsTab.css` — new chart/filter/mode-toggle styles
+- `Financial.Web/src/hooks/useTransactions.test.ts` — extended
+- `Financial.Web/src/components/__tests__/TransactionsTab.test.tsx` — extended
+
+```mermaid
+graph TD
+    A[User selects Broker, Portfolio, or Asset node] --> B[TransactionsTab]
+    B --> C[useTransactions hook]
+    C --> D{nodeType}
+    D -->|Asset| E["getAssetDetails (existing, unchanged) -> asset.transactions"]
+    D -->|Broker/Portfolio| F["getTransactionsByBroker / getTransactionsByPortfolio (F03, new)"]
+    E --> G["Period filter (F04) + zero-filling monthly aggregation"]
+    F --> G
+    G --> H["TransactionsChart (Bar/Line, recharts)"]
+    E --> I["Existing per-asset table (Asset only, unchanged)"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|------------------|-------------------------|-----------|
+| Hook architecture | Extend the existing `useTransactions` hook with Broker/Portfolio fetch branches and chart state, mirroring `useCredits`'s already-established "one hook, one `nodeType`-branched fetch, per-node-persisted filter/mode" shape | A separate `useTransactionsChart` hook composed alongside `useTransactions` | `useCredits` is the proven precedent for exactly this shape (fetch-by-node-type + period-filter + monthly-aggregate + per-node persistence) in this codebase. A second hook would duplicate the `nodeType` branching and selection-key logic `useCredits`/`useTransactions` already have, and would need its own subscription to `selectedNode` |
+| Asset chart data source | Reuses `state.asset.transactions` — the same `AssetDetailsDto` already fetched by `useTransactions`'s existing `getAssetDetails` call for the table. No new fetch for Asset scope | Fetch transactions separately for the chart even on Asset scope | Matches the PRD's explicit requirement ("computed client-side from the asset's already-loaded transaction list, no new fetch for this case") exactly, and avoids a redundant network call |
+| Shared aggregation input type | The zero-filling aggregation function accepts a minimal structural type `{ date: string; type: string; totalPrice: number }`, satisfied by both `TransactionDto` (Asset, has more fields) and `TransactionSummaryItemDto` (Broker/Portfolio) without any mapping/conversion step | Convert both DTOs to a common shape before aggregating | TypeScript's structural typing already makes both DTOs assignable to the narrower aggregation input type as-is; an explicit conversion step would be redundant code |
+| Zero-fill algorithm | Iterate every calendar month from the period's start (per `getPeriodFilterStartDate`) through the current month, creating a `netInvested: 0` bucket for any month with no matching transactions; for "All Time" (`getPeriodFilterStartDate` returns `null`), iterate from the earliest transaction's month instead | Only fill gaps between the earliest and latest transaction, ignoring the selected period's actual start | The PRD requires gap-free months specifically *within the selected period range*, not just within the data's own span — for "This Month" with zero transactions, the chart must still show one zero-value month, not an empty chart |
+| Bar/Line toggle naming | `ChartDisplayMode = 'Bar' \| 'Line'`, distinct from `useCredits`'s existing `ViewMode = 'Stacked' \| 'Grouped'` | Reuse the `ViewMode` name for both | The two toggles control conceptually different things (chart *type* vs. stacking behavior) and both hooks are imported independently — a shared name would be confusing even though there's no actual TypeScript collision (different modules) |
+| Neutral bar/line colour | A single muted slate colour (`#6b7280`) for every month's bar/point regardless of sign, distinct from the green/red/blue already used elsewhere for Bought/Sold/Credits | Reuse `SignedValueToBrushConverter`-equivalent green/red logic like Total Invested does | The PRD explicitly says no sign colouring here ("the bar's position below/above zero already conveys sign") — this is a deliberate contrast with Total Invested's colour-by-sign treatment elsewhere in the app |
+| Filter/mode persistence | Confirmed with the user: persisted per node selection via the same `Map<selectionKey, prefs>` pattern `useCredits` already uses, keyed by `buildSelectionKey`-equivalent logic (already exported from `useCredits.ts` and reusable directly, since it takes a `SelectedNode` and doesn't depend on credits-specific state) | Reset to defaults (Last 12 Months, Bar) on every node change | Confirmed for UX consistency with the already-shipped Credits tab behavior |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|---------------|---------|------------------------|
+| `Financial.Web/src/api/types.ts` | Modified | Type contract | Add `TransactionSummaryItemDto { assetName: string; date: string; type: string; totalPrice: number }`, mirroring `TransactionSummaryItemDTO` field-for-field |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | API client | Add `getTransactionsByBroker`/`getTransactionsByPortfolio`, mirroring `getCreditsByBroker`/`getCreditsByPortfolio`'s exact pattern (`/transactions/broker/{brokerName}`, `/transactions/portfolio/{brokerName}/{portfolioName}`) |
+| `Financial.Web/src/hooks/useTransactions.ts` | Modified | Data + chart state | Add `brokerPortfolioTransactions: TransactionSummaryItemDto[]` to state; add Broker/Portfolio fetch branches to the existing effect (mirroring `useCredits`'s `nodeType` branching), reusing the existing `FETCH_START`/`FETCH_ERROR` actions and a new `FETCH_TRANSACTIONS_SUCCESS` action (distinct from the existing `FETCH_SUCCESS` which sets `asset`); add `selectedFilter`/`selectedChartMode`/`filterPersistence` state and `setFilter`/`setChartMode` actions, mirroring `useCredits`'s `SET_FILTER`/`SET_MODE`/persistence Map; add a `chartData` memo selecting `state.asset?.transactions ?? []` (Asset) or `state.brokerPortfolioTransactions` (Broker/Portfolio) as the aggregation input, applying the period filter and the new zero-filling monthly aggregation function |
+| `Financial.Web/src/components/TransactionsTab.tsx` | Modified | Rendering | Add a `TransactionsChart` sub-component (period-filter buttons + Bar/Line toggle + recharts `BarChart`/`LineChart`, mirroring `CreditsTab`'s `ChartPanel`/toolbar structure); for Broker/Portfolio, render only `TransactionsChart` in place of the current placeholder text; for Asset, render `TransactionsChart` above the existing (unchanged) table |
+| `Financial.Web/src/components/TransactionsTab.css` | Modified | Styling | Add `transactions-tab__filters`/`__filter-btn`/`__filter-btn--active`, `__modes`/`__mode-btn`/`__mode-btn--active` (copied from `CreditsTab.css`'s equivalent rules), `__chart-panel`/`__chart-title`/`__chart-container` (copied from `CreditsTab.css`) |
+
+**Backend:** None — `GET /transactions/broker/{brokerName}` and `GET /transactions/portfolio/{brokerName}/{portfolioName}` are already implemented (F03, merged to `main`). No API contract, service, or data model changes required.
+
+## 5. API Contracts
+
+Not applicable — no new or modified endpoint. Both endpoints (F03) already return the shape this feature consumes:
+
+**Response Example (200 OK), `GET /transactions/broker/{brokerName}`:**
+```json
+[
+  { "assetName": "BBAS3", "date": "2025-03-20T00:00:00", "type": "Buy", "totalPrice": 9850.40 },
+  { "assetName": "KLBN4", "date": "2025-04-15T00:00:00", "type": "Sell", "totalPrice": 500.00 }
+]
+```
+
+Empty response (`[]`, HTTP 200) is a valid, expected shape (scope with no transactions) — not an error.
+
+## 6. Data Model
+
+Not applicable — no database changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|-----------------|
+| `Financial.Web/src/hooks/useTransactions.test.ts` (extended) | Unit | `useTransactions` | Broker/Portfolio fetch branching, chart-mode/filter state and persistence, zero-filling aggregation correctness, Asset scope reusing the existing fetch |
+| `Financial.Web/src/components/__tests__/TransactionsTab.test.tsx` (extended) | Unit | `TransactionsTab` | Chart renders (no table) for Broker/Portfolio; chart + table both render for Asset; filter buttons, Bar/Line toggle, loading/error states |
+
+**Test Functions:**
+
+| Test Function | Description | Assertions |
+|----------------|--------------|-------------|
+| `calls_getTransactionsByBroker_on_broker_node_selection` | Broker node selected | Client method called with the broker name |
+| `calls_getTransactionsByPortfolio_on_portfolio_node_selection` | Portfolio node selected | Client method called with broker + portfolio names |
+| `does_not_call_broker_or_portfolio_endpoints_on_asset_node_selection` | Asset node selected | Neither new client method called (reuses `getAssetDetails`) |
+| `chartData_zero_fills_months_with_no_transactions_within_selected_period` | Fixture with a gap month, `Last 3 Months` filter | Every month in the 3-month range appears, gap month has `netInvested: 0` |
+| `chartData_computes_net_invested_as_buy_minus_sell_per_month` | Fixture with Buy 1000 + Sell 300 in the same month | That month's bucket is `700` |
+| `chartData_uses_asset_transactions_for_asset_scope` | Asset node, `state.asset.transactions` populated | `chartData` derived from those transactions, not from `brokerPortfolioTransactions` |
+| `setFilter_persists_selection_per_node` | Set filter on Broker A, switch to Broker B, switch back to Broker A | Broker A's filter selection is remembered (mirrors `useCredits`'s equivalent persistence test) |
+| `setChartMode_persists_selection_per_node` | Same persistence pattern for Bar/Line | Mirrors the filter persistence test |
+| `renders_chart_only_for_broker_node_selection` (TransactionsTab) | Broker node, mocked hook returns chart data | Chart renders; no `<table>` element present |
+| `renders_chart_only_for_portfolio_node_selection` (TransactionsTab) | Portfolio node | Same as above |
+| `renders_chart_above_table_for_asset_node_selection` (TransactionsTab) | Asset node | Both chart and the existing table render; table content unchanged from current behaviour |
+| `renders_six_period_filter_buttons` (TransactionsTab) | Any scope | All 6 F04 labels present (mirrors `CreditsTab`'s equivalent test) |
+| `renders_bar_line_toggle_defaulting_to_bar` (TransactionsTab) | Fresh selection | `Bar` toggle button has the active class |
+| `clicking_line_toggle_calls_setChartMode` (TransactionsTab) | User clicks `Line` | `setChartMode('Line')` called |
+| `renders_error_state_with_retry_on_broker_portfolio_fetch_failure` (TransactionsTab) | Fetch fails for Broker/Portfolio | `ErrorState` with Retry renders in place of the chart |
+
+**Acceptance tests (PRD Section 9, F09):**
+- Selecting a Broker or Portfolio node shows the monthly chart instead of the placeholder, with no transaction table → `renders_chart_only_for_broker_node_selection` + `renders_chart_only_for_portfolio_node_selection`
+- Selecting an Asset node shows the existing table plus the new chart above it → `renders_chart_above_table_for_asset_node_selection`
+- Each month's plotted value equals `sum(Buy.totalPrice) − sum(Sell.totalPrice)` → `chartData_computes_net_invested_as_buy_minus_sell_per_month`
+- Months with no transactions within the selected period still appear with a value of 0 → `chartData_zero_fills_months_with_no_transactions_within_selected_period`
+- Chart defaults to Bar; toggling to Line re-renders the same data as a line → `renders_bar_line_toggle_defaulting_to_bar` + `clicking_line_toggle_calls_setChartMode`
+- The 6 period filter buttons correctly narrow the plotted months; default period on load is Last 12 Months → `renders_six_period_filter_buttons` + covered by the hook's default state
+- A failed Broker/Portfolio transaction fetch shows an `ErrorState` with Retry → `renders_error_state_with_retry_on_broker_portfolio_fetch_failure`
+
+**Cross-feature integration tests (PRD Section 9):**
+- The transaction list returned by F03 for a Broker or Portfolio scope is used without transformation by F09 to compute each month's net-invested value → `chartData_computes_net_invested_as_buy_minus_sell_per_month` (uses the F03 DTO shape directly, no mapping)
+- The period options and date-range rules defined by F04 are applied identically by F09 and continue to be applied identically by the existing Credits chart → satisfied by construction: F09 imports `PERIOD_FILTER_OPTIONS`/`getPeriodFilterStartDate` from the same `utils/periodFilter.ts` module F04 already established, with no F09-local reimplementation
+
+## Assumptions and Decisions (from interview)
+
+- **Filter and chart-mode selections persist per node selection**, confirmed with the user, mirroring `CreditsTab`'s existing per-node persistence UX rather than resetting to defaults on every node change.
+- **Hook extension over a new hook**: `useTransactions` is extended in place rather than adding a parallel `useTransactionsChart` hook, since `useCredits` already proves this exact shape works for the analogous Credits feature.
+- **Zero-fill spans the selected period's actual date range** (not just the data's own min/max), so a period with zero transactions still renders a fully gap-free (all-zero) chart rather than an empty one.
+- **Neutral colour (`#6b7280`)** for all bars/points regardless of sign, per the PRD's explicit "no sign colouring" requirement — a deliberate contrast with how Total Invested is coloured elsewhere in the app.


### PR DESCRIPTION
## Summary
- Extends `useTransactions` with Broker/Portfolio fetch branching (mirroring `useCredits`), per-node-persisted period filter and Bar/Line chart-mode state, and a zero-filling `buildMonthlyNetInvested` monthly aggregation
- Adds a `TransactionsChart` component (6 period-filter buttons + Bar/Line toggle + recharts) to `TransactionsTab`: Broker/Portfolio selection now shows the chart only (replacing the old placeholder), Asset selection shows the chart above the existing unchanged transaction table
- No backend changes — reuses the F03 `GET /transactions/broker/{brokerName}` and `GET /transactions/portfolio/{brokerName}/{portfolioName}` endpoints and the F04 shared period-filter module

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 336/336 passing (incl. new hook and component coverage for fetch branching, zero-fill correctness, filter/mode persistence, chart-only vs chart+table rendering)
- [x] `npm run build` — production build succeeds
- [x] Live smoke test via Playwright against the running dev server + API: verified chart renders correctly for Broker, Portfolio, and Asset node selection, Bar/Line toggle and period-filter clicks work, zero console errors throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)