### PR TITLE
feat(P04-F11): Credits Chart Bar/Line Toggle — Web Frontend

### DIFF
--- a/Financial.Web/src/components/CreditsTab.tsx
+++ b/Financial.Web/src/components/CreditsTab.tsx
@@ -13,7 +13,7 @@ import {
 import type { CreditDto } from '../api/types'
 import ErrorState from './ErrorState'
 import LoadingState from './LoadingState'
-import type { CreditFormField, ViewMode } from '../hooks/useCredits'
+import type { CreditFormField, MonthBucket, ViewMode } from '../hooks/useCredits'
 import { useCredits } from '../hooks/useCredits'
 import { PERIOD_FILTER_OPTIONS } from '../utils/periodFilter'
 import './CreditsTab.css'
@@ -163,12 +163,19 @@ function InlineForm({
   )
 }
 
+const CHART_COLORS = [DIVIDEND_COLOR, RENT_COLOR]
+
+function typeValue(type: string) {
+  return (bucket: MonthBucket) => bucket.byType[type] ?? 0
+}
+
 interface ChartPanelProps {
   chartData: ReturnType<typeof useCredits>['chartData']
+  creditTypes: string[]
   selectedMode: ViewMode
 }
 
-function ChartPanel({ chartData, selectedMode }: ChartPanelProps) {
+function ChartPanel({ chartData, creditTypes, selectedMode }: ChartPanelProps) {
   const isStacked = selectedMode === 'Stacked'
   return (
     <div className="credits-tab__chart-panel">
@@ -181,20 +188,22 @@ function ChartPanel({ chartData, selectedMode }: ChartPanelProps) {
             <YAxis tickFormatter={formatN2} tick={{ fontSize: 11 }} width={70} />
             <Tooltip formatter={(v) => (typeof v === 'number' ? formatN2(v) : v)} />
             <Legend />
-            <Bar
-              dataKey="Dividend"
-              fill={DIVIDEND_COLOR}
-              stackId={isStacked ? 'credits' : undefined}
-            >
-              <LabelList dataKey="Dividend" position="inside" formatter={(v: unknown) => typeof v === 'number' && v > 0 ? formatN2(v) : ''} style={{ fontSize: 10 }} />
-            </Bar>
-            <Bar
-              dataKey="Rent"
-              fill={RENT_COLOR}
-              stackId={isStacked ? 'credits' : undefined}
-            >
-              <LabelList dataKey="Rent" position="inside" formatter={(v: unknown) => typeof v === 'number' && v > 0 ? formatN2(v) : ''} style={{ fontSize: 10 }} />
-            </Bar>
+            {creditTypes.map((type, index) => (
+              <Bar
+                key={type}
+                dataKey={typeValue(type)}
+                name={type}
+                fill={CHART_COLORS[index % CHART_COLORS.length]}
+                stackId={isStacked ? 'credits' : undefined}
+              >
+                <LabelList
+                  dataKey={typeValue(type)}
+                  position="inside"
+                  formatter={(v: unknown) => (typeof v === 'number' && v > 0 ? formatN2(v) : '')}
+                  style={{ fontSize: 10 }}
+                />
+              </Bar>
+            ))}
           </BarChart>
         </ResponsiveContainer>
       </div>
@@ -206,6 +215,7 @@ export default function CreditsTab() {
   const {
     credits,
     chartData,
+    creditTypes,
     isLoading,
     error,
     retry,
@@ -304,7 +314,7 @@ export default function CreditsTab() {
     return (
       <div className="credits-tab">
         {toolbar}
-        <ChartPanel chartData={chartData} selectedMode={selectedMode} />
+        <ChartPanel chartData={chartData} creditTypes={creditTypes} selectedMode={selectedMode} />
       </div>
     )
   }
@@ -368,7 +378,7 @@ export default function CreditsTab() {
         />
 
         <div className="credits-tab__right">
-          <ChartPanel chartData={chartData} selectedMode={selectedMode} />
+          <ChartPanel chartData={chartData} creditTypes={creditTypes} selectedMode={selectedMode} />
         </div>
       </div>
     </div>

--- a/Financial.Web/src/components/CreditsTab.tsx
+++ b/Financial.Web/src/components/CreditsTab.tsx
@@ -5,6 +5,8 @@ import {
   CartesianGrid,
   LabelList,
   Legend,
+  Line,
+  LineChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -13,7 +15,7 @@ import {
 import type { CreditDto } from '../api/types'
 import ErrorState from './ErrorState'
 import LoadingState from './LoadingState'
-import type { CreditFormField, MonthBucket, ViewMode } from '../hooks/useCredits'
+import type { ChartType, CreditFormField, MonthBucket, ViewMode } from '../hooks/useCredits'
 import { useCredits } from '../hooks/useCredits'
 import { PERIOD_FILTER_OPTIONS } from '../utils/periodFilter'
 import './CreditsTab.css'
@@ -35,8 +37,28 @@ function formatDate(iso: string): string {
   return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()}`
 }
 
-const DIVIDEND_COLOR = '#4682b4'
-const RENT_COLOR = '#6aabdb'
+const SINGLE_TYPE_COLOR = '#4682b4'
+const PALETTE_START = { r: 173, g: 216, b: 230 }
+const PALETTE_END = { r: 8, g: 81, b: 156 }
+
+function lerpByte(from: number, to: number, t: number): number {
+  return Math.round(from + (to - from) * t)
+}
+
+function buildPalette(count: number): string[] {
+  if (count <= 0) return []
+  if (count === 1) return [SINGLE_TYPE_COLOR]
+
+  const colors: string[] = []
+  for (let i = 0; i < count; i++) {
+    const t = i / (count - 1)
+    const r = lerpByte(PALETTE_START.r, PALETTE_END.r, t)
+    const g = lerpByte(PALETTE_START.g, PALETTE_END.g, t)
+    const b = lerpByte(PALETTE_START.b, PALETTE_END.b, t)
+    colors.push(`rgb(${r}, ${g}, ${b})`)
+  }
+  return colors
+}
 
 interface CreditRowProps {
   credit: CreditDto
@@ -163,8 +185,6 @@ function InlineForm({
   )
 }
 
-const CHART_COLORS = [DIVIDEND_COLOR, RENT_COLOR]
-
 function typeValue(type: string) {
   return (bucket: MonthBucket) => bucket.byType[type] ?? 0
 }
@@ -173,38 +193,73 @@ interface ChartPanelProps {
   chartData: ReturnType<typeof useCredits>['chartData']
   creditTypes: string[]
   selectedMode: ViewMode
+  selectedChartType: ChartType
 }
 
-function ChartPanel({ chartData, creditTypes, selectedMode }: ChartPanelProps) {
+function ChartPanel({ chartData, creditTypes, selectedMode, selectedChartType }: ChartPanelProps) {
   const isStacked = selectedMode === 'Stacked'
+  const palette = buildPalette(creditTypes.length)
+
   return (
     <div className="credits-tab__chart-panel">
       <p className="credits-tab__chart-title">Credits by Month</p>
       <div className="credits-tab__chart-container">
         <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={chartData} margin={{ top: 8, right: 16, left: 8, bottom: 8 }}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" tick={{ fontSize: 11 }} />
-            <YAxis tickFormatter={formatN2} tick={{ fontSize: 11 }} width={70} />
-            <Tooltip formatter={(v) => (typeof v === 'number' ? formatN2(v) : v)} />
-            <Legend />
-            {creditTypes.map((type, index) => (
-              <Bar
-                key={type}
-                dataKey={typeValue(type)}
-                name={type}
-                fill={CHART_COLORS[index % CHART_COLORS.length]}
-                stackId={isStacked ? 'credits' : undefined}
-              >
-                <LabelList
+          {selectedChartType === 'Bar' ? (
+            <BarChart data={chartData} margin={{ top: 8, right: 16, left: 8, bottom: 8 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+              <YAxis tickFormatter={formatN2} tick={{ fontSize: 11 }} width={70} />
+              <Tooltip formatter={(v) => (typeof v === 'number' ? formatN2(v) : v)} />
+              <Legend />
+              {creditTypes.map((type, index) => (
+                <Bar
+                  key={type}
                   dataKey={typeValue(type)}
-                  position="inside"
-                  formatter={(v: unknown) => (typeof v === 'number' && v > 0 ? formatN2(v) : '')}
-                  style={{ fontSize: 10 }}
+                  name={type}
+                  fill={palette[index]}
+                  stackId={isStacked ? 'credits' : undefined}
+                >
+                  <LabelList
+                    dataKey={typeValue(type)}
+                    position="inside"
+                    formatter={(v: unknown) => (typeof v === 'number' && v > 0 ? formatN2(v) : '')}
+                    style={{ fontSize: 10 }}
+                  />
+                </Bar>
+              ))}
+            </BarChart>
+          ) : (
+            <LineChart data={chartData} margin={{ top: 8, right: 16, left: 8, bottom: 8 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+              <YAxis tickFormatter={formatN2} tick={{ fontSize: 11 }} width={70} />
+              <Tooltip formatter={(v) => (typeof v === 'number' ? formatN2(v) : v)} />
+              <Legend />
+              {isStacked ? (
+                creditTypes.map((type, index) => (
+                  <Line
+                    key={type}
+                    type="monotone"
+                    dataKey={typeValue(type)}
+                    name={type}
+                    stroke={palette[index]}
+                    strokeWidth={2}
+                    dot={{ r: 3 }}
+                  />
+                ))
+              ) : (
+                <Line
+                  type="monotone"
+                  dataKey="total"
+                  name="Total"
+                  stroke={SINGLE_TYPE_COLOR}
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
                 />
-              </Bar>
-            ))}
-          </BarChart>
+              )}
+            </LineChart>
+          )}
         </ResponsiveContainer>
       </div>
     </div>
@@ -221,8 +276,10 @@ export default function CreditsTab() {
     retry,
     selectedFilter,
     selectedMode,
+    selectedChartType,
     setFilter,
     setMode,
+    setChartType,
     isFormVisible,
     editingId,
     formDate,
@@ -296,6 +353,19 @@ export default function CreditsTab() {
       </div>
       <div className="credits-tab__modes">
         <span className="credits-tab__mode-label">View:</span>
+        {(['Bar', 'Line'] as ChartType[]).map((chartType) => (
+          <button
+            key={chartType}
+            type="button"
+            className={`credits-tab__mode-btn${selectedChartType === chartType ? ' credits-tab__mode-btn--active' : ''}`}
+            onClick={() => setChartType(chartType)}
+          >
+            {chartType}
+          </button>
+        ))}
+      </div>
+      <div className="credits-tab__modes">
+        <span className="credits-tab__mode-label">Group:</span>
         {(['Stacked', 'Grouped'] as ViewMode[]).map((mode) => (
           <button
             key={mode}
@@ -314,7 +384,12 @@ export default function CreditsTab() {
     return (
       <div className="credits-tab">
         {toolbar}
-        <ChartPanel chartData={chartData} creditTypes={creditTypes} selectedMode={selectedMode} />
+        <ChartPanel
+          chartData={chartData}
+          creditTypes={creditTypes}
+          selectedMode={selectedMode}
+          selectedChartType={selectedChartType}
+        />
       </div>
     )
   }
@@ -378,7 +453,12 @@ export default function CreditsTab() {
         />
 
         <div className="credits-tab__right">
-          <ChartPanel chartData={chartData} creditTypes={creditTypes} selectedMode={selectedMode} />
+          <ChartPanel
+            chartData={chartData}
+            creditTypes={creditTypes}
+            selectedMode={selectedMode}
+            selectedChartType={selectedChartType}
+          />
         </div>
       </div>
     </div>

--- a/Financial.Web/src/components/__tests__/CreditsTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/CreditsTab.test.tsx
@@ -49,6 +49,7 @@ const DEFAULT_HOOK: CreditsData = {
   credits: [],
   filteredCredits: [],
   chartData: [],
+  creditTypes: [],
   isLoading: false,
   error: null,
   retry: mockRetry,

--- a/Financial.Web/src/components/__tests__/CreditsTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/CreditsTab.test.tsx
@@ -14,6 +14,7 @@ const mockDeleteCredit = vi.fn()
 const mockRetry = vi.fn()
 const mockSetFilter = vi.fn()
 const mockSetMode = vi.fn()
+const mockSetChartType = vi.fn()
 
 vi.mock('recharts', () => ({
   BarChart: ({ children }: { children: React.ReactNode }) => (
@@ -55,8 +56,10 @@ const DEFAULT_HOOK: CreditsData = {
   retry: mockRetry,
   selectedFilter: 'last-12-months',
   selectedMode: 'Stacked',
+  selectedChartType: 'Bar',
   setFilter: mockSetFilter,
   setMode: mockSetMode,
+  setChartType: mockSetChartType,
   isFormVisible: false,
   editingId: null,
   formDate: '',

--- a/Financial.Web/src/components/__tests__/CreditsTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/CreditsTab.test.tsx
@@ -21,6 +21,10 @@ vi.mock('recharts', () => ({
     <div data-testid="bar-chart">{children}</div>
   ),
   Bar: () => null,
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="line-chart">{children}</div>
+  ),
+  Line: ({ name }: { name?: string }) => <div data-testid="line" data-name={name} />,
   XAxis: () => null,
   YAxis: () => null,
   CartesianGrid: () => null,
@@ -102,6 +106,7 @@ describe('CreditsTab', () => {
     mockRetry.mockReset()
     mockSetFilter.mockReset()
     mockSetMode.mockReset()
+    mockSetChartType.mockReset()
     mockHookValue = { ...DEFAULT_HOOK }
   })
 
@@ -294,5 +299,56 @@ describe('CreditsTab', () => {
     render(<CreditsTab />)
     const tbody = document.querySelector('tbody')
     expect(tbody?.children.length).toBe(0)
+  })
+
+  it('renders_bar_line_toggle_defaulting_to_bar', () => {
+    render(<CreditsTab />)
+    expect(screen.getByRole('button', { name: 'Bar' })).toHaveClass('credits-tab__mode-btn--active')
+    expect(screen.getByRole('button', { name: 'Line' })).not.toHaveClass('credits-tab__mode-btn--active')
+  })
+
+  it('clicking_line_toggle_calls_setChartType', () => {
+    render(<CreditsTab />)
+    fireEvent.click(screen.getByRole('button', { name: 'Line' }))
+    expect(mockSetChartType).toHaveBeenCalledWith('Line')
+  })
+
+  it('renders_relabelled_toggle_rows', () => {
+    render(<CreditsTab />)
+    expect(screen.getByText('View:')).toBeInTheDocument()
+    expect(screen.getByText('Group:')).toBeInTheDocument()
+  })
+
+  it('renders_bar_chart_unchanged_when_bar_selected', () => {
+    setMock({ selectedChartType: 'Bar' })
+    render(<CreditsTab />)
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument()
+    expect(screen.queryByTestId('line-chart')).not.toBeInTheDocument()
+  })
+
+  it('renders_single_total_line_when_grouped_and_line', () => {
+    setMock({
+      selectedChartType: 'Line',
+      selectedMode: 'Grouped',
+      creditTypes: ['Dividend', 'Rent'],
+      chartData: [{ month: '03/2024', total: 150, byType: { Dividend: 100, Rent: 50 } }],
+    })
+    render(<CreditsTab />)
+    const lines = screen.getAllByTestId('line')
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toHaveAttribute('data-name', 'Total')
+  })
+
+  it('renders_one_line_per_type_when_stacked_and_line', () => {
+    setMock({
+      selectedChartType: 'Line',
+      selectedMode: 'Stacked',
+      creditTypes: ['Dividend', 'Rent'],
+      chartData: [{ month: '03/2024', total: 150, byType: { Dividend: 100, Rent: 50 } }],
+    })
+    render(<CreditsTab />)
+    const lines = screen.getAllByTestId('line')
+    expect(lines).toHaveLength(2)
+    expect(lines.map((l) => l.getAttribute('data-name'))).toEqual(['Dividend', 'Rent'])
   })
 })

--- a/Financial.Web/src/hooks/useCredits.test.ts
+++ b/Financial.Web/src/hooks/useCredits.test.ts
@@ -423,4 +423,89 @@ describe('useCredits', () => {
     expect(result.current.credits[0].id).toBe('aaa')
     expect(result.current.credits[1].id).toBe('bbb')
   })
+
+  it('aggregateByMonth_computesByTypeDynamically', async () => {
+    const creditA: CreditDto = { id: 'sm1', date: '2024-03-05T00:00:00', type: 'Dividend', value: 100 }
+    const creditB: CreditDto = { id: 'sm2', date: '2024-03-20T00:00:00', type: 'Rent', value: 50 }
+    getAssetDetailsMock.mockResolvedValue({ ...ASSET_DETAILS, credits: [creditA, creditB] })
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.setFilter('all-time'))
+
+    const bucket = result.current.chartData.find((b) => b.month === '03/2024')
+    expect(bucket?.byType.Dividend).toBe(100)
+    expect(bucket?.byType.Rent).toBe(50)
+  })
+
+  it('aggregateByMonth_computesTotalAsSumOfByType', async () => {
+    const creditA: CreditDto = { id: 'sm1', date: '2024-03-05T00:00:00', type: 'Dividend', value: 100 }
+    const creditB: CreditDto = { id: 'sm2', date: '2024-03-20T00:00:00', type: 'Rent', value: 50 }
+    getAssetDetailsMock.mockResolvedValue({ ...ASSET_DETAILS, credits: [creditA, creditB] })
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.setFilter('all-time'))
+
+    const bucket = result.current.chartData.find((b) => b.month === '03/2024')
+    expect(bucket?.total).toBe(150)
+  })
+
+  it('aggregateByMonth_supportsAThirdCreditType', async () => {
+    const creditA: CreditDto = { id: 'sm1', date: '2024-03-05T00:00:00', type: 'Dividend', value: 100 }
+    const creditB: CreditDto = { id: 'sm2', date: '2024-03-20T00:00:00', type: 'Rent', value: 50 }
+    const creditC: CreditDto = { id: 'sm3', date: '2024-03-10T00:00:00', type: 'Interest', value: 30 }
+    getAssetDetailsMock.mockResolvedValue({ ...ASSET_DETAILS, credits: [creditA, creditB, creditC] })
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(3))
+    act(() => result.current.setFilter('all-time'))
+
+    expect(result.current.creditTypes).toEqual(['Dividend', 'Interest', 'Rent'])
+    const bucket = result.current.chartData.find((b) => b.month === '03/2024')
+    expect(bucket?.byType.Interest).toBe(30)
+    expect(bucket?.total).toBe(180)
+  })
+
+  it('setChartType_defaultsToBar', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    expect(result.current.selectedChartType).toBe('Bar')
+  })
+
+  it('setChartType_persistsSelectionPerNode', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    act(() => result.current.setChartType('Line'))
+    expect(result.current.selectedChartType).toBe('Line')
+
+    setNode(ASSET_NODE_B)
+    await waitFor(() => expect(getAssetDetailsMock).toHaveBeenCalledWith('XPI', 'Acoes', 'TASA4'))
+    expect(result.current.selectedChartType).toBe('Bar')
+
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(getAssetDetailsMock).toHaveBeenCalledWith('XPI', 'Acoes', 'KLBN4'))
+    await waitFor(() => expect(result.current.selectedChartType).toBe('Line'))
+  })
+
+  it('setChartType_doesNotAffectSelectedMode_forSameNode', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    const { wrapper, setNode } = createWrapper()
+    const { result } = renderHook(() => useCredits(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.credits).toHaveLength(2))
+    expect(result.current.selectedMode).toBe('Stacked')
+    act(() => result.current.setChartType('Line'))
+    expect(result.current.selectedMode).toBe('Stacked')
+  })
 })

--- a/Financial.Web/src/hooks/useCredits.ts
+++ b/Financial.Web/src/hooks/useCredits.ts
@@ -11,8 +11,8 @@ export type CreditFormField = 'formDate' | 'formType' | 'formValue'
 
 export interface MonthBucket {
   month: string
-  Dividend: number
-  Rent: number
+  total: number
+  byType: Record<string, number>
 }
 
 interface PersistedPrefs {
@@ -178,11 +178,10 @@ function aggregateByMonth(credits: CreditDto[]): MonthBucket[] {
   const map = new Map<string, MonthBucket>()
   for (const c of credits) {
     const key = buildMonthKey(new Date(c.date))
-    const existing = map.get(key) ?? { month: key, Dividend: 0, Rent: 0 }
-    const bucket: MonthBucket = { ...existing }
-    if (c.type === 'Dividend') bucket.Dividend += c.value
-    else if (c.type === 'Rent') bucket.Rent += c.value
-    map.set(key, bucket)
+    const existing = map.get(key) ?? { month: key, total: 0, byType: {} }
+    const byType = { ...existing.byType }
+    byType[c.type] = (byType[c.type] ?? 0) + c.value
+    map.set(key, { month: key, total: existing.total + c.value, byType })
   }
   return [...map.values()].sort((a, b) => {
     const [am, ay] = a.month.split('/').map(Number)
@@ -192,10 +191,19 @@ function aggregateByMonth(credits: CreditDto[]): MonthBucket[] {
   })
 }
 
+function computeCreditTypes(buckets: MonthBucket[]): string[] {
+  const types = new Set<string>()
+  for (const bucket of buckets) {
+    for (const type of Object.keys(bucket.byType)) types.add(type)
+  }
+  return [...types].sort()
+}
+
 export interface CreditsData {
   credits: CreditDto[]
   filteredCredits: CreditDto[]
   chartData: MonthBucket[]
+  creditTypes: string[]
   isLoading: boolean
   error: string | null
   retry: () => void
@@ -284,6 +292,7 @@ export function useCredits(): CreditsData {
   }, [credits, state.selectedFilter])
 
   const chartData = useMemo(() => aggregateByMonth(filteredCredits), [filteredCredits])
+  const creditTypes = useMemo(() => computeCreditTypes(chartData), [chartData])
 
   const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
 
@@ -384,6 +393,7 @@ export function useCredits(): CreditsData {
     credits,
     filteredCredits,
     chartData,
+    creditTypes,
     isLoading: state.isLoading,
     error: state.error,
     retry,

--- a/Financial.Web/src/hooks/useCredits.ts
+++ b/Financial.Web/src/hooks/useCredits.ts
@@ -6,6 +6,7 @@ import type { PeriodFilterOption } from '../utils/periodFilter'
 import { getPeriodFilterStartDate } from '../utils/periodFilter'
 
 export type ViewMode = 'Stacked' | 'Grouped'
+export type ChartType = 'Bar' | 'Line'
 export type CreditType = 'Dividend' | 'Rent'
 export type CreditFormField = 'formDate' | 'formType' | 'formValue'
 
@@ -18,10 +19,12 @@ export interface MonthBucket {
 interface PersistedPrefs {
   filter: PeriodFilterOption
   mode: ViewMode
+  chartType: ChartType
 }
 
 const DEFAULT_FILTER: PeriodFilterOption = 'last-12-months'
 const DEFAULT_MODE: ViewMode = 'Stacked'
+const DEFAULT_CHART_TYPE: ChartType = 'Bar'
 
 interface CreditsState {
   credits: CreditDto[]
@@ -30,6 +33,7 @@ interface CreditsState {
   retryCount: number
   selectedFilter: PeriodFilterOption
   selectedMode: ViewMode
+  selectedChartType: ChartType
   filterPersistence: Map<string, PersistedPrefs>
   isFormVisible: boolean
   editingId: string | null
@@ -49,6 +53,7 @@ type CreditsAction =
   | { type: 'RETRY' }
   | { type: 'SET_FILTER'; payload: { filter: PeriodFilterOption; key: string } }
   | { type: 'SET_MODE'; payload: { mode: ViewMode; key: string } }
+  | { type: 'SET_CHART_TYPE'; payload: { chartType: ChartType; key: string } }
   | { type: 'SHOW_NEW_FORM' }
   | { type: 'SHOW_EDIT_FORM'; payload: CreditDto }
   | { type: 'CANCEL_FORM' }
@@ -76,6 +81,7 @@ const INITIAL_STATE: CreditsState = {
   retryCount: 0,
   selectedFilter: DEFAULT_FILTER,
   selectedMode: DEFAULT_MODE,
+  selectedChartType: DEFAULT_CHART_TYPE,
   filterPersistence: new Map(),
   ...BLANK_FORM,
   deleteError: null,
@@ -98,6 +104,7 @@ function reducer(state: CreditsState, action: CreditsAction): CreditsState {
         filterPersistence: state.filterPersistence,
         selectedFilter: prefs?.filter ?? DEFAULT_FILTER,
         selectedMode: prefs?.mode ?? DEFAULT_MODE,
+        selectedChartType: prefs?.chartType ?? DEFAULT_CHART_TYPE,
       }
     }
     case 'FETCH_SUCCESS':
@@ -108,13 +115,30 @@ function reducer(state: CreditsState, action: CreditsAction): CreditsState {
       return { ...state, retryCount: state.retryCount + 1, error: null }
     case 'SET_FILTER': {
       const newMap = new Map(state.filterPersistence)
-      newMap.set(action.payload.key, { filter: action.payload.filter, mode: state.selectedMode })
+      newMap.set(action.payload.key, {
+        filter: action.payload.filter,
+        mode: state.selectedMode,
+        chartType: state.selectedChartType,
+      })
       return { ...state, selectedFilter: action.payload.filter, filterPersistence: newMap }
     }
     case 'SET_MODE': {
       const newMap = new Map(state.filterPersistence)
-      newMap.set(action.payload.key, { filter: state.selectedFilter, mode: action.payload.mode })
+      newMap.set(action.payload.key, {
+        filter: state.selectedFilter,
+        mode: action.payload.mode,
+        chartType: state.selectedChartType,
+      })
       return { ...state, selectedMode: action.payload.mode, filterPersistence: newMap }
+    }
+    case 'SET_CHART_TYPE': {
+      const newMap = new Map(state.filterPersistence)
+      newMap.set(action.payload.key, {
+        filter: state.selectedFilter,
+        mode: state.selectedMode,
+        chartType: action.payload.chartType,
+      })
+      return { ...state, selectedChartType: action.payload.chartType, filterPersistence: newMap }
     }
     case 'SHOW_NEW_FORM':
       return {
@@ -209,8 +233,10 @@ export interface CreditsData {
   retry: () => void
   selectedFilter: PeriodFilterOption
   selectedMode: ViewMode
+  selectedChartType: ChartType
   setFilter: (filter: PeriodFilterOption) => void
   setMode: (mode: ViewMode) => void
+  setChartType: (chartType: ChartType) => void
   isFormVisible: boolean
   editingId: string | null
   formDate: string
@@ -312,6 +338,14 @@ export function useCredits(): CreditsData {
     [selectedNode],
   )
 
+  const setChartType = useCallback(
+    (chartType: ChartType) => {
+      if (!selectedNode) return
+      dispatch({ type: 'SET_CHART_TYPE', payload: { chartType, key: buildSelectionKey(selectedNode) } })
+    },
+    [selectedNode],
+  )
+
   const showNewForm = useCallback(() => dispatch({ type: 'SHOW_NEW_FORM' }), [])
 
   const showEditForm = useCallback(
@@ -399,8 +433,10 @@ export function useCredits(): CreditsData {
     retry,
     selectedFilter: state.selectedFilter,
     selectedMode: state.selectedMode,
+    selectedChartType: state.selectedChartType,
     setFilter,
     setMode,
+    setChartType,
     isFormVisible: state.isFormVisible,
     editingId: state.editingId,
     formDate: state.formDate,

--- a/docs/P04-F11-credits-chart-bar-line-toggle-web/plan.md
+++ b/docs/P04-F11-credits-chart-bar-line-toggle-web/plan.md
@@ -1,0 +1,27 @@
+# Implementation Plan: Credits Chart Bar/Line Toggle — Web Frontend
+
+**Prerequisites:**
+- F09 (Transactions Monthly Investment Chart — Web Frontend) already merged to `main`; its Bar/Line toggle button styling and `LineChart`/`Line` usage are the reference pattern this feature mirrors for the Credits chart
+- `recharts` is already a project dependency; `LineChart`/`Line` are already used by the Transactions chart, `BarChart`/`Bar` are already used by the Credits chart
+
+### Stage 1: Dynamic Per-Type Aggregation
+
+**1. Credit-type data shape refactor** - Replace the hardcoded two-field month bucket with a dynamic per-type structure, computing which credit types are present directly from the data rather than assuming a fixed set, and computing each month's combined total alongside the per-type breakdown. Reference the spec's Technical Decisions for why this refactor is required now rather than deferred.
+
+### Stage 2: Chart Type State
+
+**2. Chart display mode state and persistence** - Add the Bar/Line chart type selection to the credits hook, defaulting to Bar, persisted per node selection alongside the existing period filter and Stacked/Grouped selections without overwriting either. Reference the spec's Technical Decisions for the persistence approach and the type-naming decision.
+
+### Stage 3: Component Rendering
+
+**3. Dynamic colour palette** - Add the computed colour palette function used to assign a distinct colour per credit type, replacing the two hardcoded colour constants, shared identically between the bar and line rendering paths. Reference the spec's Technical Decisions for the palette approach.
+
+**4. Line chart rendering** - Extend the chart panel to render a line chart when line mode is selected: a single line for the combined total when grouped, or one line per credit type when stacked. Reference the spec's Technical Decisions for the exact Grouped/Stacked line semantics.
+
+**5. Toolbar toggle rows** - Add the new Bar/Line toggle row to the chart toolbar, and relabel the existing Stacked/Grouped toggle row, following the exact button styling and click-handling pattern the existing toggle already uses. Reference the spec's Component Overview for the exact label text.
+
+### Stage 4: Tests
+
+**6. Hook test coverage** - Extend the credits hook's test file with coverage for the dynamic per-type aggregation, total computation, and chart type default/persistence behaviour including its independence from the existing Stacked/Grouped persistence. Reference the spec's Testing Strategy for the full list of test functions.
+
+**7. Component test coverage** - Extend the credits tab's test file with coverage for the Bar/Line toggle's default and click behaviour, the relabelled toggle rows, and the Grouped+Line versus Stacked+Line rendering differences, mocking `recharts` per the project's existing pattern.

--- a/docs/P04-F11-credits-chart-bar-line-toggle-web/spec.md
+++ b/docs/P04-F11-credits-chart-bar-line-toggle-web/spec.md
@@ -1,0 +1,112 @@
+# F11. Credits Chart Bar/Line Toggle — Web Frontend
+
+## 1. Technical Overview
+
+**What:** Add a second, independent toggle to the Credits tab's chart — chart display mode (`Bar`/`Line`) — alongside the existing Stacked/Grouped grouping toggle, at all three node levels (Broker, Portfolio, Asset). Grouped + Line renders a single line for the combined monthly total; Stacked + Line renders one line per credit type (not cumulative). As part of this change, the web's credit-type aggregation is refactored from a hardcoded two-field shape (`{ month, Dividend, Rent }`) into a dynamic per-type structure, mirroring the pattern the WPF app's `CreditsMonthTypeTotals`/`TotalsByType` already uses, so a future third credit type requires no chart code changes on either platform.
+
+**Why:** The Transactions chart (F09) already shipped a Bar/Line toggle; the Credits chart — a conceptually identical "monthly trend" chart — was missed from that pass and only offers Bar. This feature closes that gap and, per the confirmed requirement, also fixes the underlying data-shape mismatch between web (hardcoded fields) and WPF (dynamic dictionary) so the "any number of credit types" intent is actually realized on both platforms, not just described in the PRD.
+
+**Scope:**
+- Included: refactor `useCredits`'s `MonthBucket`/`aggregateByMonth` to a dynamic per-type shape; new `ChartType` state (`'Bar' | 'Line'`, default `Bar`) with its own `setChartType` action, persisted per node selection alongside the existing filter/mode persistence; a dynamic blue-gradient colour palette (replacing the two hardcoded `DIVIDEND_COLOR`/`RENT_COLOR` constants) reused by both Bar and Line rendering; `CreditsTab`'s `ChartPanel` extended to render `recharts` `LineChart`/`Line` for Line mode; a second toolbar toggle row ("View: Bar / Line", with the existing toggle relabelled "Group: Stacked / Grouped"); unit test coverage.
+- Excluded: any backend change (none needed — this is purely a client-side rendering/aggregation change over already-fetched credit data); the WPF equivalent (F12, separate feature); any change to the Transactions chart (F09/F10, already shipped, untouched by this feature).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/hooks/useCredits.ts` — `MonthBucket` shape, `aggregateByMonth`, new `ChartType` state/persistence/action
+- `Financial.Web/src/components/CreditsTab.tsx` — `ChartPanel` Line rendering, dynamic colour palette, second toggle row
+- `Financial.Web/src/components/CreditsTab.css` — no new classes required (existing `.credits-tab__modes`/`.credits-tab__mode-btn` rules are reused for the second toggle row)
+- `Financial.Web/src/hooks/useCredits.test.ts` — extended
+- `Financial.Web/src/components/__tests__/CreditsTab.test.tsx` — extended
+
+```mermaid
+graph TD
+    A["User selects Broker, Portfolio, or Asset node"] --> B[CreditsTab]
+    B --> C[useCredits hook]
+    C --> D["Already-fetched credits (unchanged fetch logic)"]
+    D --> E["aggregateByMonth (refactored: dynamic per-type map + total)"]
+    E --> F{"selectedChartType"}
+    F -->|Bar| G["recharts BarChart (existing, now reads dynamic per-type keys)"]
+    F -->|Line, Grouped| H["recharts LineChart — single Line on 'total'"]
+    F -->|Line, Stacked| I["recharts LineChart — one Line per credit type"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|------------------|-------------------------|-----------|
+| Credit-type data shape | Refactor `MonthBucket` from hardcoded `{ month, Dividend, Rent }` fields to a dynamic shape (`{ month, total, byType: Record<string, number> }`), with the set of type keys computed at aggregation time from the actual credit data present, mirroring WPF's already-dynamic `CreditsMonthTypeTotals.TotalsByType` | Keep the hardcoded two-field shape and only make the new Line path dynamic | Confirmed with the user: only the full refactor genuinely satisfies "this can change in the future" on both platforms; the partial option would leave Bar (existing) and Line (new) reading different, inconsistent data shapes for the same underlying aggregation |
+| Stacked + Line rendering | One `Line` series per credit type, each plotting that type's own independent monthly value — not a cumulative stacked line/area | Cumulative stacked lines (each line's height = running sum of itself + all types below it) | Confirmed with the user: separate, non-cumulative lines are simpler to read and match the mental model of "the same per-type breakdown as Stacked bars, just drawn as lines" |
+| Grouped + Line rendering | A single `Line` series plotting `total` (sum across all credit types) per month | One line per type, unstacked (same as Stacked+Line) | Directly specified by the PRD: "when Grouped should have one line and use the total" — Grouped's defining characteristic (one measure per month, not broken out by type) carries over to Line mode |
+| Toggle labelling | New row: "View: Bar / Line" (reuses the exact label the Transactions chart's own Bar/Line toggle already uses). Existing row relabelled: "Group: Stacked / Grouped" (was "View:") | Keep "View:" on the existing Stacked/Grouped row and label the new row "Chart Type:" | Confirmed with the user: reusing "View:" for Bar/Line keeps the label consistent with the Transactions chart's identical toggle, and "Group:" unambiguously names what Stacked/Grouped actually controls now that two toggle rows exist |
+| New toggle type naming | A `ChartType = 'Bar' \| 'Line'` type defined locally in `useCredits.ts`, distinct from `useTransactions.ts`'s existing `ChartDisplayMode` (same shape, different module) | Import and reuse `ChartDisplayMode` from `useTransactions.ts` | Mirrors F09's own established precedent (documented in its spec's Technical Decisions) of keeping Bar/Line toggle types feature-local even without an actual TypeScript collision, so `useCredits` and `useTransactions` remain independent of each other |
+| Colour palette | A computed blue-gradient palette function (light → dark blue, one shade per credit type index), replacing the two hardcoded `DIVIDEND_COLOR`/`RENT_COLOR` hex constants; reused identically by Bar and Line rendering so a type's colour doesn't change when toggling chart type | Keep the two hardcoded constants and add a fallback grey for any 3rd+ type | Mirrors WPF's existing `CreditsChartBuilder.BuildBluePalette` gradient-interpolation approach exactly, giving both platforms the same colour-scaling behaviour as credit types are added in the future |
+| Persistence | Extend the existing per-node `PersistedPrefs` record (already storing `{ filter, mode }` in one `Map<selectionKey, prefs>` entry) with a third field, `chartType`, rather than adding a second `Map` | A separate `Map<selectionKey, ChartType>` dedicated to chart type | Minimal, consistent extension of the proven single-record-per-node pattern; mirrors F12 (WPF)'s equivalent decision to extend the single `CreditsViewState` struct rather than add a second dictionary |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|---------------|---------|------------------------|
+| `Financial.Web/src/hooks/useCredits.ts` | Modified | Data + chart state | Replace `MonthBucket { month, Dividend, Rent }` with `MonthBucket { month, total, byType }`; rewrite `aggregateByMonth` to compute `byType` dynamically from the credit types actually present in the filtered credits (mirroring `_creditsChartTypes` on WPF) and `total` as the sum of `byType`'s values; add `ChartType` type, `selectedChartType` state (default `'Bar'`), `SET_CHART_TYPE` reducer action, `setChartType` callback, and extend `PersistedPrefs`/`filterPersistence` with the third `chartType` field, mirroring the existing `filter`/`mode` persistence exactly |
+| `Financial.Web/src/components/CreditsTab.tsx` | Modified | Rendering | Add a dynamic blue-gradient palette function (replacing `DIVIDEND_COLOR`/`RENT_COLOR`); extend `ChartPanel` to branch on `selectedChartType`: Bar mode renders the existing `BarChart` (now iterating `creditTypes` dynamically instead of two hardcoded `<Bar>` elements), Line mode renders a `LineChart` with either one `Line` (`dataKey="total"`, Grouped) or one `Line` per type (`dataKey={type}`, Stacked); add the second toolbar toggle row ("View: Bar / Line") next to the existing (relabelled "Group:") row |
+| `Financial.Web/src/components/CreditsTab.css` | Unmodified | — | Existing `.credits-tab__modes`/`.credits-tab__mode-label`/`.credits-tab__mode-btn`/`.credits-tab__mode-btn--active` rules are reused as-is for the second toggle row; `.credits-tab__controls` already has `flex-wrap: wrap`, so no layout changes are needed |
+| `Financial.Web/src/hooks/useCredits.test.ts` | Modified | Test coverage | Extend with tests for dynamic per-type aggregation, `total` computation, `setChartType`/persistence, and persistence independence from `setMode` |
+| `Financial.Web/src/components/__tests__/CreditsTab.test.tsx` | Modified | Test coverage | Extend with tests for Bar/Line toggle rendering, Grouped+Line single-total-line behaviour, Stacked+Line per-type-lines behaviour, and the relabelled toggle rows |
+
+**Backend:** None — this feature operates entirely on already-fetched `CreditDto[]` data; no API contract changes.
+
+## 5. API Contracts
+
+Not applicable — no new or modified endpoint. This feature is a client-side aggregation and rendering change only.
+
+## 6. Data Model
+
+Not applicable — no database or DTO changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|-----------------|
+| `Financial.Web/src/hooks/useCredits.test.ts` (extended) | Unit | `useCredits` | Dynamic per-type aggregation correctness, `total` computation, chart type default/persistence, independence from Stacked/Grouped persistence |
+| `Financial.Web/src/components/__tests__/CreditsTab.test.tsx` (extended) | Unit | `CreditsTab` | Bar/Line toggle rendering and default, Grouped+Line single line, Stacked+Line one line per type, relabelled toggle rows, click handlers |
+
+**Test Functions:**
+
+| Test Function | Description | Assertions |
+|----------------|--------------|-------------|
+| `aggregateByMonth_computesByTypeDynamically` | Fixture with Dividend + Rent credits in the same month | Bucket's `byType` has both `Dividend` and `Rent` keys with correct summed values |
+| `aggregateByMonth_computesTotalAsSumOfByType` | Fixture with Dividend 100 + Rent 50 in the same month | Bucket's `total` is `150` |
+| `aggregateByMonth_supportsAThirdCreditType` | Fixture with a credit of a hypothetical third type (e.g. `'Interest'`) | Bucket's `byType` includes the third type without any hardcoded-field limitation |
+| `setChartType_defaultsToBar` | Fresh node selection | `selectedChartType` is `'Bar'` |
+| `setChartType_persistsSelectionPerNode` | Set chart type on Broker A, switch to Broker B, switch back to Broker A | Broker A's chart type selection is remembered (mirrors the existing `setMode`/`setFilter` persistence test pattern) |
+| `setChartType_doesNotAffectSelectedMode_forSameNode` | Set chart type to `Line` on a node whose mode is `Stacked` | `selectedMode` remains `Stacked`, confirming the two toggles persist independently |
+| `renders_bar_line_toggle_defaulting_to_bar` (CreditsTab) | Fresh render | "Bar" toggle button has the active class; "Line" does not |
+| `clicking_line_toggle_calls_setChartType` (CreditsTab) | User clicks "Line" | `setChartType('Line')` called |
+| `renders_relabelled_group_toggle` (CreditsTab) | Any render | Label text "Group:" is present (not "View:") for the Stacked/Grouped row, and "View:" is present for the new Bar/Line row |
+| `renders_single_total_line_when_grouped_and_line` (CreditsTab) | `selectedMode: 'Grouped'`, `selectedChartType: 'Line'`, chart data with `total` values | Exactly one `Line` element renders, keyed on `total` |
+| `renders_one_line_per_type_when_stacked_and_line` (CreditsTab) | `selectedMode: 'Stacked'`, `selectedChartType: 'Line'`, chart data with 2 credit types | Exactly two `Line` elements render, one per type present in the data |
+| `renders_bar_chart_unchanged_when_bar_selected` (CreditsTab) | `selectedChartType: 'Bar'` (default) | `BarChart` renders (not `LineChart`), preserving existing Stacked/Grouped bar behaviour |
+
+**Acceptance tests (PRD Section 9, F11):**
+- The Credits chart offers a Bar/Line toggle independent from the existing Stacked/Grouped toggle, at Broker, Portfolio, and Asset levels → `renders_bar_line_toggle_defaulting_to_bar` (mocked hook covers all three scopes identically since `CreditsTab` renders the same toolbar regardless of `nodeType`)
+- Default chart display mode is Bar; existing Stacked/Grouped bar rendering is visually unchanged when Bar is selected → `setChartType_defaultsToBar` + `renders_bar_chart_unchanged_when_bar_selected`
+- Selecting Line with Grouped selected renders a single line representing the combined total → `renders_single_total_line_when_grouped_and_line`
+- Selecting Line with Stacked selected renders one line per credit type, not cumulative → `renders_one_line_per_type_when_stacked_and_line`
+- Changing either toggle does not trigger a new network request → satisfied by construction: `setChartType`/`setMode` only dispatch reducer actions over already-fetched `state.credits`, no `apiClient` call in either action creator (consistent with the existing `setMode`/`setFilter` behaviour, unchanged by this feature)
+- The Bar/Line selection persists per node selection, independent from the Stacked/Grouped selection's own persistence → `setChartType_persistsSelectionPerNode` + `setChartType_doesNotAffectSelectedMode_forSameNode`
+
+**Cross-feature integration tests (PRD Section 9):**
+- F11 has no `Consumes` block (it operates on already-fetched Credits data, not on output from another Section 6 feature) — no cross-feature integration criteria apply, consistent with the PRD's rule that features without Consumes generate none.
+
+## Assumptions and Decisions (from interview)
+
+- **Web's credit-type aggregation is refactored to a dynamic per-type shape**, confirmed with the user, rather than keeping the hardcoded `Dividend`/`Rent` fields and only making the new Line path dynamic — this is the only option that genuinely satisfies the PRD's "this can change in the future" requirement on the web platform, matching WPF's already-dynamic approach.
+- **Stacked + Line renders separate, non-cumulative lines** (one per credit type), confirmed with the user, rather than a cumulative stacked line/area.
+- **Toggle labels are "View: Bar / Line" (new) and "Group: Stacked / Grouped" (relabelled from "View:")**, confirmed with the user.
+- **The new `ChartType` type is defined locally in `useCredits.ts`**, not imported from `useTransactions.ts`'s `ChartDisplayMode`, following F09's own documented precedent of keeping Bar/Line toggle types feature-local.
+- **Colour palette is a computed blue gradient (one shade per type index)**, mirroring WPF's `BuildBluePalette`, replacing the two hardcoded hex constants — not explicitly specified in the PRD, inferred from the dynamic-types decision (a fixed two-constant palette cannot cover an arbitrary type count) and from cross-platform consistency with WPF's existing approach.
+- **Persistence extends the existing single per-node `PersistedPrefs` record** with a third field rather than adding a second `Map`, matching the minimal-extension approach and F12 (WPF)'s equivalent decision for `CreditsViewState`.

--- a/docs/prd/P04-prd-broker-level-view-improvements/prd-broker-level-view-improvements.md
+++ b/docs/prd/P04-prd-broker-level-view-improvements/prd-broker-level-view-improvements.md
@@ -8,6 +8,8 @@ This feature set fixes the WPF layout bug, adds a Total Invested total (Total Bo
 
 Separately, the Transactions tab — currently available only for individual assets — is extended to Broker and Portfolio levels and gains a new monthly investment chart (Bought − Sold per calendar month), rendered as bars by default with an optional line view, filterable by six time periods (This Month, Last 3 Months, Last 6 Months, Last 12 Months, YTD, All Time). This same expanded period-filter set is also applied to the existing Credits tab chart for consistency across the two features.
 
+Finally, the existing Credits tab chart — which today only offers a Stacked/Grouped bar view — gains the same Bar/Line display toggle as the new Transactions chart, at all three node levels (Broker, Portfolio, Asset) and in both UIs. The two toggles are independent: switching to Line while Grouped is selected plots a single line for the combined total, while switching to Line while Stacked is selected plots one line per credit type, matching the per-type breakdown the Stacked bars already show.
+
 ---
 
 ## 2. Problem and Opportunity
@@ -28,6 +30,9 @@ Separately, the Transactions tab — currently available only for individual ass
 **No visibility into investment pace over time**
 - The Transactions tab shows only a flat list of individual Buy/Sell rows for a single asset; there is no way to see how much net capital was deployed per month, whether spending is accelerating or slowing, or to view this at the Broker or Portfolio level at all (the tab does not support those node types today)
 
+**Inconsistent chart flexibility between Credits and Transactions**
+- The Credits tab chart only offers a Stacked/Grouped bar view; once the new Transactions chart ships with a Bar/Line toggle, the two charts would offer inconsistent visualization options for what is conceptually the same kind of monthly trend data, with no way to view Credits as a line
+
 ### The Opportunity
 
 Each problem maps to a concrete deliverable:
@@ -35,6 +40,7 @@ Each problem maps to a concrete deliverable:
 - No net investment figure → F01 introduces a Total Invested total, surfaced in both UIs by F05 (Web) and F06 (WPF)
 - No visual breakdown → F02 computes an Encerradas-and-inactive-asset-excluded breakdown of portfolios and assets by Total Invested; F07 (Web) and F08 (WPF) render it as pie charts on the Broker Summary screen
 - No investment-pace visibility → F03 provides aggregated transaction data for Broker and Portfolio scopes; F09 (Web) and F10 (WPF) render the monthly Bought-minus-Sold chart with period filtering, extending the Transactions tab beyond its current Asset-only scope; F04 extends the period-filter options (adding YTD) consistently across both the Credits and Transactions charts
+- Inconsistent chart flexibility → F11 (Web) and F12 (WPF) add the same Bar/Line toggle to the existing Credits chart, independent from its Stacked/Grouped grouping, at all three node levels
 
 ---
 
@@ -66,6 +72,9 @@ Each problem maps to a concrete deliverable:
 
 **Surface monthly investment pace with flexible time filtering**
 - Metric: The Transactions tab renders a monthly Bought-minus-Sold chart for Asset, Portfolio, and Broker selections, supporting 6 period filters and a Bar/Line display toggle, in both UIs
+
+**Bring the same display flexibility to the Credits chart**
+- Metric: The Credits chart supports an independent Bar/Line display toggle alongside its existing Stacked/Grouped grouping, for Asset, Portfolio, and Broker selections, in both UIs
 
 ---
 
@@ -126,6 +135,17 @@ Each problem maps to a concrete deliverable:
 
 - As a user, I want the same monthly investment chart, period filters, and Bar/Line toggle available in WPF as in the web app so that both interfaces offer the same investment-pace insight
 - As a user, I want selecting a Broker or Portfolio node in WPF to show this chart instead of the current "transactions only available for individual assets" message so that the desktop app matches the web app's capability
+
+### F11. Credits Chart Bar/Line Toggle — Web Frontend
+
+- As a user, I want to switch the Credits chart between bar and line display, mirroring the Transactions chart's toggle, so that I can pick the visual style I find clearest
+- As a user, I want the Stacked/Grouped grouping to keep working when I switch to Line view, so that I don't lose the breakdown I'm used to
+- As a user, I want a single line showing my combined total when Grouped is selected, and one line per credit type when Stacked is selected, so that the line view respects the same grouping choice as the bar view
+- As a user, I want my Bar/Line choice to persist per Broker, Portfolio, or Asset selection, consistent with how the Stacked/Grouped choice already persists
+
+### F12. Credits Chart Bar/Line Toggle — WPF
+
+- As a user, I want the same Bar/Line toggle and behavior available in WPF as in the web app so that both interfaces offer the same Credits chart flexibility
 
 ---
 
@@ -336,6 +356,47 @@ Each problem maps to a concrete deliverable:
 
 ---
 
+### F11. Credits Chart Bar/Line Toggle — Web Frontend
+
+**Capabilities:**
+- `CreditsTab`'s chart gains a second, independent toggle control — chart display mode (`Bar`/`Line`) — alongside the existing Stacked/Grouped grouping toggle; the two toggles are orthogonal and both remain available regardless of the other's selection
+- Toggle rows are labelled "View: Bar / Line" (new, matching the label already used by the Transactions chart's own Bar/Line toggle) and "Group: Stacked / Grouped" (the existing toggle, relabelled from "View:" to "Group:" to avoid ambiguity with the new row)
+- **Bar + Grouped** and **Bar + Stacked**: existing bar rendering, completely unchanged visually and behaviourally
+- **Line + Grouped**: renders a single `recharts` `Line` series plotting the combined total (sum across all credit types) for each month
+- **Line + Stacked**: renders one `recharts` `Line` series per credit type (e.g. Dividend, Rent), each showing that type's own monthly value; lines are drawn independently, not cumulatively stacked on top of one another; the series set is computed dynamically from the same per-type breakdown the Stacked bars already use, so it automatically supports any number of credit types, not just the two that exist today
+- Default chart display mode is Bar, preserving current behaviour for existing users; default grouping remains Stacked, unchanged from today
+- The chart display mode selection persists per node selection (Broker/Portfolio/Asset), using the same per-node persistence mechanism already used for the Stacked/Grouped selection, but stored independently so the two choices don't overwrite each other
+- Applies at all three node levels (Broker, Portfolio, Asset), since all three already render the same shared chart component today
+- Line series reuse the same colours already assigned to each credit type for the Bar view, for visual consistency when toggling between the two chart types
+
+**Experience:**
+1. User selects a Broker, Portfolio, or Asset node and opens the Credits tab, as today
+2. Two independent toggle rows appear above the chart: "View: Bar / Line" and "Group: Stacked / Grouped"
+3. Changing either toggle re-renders the chart instantly from already-fetched data; no new network request is triggered
+4. Switching to Line while Grouped is selected shows one line for the combined total; switching to Line while Stacked is selected shows one line per credit type
+5. Switching back to Bar restores the exact pre-existing Stacked/Grouped bar rendering
+6. The chosen chart display mode is remembered when navigating away and back to the same node; a different node defaults to Bar until changed
+
+---
+
+### F12. Credits Chart Bar/Line Toggle — WPF
+
+**Capabilities:**
+- Mirrors F11 exactly on the WPF desktop app: a new `ChartTypeModes`-equivalent collection (Bar/Line) is added to `AssetDetailsViewModel` alongside the existing `CreditsTypeModes` (Stacked/Grouped) collection, bound as a second, independent toggle row in the Credits tab's XAML template
+- `CreditsChartBuilder` gains Line-rendering support using `OxyPlot.Series.LineSeries`, mirroring the existing `RectangleBarSeries` construction: one `LineSeries` for the combined total when Grouped, one `LineSeries` per credit type when Stacked (not cumulative), reusing the same per-type colour assignment as the existing bar series
+- The existing `CreditsViewState` (per-node persisted Filter + Mode) is extended with the new chart display mode dimension, so all three selections (period filter, Stacked/Grouped, Bar/Line) persist together per node, exactly mirroring the existing per-node persistence mechanism
+- Default chart display mode is Bar; default grouping remains Stacked, both unchanged from today
+- Applies at all three node levels (Broker, Portfolio, Asset), reusing the same shared `CreditsPlotModel` binding and `DataTemplate`s already used for all three today
+
+**Experience:**
+1. User selects a Broker, Portfolio, or Asset node and views the Credits tab, as today
+2. Two independent toggle button rows are shown: the existing Stacked/Grouped row and the new Bar/Line row
+3. Changing either selection rebuilds the `PlotModel` synchronously from already-loaded credit data; no new fetch occurs
+4. Line + Grouped shows one line for the total; Line + Stacked shows one line per credit type
+5. Selecting a different node restores that node's own persisted chart display mode (or the Bar default, if never set)
+
+---
+
 ## 7. Out of Scope
 
 **Pie charts outside the Broker screen**
@@ -359,8 +420,8 @@ Each problem maps to a concrete deliverable:
 **Real-time or live-updating charts**
 - Charts reflect data as of the moment they were fetched; there is no polling, websocket, or auto-refresh behaviour
 
-**New chart types for the Credits tab**
-- F04 only adds the YTD period option and relabels two existing options; the Credits tab's existing Stacked/Grouped bar chart type is not changed
+**Cumulative stacked lines for the Credits chart**
+- When Stacked + Line is selected (F11/F12), each credit type's line plots its own independent monthly value; lines are not drawn as a cumulative stacked area, since that would be harder to read than the existing Stacked bar view
 
 **Manual data refresh controls**
 - None of the new charts include a manual Refresh button; they load automatically on node selection, consistent with how Total Invested and the breakdown data are fetched
@@ -381,11 +442,13 @@ Each problem maps to a concrete deliverable:
 | F08 | Broker Breakdown Pie Charts — WPF | 2 | F02 |
 | F09 | Transactions Monthly Investment Chart — Web Frontend | 2 | F03, F04 |
 | F10 | Transactions Monthly Investment Chart — WPF | 2 | F03, F04 |
+| F11 | Credits Chart Bar/Line Toggle — Web Frontend | 2 | None |
+| F12 | Credits Chart Bar/Line Toggle — WPF | 2 | None |
 
 ### Execution Waves
 Features within the same wave can be built in parallel. A wave starts only after every feature in earlier waves is complete.
 
-- **Wave 1**: F01, F02, F03, F04
+- **Wave 1**: F01, F02, F03, F04, F11, F12
 - **Wave 2**: F05, F06, F07, F08, F09, F10
 
 ### Priority levels
@@ -403,6 +466,8 @@ graph TD
   F03 --> F10[WPF Monthly Chart]
   F04[Period Filter YTD] --> F09
   F04 --> F10
+  F11[Web Credits Bar/Line]
+  F12[WPF Credits Bar/Line]
 ```
 
 ---
@@ -483,6 +548,22 @@ graph TD
 - [ ] Chart values and zero-fill behaviour match the web frontend's computation for the same underlying data
 - [ ] Bar is the default chart type; toggling to Line updates the `PlotModel` accordingly
 - [ ] All 6 period filters are available and correctly filter the plotted months
+
+### F11. Credits Chart Bar/Line Toggle — Web Frontend
+- [ ] The Credits chart offers a Bar/Line toggle independent from the existing Stacked/Grouped toggle, at Broker, Portfolio, and Asset levels
+- [ ] Default chart display mode is Bar; existing Stacked/Grouped bar rendering is visually unchanged when Bar is selected
+- [ ] Selecting Line with Grouped selected renders a single line representing the combined total across all credit types per month
+- [ ] Selecting Line with Stacked selected renders one line per credit type, not cumulative, matching the number of types present in the data
+- [ ] Changing either toggle does not trigger a new network request
+- [ ] The Bar/Line selection persists per node selection (Broker/Portfolio/Asset), independent from the Stacked/Grouped selection's own persistence
+
+### F12. Credits Chart Bar/Line Toggle — WPF
+- [ ] The Credits chart offers a Bar/Line toggle independent from the existing Stacked/Grouped toggle, at Broker, Portfolio, and Asset levels
+- [ ] Default chart display mode is Bar; existing Stacked/Grouped bar rendering is visually unchanged when Bar is selected
+- [ ] Selecting Line with Grouped selected renders a single line representing the combined total across all credit types per month
+- [ ] Selecting Line with Stacked selected renders one line per credit type, not cumulative, matching the number of types present in the data
+- [ ] Chart values in Line mode match the Bar mode's underlying data exactly
+- [ ] The Bar/Line selection persists per node selection (Broker/Portfolio/Asset), independent from the Stacked/Grouped selection's own persistence
 
 ### Cross-Feature Integration
 - [ ] `totalInvested` computed by F01 for Broker scope is displayed without transformation in F05's and F06's fourth total


### PR DESCRIPTION
## Summary
- Refactors the Credits chart's `MonthBucket` from a hardcoded `{ Dividend, Rent }` shape to a dynamic `{ total, byType }` shape, mirroring WPF's already-dynamic `CreditsMonthTypeTotals`, so a future third credit type needs no chart code changes on either platform
- Adds a second, independent toggle ("View: Bar / Line") alongside the existing Stacked/Grouped toggle (relabelled "Group:"), at Broker, Portfolio, and Asset levels
- Grouped + Line renders a single line for the combined monthly total; Stacked + Line renders one line per credit type (not cumulative)
- Adds a dynamic blue-gradient colour palette (replacing the two hardcoded hex constants), reused identically by Bar and Line rendering
- Includes a PRD amendment (F11/F12) for this previously-missed requirement from the P04 PRD
- No backend changes — purely client-side aggregation and rendering over already-fetched credit data

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 348/348 passing, incl. new coverage for dynamic per-type aggregation (including a 3rd credit type), total computation, chart-type default/persistence and its independence from Stacked/Grouped persistence, and Grouped+Line vs Stacked+Line rendering
- [x] `npm run build` — production build succeeds
- [x] Live smoke test via Playwright against the running dev server + API: verified all 4 Bar/Line × Stacked/Grouped combinations render correctly at Broker scope, verified Asset scope (table + chart), zero console errors throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)