### PR TITLE
feat(P04-F10): Transactions Monthly Investment Chart — WPF

### DIFF
--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -685,136 +685,345 @@
 
                 <!-- Transactions Tab -->
                 <TabItem Header="Transactions">
-                    <DockPanel>
-                        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,8">
-                            <Button Command="{Binding AssetDetails.AddTransactionCommand}" ToolTip="New transaction">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE710;" Margin="0,0,6,0"/>
-                                    <TextBlock Text="New"/>
+                    <TabItem.Resources>
+                        <DataTemplate x:Key="TransactionsAssetTemplate">
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="2*"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,8">
+                                    <Button Command="{Binding AssetDetails.AddTransactionCommand}" ToolTip="New transaction">
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE710;" Margin="0,0,6,0"/>
+                                            <TextBlock Text="New"/>
+                                        </StackPanel>
+                                    </Button>
                                 </StackPanel>
-                            </Button>
-                        </StackPanel>
-                        <DataGrid ItemsSource="{Binding AssetDetails.Transactions}"
-                                  SelectedItem="{Binding AssetDetails.SelectedTransaction, Mode=TwoWay}"
-                                  AutoGenerateColumns="False"
-                                  CanUserAddRows="False"
-                                  IsReadOnly="True">
-                            <DataGrid.InputBindings>
-                                <MouseBinding MouseAction="LeftDoubleClick"
-                                              Command="{Binding AssetDetails.UpdateTransactionCommand}"/>
-                            </DataGrid.InputBindings>
-                            <DataGrid.Columns>
-                                <DataGridTemplateColumn Header="" Width="Auto">
-                                    <DataGridTemplateColumn.CellTemplate>
+                                <DataGrid Grid.Row="1"
+                                          ItemsSource="{Binding AssetDetails.Transactions}"
+                                          SelectedItem="{Binding AssetDetails.SelectedTransaction, Mode=TwoWay}"
+                                          AutoGenerateColumns="False"
+                                          CanUserAddRows="False"
+                                          IsReadOnly="True">
+                                    <DataGrid.InputBindings>
+                                        <MouseBinding MouseAction="LeftDoubleClick"
+                                                      Command="{Binding AssetDetails.UpdateTransactionCommand}"/>
+                                    </DataGrid.InputBindings>
+                                    <DataGrid.Columns>
+                                        <DataGridTemplateColumn Header="" Width="Auto">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <StackPanel Orientation="Horizontal">
+                                                        <Button Command="{Binding DataContext.AssetDetails.UpdateTransactionCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                                CommandParameter="{Binding}"
+                                                                ToolTip="Update"
+                                                                Padding="2"
+                                                                Margin="0,0,4,0">
+                                                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE70F;"/>
+                                                        </Button>
+                                                        <Button Command="{Binding DataContext.AssetDetails.DeleteTransactionCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                                CommandParameter="{Binding}"
+                                                                ToolTip="Delete"
+                                                                Padding="2">
+                                                            <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE74D;"/>
+                                                        </Button>
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+                                        <DataGridTextColumn Header="Date"
+                                                            Binding="{Binding Date, Converter={StaticResource DateFormatConverter}, ConverterParameter='d'}"
+                                                            Width="Auto"/>
+                                        <DataGridTextColumn Header="Type"
+                                                            Binding="{Binding Type}"
+                                                            Width="Auto">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Foreground"
+                                                            Value="{Binding Type, Converter={StaticResource TransactionTypeToColorConverter}}"/>
+                                                    <Setter Property="FontWeight" Value="Bold"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Quantity"
+                                                            Binding="{Binding Quantity, StringFormat=N8}"
+                                                            Width="Auto">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Unit Price"
+                                                            Binding="{Binding UnitPrice, StringFormat=N2}"
+                                                            Width="Auto">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Fees"
+                                                            Binding="{Binding Fees, StringFormat=N2}"
+                                                            Width="Auto">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                        <DataGridTextColumn Header="Total"
+                                                            Binding="{Binding TotalPrice, StringFormat=N2}"
+                                                            Width="*"
+                                                            IsReadOnly="True">
+                                            <DataGridTextColumn.ElementStyle>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                    <Setter Property="FontWeight" Value="Bold"/>
+                                                </Style>
+                                            </DataGridTextColumn.ElementStyle>
+                                        </DataGridTextColumn>
+                                    </DataGrid.Columns>
+                                    <DataGrid.RowStyle>
+                                        <Style TargetType="DataGridRow">
+                                            <Style.Triggers>
+                                                <Trigger Property="IsSelected" Value="True">
+                                                    <Setter Property="Background" Value="LightYellow"/>
+                                                </Trigger>
+                                                <MultiTrigger>
+                                                    <MultiTrigger.Conditions>
+                                                        <Condition Property="IsSelected" Value="True"/>
+                                                        <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
+                                                    </MultiTrigger.Conditions>
+                                                    <Setter Property="Background" Value="LightYellow"/>
+                                                </MultiTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </DataGrid.RowStyle>
+                                    <DataGrid.CellStyle>
+                                        <Style TargetType="DataGridCell">
+                                            <Style.Triggers>
+                                                <Trigger Property="IsSelected" Value="True">
+                                                    <Setter Property="Background" Value="LightYellow"/>
+                                                    <Setter Property="Foreground" Value="Black"/>
+                                                </Trigger>
+                                                <MultiTrigger>
+                                                    <MultiTrigger.Conditions>
+                                                        <Condition Property="IsSelected" Value="True"/>
+                                                        <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
+                                                    </MultiTrigger.Conditions>
+                                                    <Setter Property="Background" Value="LightYellow"/>
+                                                    <Setter Property="Foreground" Value="Black"/>
+                                                </MultiTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </DataGrid.CellStyle>
+                                </DataGrid>
+                                <GridSplitter Grid.Row="2"
+                                              Height="6"
+                                              HorizontalAlignment="Stretch"
+                                              Background="#E0E0E0"
+                                              ResizeDirection="Rows"
+                                              ResizeBehavior="PreviousAndNext"/>
+                                <oxy:PlotView Grid.Row="3"
+                                              Background="Transparent"
+                                              Model="{Binding AssetDetails.TransactionsPlotModel}"
+                                              SizeChanged="OnTransactionsPlotSizeChanged" />
+                                <StackPanel Grid.Row="4"
+                                            Orientation="Horizontal"
+                                            HorizontalAlignment="Center"
+                                            Margin="0,8,0,0">
+                                    <TextBlock Text="View:" Margin="0,0,8,0" Foreground="#666666"/>
+                                    <ItemsControl ItemsSource="{Binding AssetDetails.ChartTypeModes}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <StackPanel Orientation="Horizontal"/>
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Button Command="{Binding DataContext.AssetDetails.SelectTransactionsChartModeCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                        CommandParameter="{Binding}"
+                                                        Background="Transparent"
+                                                        BorderThickness="0"
+                                                        Padding="4,0"
+                                                        Margin="0,0,12,0">
+                                                    <TextBlock Text="{Binding Label}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Foreground" Value="#007ACC"/>
+                                                                <Setter Property="TextDecorations" Value="Underline"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                                        <Setter Property="Foreground" Value="Black"/>
+                                                                        <Setter Property="TextDecorations" Value="{x:Null}"/>
+                                                                        <Setter Property="FontWeight" Value="Bold"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Button>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                                <ItemsControl Grid.Row="5"
+                                              ItemsSource="{Binding AssetDetails.TransactionsFilters}"
+                                              HorizontalAlignment="Center"
+                                              Margin="0,6,0,0">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Horizontal"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
                                         <DataTemplate>
-                                            <StackPanel Orientation="Horizontal">
-                                                <Button Command="{Binding DataContext.AssetDetails.UpdateTransactionCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                                                        CommandParameter="{Binding}"
-                                                        ToolTip="Update"
-                                                        Padding="2"
-                                                        Margin="0,0,4,0">
-                                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE70F;"/>
-                                                </Button>
-                                                <Button Command="{Binding DataContext.AssetDetails.DeleteTransactionCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                                                        CommandParameter="{Binding}"
-                                                        ToolTip="Delete"
-                                                        Padding="2">
-                                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE74D;"/>
-                                                </Button>
-                                            </StackPanel>
+                                            <Button Command="{Binding DataContext.AssetDetails.SelectTransactionsFilterCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    Background="Transparent"
+                                                    BorderThickness="0"
+                                                    Padding="4,0"
+                                                    Margin="0,0,12,0">
+                                                <TextBlock Text="{Binding Label}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Foreground" Value="#007ACC"/>
+                                                            <Setter Property="TextDecorations" Value="Underline"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                                    <Setter Property="Foreground" Value="Black"/>
+                                                                    <Setter Property="TextDecorations" Value="{x:Null}"/>
+                                                                    <Setter Property="FontWeight" Value="Bold"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Button>
                                         </DataTemplate>
-                                    </DataGridTemplateColumn.CellTemplate>
-                                </DataGridTemplateColumn>
-                                <DataGridTextColumn Header="Date" 
-                                                    Binding="{Binding Date, Converter={StaticResource DateFormatConverter}, ConverterParameter='d'}" 
-                                                    Width="Auto"/>
-                                <DataGridTextColumn Header="Type" 
-                                                    Binding="{Binding Type}" 
-                                                    Width="Auto">
-                                    <DataGridTextColumn.ElementStyle>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Foreground" 
-                                                    Value="{Binding Type, Converter={StaticResource TransactionTypeToColorConverter}}"/>
-                                            <Setter Property="FontWeight" Value="Bold"/>
-                                        </Style>
-                                    </DataGridTextColumn.ElementStyle>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Header="Quantity" 
-                                                    Binding="{Binding Quantity, StringFormat=N8}" 
-                                                    Width="Auto">
-                                    <DataGridTextColumn.ElementStyle>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="TextAlignment" Value="Right"/>
-                                        </Style>
-                                    </DataGridTextColumn.ElementStyle>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Header="Unit Price" 
-                                                    Binding="{Binding UnitPrice, StringFormat=N2}" 
-                                                    Width="Auto">
-                                    <DataGridTextColumn.ElementStyle>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="TextAlignment" Value="Right"/>
-                                        </Style>
-                                    </DataGridTextColumn.ElementStyle>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Header="Fees" 
-                                                    Binding="{Binding Fees, StringFormat=N2}" 
-                                                    Width="Auto">
-                                    <DataGridTextColumn.ElementStyle>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="TextAlignment" Value="Right"/>
-                                        </Style>
-                                    </DataGridTextColumn.ElementStyle>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Header="Total" 
-                                                    Binding="{Binding TotalPrice, StringFormat=N2}" 
-                                                    Width="*"
-                                                    IsReadOnly="True">
-                                    <DataGridTextColumn.ElementStyle>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="TextAlignment" Value="Right"/>
-                                            <Setter Property="FontWeight" Value="Bold"/>
-                                        </Style>
-                                    </DataGridTextColumn.ElementStyle>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                            <DataGrid.RowStyle>
-                                <Style TargetType="DataGridRow">
-                                    <Style.Triggers>
-                                        <Trigger Property="IsSelected" Value="True">
-                                            <Setter Property="Background" Value="LightYellow"/>
-                                        </Trigger>
-                                        <MultiTrigger>
-                                            <MultiTrigger.Conditions>
-                                                <Condition Property="IsSelected" Value="True"/>
-                                                <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                            </MultiTrigger.Conditions>
-                                            <Setter Property="Background" Value="LightYellow"/>
-                                        </MultiTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </DataGrid.RowStyle>
-                            <DataGrid.CellStyle>
-                            <Style TargetType="DataGridCell">
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </Grid>
+                        </DataTemplate>
+                        <DataTemplate x:Key="TransactionsAggregateTemplate">
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.Row="0"
+                                           Text="Loading transactions..."
+                                           Margin="0,0,0,8"
+                                           Visibility="{Binding AssetDetails.IsTransactionsLoading, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                <TextBlock Grid.Row="1"
+                                           Text="{Binding AssetDetails.TransactionsError}"
+                                           Foreground="DarkRed"
+                                           Margin="0,0,0,8"
+                                           Visibility="{Binding AssetDetails.HasTransactionsError, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                <oxy:PlotView Grid.Row="2"
+                                              Background="Transparent"
+                                              Model="{Binding AssetDetails.TransactionsPlotModel}"
+                                              SizeChanged="OnTransactionsPlotSizeChanged" />
+                                <StackPanel Grid.Row="3"
+                                            Orientation="Horizontal"
+                                            HorizontalAlignment="Center"
+                                            Margin="0,8,0,0">
+                                    <TextBlock Text="View:" Margin="0,0,8,0" Foreground="#666666"/>
+                                    <ItemsControl ItemsSource="{Binding AssetDetails.ChartTypeModes}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <StackPanel Orientation="Horizontal"/>
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Button Command="{Binding DataContext.AssetDetails.SelectTransactionsChartModeCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                        CommandParameter="{Binding}"
+                                                        Background="Transparent"
+                                                        BorderThickness="0"
+                                                        Padding="4,0"
+                                                        Margin="0,0,12,0">
+                                                    <TextBlock Text="{Binding Label}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Foreground" Value="#007ACC"/>
+                                                                <Setter Property="TextDecorations" Value="Underline"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                                        <Setter Property="Foreground" Value="Black"/>
+                                                                        <Setter Property="TextDecorations" Value="{x:Null}"/>
+                                                                        <Setter Property="FontWeight" Value="Bold"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Button>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                                <ItemsControl Grid.Row="4"
+                                              ItemsSource="{Binding AssetDetails.TransactionsFilters}"
+                                              HorizontalAlignment="Center"
+                                              Margin="0,6,0,0">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Horizontal"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Button Command="{Binding DataContext.AssetDetails.SelectTransactionsFilterCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    Background="Transparent"
+                                                    BorderThickness="0"
+                                                    Padding="4,0"
+                                                    Margin="0,0,12,0">
+                                                <TextBlock Text="{Binding Label}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Foreground" Value="#007ACC"/>
+                                                            <Setter Property="TextDecorations" Value="Underline"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                                    <Setter Property="Foreground" Value="Black"/>
+                                                                    <Setter Property="TextDecorations" Value="{x:Null}"/>
+                                                                    <Setter Property="FontWeight" Value="Bold"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </Button>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </Grid>
+                        </DataTemplate>
+                    </TabItem.Resources>
+                    <ContentControl Content="{Binding}">
+                        <ContentControl.Style>
+                            <Style TargetType="ContentControl">
+                                <Setter Property="ContentTemplate" Value="{StaticResource TransactionsAssetTemplate}"/>
                                 <Style.Triggers>
-                                    <Trigger Property="IsSelected" Value="True">
-                                        <Setter Property="Background" Value="LightYellow"/>
-                                        <Setter Property="Foreground" Value="Black"/>
-                                    </Trigger>
-                                    <MultiTrigger>
-                                        <MultiTrigger.Conditions>
-                                            <Condition Property="IsSelected" Value="True"/>
-                                            <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                        </MultiTrigger.Conditions>
-                                        <Setter Property="Background" Value="LightYellow"/>
-                                        <Setter Property="Foreground" Value="Black"/>
-                                    </MultiTrigger>
+                                    <DataTrigger Binding="{Binding AssetDetails.IsTransactionsAggregateView}" Value="True">
+                                        <Setter Property="ContentTemplate" Value="{StaticResource TransactionsAggregateTemplate}"/>
+                                    </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </DataGrid.CellStyle>
-                    </DataGrid>
-                </DockPanel>
-            </TabItem>
+                        </ContentControl.Style>
+                    </ContentControl>
+                </TabItem>
 
                 <!-- Credits Tab -->
                 <TabItem Header="Credits">

--- a/Financial.App/Components/NavigationView.xaml.cs
+++ b/Financial.App/Components/NavigationView.xaml.cs
@@ -20,6 +20,14 @@ namespace Financial.Presentation.App.Components
                 viewModel.AssetDetails.UpdateCreditsPlotWidth(e.NewSize.Width);
             }
         }
+
+        private void OnTransactionsPlotSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (DataContext is IMainNavigationViewModel viewModel)
+            {
+                viewModel.AssetDetails.UpdateTransactionsPlotWidth(e.NewSize.Width);
+            }
+        }
     }
 }
 

--- a/Financial.App/Financial.App.csproj
+++ b/Financial.App/Financial.App.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Financial.Presentation.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -16,6 +16,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private readonly ICreditService _creditService;
     private readonly IAssetPriceService _assetPriceService;
     private readonly IBrokerBreakdownQueryService _brokerBreakdownQueryService;
+    private readonly ITransactionQueryService _transactionQueryService;
     private readonly TodayInfoTracker _todayInfo;
     private readonly TransactionActions _transactionActions;
     private readonly CreditActions _creditActions;
@@ -29,6 +30,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private readonly RelayCommand _copyAssetNameCommand;
     private readonly RelayCommand _selectCreditsFilterCommand;
     private readonly RelayCommand _selectCreditsTypeModeCommand;
+    private readonly RelayCommand _selectTransactionsFilterCommand;
+    private readonly RelayCommand _selectTransactionsChartModeCommand;
     private string _assetName = string.Empty;
     private string _brokerName = string.Empty;
     private string _portfolioName = string.Empty;
@@ -74,6 +77,19 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private CreditDTO? _selectedCredit;
     private IReadOnlyList<CreditsMonthTypeTotals> _creditsChartMonths = Array.Empty<CreditsMonthTypeTotals>();
     private IReadOnlyList<string> _creditsChartTypes = Array.Empty<string>();
+    private PlotModel? _transactionsPlotModel;
+    private PeriodFilter _selectedTransactionsFilter = PeriodFilter.Last12Months;
+    private ChartTypeMode _selectedTransactionsChartMode = ChartTypeMode.Bar;
+    private const string DefaultTransactionsContextKey = "default";
+    private readonly Dictionary<string, TransactionsViewState> _transactionsViewStateByKey = new(StringComparer.OrdinalIgnoreCase);
+    private string _transactionsContextKey = DefaultTransactionsContextKey;
+    private double _transactionsPlotWidth;
+    private bool _isTransactionsAggregateView;
+    private bool _isTransactionsLoading;
+    private string? _transactionsError;
+    private CancellationTokenSource? _transactionsCts;
+    private IReadOnlyList<TransactionSummaryItemDTO> _brokerPortfolioTransactions = Array.Empty<TransactionSummaryItemDTO>();
+    private IReadOnlyList<TransactionMonthNet> _transactionsChartMonths = Array.Empty<TransactionMonthNet>();
 
     public string AssetName { get => _assetName; private set => SetProperty(ref _assetName, value); }
     public string BrokerName { get => _brokerName; private set => SetProperty(ref _brokerName, value); }
@@ -238,6 +254,31 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public ObservableCollection<CreditsFilterOptionViewModel> CreditsFilters { get; } = new();
     public ObservableCollection<CreditsTypeModeOptionViewModel> CreditsTypeModes { get; } = new();
 
+    public PlotModel? TransactionsPlotModel { get => _transactionsPlotModel; private set => SetProperty(ref _transactionsPlotModel, value); }
+
+    public bool IsTransactionsAggregateView
+    {
+        get => _isTransactionsAggregateView;
+        private set => SetProperty(ref _isTransactionsAggregateView, value);
+    }
+
+    public bool IsTransactionsLoading
+    {
+        get => _isTransactionsLoading;
+        private set => SetProperty(ref _isTransactionsLoading, value);
+    }
+
+    public string? TransactionsError
+    {
+        get => _transactionsError;
+        private set { if (SetProperty(ref _transactionsError, value)) OnPropertyChanged(nameof(HasTransactionsError)); }
+    }
+
+    public bool HasTransactionsError => TransactionsError != null;
+
+    public ObservableCollection<TransactionsFilterOptionViewModel> TransactionsFilters { get; } = new();
+    public ObservableCollection<ChartTypeModeOptionViewModel> ChartTypeModes { get; } = new();
+
     public TransactionDTO? SelectedTransaction
     {
         get => _selectedTransaction;
@@ -260,17 +301,21 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public RelayCommand CopyAssetNameCommand => _copyAssetNameCommand;
     public RelayCommand SelectCreditsFilterCommand => _selectCreditsFilterCommand;
     public RelayCommand SelectCreditsTypeModeCommand => _selectCreditsTypeModeCommand;
+    public RelayCommand SelectTransactionsFilterCommand => _selectTransactionsFilterCommand;
+    public RelayCommand SelectTransactionsChartModeCommand => _selectTransactionsChartModeCommand;
 
     public AssetDetailsViewModel(
         ITransactionService transactionService,
         ICreditService creditService,
         IAssetPriceService assetPriceService,
-        IBrokerBreakdownQueryService brokerBreakdownQueryService)
+        IBrokerBreakdownQueryService brokerBreakdownQueryService,
+        ITransactionQueryService transactionQueryService)
     {
         _transactionService = transactionService ?? throw new ArgumentNullException(nameof(transactionService));
         _creditService = creditService ?? throw new ArgumentNullException(nameof(creditService));
         _assetPriceService = assetPriceService ?? throw new ArgumentNullException(nameof(assetPriceService));
         _brokerBreakdownQueryService = brokerBreakdownQueryService ?? throw new ArgumentNullException(nameof(brokerBreakdownQueryService));
+        _transactionQueryService = transactionQueryService ?? throw new ArgumentNullException(nameof(transactionQueryService));
         _todayInfo = new TodayInfoTracker(ApplyTodayInfo, ResetTodayInfo, UpdateCommandStates);
         _transactionActions = new TransactionActions(
             _transactionService,
@@ -298,8 +343,12 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         _copyAssetNameCommand = new RelayCommand(CopyAssetName, CanCopyAssetName);
         _selectCreditsFilterCommand = new RelayCommand(SelectCreditsFilter);
         _selectCreditsTypeModeCommand = new RelayCommand(SelectCreditsTypeMode);
+        _selectTransactionsFilterCommand = new RelayCommand(SelectTransactionsFilter);
+        _selectTransactionsChartModeCommand = new RelayCommand(SelectTransactionsChartMode);
         InitializeCreditsFilters();
         InitializeCreditsTypeModes();
+        InitializeTransactionsFilters();
+        InitializeChartTypeModes();
     }
 
     public void LoadPortfolioSummary(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits, IReadOnlyList<PortfolioAssetSummaryItemDTO> assetItems)
@@ -337,6 +386,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         IsPortfolioView = false;
         IsBrokerView = false;
         CancelAndResetBreakdownFetch();
+        IsTransactionsAggregateView = false;
+        CancelAndResetTransactionsFetch();
         var assetKey = BuildAssetKey(details.BrokerName, details.PortfolioName, details.Name);
         _todayInfo.UpdateAssetKey(assetKey);
 
@@ -368,6 +419,9 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
             Credits.Add(credit);
         ApplyCreditsFilter();
 
+        SetTransactionsContext(BuildCreditsAssetKey(details.BrokerName, details.PortfolioName, details.Name), rebuild: false);
+        ApplyTransactionsFilter();
+
         SelectedTransaction = null;
         SelectedCredit = null;
         UpdateCommandStates();
@@ -394,6 +448,9 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         IsCreditsAggregateView = false;
         HasCreditsContext = false;
         _creditsContextKey = DefaultCreditsContextKey;
+        IsTransactionsAggregateView = false;
+        CancelAndResetTransactionsFetch();
+        _transactionsContextKey = DefaultTransactionsContextKey;
         SelectedTransaction = null;
         SelectedCredit = null;
         UpdateCommandStates();
@@ -433,6 +490,54 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
     {
         LoadAggregateCredits(BuildPortfolioKey(brokerName, portfolioName), summary, credits);
+    }
+
+    public Task LoadBrokerTransactions(string brokerName)
+    {
+        CancelAndResetTransactionsFetch();
+        IsTransactionsLoading = true;
+
+        _transactionsCts = new CancellationTokenSource();
+        var token = _transactionsCts.Token;
+        return Task.Run(() =>
+        {
+            try
+            {
+                var transactions = _transactionQueryService.GetTransactionsByBroker(brokerName);
+                if (token.IsCancellationRequested) return;
+                ApplyFetchedTransactions(transactions);
+            }
+            catch
+            {
+                if (token.IsCancellationRequested) return;
+                TransactionsError = "Unable to load transactions";
+                IsTransactionsLoading = false;
+            }
+        }, token);
+    }
+
+    public Task LoadPortfolioTransactions(string brokerName, string portfolioName)
+    {
+        CancelAndResetTransactionsFetch();
+        IsTransactionsLoading = true;
+
+        _transactionsCts = new CancellationTokenSource();
+        var token = _transactionsCts.Token;
+        return Task.Run(() =>
+        {
+            try
+            {
+                var transactions = _transactionQueryService.GetTransactionsByPortfolio(brokerName, portfolioName);
+                if (token.IsCancellationRequested) return;
+                ApplyFetchedTransactions(transactions);
+            }
+            catch
+            {
+                if (token.IsCancellationRequested) return;
+                TransactionsError = "Unable to load transactions";
+                IsTransactionsLoading = false;
+            }
+        }, token);
     }
 
     private bool HasAssetContext =>
@@ -510,6 +615,10 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
             Credits.Add(credit);
         TotalCredits = credits.Sum(credit => credit.Value);
         ApplyCreditsFilter();
+
+        IsTransactionsAggregateView = true;
+        CancelAndResetTransactionsFetch();
+        SetTransactionsContext(contextKey, rebuild: false);
 
         SelectedTransaction = null;
         SelectedCredit = null;
@@ -597,6 +706,25 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         OnPropertyChanged(nameof(HasBreakdownData));
     }
 
+    private void ApplyFetchedTransactions(IReadOnlyList<TransactionSummaryItemDTO> transactions)
+    {
+        _brokerPortfolioTransactions = transactions;
+        ApplyTransactionsFilter();
+        IsTransactionsLoading = false;
+    }
+
+    private void CancelAndResetTransactionsFetch()
+    {
+        _transactionsCts?.Cancel();
+        _transactionsCts?.Dispose();
+        _transactionsCts = null;
+        IsTransactionsLoading = false;
+        TransactionsError = null;
+        TransactionsPlotModel = null;
+        _brokerPortfolioTransactions = Array.Empty<TransactionSummaryItemDTO>();
+        _transactionsChartMonths = Array.Empty<TransactionMonthNet>();
+    }
+
     private void SubscribeToRowPriceChanges(PortfolioAssetSummaryRowViewModel row)
     {
         void Handler(object? sender, PropertyChangedEventArgs e)
@@ -642,6 +770,13 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         if (plotWidth <= 0 || CreditsPlotModel == null) return;
         _creditsPlotWidth = plotWidth;
         CreditsChartBuilder.ApplyLabelDensity(CreditsPlotModel, _creditsPlotWidth, _creditsChartMonths, _creditsChartTypes, _selectedCreditsTypeMode);
+    }
+
+    public void UpdateTransactionsPlotWidth(double plotWidth)
+    {
+        if (plotWidth <= 0 || TransactionsPlotModel == null) return;
+        _transactionsPlotWidth = plotWidth;
+        TransactionsChartBuilder.ApplyLabelDensity(TransactionsPlotModel, _transactionsPlotWidth, _transactionsChartMonths);
     }
 
     private void InitializeCreditsFilters()
@@ -783,6 +918,114 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     {
         if (!string.IsNullOrWhiteSpace(_creditsContextKey))
             _creditsViewStateByKey[_creditsContextKey] = new CreditsViewState(_selectedCreditsFilter, _selectedCreditsTypeMode);
+    }
+
+    private void InitializeTransactionsFilters()
+    {
+        TransactionsFilters.Clear();
+        foreach (var (label, filter) in PeriodFilterHelper.Options)
+            TransactionsFilters.Add(new TransactionsFilterOptionViewModel(label, filter));
+        SetTransactionsFilter(PeriodFilter.Last12Months, rebuild: false);
+    }
+
+    private void InitializeChartTypeModes()
+    {
+        ChartTypeModes.Clear();
+        ChartTypeModes.Add(new ChartTypeModeOptionViewModel("Bar", ChartTypeMode.Bar));
+        ChartTypeModes.Add(new ChartTypeModeOptionViewModel("Line", ChartTypeMode.Line));
+        SetTransactionsChartMode(ChartTypeMode.Bar, rebuild: false);
+    }
+
+    private void SelectTransactionsFilter(object? parameter)
+    {
+        if (parameter is TransactionsFilterOptionViewModel option) { SetTransactionsFilter(option.Filter); return; }
+        if (parameter is PeriodFilter filter) SetTransactionsFilter(filter);
+    }
+
+    private void SelectTransactionsChartMode(object? parameter)
+    {
+        if (parameter is ChartTypeModeOptionViewModel option) { SetTransactionsChartMode(option.Mode); return; }
+        if (parameter is ChartTypeMode mode) SetTransactionsChartMode(mode);
+    }
+
+    private void SetTransactionsFilter(PeriodFilter filter, bool rebuild = true)
+    {
+        if (_selectedTransactionsFilter == filter && TransactionsFilters.Count > 0)
+        {
+            UpdateTransactionsFilterSelection();
+            return;
+        }
+        _selectedTransactionsFilter = filter;
+        UpdateTransactionsFilterSelection();
+        UpdateTransactionsViewState();
+        if (rebuild) ApplyTransactionsFilter();
+    }
+
+    private void SetTransactionsChartMode(ChartTypeMode mode, bool rebuild = true)
+    {
+        if (_selectedTransactionsChartMode == mode && ChartTypeModes.Count > 0)
+        {
+            UpdateTransactionsChartModeSelection();
+            return;
+        }
+        _selectedTransactionsChartMode = mode;
+        UpdateTransactionsChartModeSelection();
+        UpdateTransactionsViewState();
+        if (rebuild) ApplyTransactionsFilter();
+    }
+
+    private void UpdateTransactionsFilterSelection()
+    {
+        foreach (var option in TransactionsFilters)
+            option.IsSelected = option.Filter == _selectedTransactionsFilter;
+    }
+
+    private void UpdateTransactionsChartModeSelection()
+    {
+        foreach (var option in ChartTypeModes)
+            option.IsSelected = option.Mode == _selectedTransactionsChartMode;
+    }
+
+    private void ApplyTransactionsFilter()
+    {
+        IEnumerable<(DateTime Date, string Type, decimal TotalPrice)> source = IsTransactionsAggregateView
+            ? _brokerPortfolioTransactions.Select(t => (t.Date, t.Type, t.TotalPrice))
+            : Transactions.Select(t => (t.Date, t.Type, t.TotalPrice));
+
+        var months = TransactionsMonthlyAggregator.BuildMonthlyNetInvested(source, _selectedTransactionsFilter, DateTime.Today);
+        _transactionsChartMonths = months;
+        TransactionsPlotModel = TransactionsChartBuilder.Build(months, _selectedTransactionsChartMode);
+        if (TransactionsPlotModel != null)
+            TransactionsChartBuilder.ApplyLabelDensity(TransactionsPlotModel, _transactionsPlotWidth, months);
+    }
+
+    private void SetTransactionsContext(string contextKey, bool rebuild = true)
+    {
+        _transactionsContextKey = string.IsNullOrWhiteSpace(contextKey) ? DefaultTransactionsContextKey : contextKey;
+        var state = GetTransactionsViewState(_transactionsContextKey);
+        ApplyTransactionsViewState(state, rebuild);
+    }
+
+    private TransactionsViewState GetTransactionsViewState(string contextKey)
+    {
+        if (_transactionsViewStateByKey.TryGetValue(contextKey, out var state))
+            return state;
+        state = new TransactionsViewState(PeriodFilter.Last12Months, ChartTypeMode.Bar);
+        _transactionsViewStateByKey[contextKey] = state;
+        return state;
+    }
+
+    private void ApplyTransactionsViewState(TransactionsViewState state, bool rebuild)
+    {
+        SetTransactionsFilter(state.Filter, rebuild: false);
+        SetTransactionsChartMode(state.Mode, rebuild: false);
+        if (rebuild) ApplyTransactionsFilter();
+    }
+
+    private void UpdateTransactionsViewState()
+    {
+        if (!string.IsNullOrWhiteSpace(_transactionsContextKey))
+            _transactionsViewStateByKey[_transactionsContextKey] = new TransactionsViewState(_selectedTransactionsFilter, _selectedTransactionsChartMode);
     }
 
     private static string BuildAssetKey(string brokerName, string portfolioName, string assetName) =>

--- a/Financial.App/ViewModels/ChartTypeMode.cs
+++ b/Financial.App/ViewModels/ChartTypeMode.cs
@@ -1,0 +1,7 @@
+namespace Financial.Presentation.App.ViewModels;
+
+public enum ChartTypeMode
+{
+    Bar,
+    Line
+}

--- a/Financial.App/ViewModels/ChartTypeModeOptionViewModel.cs
+++ b/Financial.App/ViewModels/ChartTypeModeOptionViewModel.cs
@@ -1,0 +1,21 @@
+namespace Financial.Presentation.App.ViewModels;
+
+public sealed class ChartTypeModeOptionViewModel : ViewModelBase
+{
+    private bool _isSelected;
+
+    public ChartTypeModeOptionViewModel(string label, ChartTypeMode mode)
+    {
+        Label = label;
+        Mode = mode;
+    }
+
+    public string Label { get; }
+    public ChartTypeMode Mode { get; }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => SetProperty(ref _isSelected, value);
+    }
+}

--- a/Financial.App/ViewModels/IAssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/IAssetDetailsViewModel.cs
@@ -16,5 +16,6 @@ public interface IAssetDetailsViewModel
     void Clear();
     Task EnsureTodayInfoLoadedAsync();
     void UpdateCreditsPlotWidth(double plotWidth);
+    void UpdateTransactionsPlotWidth(double plotWidth);
 }
 

--- a/Financial.App/ViewModels/IAssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/IAssetDetailsViewModel.cs
@@ -9,8 +9,10 @@ public interface IAssetDetailsViewModel
     void LoadAssetDetails(AssetDetailsDTO details);
     void LoadBrokerSummary(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
     Task LoadBrokerBreakdown(string brokerName);
+    Task LoadBrokerTransactions(string brokerName);
     void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
     void LoadPortfolioSummary(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits, IReadOnlyList<PortfolioAssetSummaryItemDTO> assetItems);
+    Task LoadPortfolioTransactions(string brokerName, string portfolioName);
     void Clear();
     Task EnsureTodayInfoLoadedAsync();
     void UpdateCreditsPlotWidth(double plotWidth);

--- a/Financial.App/ViewModels/MainNavigationViewModel.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModel.cs
@@ -15,7 +15,8 @@ public class MainNavigationViewModel : MainNavigationViewModelBase<AssetDetailsV
         ITransactionService transactionService,
         ICreditService creditService,
         IAssetPriceService assetPriceService,
-        IBrokerBreakdownQueryService brokerBreakdownQueryService)
+        IBrokerBreakdownQueryService brokerBreakdownQueryService,
+        ITransactionQueryService transactionQueryService)
         : base(
             navigationService ?? throw new ArgumentNullException(nameof(navigationService)),
             creditQueryService ?? throw new ArgumentNullException(nameof(creditQueryService)),
@@ -25,7 +26,8 @@ public class MainNavigationViewModel : MainNavigationViewModelBase<AssetDetailsV
                 transactionService ?? throw new ArgumentNullException(nameof(transactionService)),
                 creditService ?? throw new ArgumentNullException(nameof(creditService)),
                 assetPriceService ?? throw new ArgumentNullException(nameof(assetPriceService)),
-                brokerBreakdownQueryService ?? throw new ArgumentNullException(nameof(brokerBreakdownQueryService))))
+                brokerBreakdownQueryService ?? throw new ArgumentNullException(nameof(brokerBreakdownQueryService)),
+                transactionQueryService ?? throw new ArgumentNullException(nameof(transactionQueryService))))
     {
     }
 }

--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -278,6 +278,7 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
         var credits = _creditQueryService.GetCreditsByPortfolio(brokerName, portfolioName);
         var assetItems = _portfolioAssetSummaryQueryService.GetPortfolioAssetsSummary(brokerName, portfolioName);
         AssetDetails.LoadPortfolioSummary(brokerName, portfolioName, summary, credits, assetItems);
+        _ = AssetDetails.LoadPortfolioTransactions(brokerName, portfolioName);
     }
 
     private void LoadBrokerCredits(TreeNodeViewModel brokerNode)
@@ -293,5 +294,6 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
         var credits = _creditQueryService.GetCreditsByBroker(brokerName);
         AssetDetails.LoadBrokerSummary(brokerName, summary, credits);
         _ = AssetDetails.LoadBrokerBreakdown(brokerName);
+        _ = AssetDetails.LoadBrokerTransactions(brokerName);
     }
 }

--- a/Financial.App/ViewModels/TransactionsChartBuilder.cs
+++ b/Financial.App/ViewModels/TransactionsChartBuilder.cs
@@ -1,0 +1,153 @@
+using OxyPlot;
+using OxyPlot.Annotations;
+using OxyPlot.Axes;
+using OxyPlot.Series;
+
+namespace Financial.Presentation.App.ViewModels;
+
+internal static class TransactionsChartBuilder
+{
+    private const string TransactionsValueLabelTag = "TransactionsValueLabel";
+    private const double BarWidth = 0.8;
+    private const double MinLabelWidth = 52;
+    private static readonly OxyColor NeutralColor = OxyColor.FromRgb(107, 114, 128);
+
+    public static PlotModel Build(IReadOnlyList<TransactionMonthNet> months, ChartTypeMode mode)
+    {
+        var (model, categoryAxis) = CreateModelWithAxes();
+
+        if (months.Count == 0)
+            return model;
+
+        foreach (var month in months)
+            categoryAxis.Labels.Add(month.Month.ToString("MM/yyyy"));
+
+        model.Series.Add(mode == ChartTypeMode.Bar
+            ? BuildBarSeries(months)
+            : BuildLineSeries(months));
+
+        return model;
+    }
+
+    public static void ApplyLabelDensity(
+        PlotModel model,
+        double plotWidth,
+        IReadOnlyList<TransactionMonthNet> months)
+    {
+        if (plotWidth <= 0) return;
+
+        var categoryAxis = model.Axes.OfType<CategoryAxis>().FirstOrDefault();
+        if (categoryAxis == null || categoryAxis.Labels.Count == 0) return;
+
+        var maxVisibleLabels = Math.Max(1, (int)Math.Floor(plotWidth / MinLabelWidth));
+        var step = Math.Max(1, (int)Math.Ceiling((double)categoryAxis.Labels.Count / maxVisibleLabels));
+        categoryAxis.MajorStep = step;
+        categoryAxis.MinorStep = 1;
+        UpdateValueLabels(model, step, months);
+        model.InvalidatePlot(false);
+    }
+
+    private static (PlotModel model, CategoryAxis categoryAxis) CreateModelWithAxes()
+    {
+        var model = new PlotModel { Title = "Net Invested by Month" };
+        var categoryAxis = new CategoryAxis
+        {
+            Position = AxisPosition.Bottom,
+            GapWidth = 0.2,
+            IsPanEnabled = false,
+            IsZoomEnabled = false
+        };
+        var valueAxis = new LinearAxis
+        {
+            Position = AxisPosition.Left,
+            MajorGridlineStyle = LineStyle.Solid,
+            MinorGridlineStyle = LineStyle.Dot,
+            IsPanEnabled = false,
+            IsZoomEnabled = false,
+            MaximumPadding = 0.1,
+            MinimumPadding = 0.1
+        };
+        model.Axes.Add(categoryAxis);
+        model.Axes.Add(valueAxis);
+        return (model, categoryAxis);
+    }
+
+    private static RectangleBarSeries BuildBarSeries(IReadOnlyList<TransactionMonthNet> months)
+    {
+        var series = new RectangleBarSeries
+        {
+            FillColor = NeutralColor,
+            StrokeColor = OxyColors.SlateGray,
+            StrokeThickness = 1
+        };
+
+        var half = BarWidth / 2;
+        for (var monthIndex = 0; monthIndex < months.Count; monthIndex++)
+        {
+            var value = (double)months[monthIndex].NetInvested;
+            var x0 = monthIndex - half;
+            var x1 = monthIndex + half;
+            var y0 = Math.Min(0, value);
+            var y1 = Math.Max(0, value);
+            series.Items.Add(new RectangleBarItem(x0, y0, x1, y1));
+        }
+
+        return series;
+    }
+
+    private static LineSeries BuildLineSeries(IReadOnlyList<TransactionMonthNet> months)
+    {
+        var series = new LineSeries
+        {
+            Color = NeutralColor,
+            StrokeThickness = 2,
+            MarkerType = MarkerType.Circle,
+            MarkerSize = 3,
+            MarkerFill = NeutralColor
+        };
+
+        for (var monthIndex = 0; monthIndex < months.Count; monthIndex++)
+            series.Points.Add(new DataPoint(monthIndex, (double)months[monthIndex].NetInvested));
+
+        return series;
+    }
+
+    private static void UpdateValueLabels(PlotModel model, int step, IReadOnlyList<TransactionMonthNet> months)
+    {
+        for (var index = model.Annotations.Count - 1; index >= 0; index--)
+        {
+            if (model.Annotations[index].Tag is string tag &&
+                string.Equals(tag, TransactionsValueLabelTag, StringComparison.Ordinal))
+            {
+                model.Annotations.RemoveAt(index);
+            }
+        }
+
+        if (months.Count == 0) return;
+
+        for (var monthIndex = 0; monthIndex < months.Count; monthIndex += step)
+        {
+            var value = months[monthIndex].NetInvested;
+            if (value == 0) continue;
+            AddValueLabel(model, monthIndex, value);
+        }
+    }
+
+    private static void AddValueLabel(PlotModel model, double x, decimal value)
+    {
+        var y = (double)value;
+        model.Annotations.Add(new TextAnnotation
+        {
+            Text = value.ToString("N2"),
+            TextPosition = new DataPoint(x, y),
+            TextHorizontalAlignment = OxyPlot.HorizontalAlignment.Center,
+            TextVerticalAlignment = value >= 0 ? OxyPlot.VerticalAlignment.Bottom : OxyPlot.VerticalAlignment.Top,
+            Offset = value >= 0 ? new ScreenVector(0, -6) : new ScreenVector(0, 6),
+            TextColor = OxyColors.Black,
+            Stroke = OxyColors.Undefined,
+            Tag = TransactionsValueLabelTag,
+            ClipByXAxis = true,
+            ClipByYAxis = false
+        });
+    }
+}

--- a/Financial.App/ViewModels/TransactionsFilterOptionViewModel.cs
+++ b/Financial.App/ViewModels/TransactionsFilterOptionViewModel.cs
@@ -1,0 +1,23 @@
+using Financial.Presentation.App.Helpers;
+
+namespace Financial.Presentation.App.ViewModels;
+
+public sealed class TransactionsFilterOptionViewModel : ViewModelBase
+{
+    private bool _isSelected;
+
+    public TransactionsFilterOptionViewModel(string label, PeriodFilter filter)
+    {
+        Label = label;
+        Filter = filter;
+    }
+
+    public string Label { get; }
+    public PeriodFilter Filter { get; }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => SetProperty(ref _isSelected, value);
+    }
+}

--- a/Financial.App/ViewModels/TransactionsMonthlyAggregator.cs
+++ b/Financial.App/ViewModels/TransactionsMonthlyAggregator.cs
@@ -1,0 +1,44 @@
+using Financial.Presentation.App.Helpers;
+
+namespace Financial.Presentation.App.ViewModels;
+
+internal sealed record TransactionMonthNet(DateTime Month, decimal NetInvested);
+
+internal static class TransactionsMonthlyAggregator
+{
+    private const string BuyType = "Buy";
+
+    public static IReadOnlyList<TransactionMonthNet> BuildMonthlyNetInvested(
+        IEnumerable<(DateTime Date, string Type, decimal TotalPrice)> transactions,
+        PeriodFilter filter,
+        DateTime referenceDate)
+    {
+        var items = transactions.ToList();
+
+        var netByMonth = new Dictionary<DateTime, decimal>();
+        foreach (var (date, type, totalPrice) in items)
+        {
+            var month = StartOfMonth(date);
+            var delta = string.Equals(type, BuyType, StringComparison.OrdinalIgnoreCase) ? totalPrice : -totalPrice;
+            netByMonth[month] = netByMonth.GetValueOrDefault(month) + delta;
+        }
+
+        var (periodStart, _) = PeriodFilterHelper.GetDateRange(filter, referenceDate);
+        var rangeStart = periodStart.HasValue
+            ? StartOfMonth(periodStart.Value)
+            : items.Count > 0
+                ? StartOfMonth(items.Min(t => t.Date))
+                : StartOfMonth(referenceDate);
+
+        var rangeEnd = StartOfMonth(referenceDate);
+        var buckets = new List<TransactionMonthNet>();
+        for (var cursor = rangeStart; cursor <= rangeEnd; cursor = cursor.AddMonths(1))
+        {
+            buckets.Add(new TransactionMonthNet(cursor, netByMonth.GetValueOrDefault(cursor)));
+        }
+
+        return buckets;
+    }
+
+    private static DateTime StartOfMonth(DateTime date) => new(date.Year, date.Month, 1);
+}

--- a/Financial.App/ViewModels/TransactionsViewState.cs
+++ b/Financial.App/ViewModels/TransactionsViewState.cs
@@ -1,0 +1,5 @@
+using Financial.Presentation.App.Helpers;
+
+namespace Financial.Presentation.App.ViewModels;
+
+internal readonly record struct TransactionsViewState(PeriodFilter Filter, ChartTypeMode Mode);

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
@@ -7,13 +7,16 @@ namespace Financial.Presentation.Tests.ViewModels;
 
 public class AssetDetailsViewModelBrokerSummaryTests
 {
-    private static AssetDetailsViewModel BuildViewModel(IBrokerBreakdownQueryService? brokerBreakdownQueryService = null)
+    private static AssetDetailsViewModel BuildViewModel(
+        IBrokerBreakdownQueryService? brokerBreakdownQueryService = null,
+        ITransactionQueryService? transactionQueryService = null)
     {
         return new AssetDetailsViewModel(
             new StubTransactionService(),
             new StubCreditService(),
             new StubAssetPriceService(),
-            brokerBreakdownQueryService ?? new StubBrokerBreakdownQueryService());
+            brokerBreakdownQueryService ?? new StubBrokerBreakdownQueryService(),
+            transactionQueryService ?? new StubTransactionQueryService());
     }
 
     [Fact]
@@ -283,6 +286,12 @@ public class AssetDetailsViewModelBrokerSummaryTests
     {
         public AssetPriceDTO GetCurrentPrice(AssetPriceRequestDTO request) =>
             new() { Exchange = request.Exchange, Ticker = request.Ticker, Price = 0m };
+    }
+
+    private sealed class StubTransactionQueryService : ITransactionQueryService
+    {
+        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName) => [];
+        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName) => [];
     }
 
     private sealed class StubTransactionService : ITransactionService

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
@@ -13,7 +13,8 @@ public class AssetDetailsViewModelPortfolioSummaryTests
             new StubTransactionService(),
             new StubCreditService(),
             priceService ?? new NeverResolvingPriceService(),
-            new StubBrokerBreakdownQueryService());
+            new StubBrokerBreakdownQueryService(),
+            new StubTransactionQueryService());
     }
 
     private static IReadOnlyList<PortfolioAssetSummaryItemDTO> BuildItems(int count = 2)
@@ -273,6 +274,12 @@ public class AssetDetailsViewModelPortfolioSummaryTests
     private sealed class StubBrokerBreakdownQueryService : IBrokerBreakdownQueryService
     {
         public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName) => [];
+    }
+
+    private sealed class StubTransactionQueryService : ITransactionQueryService
+    {
+        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName) => [];
+        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName) => [];
     }
 
     private sealed class NeverResolvingPriceService : IAssetPriceService

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelTransactionsChartTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelTransactionsChartTests.cs
@@ -1,0 +1,235 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Presentation.App.Helpers;
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class AssetDetailsViewModelTransactionsChartTests
+{
+    private static AssetDetailsViewModel BuildViewModel(
+        IBrokerBreakdownQueryService? brokerBreakdownQueryService = null,
+        ITransactionQueryService? transactionQueryService = null)
+    {
+        return new AssetDetailsViewModel(
+            new StubTransactionService(),
+            new StubCreditService(),
+            new StubAssetPriceService(),
+            brokerBreakdownQueryService ?? new StubBrokerBreakdownQueryService(),
+            transactionQueryService ?? new StubTransactionQueryService());
+    }
+
+    private static AssetDetailsDTO BuildAssetDetails(List<TransactionDTO> transactions) => new()
+    {
+        Name = "BBAS3",
+        BrokerName = "XPI",
+        PortfolioName = "Acoes",
+        Ticker = "BBAS3",
+        ISIN = "",
+        Exchange = "BVMF",
+        Country = Financial.Domain.Entities.CountryCode.Unknown,
+        LocalTypeCode = "",
+        Class = Financial.Domain.Entities.GlobalAssetClass.Unknown,
+        Quantity = 100m,
+        AveragePrice = 20m,
+        IsActive = true,
+        TotalBought = 2000m,
+        TotalSold = 0m,
+        TotalCredits = 0m,
+        Transactions = transactions,
+        Credits = [],
+    };
+
+    [Fact]
+    public void LoadBrokerTransactions_SetsIsTransactionsLoadingTrue_Synchronously()
+    {
+        var vm = BuildViewModel();
+        _ = vm.LoadBrokerTransactions("XPI");
+        vm.IsTransactionsLoading.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LoadBrokerTransactions_PopulatesTransactionsPlotModel_OnSuccess()
+    {
+        var stub = new StubTransactionQueryService
+        {
+            BrokerTransactions = [new() { AssetName = "BBAS3", Date = DateTime.Today, Type = "Buy", TotalPrice = 1000m }],
+        };
+        var vm = BuildViewModel(transactionQueryService: stub);
+
+        await vm.LoadBrokerTransactions("XPI");
+
+        vm.TransactionsPlotModel.Should().NotBeNull();
+        vm.TransactionsPlotModel!.Series.Should().HaveCount(1);
+        vm.IsTransactionsLoading.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task LoadBrokerTransactions_SetsTransactionsError_OnFailure()
+    {
+        var stub = new StubTransactionQueryService { ExceptionToThrow = new InvalidOperationException("boom") };
+        var vm = BuildViewModel(transactionQueryService: stub);
+
+        await vm.LoadBrokerTransactions("XPI");
+
+        vm.TransactionsError.Should().NotBeNull();
+        vm.IsTransactionsLoading.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task LoadPortfolioTransactions_PassesCorrectBrokerAndPortfolioName()
+    {
+        var stub = new StubTransactionQueryService();
+        var vm = BuildViewModel(transactionQueryService: stub);
+
+        await vm.LoadPortfolioTransactions("XPI", "Acoes");
+
+        stub.LastPortfolioBrokerName.Should().Be("XPI");
+        stub.LastPortfolioName.Should().Be("Acoes");
+    }
+
+    [Fact]
+    public void LoadAssetDetails_BuildsTransactionsPlotModel_FromAlreadyLoadedTransactions_NoNewFetch()
+    {
+        var stub = new StubTransactionQueryService();
+        var vm = BuildViewModel(transactionQueryService: stub);
+
+        vm.LoadAssetDetails(BuildAssetDetails([
+            new() { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Buy", Quantity = 100m, UnitPrice = 20m, Fees = 0m, TotalPrice = 2000m },
+        ]));
+
+        vm.TransactionsPlotModel.Should().NotBeNull();
+        vm.TransactionsPlotModel!.Series.Should().HaveCount(1);
+        stub.LastBrokerName.Should().BeNull();
+        stub.LastPortfolioBrokerName.Should().BeNull();
+    }
+
+    [Fact]
+    public void LoadAssetDetails_SetsIsTransactionsAggregateViewFalse()
+    {
+        var vm = BuildViewModel();
+        vm.LoadAssetDetails(BuildAssetDetails([]));
+        vm.IsTransactionsAggregateView.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LoadBrokerSummary_SetsIsTransactionsAggregateViewTrue()
+    {
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), []);
+        vm.IsTransactionsAggregateView.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetTransactionsFilter_PersistsSelectionPerNode()
+    {
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("BrokerA", new AggregatedSummaryDTO(), []);
+
+        vm.SelectTransactionsFilterCommand.Execute(PeriodFilter.Ytd);
+        vm.TransactionsFilters.First(f => f.Filter == PeriodFilter.Ytd).IsSelected.Should().BeTrue();
+
+        vm.LoadBrokerSummary("BrokerB", new AggregatedSummaryDTO(), []);
+        vm.TransactionsFilters.First(f => f.Filter == PeriodFilter.Last12Months).IsSelected.Should().BeTrue();
+
+        vm.LoadBrokerSummary("BrokerA", new AggregatedSummaryDTO(), []);
+        vm.TransactionsFilters.First(f => f.Filter == PeriodFilter.Ytd).IsSelected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetTransactionsChartMode_PersistsSelectionPerNode()
+    {
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("BrokerA", new AggregatedSummaryDTO(), []);
+
+        vm.SelectTransactionsChartModeCommand.Execute(ChartTypeMode.Line);
+        vm.ChartTypeModes.First(m => m.Mode == ChartTypeMode.Line).IsSelected.Should().BeTrue();
+
+        vm.LoadBrokerSummary("BrokerB", new AggregatedSummaryDTO(), []);
+        vm.ChartTypeModes.First(m => m.Mode == ChartTypeMode.Bar).IsSelected.Should().BeTrue();
+
+        vm.LoadBrokerSummary("BrokerA", new AggregatedSummaryDTO(), []);
+        vm.ChartTypeModes.First(m => m.Mode == ChartTypeMode.Line).IsSelected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetTransactionsFilter_DoesNotAffectCreditsFilter_ForSameNode()
+    {
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("BrokerA", new AggregatedSummaryDTO(), []);
+
+        vm.SelectTransactionsFilterCommand.Execute(PeriodFilter.Ytd);
+
+        vm.CreditsFilters.First(f => f.Filter == PeriodFilter.Last12Months).IsSelected.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Clear_AfterLoadBrokerTransactions_ResetsTransactionsState()
+    {
+        var stub = new StubTransactionQueryService
+        {
+            BrokerTransactions = [new() { AssetName = "BBAS3", Date = DateTime.Today, Type = "Buy", TotalPrice = 500m }],
+        };
+        var vm = BuildViewModel(transactionQueryService: stub);
+        vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), []);
+        await vm.LoadBrokerTransactions("XPI");
+
+        vm.Clear();
+
+        vm.TransactionsPlotModel.Should().BeNull();
+        vm.IsTransactionsLoading.Should().BeFalse();
+        vm.TransactionsError.Should().BeNull();
+        vm.IsTransactionsAggregateView.Should().BeFalse();
+    }
+
+    private sealed class StubTransactionQueryService : ITransactionQueryService
+    {
+        public IReadOnlyList<TransactionSummaryItemDTO> BrokerTransactions { get; set; } = [];
+        public IReadOnlyList<TransactionSummaryItemDTO> PortfolioTransactions { get; set; } = [];
+        public Exception? ExceptionToThrow { get; set; }
+        public string? LastBrokerName { get; private set; }
+        public string? LastPortfolioBrokerName { get; private set; }
+        public string? LastPortfolioName { get; private set; }
+
+        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName)
+        {
+            LastBrokerName = brokerName;
+            if (ExceptionToThrow != null) throw ExceptionToThrow;
+            return BrokerTransactions;
+        }
+
+        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName)
+        {
+            LastPortfolioBrokerName = brokerName;
+            LastPortfolioName = portfolioName;
+            if (ExceptionToThrow != null) throw ExceptionToThrow;
+            return PortfolioTransactions;
+        }
+    }
+
+    private sealed class StubBrokerBreakdownQueryService : IBrokerBreakdownQueryService
+    {
+        public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName) => [];
+    }
+
+    private sealed class StubAssetPriceService : IAssetPriceService
+    {
+        public AssetPriceDTO GetCurrentPrice(AssetPriceRequestDTO request) =>
+            new() { Exchange = request.Exchange, Ticker = request.Ticker, Price = 0m };
+    }
+
+    private sealed class StubTransactionService : ITransactionService
+    {
+        public Task<AssetDetailsDTO?> AddTransactionAsync(TransactionCreateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> UpdateTransactionAsync(TransactionUpdateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> DeleteTransactionAsync(TransactionDeleteDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+    }
+
+    private sealed class StubCreditService : ICreditService
+    {
+        public Task<AssetDetailsDTO?> AddCreditAsync(CreditCreateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> UpdateCreditAsync(CreditUpdateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> DeleteCreditAsync(CreditDeleteDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+    }
+}

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -287,6 +287,7 @@ public class MainNavigationViewModelBaseTests
         public void Clear() => WasCleared = true;
         public Task EnsureTodayInfoLoadedAsync() => Task.CompletedTask;
         public void UpdateCreditsPlotWidth(double plotWidth) { }
+        public void UpdateTransactionsPlotWidth(double plotWidth) { }
     }
 
     private sealed class StubPortfolioAssetSummaryQueryService : IPortfolioAssetSummaryQueryService

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -237,6 +237,11 @@ public class MainNavigationViewModelBaseTests
         public bool WasBrokerSummaryLoaded { get; private set; }
         public string? LastBrokerBreakdownName { get; private set; }
         public bool WasBrokerBreakdownLoaded { get; private set; }
+        public string? LastBrokerTransactionsName { get; private set; }
+        public bool WasBrokerTransactionsLoaded { get; private set; }
+        public string? LastPortfolioTransactionsBrokerName { get; private set; }
+        public string? LastPortfolioTransactionsPortfolioName { get; private set; }
+        public bool WasPortfolioTransactionsLoaded { get; private set; }
         public bool IsPortfolioView => false;
         public bool IsBrokerView => false;
 
@@ -255,6 +260,13 @@ public class MainNavigationViewModelBaseTests
             return Task.CompletedTask;
         }
 
+        public Task LoadBrokerTransactions(string brokerName)
+        {
+            LastBrokerTransactionsName = brokerName;
+            WasBrokerTransactionsLoaded = true;
+            return Task.CompletedTask;
+        }
+
         public void LoadPortfolioCredits(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits) { }
 
         public void LoadPortfolioSummary(string brokerName, string portfolioName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits, IReadOnlyList<PortfolioAssetSummaryItemDTO> assetItems)
@@ -262,6 +274,14 @@ public class MainNavigationViewModelBaseTests
             LastPortfolioSummary = summary;
             LastPortfolioAssetItems = assetItems;
             WasPortfolioSummaryLoaded = true;
+        }
+
+        public Task LoadPortfolioTransactions(string brokerName, string portfolioName)
+        {
+            LastPortfolioTransactionsBrokerName = brokerName;
+            LastPortfolioTransactionsPortfolioName = portfolioName;
+            WasPortfolioTransactionsLoaded = true;
+            return Task.CompletedTask;
         }
 
         public void Clear() => WasCleared = true;

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -96,6 +96,35 @@ public class MainNavigationViewModelBaseTests
     }
 
     [Fact]
+    public void SelectingBrokerNode_CallsLoadBrokerTransactionsOnDetailsViewModel()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var brokerNode = BuildBrokerNode("XPI");
+        vm.SelectedNode = brokerNode;
+
+        spy.WasBrokerTransactionsLoaded.Should().BeTrue();
+        spy.LastBrokerTransactionsName.Should().Be("XPI");
+    }
+
+    [Fact]
+    public void SelectingPortfolioNode_CallsLoadPortfolioTransactionsOnDetailsViewModel()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var portfolioNode = BuildPortfolioNode("XPI", "FII");
+        vm.SelectedNode = portfolioNode;
+
+        spy.WasPortfolioTransactionsLoaded.Should().BeTrue();
+        spy.LastPortfolioTransactionsBrokerName.Should().Be("XPI");
+        spy.LastPortfolioTransactionsPortfolioName.Should().Be("FII");
+    }
+
+    [Fact]
     public void SelectingPortfolioNode_WhenMissingMetadata_ClearsDetails()
     {
         var summaryService = new StubSummaryQueryService();
@@ -160,6 +189,20 @@ public class MainNavigationViewModelBaseTests
     }
 
     [Fact]
+    public void SelectingAssetNode_DoesNotCallLoadBrokerOrPortfolioTransactions()
+    {
+        var summaryService = new StubSummaryQueryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var vm = new TestableNavigationViewModel(summaryService, spy);
+
+        var assetNode = BuildAssetNode("XPI", "Acoes", "BBAS3");
+        vm.SelectedNode = assetNode;
+
+        spy.WasBrokerTransactionsLoaded.Should().BeFalse();
+        spy.WasPortfolioTransactionsLoaded.Should().BeFalse();
+    }
+
+    [Fact]
     public void SelectingBrokerNode_DoesNotCallLoadPortfolioSummary()
     {
         var summaryService = new StubSummaryQueryService();
@@ -205,6 +248,35 @@ public class MainNavigationViewModelBaseTests
             Children = []
         };
         return new TreeNodeViewModel(brokerDto);
+    }
+
+    private static TreeNodeViewModel BuildAssetNode(string brokerName, string portfolioName, string assetName)
+    {
+        var brokerDto = new TreeNodeDTO
+        {
+            NodeType = TreeNodeTypes.Broker,
+            DisplayName = brokerName,
+            Metadata = new Dictionary<string, object> { ["BrokerName"] = brokerName },
+            Children = []
+        };
+        var portfolioDto = new TreeNodeDTO
+        {
+            NodeType = TreeNodeTypes.Portfolio,
+            DisplayName = portfolioName,
+            Metadata = new Dictionary<string, object> { ["PortfolioName"] = portfolioName },
+            Children = []
+        };
+        var assetDto = new TreeNodeDTO
+        {
+            NodeType = TreeNodeTypes.Asset,
+            DisplayName = assetName,
+            Metadata = new Dictionary<string, object> { ["AssetName"] = assetName },
+            Children = []
+        };
+
+        var brokerNode = new TreeNodeViewModel(brokerDto);
+        var portfolioNode = new TreeNodeViewModel(portfolioDto, brokerNode);
+        return new TreeNodeViewModel(assetDto, portfolioNode);
     }
 
     private static TreeNodeViewModel BuildNodeWithoutMetadata(string nodeType)

--- a/Tests/Financial.Presentation.Tests/ViewModels/TransactionsChartBuilderTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/TransactionsChartBuilderTests.cs
@@ -1,0 +1,45 @@
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+using OxyPlot.Series;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class TransactionsChartBuilderTests
+{
+    [Fact]
+    public void Build_BarMode_ProducesOneRectangleBarSeries()
+    {
+        var months = new List<TransactionMonthNet>
+        {
+            new(new DateTime(2026, 6, 1), 500m),
+            new(new DateTime(2026, 7, 1), -200m),
+        };
+
+        var model = TransactionsChartBuilder.Build(months, ChartTypeMode.Bar);
+
+        model.Series.Should().ContainSingle().Which.Should().BeOfType<RectangleBarSeries>();
+    }
+
+    [Fact]
+    public void Build_LineMode_ProducesOneLineSeriesWithMatchingPointCount()
+    {
+        var months = new List<TransactionMonthNet>
+        {
+            new(new DateTime(2026, 6, 1), 500m),
+            new(new DateTime(2026, 7, 1), -200m),
+        };
+
+        var model = TransactionsChartBuilder.Build(months, ChartTypeMode.Line);
+
+        var series = model.Series.Should().ContainSingle().Which.Should().BeOfType<LineSeries>().Subject;
+        series.Points.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Build_EmptyMonths_ProducesNoSeries()
+    {
+        var model = TransactionsChartBuilder.Build(new List<TransactionMonthNet>(), ChartTypeMode.Bar);
+
+        model.Series.Should().BeEmpty();
+    }
+}

--- a/Tests/Financial.Presentation.Tests/ViewModels/TransactionsMonthlyAggregatorTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/TransactionsMonthlyAggregatorTests.cs
@@ -1,0 +1,88 @@
+using Financial.Presentation.App.Helpers;
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class TransactionsMonthlyAggregatorTests
+{
+    private static readonly DateTime ReferenceDate = new(2026, 7, 15);
+
+    [Fact]
+    public void BuildMonthlyNetInvested_ZeroFillsMonthsWithNoTransactions()
+    {
+        var transactions = new[]
+        {
+            (Date: new DateTime(2026, 5, 10), Type: "Buy", TotalPrice: 500m),
+        };
+
+        var result = TransactionsMonthlyAggregator.BuildMonthlyNetInvested(
+            transactions, PeriodFilter.Last3Months, ReferenceDate);
+
+        result.Should().HaveCount(3);
+        result.Select(m => m.Month).Should().Equal(
+            new DateTime(2026, 5, 1), new DateTime(2026, 6, 1), new DateTime(2026, 7, 1));
+        result[0].NetInvested.Should().Be(500m);
+        result[1].NetInvested.Should().Be(0m);
+        result[2].NetInvested.Should().Be(0m);
+    }
+
+    [Fact]
+    public void BuildMonthlyNetInvested_ComputesBuyMinusSellPerMonth()
+    {
+        var transactions = new[]
+        {
+            (Date: new DateTime(2026, 7, 5), Type: "Buy", TotalPrice: 1000m),
+            (Date: new DateTime(2026, 7, 20), Type: "Sell", TotalPrice: 300m),
+        };
+
+        var result = TransactionsMonthlyAggregator.BuildMonthlyNetInvested(
+            transactions, PeriodFilter.ThisMonth, ReferenceDate);
+
+        result.Should().ContainSingle();
+        result[0].NetInvested.Should().Be(700m);
+    }
+
+    [Fact]
+    public void BuildMonthlyNetInvested_AllTime_StartsFromEarliestTransaction()
+    {
+        var transactions = new[]
+        {
+            (Date: new DateTime(2023, 1, 15), Type: "Buy", TotalPrice: 100m),
+            (Date: new DateTime(2026, 6, 1), Type: "Buy", TotalPrice: 200m),
+        };
+
+        var result = TransactionsMonthlyAggregator.BuildMonthlyNetInvested(
+            transactions, PeriodFilter.AllTime, ReferenceDate);
+
+        result.First().Month.Should().Be(new DateTime(2023, 1, 1));
+        result.Last().Month.Should().Be(new DateTime(2026, 7, 1));
+    }
+
+    [Fact]
+    public void BuildMonthlyNetInvested_EmptyInput_ReturnsSingleZeroMonth()
+    {
+        var result = TransactionsMonthlyAggregator.BuildMonthlyNetInvested(
+            Array.Empty<(DateTime Date, string Type, decimal TotalPrice)>(),
+            PeriodFilter.ThisMonth,
+            ReferenceDate);
+
+        result.Should().ContainSingle();
+        result[0].Month.Should().Be(new DateTime(2026, 7, 1));
+        result[0].NetInvested.Should().Be(0m);
+    }
+
+    [Fact]
+    public void BuildMonthlyNetInvested_SellExceedingBuy_ProducesNegativeMonth()
+    {
+        var transactions = new[]
+        {
+            (Date: new DateTime(2026, 7, 1), Type: "Sell", TotalPrice: 400m),
+        };
+
+        var result = TransactionsMonthlyAggregator.BuildMonthlyNetInvested(
+            transactions, PeriodFilter.ThisMonth, ReferenceDate);
+
+        result[0].NetInvested.Should().Be(-400m);
+    }
+}

--- a/docs/P04-F10-transactions-monthly-investment-chart-wpf/plan.md
+++ b/docs/P04-F10-transactions-monthly-investment-chart-wpf/plan.md
@@ -1,0 +1,39 @@
+# Implementation Plan: Transactions Monthly Investment Chart — WPF
+
+**Prerequisites:**
+- F03 (Broker & Portfolio Transactions Aggregation Service — Application Layer) already merged to `main`; `ITransactionQueryService` is already registered in DI and implemented
+- F04 (Chart Period Filter — YTD Extension) already merged to `main`; `PeriodFilterHelper` is already implemented and in use by the WPF Credits tab
+- F09 (Transactions Monthly Investment Chart — Web Frontend) already merged to `main`; its zero-fill algorithm and neutral-colour decision are the reference this feature mirrors on the WPF side
+- `OxyPlot.Wpf` is already a project dependency; `RectangleBarSeries` is already used by `CreditsChartBuilder`, `LineSeries` is not yet used anywhere and will be introduced by this feature
+
+### Stage 1: Aggregation and Chart Building
+
+**1. Monthly net-invested aggregator** - Add the pure, independently testable calculation that groups transactions by calendar month (Buy minus Sell) and zero-fills every month across the selected period's actual date range, working identically against either the Asset-scope or Broker/Portfolio-scope transaction shape via a minimal tuple projection at each call site. Reference the spec's Technical Decisions for the zero-fill algorithm and the shared-input-shape approach.
+
+**2. Chart type enum and option view models** - Add the Bar/Line chart-type enum and the small view models backing its toggle buttons and the transactions period-filter buttons, mirroring the existing Credits tab's equivalent view models field-for-field.
+
+**3. Transactions chart builder** - Add the OxyPlot `PlotModel` builder producing a single-series Bar or Line chart from the aggregated monthly data, using one neutral colour regardless of sign, plus the month-label density adjustment for narrow plot widths. Reference the spec's Component Overview for the exact mirroring of `CreditsChartBuilder`.
+
+### Stage 2: ViewModel Wiring
+
+**4. Async Broker/Portfolio transaction fetch** - Extend `AssetDetailsViewModel` with the injected transaction query service and the two new async load methods for Broker and Portfolio scope, following the same cancellable background-fetch pattern already used for the broker breakdown pie charts. Reference the spec's Technical Decisions for why this mirrors `LoadBrokerBreakdown` rather than a synchronous parameter-passing approach.
+
+**5. Filter and chart-mode state with per-node persistence** - Add the transactions period-filter and Bar/Line chart-mode selection state to `AssetDetailsViewModel`, persisted per node selection in a dictionary independent from the existing Credits tab's persistence, reusing the existing node-identity key-building logic. Reference the spec's Technical Decisions for the persistence approach.
+
+**6. Asset-scope chart integration** - Extend the existing asset-loading path to rebuild the transactions chart from the already-loaded transaction collection with no new fetch, and ensure the aggregate-view flag and all new state reset correctly when switching between Asset, Broker, Portfolio, and cleared selections. Reference the spec's Component Overview for exactly which existing methods are extended.
+
+**7. Navigation dispatch and DI wiring** - Wire the two new async load calls into the existing Broker/Portfolio node-selection dispatch path, and thread the newly injected service through the app's dependency injection constructor chain. Reference the spec's Component Overview for the exact call sites.
+
+### Stage 3: UI
+
+**8. Transactions tab template split** - Replace the Transactions tab's single always-visible `DataGrid` with two selectable templates: one for Asset selection (existing `DataGrid` plus the new chart above it in a resizable split, mirroring the Credits tab's asset template) and one for Broker/Portfolio selection (chart only, no `DataGrid`, no "New" button). Reference the spec's Technical Decisions for the resizable-split choice and the Component Overview for the exact template structure to mirror.
+
+**9. Chart interaction wiring** - Wire the period-filter buttons, the Bar/Line toggle, and the plot-width-driven label-density adjustment into the new templates, following the exact binding and code-behind pattern already used by the Credits tab's chart.
+
+### Stage 4: Tests
+
+**10. Aggregator test coverage** - Add unit tests for the new monthly aggregation covering zero-fill correctness across period filters, Buy-minus-Sell math, the All-Time earliest-transaction fallback, and empty-input handling. Reference the spec's Testing Strategy for the full list of test functions.
+
+**11. ViewModel test coverage** - Add unit tests for the new `AssetDetailsViewModel` behaviour covering loading/error/success states for both new async load methods, Asset-scope reuse of already-loaded data with no new fetch, per-node filter/mode persistence independent of the Credits tab's own persistence, and state reset on `Clear()`.
+
+**12. Navigation dispatch test coverage** - Extend the existing navigation view model tests to confirm Broker and Portfolio node selection dispatch the two new load calls with the correct arguments, and that Asset node selection does not.

--- a/docs/P04-F10-transactions-monthly-investment-chart-wpf/spec.md
+++ b/docs/P04-F10-transactions-monthly-investment-chart-wpf/spec.md
@@ -1,0 +1,137 @@
+# F10. Transactions Monthly Investment Chart — WPF
+
+## 1. Technical Overview
+
+**What:** Extend the WPF desktop app's Transactions tab to render a monthly net-invested chart (`sum(Buy.TotalPrice) − sum(Sell.TotalPrice)` per calendar month, zero-filled for gap months) for Broker, Portfolio, and Asset node selection — the exact desktop counterpart of F09 (Web). For Broker/Portfolio selection (currently an empty `DataGrid` bound to an always-empty `Transactions` collection, with no dedicated message), the chart becomes the *only* content — no `DataGrid`. For Asset selection, the existing `DataGrid` is unchanged and the chart is added above it in a resizable split, computed from the asset's already-loaded `Transactions` collection. A Bar/Line toggle (default Bar) and the same six F04 period-filter buttons (default Last 12 Months) control the chart, both persisted per node selection, mirroring the existing Credits tab's `CreditsFilters`/`CreditsTypeModes` UX exactly.
+
+**Why:** F03 already exposes `ITransactionQueryService.GetTransactionsByBroker`/`GetTransactionsByPortfolio` in-process (no HTTP hop needed — WPF calls Application-layer services directly via DI, unlike the web client), and F04 already provides `PeriodFilterHelper` with the canonical six-option period set. F08 already established the exact async-fetch-with-loading/error-state pattern this feature needs (`LoadBrokerBreakdown`, `IsBreakdownLoading`, `BreakdownError`, `CancellationTokenSource`-based cancel-on-reselect), and the existing Credits tab (`CreditsChartBuilder`, `CreditsFilters`, `CreditsTypeModes`, per-node `_creditsViewStateByKey` persistence) already established the exact chart/filter/mode/persistence pattern. This feature wires these three already-proven patterns together for the Transactions tab, mirroring F09's web implementation so both platforms compute and display identical chart data.
+
+**Scope:**
+- Included: a new pure `TransactionsMonthlyAggregator` (zero-filling monthly net-invested calculation, unit-testable independent of OxyPlot/ViewModel wiring); a new `TransactionsChartBuilder` (OxyPlot `PlotModel` construction for Bar and Line modes, single neutral series colour); `AssetDetailsViewModel` extended with `LoadBrokerTransactions`/`LoadPortfolioTransactions` async methods, filter/mode state, and per-node persistence; `MainNavigationViewModelBase` wiring the two new load calls on Broker/Portfolio selection; `NavigationView.xaml` Transactions tab split into an Asset template (existing `DataGrid` + new chart above it, resizable) and an Aggregate template (chart only); unit test coverage.
+- Excluded: any backend change (F03/F04 already complete, merged to `main`); the Web implementation (F09, already complete, merged to `main` via PR #126) — this feature only covers the WPF (`Financial.App`) side.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.App/ViewModels/TransactionsMonthlyAggregator.cs` (new) — pure zero-filling monthly aggregation
+- `Financial.App/ViewModels/TransactionsChartBuilder.cs` (new) — OxyPlot `PlotModel` construction for Bar/Line
+- `Financial.App/ViewModels/ChartTypeMode.cs` (new) — `Bar`/`Line` enum
+- `Financial.App/ViewModels/ChartTypeModeOptionViewModel.cs` (new) — mirrors `CreditsTypeModeOptionViewModel`
+- `Financial.App/ViewModels/TransactionsFilterOptionViewModel.cs` (new) — mirrors `CreditsFilterOptionViewModel`
+- `Financial.App/ViewModels/TransactionsViewState.cs` (new) — mirrors `CreditsViewState`
+- `Financial.App/ViewModels/IAssetDetailsViewModel.cs` (modified) — two new async load methods on the interface
+- `Financial.App/ViewModels/AssetDetailsViewModel.cs` (modified) — chart state, async fetch, filter/mode persistence, DI constructor change
+- `Financial.App/ViewModels/MainNavigationViewModel.cs` (modified) — DI constructor change (new `ITransactionQueryService` parameter)
+- `Financial.App/ViewModels/MainNavigationViewModelBase.cs` (modified) — dispatch the two new load calls on Broker/Portfolio node selection
+- `Financial.App/Components/NavigationView.xaml` (modified) — Transactions tab split into Asset/Aggregate `DataTemplate`s
+- `Financial.App/Components/NavigationView.xaml.cs` (modified) — new `PlotView.SizeChanged` handler for label-density
+- Test files: `Tests/Financial.Presentation.Tests/ViewModels/TransactionsMonthlyAggregatorTests.cs` (new), `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelTransactionsChartTests.cs` (new), `Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs` (modified)
+
+```mermaid
+graph TD
+    A["User selects Broker, Portfolio, or Asset node"] --> B[MainNavigationViewModelBase]
+    B --> C{NodeType}
+    C -->|Asset| D["LoadAssetDetails (existing, unchanged) -> Transactions collection"]
+    C -->|Broker/Portfolio| E["LoadBrokerTransactions / LoadPortfolioTransactions (new, async)"]
+    E --> F["ITransactionQueryService (F03, already implemented)"]
+    D --> G["PeriodFilterHelper (F04) + TransactionsMonthlyAggregator (new, zero-fill)"]
+    F --> G
+    G --> H["TransactionsChartBuilder (new) -> TransactionsPlotModel"]
+    H --> I["NavigationView.xaml Transactions tab (Bar/Line toggle, filter buttons)"]
+    D --> J["Existing DataGrid (Asset only, unchanged)"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|------------------|-------------------------|-----------|
+| Aggregation extraction | A separate, independently testable static `TransactionsMonthlyAggregator` class, mirroring F09 web's exported `buildMonthlyNetInvested` function | Inline grouping inside `AssetDetailsViewModel`, mirroring how the existing Credits chart's `RefreshCreditsByMonthChart` does its own grouping inline | Confirmed with the user: the zero-fill math gets its own dedicated unit tests (gap months, Buy-minus-Sell per month) independent of ViewModel/OxyPlot wiring, and both `LoadBrokerTransactions` and `LoadPortfolioTransactions` reuse the same pure function without duplicating the grouping loop |
+| Asset-scope chart layout | Resizable `GridSplitter` layout in a new `TransactionsAssetTemplate`, exactly mirroring `CreditsAssetTemplate`'s `Grid` row structure (`DataGrid` → `GridSplitter` → `oxy:PlotView` → mode toggle → filter buttons) | A simpler fixed-height chart panel above a scrollable `DataGrid`, with no drag handle | Confirmed with the user: matches the Credits tab's already-familiar resizable interaction, reusing the same XAML structure and a new `OnTransactionsPlotSizeChanged` handler mirroring `OnCreditsPlotSizeChanged` |
+| Shared aggregation input shape | `TransactionsMonthlyAggregator.BuildMonthlyNetInvested` accepts `IEnumerable<(DateTime Date, string Type, decimal TotalPrice)>`; call sites project `TransactionDTO` (Asset) or `TransactionSummaryItemDTO` (Broker/Portfolio) into that tuple shape with a one-line `.Select(...)` | Define a shared marker interface implemented by both DTOs | C# has no structural typing (unlike TypeScript, where F09 accepted both DTOs directly via a minimal structural interface); a tuple projection is the idiomatic C# equivalent — one line per call site, no new interface, no risk of coupling `TransactionDTO`/`TransactionSummaryItemDTO` to a Presentation-layer contract |
+| Where `ITransactionQueryService` is injected | Into `AssetDetailsViewModel`'s constructor, exactly mirroring how `IBrokerBreakdownQueryService` (F08) is injected there rather than into `MainNavigationViewModelBase` | Inject into `MainNavigationViewModelBase` and pass the fetched data down as method parameters, mirroring `LoadBrokerCredits`/`LoadPortfolioCredits`'s synchronous pattern | `LoadBrokerBreakdown` is the closer precedent (an async, cancellable, per-node fetch triggered by `MainNavigationViewModelBase` but owned end-to-end by `AssetDetailsViewModel`), and keeps `MainNavigationViewModelBase`'s constructor from growing a fourth query-service parameter for a fetch it doesn't otherwise need to know about |
+| Async fetch/loading/error pattern | Mirrors `LoadBrokerBreakdown` exactly: `CancellationTokenSource`-based cancel-on-reselect, `IsTransactionsLoading`/`TransactionsError` properties, `Task.Run` background fetch, `RunOnUIThread` for any `ObservableCollection` mutation | A simpler fire-and-forget `async void` with no cancellation | Reuses a pattern already proven correct in this codebase (F08); avoids reintroducing the exact WPF `ObservableCollection`-cross-thread-mutation bug class this app has hit before |
+| Per-node filter/mode persistence | A second `Dictionary<string, TransactionsViewState>` (`_transactionsViewStateByKey`), independent of `_creditsViewStateByKey`, but reusing the same `BuildBrokerKey`/`BuildPortfolioKey`/`BuildCreditsAssetKey` private key-builder methods already used by the Credits tab | Share a single per-node dictionary keyed by node identity, storing both Credits and Transactions state in one record | The PRD explicitly requires the Transactions chart's period selection to be "independent from the Credits tab's currently-selected period" for the same node — a shared dictionary would couple the two features' state; reusing the existing key-builder methods (identical node-identity string format) avoids duplicating that logic while keeping the two dictionaries independent |
+| Bar/Line neutral colour | `OxyColor.FromRgb(107, 114, 128)` (`#6b7280`), the exact hex F09 (Web) uses, for every month's bar/point regardless of sign | Reuse `CreditsChartBuilder`'s blue palette or a red/green sign-based colour | Matches F09 web exactly (cross-platform consistency is an explicit PRD goal) and the PRD's explicit "no sign colouring" requirement — the bar's position below/above zero already conveys sign |
+| "New transaction" button visibility for Broker/Portfolio | Omitted entirely from the new `TransactionsAggregateTemplate`, mirroring how `CreditsAggregateTemplate` already omits its "New credit" button | Keep the button visible but disabled | Direct precedent already established by the Credits tab; `CanEditTransactions()` already gates on `HasAssetContext`, but hiding the control entirely (rather than showing a button that does nothing) is the pattern this codebase already uses |
+
+## 4. Component Overview
+
+**WPF (`Financial.App`):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|---------------|---------|------------------------|
+| `Financial.App/ViewModels/TransactionsMonthlyAggregator.cs` | New | Pure aggregation | Static `BuildMonthlyNetInvested(IEnumerable<(DateTime Date, string Type, decimal TotalPrice)> transactions, PeriodFilter filter, DateTime referenceDate)` returning `IReadOnlyList<TransactionMonthNet>` (a small `Month`/`NetInvested` record); groups by calendar month (`Buy` positive, `Sell` negative), then zero-fills every month across the selected period's actual range (via `PeriodFilterHelper.GetDateRange`) through the current month — for `AllTime`, starts from the earliest transaction's month instead, mirroring F09's exact zero-fill algorithm |
+| `Financial.App/ViewModels/TransactionsChartBuilder.cs` | New | Chart rendering | `internal static class` mirroring `CreditsChartBuilder`'s structure; `Build(IReadOnlyList<TransactionMonthNet> months, ChartTypeMode mode)` returns a `PlotModel` with one `RectangleBarSeries` (Bar mode) or one `LineSeries` (Line mode), both using the single neutral colour; `ApplyLabelDensity(...)` mirrors `CreditsChartBuilder.ApplyLabelDensity` for month-label thinning on narrow plot widths |
+| `Financial.App/ViewModels/ChartTypeMode.cs` | New | Chart type enum | `public enum ChartTypeMode { Bar, Line }`, mirroring `CreditsTypeChartMode` |
+| `Financial.App/ViewModels/ChartTypeModeOptionViewModel.cs` | New | Toggle button binding | `Label`, `Mode` (`ChartTypeMode`), `IsSelected`, mirroring `CreditsTypeModeOptionViewModel` field-for-field |
+| `Financial.App/ViewModels/TransactionsFilterOptionViewModel.cs` | New | Filter button binding | `Label`, `Filter` (`PeriodFilter`), `IsSelected`, mirroring `CreditsFilterOptionViewModel` field-for-field |
+| `Financial.App/ViewModels/TransactionsViewState.cs` | New | Per-node persisted state | `internal readonly record struct TransactionsViewState(PeriodFilter Filter, ChartTypeMode Mode)`, mirroring `CreditsViewState` |
+| `Financial.App/ViewModels/IAssetDetailsViewModel.cs` | Modified | Interface contract | Add `Task LoadBrokerTransactions(string brokerName)` and `Task LoadPortfolioTransactions(string brokerName, string portfolioName)`, mirroring the existing `Task LoadBrokerBreakdown(string brokerName)` entry |
+| `Financial.App/ViewModels/AssetDetailsViewModel.cs` | Modified | Chart state + async fetch | Inject `ITransactionQueryService` via constructor; add `IsTransactionsAggregateView`, `TransactionsPlotModel`, `IsTransactionsLoading`, `TransactionsError`, `HasTransactionsError`, `TransactionsFilters` (`ObservableCollection<TransactionsFilterOptionViewModel>`), `ChartTypeModes` (`ObservableCollection<ChartTypeModeOptionViewModel>`), `SelectTransactionsFilterCommand`, `SelectTransactionsChartModeCommand`; implement `LoadBrokerTransactions`/`LoadPortfolioTransactions` mirroring `LoadBrokerBreakdown`'s `CancellationTokenSource`/`Task.Run`/`RunOnUIThread` pattern, storing the raw fetched `IReadOnlyList<TransactionSummaryItemDTO>` for client-side re-filtering; extend `LoadAssetDetails` to rebuild the chart from the already-loaded `Transactions` collection (no new fetch) and set `IsTransactionsAggregateView = false`; extend `LoadBrokerSummary`/`LoadPortfolioSummary`(via the shared `LoadAggregateCredits` helper) to set `IsTransactionsAggregateView = true`; extend `Clear()` to reset all new state, mirroring `CancelAndResetBreakdownFetch` |
+| `Financial.App/ViewModels/MainNavigationViewModel.cs` | Modified | DI wiring | Add `ITransactionQueryService transactionQueryService` constructor parameter, passed through to `AssetDetailsViewModel`'s constructor (already registered in DI via `AddFinancialApplication()`, no new registration needed) |
+| `Financial.App/ViewModels/MainNavigationViewModelBase.cs` | Modified | Dispatch | In `LoadBrokerCredits`/`LoadPortfolioCredits`, add a fire-and-forget call to `AssetDetails.LoadBrokerTransactions(brokerName)` / `AssetDetails.LoadPortfolioTransactions(brokerName, portfolioName)`, mirroring the existing `_ = AssetDetails.LoadBrokerBreakdown(brokerName);` call |
+| `Financial.App/Components/NavigationView.xaml` | Modified | Rendering | Split the Transactions `TabItem` into `TransactionsAssetTemplate` (existing `DataGrid` + `GridSplitter` + new `oxy:PlotView` + mode toggle + filter buttons, mirroring `CreditsAssetTemplate`'s `Grid` row structure) and `TransactionsAggregateTemplate` (chart, toggle, and filters only — no `DataGrid`, no "New" button, mirroring `CreditsAggregateTemplate`); select between them via a `ContentControl` + `DataTrigger` on a new `AssetDetails.IsTransactionsAggregateView` binding, mirroring the existing `IsCreditsAggregateView` trigger |
+| `Financial.App/Components/NavigationView.xaml.cs` | Modified | Label density | Add `OnTransactionsPlotSizeChanged`, mirroring `OnCreditsPlotSizeChanged`, calling a new `AssetDetails.UpdateTransactionsPlotWidth(double)` method |
+
+**Backend:** None — `ITransactionQueryService.GetTransactionsByBroker`/`GetTransactionsByPortfolio` (F03) and `PeriodFilterHelper` (F04) are already implemented and merged to `main`.
+
+## 5. API Contracts
+
+Not applicable — WPF calls `ITransactionQueryService` directly in-process via dependency injection (already registered by `AddFinancialApplication()`); there is no HTTP contract on this side, unlike the web frontend's F09.
+
+## 6. Data Model
+
+Not applicable — no database changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|-----------------|
+| `Tests/Financial.Presentation.Tests/ViewModels/TransactionsMonthlyAggregatorTests.cs` (new) | Unit | `TransactionsMonthlyAggregator` | Zero-fill correctness, Buy-minus-Sell per-month math, `AllTime` earliest-transaction fallback, empty-input handling |
+| `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelTransactionsChartTests.cs` (new) | Unit | `AssetDetailsViewModel` | `LoadBrokerTransactions`/`LoadPortfolioTransactions` loading/error/success state, `TransactionsPlotModel` population, Asset-scope reusing `Transactions` with no new fetch, filter/mode persistence per node, `Clear()` resetting state |
+| `Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs` (modified) | Unit | `MainNavigationViewModelBase` | Broker/Portfolio node selection dispatches `LoadBrokerTransactions`/`LoadPortfolioTransactions` with correct arguments; Asset node selection does not |
+
+**Test Functions:**
+
+| Test Function | Description | Assertions |
+|----------------|--------------|-------------|
+| `BuildMonthlyNetInvested_ZeroFillsMonthsWithNoTransactions` | Fixture with a gap month, `Last3Months` filter | Every month in the 3-month range appears; gap month has `NetInvested == 0` |
+| `BuildMonthlyNetInvested_ComputesBuyMinusSellPerMonth` | Fixture with Buy 1000 + Sell 300 in the same month | That month's bucket is `700` |
+| `BuildMonthlyNetInvested_AllTime_StartsFromEarliestTransaction` | `AllTime` filter, transactions spanning several years | Result starts at the earliest transaction's month, not an arbitrary lower bound |
+| `BuildMonthlyNetInvested_EmptyInput_ReturnsSingleZeroMonth` | No transactions, `ThisMonth` filter | Returns one bucket (the current month) with `NetInvested == 0`, mirroring F09's "period with zero transactions still renders a gap-free chart" requirement |
+| `LoadBrokerTransactions_SetsIsTransactionsLoadingTrue_Synchronously` | Fetch in flight | `IsTransactionsLoading` is `true` immediately after calling, before the awaited `Task` completes |
+| `LoadBrokerTransactions_PopulatesTransactionsPlotModel_OnSuccess` | Stub service returns transactions | `TransactionsPlotModel` is non-null with one series after await |
+| `LoadBrokerTransactions_SetsTransactionsError_OnFailure` | Stub service throws | `TransactionsError` is non-null, `IsTransactionsLoading` is `false` |
+| `LoadPortfolioTransactions_PassesCorrectBrokerAndPortfolioName` | Stub service records last call args | Stub received the exact broker/portfolio name passed |
+| `LoadAssetDetails_BuildsTransactionsPlotModel_FromAlreadyLoadedTransactions_NoNewFetch` | Asset node with transactions | `TransactionsPlotModel` populated; the injected `ITransactionQueryService` stub records zero calls |
+| `LoadAssetDetails_SetsIsTransactionsAggregateViewFalse` | Asset node selection | `IsTransactionsAggregateView` is `false` |
+| `LoadBrokerTransactions_SetsIsTransactionsAggregateViewTrue` | Broker node selection | `IsTransactionsAggregateView` is `true` |
+| `SetTransactionsFilter_PersistsSelectionPerNode` | Set filter on Broker A, switch to Broker B, switch back to Broker A | Broker A's filter selection is remembered (mirrors the Credits tab's equivalent persistence behaviour) |
+| `SetTransactionsChartMode_PersistsSelectionPerNode` | Same persistence pattern for Bar/Line | Mirrors the filter persistence test |
+| `SetTransactionsFilter_DoesNotAffectCreditsFilter_ForSameNode` | Set Transactions filter to `Ytd` on a node whose Credits filter is `Last12Months` | `CreditsFilters`' selected option is unchanged — confirms the two per-node dictionaries are independent |
+| `Clear_AfterLoadBrokerTransactions_ResetsTransactionsState` | Broker selected, then cleared | `TransactionsPlotModel` is `null`, `IsTransactionsLoading` is `false`, `TransactionsError` is `null` |
+| `SelectingBrokerNode_CallsLoadBrokerTransactionsOnDetailsViewModel` (MainNavigationViewModelBase) | Broker node selected | Spy records the call with the correct broker name |
+| `SelectingPortfolioNode_CallsLoadPortfolioTransactionsOnDetailsViewModel` (MainNavigationViewModelBase) | Portfolio node selected | Spy records the call with the correct broker/portfolio names |
+| `SelectingAssetNode_DoesNotCallLoadBrokerOrPortfolioTransactions` (MainNavigationViewModelBase) | Asset node selected | Spy records zero calls to either new method (reuses `LoadAssetDetails`) |
+
+**Acceptance tests (PRD Section 9, F10):**
+- Selecting a Broker or Portfolio node in WPF's Transactions tab shows the monthly chart with no `DataGrid` → covered by the `TransactionsAggregateTemplate` binding (verified via the ViewModel's `IsTransactionsAggregateView` tests; XAML template selection itself is exercised via manual/live smoke check per the `implement-feature` skill's Step 6.4, since WPF `DataTemplate` selection is not unit-testable without a running visual tree)
+- Selecting an Asset node shows the existing `DataGrid` plus the new chart above it → `LoadAssetDetails_BuildsTransactionsPlotModel_FromAlreadyLoadedTransactions_NoNewFetch` + `LoadAssetDetails_SetsIsTransactionsAggregateViewFalse`
+- Chart values and zero-fill behaviour match the web frontend's computation for the same underlying data → `BuildMonthlyNetInvested_ComputesBuyMinusSellPerMonth` + `BuildMonthlyNetInvested_ZeroFillsMonthsWithNoTransactions` (same algorithm as F09's `buildMonthlyNetInvested`, verified independently in C#)
+- Bar is the default chart type; toggling to Line updates the `PlotModel` accordingly → `SetTransactionsChartMode_PersistsSelectionPerNode` + default-state assertion in the aggregator/chart-builder tests
+- All 6 period filters are available and correctly filter the plotted months → `BuildMonthlyNetInvested_ZeroFillsMonthsWithNoTransactions` (parametrized across filters) + `SetTransactionsFilter_PersistsSelectionPerNode`
+
+**Cross-feature integration tests (PRD Section 9):**
+- The transaction list returned by F03 for a Broker or Portfolio scope is used without transformation by F10 to compute each month's net-invested value → `LoadPortfolioTransactions_PassesCorrectBrokerAndPortfolioName` (the stub `ITransactionQueryService` returns raw `TransactionSummaryItemDTO` records, consumed directly by the tuple-projection call site with no mapping)
+- The period options and date-range rules defined by F04 are applied identically by F10 and continue to be applied identically by the existing Credits chart → satisfied by construction: `TransactionsMonthlyAggregator` calls the same `PeriodFilterHelper.GetDateRange` F04 already established, with no F10-local reimplementation
+- Chart values and zero-fill behaviour match F09's (Web) computation for the same underlying data → `BuildMonthlyNetInvested_ComputesBuyMinusSellPerMonth` and `BuildMonthlyNetInvested_ZeroFillsMonthsWithNoTransactions` assert the same month-grouping/zero-fill semantics as F09's `buildMonthlyNetInvested` test suite (same inputs, same expected outputs, expressed in C# against the WPF DTOs)
+
+## Assumptions and Decisions (from interview)
+
+- **Aggregation extracted as a separate static `TransactionsMonthlyAggregator`** rather than embedded inline in `AssetDetailsViewModel`, confirmed with the user, for independent, focused unit testability of the zero-fill math — mirrors F09 (Web)'s exported `buildMonthlyNetInvested`.
+- **Asset-scope chart layout uses a resizable `GridSplitter`**, confirmed with the user, exactly mirroring the existing Credits tab's `CreditsAssetTemplate` structure, rather than a simpler fixed-height panel.
+- **Default period filter is Last 12 Months and default chart mode is Bar**, matching F09 (Web) exactly for cross-platform consistency — the PRD does not explicitly restate this default for F10, but F09's explicit "default selected period on load is Last 12 Months" and the PRD's repeated cross-platform-consistency goal make this the only reasonable choice.
+- **No Retry button on a failed Broker/Portfolio transaction fetch**, matching F08 (WPF)'s existing breakdown-fetch error UX exactly ("A failed breakdown fetch shows an inline error; the four totals remain visible" — no Retry button in WPF's established pattern, unlike Web's `ErrorState`-with-Retry component). Re-selecting the node (or selecting a different node and back) re-triggers the fetch, consistent with how the existing breakdown fetch already behaves.
+- **Per-node filter/mode persistence uses a second, independent dictionary** (`_transactionsViewStateByKey`), confirmed by the PRD's explicit "independent from the Credits tab's currently-selected period" requirement — not ambiguous, directly stated.


### PR DESCRIPTION
## Summary
- Adds `TransactionsMonthlyAggregator` (zero-filling Buy-minus-Sell monthly grouping, mirroring F09 web's `buildMonthlyNetInvested`) and `TransactionsChartBuilder` (OxyPlot Bar/Line `PlotModel` with a single neutral series colour)
- Extends `AssetDetailsViewModel` with `LoadBrokerTransactions`/`LoadPortfolioTransactions` (cancellable async fetch mirroring `LoadBrokerBreakdown`'s pattern), per-node-persisted period filter and Bar/Line chart-mode state (independent from the Credits tab's own persistence)
- Splits the WPF Transactions tab into two `DataTemplate`s: Broker/Portfolio selection now shows the chart only (no `DataGrid`), Asset selection keeps the existing `DataGrid` with the chart added above it in a resizable `GridSplitter` layout
- No backend changes — reuses F03's `ITransactionQueryService` (called in-process via DI, no HTTP) and F04's `PeriodFilterHelper`

## Test plan
- [x] `dotnet build` (Financial.App) — clean
- [x] `dotnet test` (Financial.Presentation.Tests) — 123/123 passing, incl. new coverage for zero-fill correctness, fetch loading/error states, Asset-scope reuse of already-loaded data with no new fetch, per-node filter/mode persistence independent of Credits, and Broker/Portfolio/Asset dispatch routing
- [x] `dotnet test` across Domain/Application/Infrastructure test projects — no regressions
- [x] Live smoke test: launched the compiled WPF app against real data, drove it with Windows UI Automation — verified the chart renders correctly for Broker, Portfolio, and Asset node selection; Bar/Line toggle and period-filter clicks work; confirmed per-node state is independent (e.g. Broker kept Line/YTD while a freshly-selected Asset defaulted to Bar/Last 12 Months); zero crashes across the full interaction sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)