### PR TITLE
feat(P04-F12): Credits chart Bar/Line toggle — WPF

### DIFF
--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -1037,6 +1037,7 @@
                                     <RowDefinition Height="2*"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
                                 <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,8">
                                     <Button Command="{Binding AssetDetails.AddCreditCommand}" ToolTip="New credit">
@@ -1146,6 +1147,45 @@
                                             HorizontalAlignment="Center"
                                             Margin="0,8,0,0">
                                     <TextBlock Text="View:" Margin="0,0,8,0" Foreground="#666666"/>
+                                    <ItemsControl ItemsSource="{Binding AssetDetails.CreditsChartTypes}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <StackPanel Orientation="Horizontal"/>
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Button Command="{Binding DataContext.AssetDetails.SelectCreditsChartTypeCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                        CommandParameter="{Binding}"
+                                                        Background="Transparent"
+                                                        BorderThickness="0"
+                                                        Padding="4,0"
+                                                        Margin="0,0,12,0">
+                                                    <TextBlock Text="{Binding Label}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Foreground" Value="#007ACC"/>
+                                                                <Setter Property="TextDecorations" Value="Underline"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                                        <Setter Property="Foreground" Value="Black"/>
+                                                                        <Setter Property="TextDecorations" Value="{x:Null}"/>
+                                                                        <Setter Property="FontWeight" Value="Bold"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Button>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                                <StackPanel Grid.Row="5"
+                                            Orientation="Horizontal"
+                                            HorizontalAlignment="Center"
+                                            Margin="0,6,0,0">
+                                    <TextBlock Text="Group:" Margin="0,0,8,0" Foreground="#666666"/>
                                     <ItemsControl ItemsSource="{Binding AssetDetails.CreditsTypeModes}">
                                         <ItemsControl.ItemsPanel>
                                             <ItemsPanelTemplate>
@@ -1180,7 +1220,7 @@
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
                                 </StackPanel>
-                                <ItemsControl Grid.Row="5"
+                                <ItemsControl Grid.Row="6"
                                               ItemsSource="{Binding AssetDetails.CreditsFilters}"
                                               HorizontalAlignment="Center"
                                               Margin="0,6,0,0">
@@ -1224,6 +1264,7 @@
                                     <RowDefinition Height="*"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
                                 <oxy:PlotView Grid.Row="0"
                                               Background="Transparent"
@@ -1234,6 +1275,45 @@
                                             HorizontalAlignment="Center"
                                             Margin="0,8,0,0">
                                     <TextBlock Text="View:" Margin="0,0,8,0" Foreground="#666666"/>
+                                    <ItemsControl ItemsSource="{Binding AssetDetails.CreditsChartTypes}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <StackPanel Orientation="Horizontal"/>
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Button Command="{Binding DataContext.AssetDetails.SelectCreditsChartTypeCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                        CommandParameter="{Binding}"
+                                                        Background="Transparent"
+                                                        BorderThickness="0"
+                                                        Padding="4,0"
+                                                        Margin="0,0,12,0">
+                                                    <TextBlock Text="{Binding Label}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Foreground" Value="#007ACC"/>
+                                                                <Setter Property="TextDecorations" Value="Underline"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                                        <Setter Property="Foreground" Value="Black"/>
+                                                                        <Setter Property="TextDecorations" Value="{x:Null}"/>
+                                                                        <Setter Property="FontWeight" Value="Bold"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Button>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                                <StackPanel Grid.Row="2"
+                                            Orientation="Horizontal"
+                                            HorizontalAlignment="Center"
+                                            Margin="0,6,0,0">
+                                    <TextBlock Text="Group:" Margin="0,0,8,0" Foreground="#666666"/>
                                     <ItemsControl ItemsSource="{Binding AssetDetails.CreditsTypeModes}">
                                         <ItemsControl.ItemsPanel>
                                             <ItemsPanelTemplate>
@@ -1268,7 +1348,7 @@
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
                                 </StackPanel>
-                                <ItemsControl Grid.Row="2"
+                                <ItemsControl Grid.Row="3"
                                               ItemsSource="{Binding AssetDetails.CreditsFilters}"
                                               HorizontalAlignment="Center"
                                               Margin="0,6,0,0">

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -775,7 +775,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     {
         if (plotWidth <= 0 || CreditsPlotModel == null) return;
         _creditsPlotWidth = plotWidth;
-        CreditsChartBuilder.ApplyLabelDensity(CreditsPlotModel, _creditsPlotWidth, _creditsChartMonths, _creditsChartTypes, _selectedCreditsTypeMode);
+        CreditsChartBuilder.ApplyLabelDensity(CreditsPlotModel, _creditsPlotWidth, _creditsChartMonths, _creditsChartTypes, _selectedCreditsTypeMode, _selectedCreditsChartType);
     }
 
     public void UpdateTransactionsPlotWidth(double plotWidth)
@@ -925,9 +925,9 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         foreach (var group in grouped)
             CreditsByMonthChart.Add(new KeyValuePair<string, decimal>(group.Month.ToString("MM/yyyy"), group.Total));
 
-        CreditsPlotModel = CreditsChartBuilder.Build(grouped, _creditsChartTypes, _selectedCreditsTypeMode);
+        CreditsPlotModel = CreditsChartBuilder.Build(grouped, _creditsChartTypes, _selectedCreditsTypeMode, _selectedCreditsChartType);
         if (CreditsPlotModel != null)
-            CreditsChartBuilder.ApplyLabelDensity(CreditsPlotModel, _creditsPlotWidth, _creditsChartMonths, _creditsChartTypes, _selectedCreditsTypeMode);
+            CreditsChartBuilder.ApplyLabelDensity(CreditsPlotModel, _creditsPlotWidth, _creditsChartMonths, _creditsChartTypes, _selectedCreditsTypeMode, _selectedCreditsChartType);
     }
 
     private void SetCreditsContext(string contextKey, bool rebuild = true)

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -30,6 +30,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private readonly RelayCommand _copyAssetNameCommand;
     private readonly RelayCommand _selectCreditsFilterCommand;
     private readonly RelayCommand _selectCreditsTypeModeCommand;
+    private readonly RelayCommand _selectCreditsChartTypeCommand;
     private readonly RelayCommand _selectTransactionsFilterCommand;
     private readonly RelayCommand _selectTransactionsChartModeCommand;
     private string _assetName = string.Empty;
@@ -53,6 +54,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private PlotModel? _creditsPlotModel;
     private PeriodFilter _selectedCreditsFilter = PeriodFilter.Last12Months;
     private CreditsTypeChartMode _selectedCreditsTypeMode = CreditsTypeChartMode.Stacked;
+    private CreditsChartType _selectedCreditsChartType = CreditsChartType.Bar;
     private const string DefaultCreditsContextKey = "default";
     private readonly Dictionary<string, CreditsViewState> _creditsViewStateByKey = new(StringComparer.OrdinalIgnoreCase);
     private string _creditsContextKey = DefaultCreditsContextKey;
@@ -253,6 +255,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public ObservableCollection<KeyValuePair<string, decimal>> CreditsByMonthChart { get; } = new();
     public ObservableCollection<CreditsFilterOptionViewModel> CreditsFilters { get; } = new();
     public ObservableCollection<CreditsTypeModeOptionViewModel> CreditsTypeModes { get; } = new();
+    public ObservableCollection<CreditsChartTypeOptionViewModel> CreditsChartTypes { get; } = new();
 
     public PlotModel? TransactionsPlotModel { get => _transactionsPlotModel; private set => SetProperty(ref _transactionsPlotModel, value); }
 
@@ -301,6 +304,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public RelayCommand CopyAssetNameCommand => _copyAssetNameCommand;
     public RelayCommand SelectCreditsFilterCommand => _selectCreditsFilterCommand;
     public RelayCommand SelectCreditsTypeModeCommand => _selectCreditsTypeModeCommand;
+    public RelayCommand SelectCreditsChartTypeCommand => _selectCreditsChartTypeCommand;
     public RelayCommand SelectTransactionsFilterCommand => _selectTransactionsFilterCommand;
     public RelayCommand SelectTransactionsChartModeCommand => _selectTransactionsChartModeCommand;
 
@@ -343,10 +347,12 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         _copyAssetNameCommand = new RelayCommand(CopyAssetName, CanCopyAssetName);
         _selectCreditsFilterCommand = new RelayCommand(SelectCreditsFilter);
         _selectCreditsTypeModeCommand = new RelayCommand(SelectCreditsTypeMode);
+        _selectCreditsChartTypeCommand = new RelayCommand(SelectCreditsChartType);
         _selectTransactionsFilterCommand = new RelayCommand(SelectTransactionsFilter);
         _selectTransactionsChartModeCommand = new RelayCommand(SelectTransactionsChartMode);
         InitializeCreditsFilters();
         InitializeCreditsTypeModes();
+        InitializeCreditsChartTypes();
         InitializeTransactionsFilters();
         InitializeChartTypeModes();
     }
@@ -795,6 +801,14 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         SetCreditsTypeMode(CreditsTypeChartMode.Stacked, rebuild: false);
     }
 
+    private void InitializeCreditsChartTypes()
+    {
+        CreditsChartTypes.Clear();
+        CreditsChartTypes.Add(new CreditsChartTypeOptionViewModel("Bar", CreditsChartType.Bar));
+        CreditsChartTypes.Add(new CreditsChartTypeOptionViewModel("Line", CreditsChartType.Line));
+        SetCreditsChartType(CreditsChartType.Bar, rebuild: false);
+    }
+
     private void SelectCreditsFilter(object? parameter)
     {
         if (parameter is CreditsFilterOptionViewModel option) { SetCreditsFilter(option.Filter); return; }
@@ -805,6 +819,12 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     {
         if (parameter is CreditsTypeModeOptionViewModel option) { SetCreditsTypeMode(option.Mode); return; }
         if (parameter is CreditsTypeChartMode mode) SetCreditsTypeMode(mode);
+    }
+
+    private void SelectCreditsChartType(object? parameter)
+    {
+        if (parameter is CreditsChartTypeOptionViewModel option) { SetCreditsChartType(option.ChartType); return; }
+        if (parameter is CreditsChartType chartType) SetCreditsChartType(chartType);
     }
 
     private void SetCreditsFilter(PeriodFilter filter, bool rebuild = true)
@@ -833,6 +853,19 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         if (rebuild) ApplyCreditsFilter();
     }
 
+    private void SetCreditsChartType(CreditsChartType chartType, bool rebuild = true)
+    {
+        if (_selectedCreditsChartType == chartType && CreditsChartTypes.Count > 0)
+        {
+            UpdateCreditsChartTypeSelection();
+            return;
+        }
+        _selectedCreditsChartType = chartType;
+        UpdateCreditsChartTypeSelection();
+        UpdateCreditsViewState();
+        if (rebuild) ApplyCreditsFilter();
+    }
+
     private void UpdateCreditsFilterSelection()
     {
         foreach (var option in CreditsFilters)
@@ -843,6 +876,12 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     {
         foreach (var option in CreditsTypeModes)
             option.IsSelected = option.Mode == _selectedCreditsTypeMode;
+    }
+
+    private void UpdateCreditsChartTypeSelection()
+    {
+        foreach (var option in CreditsChartTypes)
+            option.IsSelected = option.ChartType == _selectedCreditsChartType;
     }
 
     private void ApplyCreditsFilter()
@@ -902,7 +941,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     {
         if (_creditsViewStateByKey.TryGetValue(contextKey, out var state))
             return state;
-        state = new CreditsViewState(PeriodFilter.Last12Months, CreditsTypeChartMode.Stacked);
+        state = new CreditsViewState(PeriodFilter.Last12Months, CreditsTypeChartMode.Stacked, CreditsChartType.Bar);
         _creditsViewStateByKey[contextKey] = state;
         return state;
     }
@@ -911,13 +950,14 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     {
         SetCreditsFilter(state.Filter, rebuild: false);
         SetCreditsTypeMode(state.Mode, rebuild: false);
+        SetCreditsChartType(state.ChartType, rebuild: false);
         if (rebuild) ApplyCreditsFilter();
     }
 
     private void UpdateCreditsViewState()
     {
         if (!string.IsNullOrWhiteSpace(_creditsContextKey))
-            _creditsViewStateByKey[_creditsContextKey] = new CreditsViewState(_selectedCreditsFilter, _selectedCreditsTypeMode);
+            _creditsViewStateByKey[_creditsContextKey] = new CreditsViewState(_selectedCreditsFilter, _selectedCreditsTypeMode, _selectedCreditsChartType);
     }
 
     private void InitializeTransactionsFilters()

--- a/Financial.App/ViewModels/CreditsChartBuilder.cs
+++ b/Financial.App/ViewModels/CreditsChartBuilder.cs
@@ -14,18 +14,31 @@ internal static class CreditsChartBuilder
     public static PlotModel Build(
         IReadOnlyList<CreditsMonthTypeTotals> grouped,
         IReadOnlyList<string> creditTypes,
-        CreditsTypeChartMode mode)
+        CreditsTypeChartMode mode,
+        CreditsChartType chartType)
     {
         var (model, categoryAxis) = CreateModelWithAxes();
 
         if (grouped.Count == 0 || creditTypes.Count == 0)
             return model;
 
-        var seriesByType = CreateBarSeries(creditTypes);
-        PopulateBarItems(grouped, creditTypes, seriesByType, categoryAxis, mode);
+        foreach (var month in grouped)
+            categoryAxis.Labels.Add(month.Month.ToString("MM/yyyy"));
 
-        foreach (var series in seriesByType)
-            model.Series.Add(series);
+        if (chartType == CreditsChartType.Bar)
+        {
+            var seriesByType = CreateBarSeries(creditTypes);
+            PopulateBarItems(grouped, creditTypes, seriesByType, mode);
+            foreach (var series in seriesByType)
+                model.Series.Add(series);
+        }
+        else
+        {
+            var seriesByType = CreateLineSeries(creditTypes, mode);
+            PopulateLineItems(grouped, creditTypes, seriesByType, mode);
+            foreach (var series in seriesByType)
+                model.Series.Add(series);
+        }
 
         return model;
     }
@@ -35,7 +48,8 @@ internal static class CreditsChartBuilder
         double plotWidth,
         IReadOnlyList<CreditsMonthTypeTotals> chartMonths,
         IReadOnlyList<string> chartTypes,
-        CreditsTypeChartMode mode)
+        CreditsTypeChartMode mode,
+        CreditsChartType chartType)
     {
         if (plotWidth <= 0) return;
 
@@ -46,7 +60,7 @@ internal static class CreditsChartBuilder
         var step = Math.Max(1, (int)Math.Ceiling((double)categoryAxis.Labels.Count / maxVisibleLabels));
         categoryAxis.MajorStep = step;
         categoryAxis.MinorStep = 1;
-        UpdateValueLabels(model, step, chartMonths, chartTypes, mode);
+        UpdateValueLabels(model, step, chartMonths, chartTypes, mode, chartType);
         model.InvalidatePlot(false);
     }
 
@@ -92,7 +106,6 @@ internal static class CreditsChartBuilder
         IReadOnlyList<CreditsMonthTypeTotals> grouped,
         IReadOnlyList<string> creditTypes,
         List<RectangleBarSeries> seriesByType,
-        CategoryAxis categoryAxis,
         CreditsTypeChartMode mode)
     {
         var halfGroupWidth = BarGroupWidth / 2;
@@ -101,7 +114,6 @@ internal static class CreditsChartBuilder
         for (var monthIndex = 0; monthIndex < grouped.Count; monthIndex++)
         {
             var month = grouped[monthIndex];
-            categoryAxis.Labels.Add(month.Month.ToString("MM/yyyy"));
 
             var positiveStack = 0.0;
             var negativeStack = 0.0;
@@ -142,12 +154,70 @@ internal static class CreditsChartBuilder
         }
     }
 
+    private static List<LineSeries> CreateLineSeries(IReadOnlyList<string> creditTypes, CreditsTypeChartMode mode)
+    {
+        if (mode == CreditsTypeChartMode.Grouped)
+        {
+            return new List<LineSeries>
+            {
+                new()
+                {
+                    Title = "Total",
+                    Color = OxyColors.SteelBlue,
+                    StrokeThickness = 2,
+                    MarkerType = MarkerType.Circle,
+                    MarkerSize = 3,
+                    MarkerFill = OxyColors.SteelBlue
+                }
+            };
+        }
+
+        var palette = BuildBluePalette(creditTypes.Count);
+        return creditTypes
+            .Select((type, index) => new LineSeries
+            {
+                Title = type,
+                Color = palette[index],
+                StrokeThickness = 2,
+                MarkerType = MarkerType.Circle,
+                MarkerSize = 3,
+                MarkerFill = palette[index]
+            })
+            .ToList();
+    }
+
+    private static void PopulateLineItems(
+        IReadOnlyList<CreditsMonthTypeTotals> grouped,
+        IReadOnlyList<string> creditTypes,
+        List<LineSeries> seriesByType,
+        CreditsTypeChartMode mode)
+    {
+        for (var monthIndex = 0; monthIndex < grouped.Count; monthIndex++)
+        {
+            var month = grouped[monthIndex];
+
+            if (mode == CreditsTypeChartMode.Grouped)
+            {
+                seriesByType[0].Points.Add(new DataPoint(monthIndex, (double)month.Total));
+                continue;
+            }
+
+            for (var typeIndex = 0; typeIndex < creditTypes.Count; typeIndex++)
+            {
+                var type = creditTypes[typeIndex];
+                var value = month.TotalsByType.TryGetValue(type, out var total) ? (double)total : 0d;
+                seriesByType[typeIndex].Points.Add(new DataPoint(monthIndex, value));
+            }
+        }
+    }
+
     private static void UpdateValueLabels(
         PlotModel model,
         int step,
         IReadOnlyList<CreditsMonthTypeTotals> chartMonths,
         IReadOnlyList<string> chartTypes,
-        CreditsTypeChartMode mode)
+        CreditsTypeChartMode mode,
+        CreditsChartType chartType)
     {
         for (var index = model.Annotations.Count - 1; index >= 0; index--)
         {
@@ -160,6 +230,12 @@ internal static class CreditsChartBuilder
 
         if (chartMonths.Count == 0 || chartTypes.Count == 0) return;
 
+        // A combination renders as a single visual series (one Total label) when either
+        // Bar bars are stacked into one bar, or Line collapses into one line; otherwise
+        // each credit type has its own bar/line and gets its own label.
+        var isSingleSeries = (chartType == CreditsChartType.Bar && mode == CreditsTypeChartMode.Stacked)
+            || (chartType == CreditsChartType.Line && mode == CreditsTypeChartMode.Grouped);
+
         var halfGroupWidth = BarGroupWidth / 2;
         var barWidth = BarGroupWidth / chartTypes.Count;
 
@@ -167,7 +243,7 @@ internal static class CreditsChartBuilder
         {
             var month = chartMonths[monthIndex];
 
-            if (mode == CreditsTypeChartMode.Stacked)
+            if (isSingleSeries)
             {
                 AddValueLabel(model, monthIndex, month.Total, month.Total);
                 continue;
@@ -179,8 +255,10 @@ internal static class CreditsChartBuilder
                 var value = month.TotalsByType.TryGetValue(type, out var total) ? total : 0m;
                 if (value == 0) continue;
 
-                var x0 = monthIndex - halfGroupWidth + (barWidth * typeIndex);
-                AddValueLabel(model, x0 + (barWidth / 2), value, value);
+                var labelX = chartType == CreditsChartType.Bar
+                    ? monthIndex - halfGroupWidth + (barWidth * typeIndex) + (barWidth / 2)
+                    : monthIndex;
+                AddValueLabel(model, labelX, value, value);
             }
         }
     }

--- a/Financial.App/ViewModels/CreditsChartType.cs
+++ b/Financial.App/ViewModels/CreditsChartType.cs
@@ -1,0 +1,7 @@
+namespace Financial.Presentation.App.ViewModels;
+
+public enum CreditsChartType
+{
+    Bar,
+    Line
+}

--- a/Financial.App/ViewModels/CreditsChartTypeOptionViewModel.cs
+++ b/Financial.App/ViewModels/CreditsChartTypeOptionViewModel.cs
@@ -1,0 +1,21 @@
+namespace Financial.Presentation.App.ViewModels;
+
+public sealed class CreditsChartTypeOptionViewModel : ViewModelBase
+{
+    private bool _isSelected;
+
+    public CreditsChartTypeOptionViewModel(string label, CreditsChartType chartType)
+    {
+        Label = label;
+        ChartType = chartType;
+    }
+
+    public string Label { get; }
+    public CreditsChartType ChartType { get; }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => SetProperty(ref _isSelected, value);
+    }
+}

--- a/Financial.App/ViewModels/CreditsViewState.cs
+++ b/Financial.App/ViewModels/CreditsViewState.cs
@@ -2,4 +2,4 @@ using Financial.Presentation.App.Helpers;
 
 namespace Financial.Presentation.App.ViewModels;
 
-internal readonly record struct CreditsViewState(PeriodFilter Filter, CreditsTypeChartMode Mode);
+internal readonly record struct CreditsViewState(PeriodFilter Filter, CreditsTypeChartMode Mode, CreditsChartType ChartType);

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelCreditsChartTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelCreditsChartTests.cs
@@ -1,0 +1,103 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class AssetDetailsViewModelCreditsChartTests
+{
+    private static AssetDetailsViewModel BuildViewModel()
+    {
+        return new AssetDetailsViewModel(
+            new StubTransactionService(),
+            new StubCreditService(),
+            new StubAssetPriceService(),
+            new StubBrokerBreakdownQueryService(),
+            new StubTransactionQueryService());
+    }
+
+    [Fact]
+    public void SetCreditsChartType_DefaultsToBar()
+    {
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), []);
+        vm.CreditsChartTypes.First(t => t.ChartType == CreditsChartType.Bar).IsSelected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetCreditsChartType_PersistsSelectionPerNode()
+    {
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("BrokerA", new AggregatedSummaryDTO(), []);
+
+        vm.SelectCreditsChartTypeCommand.Execute(CreditsChartType.Line);
+        vm.CreditsChartTypes.First(t => t.ChartType == CreditsChartType.Line).IsSelected.Should().BeTrue();
+
+        vm.LoadBrokerSummary("BrokerB", new AggregatedSummaryDTO(), []);
+        vm.CreditsChartTypes.First(t => t.ChartType == CreditsChartType.Bar).IsSelected.Should().BeTrue();
+
+        vm.LoadBrokerSummary("BrokerA", new AggregatedSummaryDTO(), []);
+        vm.CreditsChartTypes.First(t => t.ChartType == CreditsChartType.Line).IsSelected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetCreditsChartType_DoesNotAffectSelectedTypeMode_ForSameNode()
+    {
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("BrokerA", new AggregatedSummaryDTO(), []);
+
+        vm.SelectCreditsChartTypeCommand.Execute(CreditsChartType.Line);
+
+        vm.CreditsTypeModes.First(m => m.Mode == CreditsTypeChartMode.Stacked).IsSelected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetCreditsChartType_RebuildsCreditsPlotModel()
+    {
+        var credits = new List<CreditDTO>
+        {
+            new() { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Dividend", Value = 100m },
+        };
+        var vm = BuildViewModel();
+        vm.LoadBrokerSummary("XPI", new AggregatedSummaryDTO(), credits);
+        vm.CreditsPlotModel.Should().NotBeNull();
+        var barSeriesCount = vm.CreditsPlotModel!.Series.Count;
+
+        vm.SelectCreditsChartTypeCommand.Execute(CreditsChartType.Line);
+
+        vm.CreditsPlotModel.Should().NotBeNull();
+        vm.CreditsPlotModel!.Series.Should().HaveCount(barSeriesCount);
+    }
+
+    private sealed class StubBrokerBreakdownQueryService : IBrokerBreakdownQueryService
+    {
+        public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName) => [];
+    }
+
+    private sealed class StubTransactionQueryService : ITransactionQueryService
+    {
+        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName) => [];
+        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName) => [];
+    }
+
+    private sealed class StubAssetPriceService : IAssetPriceService
+    {
+        public AssetPriceDTO GetCurrentPrice(AssetPriceRequestDTO request) =>
+            new() { Exchange = request.Exchange, Ticker = request.Ticker, Price = 0m };
+    }
+
+    private sealed class StubTransactionService : ITransactionService
+    {
+        public Task<AssetDetailsDTO?> AddTransactionAsync(TransactionCreateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> UpdateTransactionAsync(TransactionUpdateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> DeleteTransactionAsync(TransactionDeleteDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+    }
+
+    private sealed class StubCreditService : ICreditService
+    {
+        public Task<AssetDetailsDTO?> AddCreditAsync(CreditCreateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> UpdateCreditAsync(CreditUpdateDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+        public Task<AssetDetailsDTO?> DeleteCreditAsync(CreditDeleteDTO request) => Task.FromResult<AssetDetailsDTO?>(null);
+    }
+}

--- a/Tests/Financial.Presentation.Tests/ViewModels/CreditsChartBuilderTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/CreditsChartBuilderTests.cs
@@ -1,0 +1,71 @@
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+using OxyPlot.Series;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class CreditsChartBuilderTests
+{
+    private static List<CreditsMonthTypeTotals> BuildMonths() => new()
+    {
+        new CreditsMonthTypeTotals(
+            new DateTime(2026, 6, 1),
+            new Dictionary<string, decimal> { ["Dividend"] = 100m, ["Rent"] = 50m }),
+        new CreditsMonthTypeTotals(
+            new DateTime(2026, 7, 1),
+            new Dictionary<string, decimal> { ["Dividend"] = 200m, ["Rent"] = 30m }),
+    };
+
+    [Fact]
+    public void Build_BarMode_ProducesOneSeriesPerCreditType()
+    {
+        var months = BuildMonths();
+        var creditTypes = new List<string> { "Dividend", "Rent" };
+
+        var model = CreditsChartBuilder.Build(months, creditTypes, CreditsTypeChartMode.Stacked, CreditsChartType.Bar);
+
+        model.Series.Should().HaveCount(2);
+        model.Series.Should().AllBeOfType<RectangleBarSeries>();
+    }
+
+    [Fact]
+    public void Build_LineMode_Grouped_ProducesSingleSeriesOnTotal()
+    {
+        var months = BuildMonths();
+        var creditTypes = new List<string> { "Dividend", "Rent" };
+
+        var model = CreditsChartBuilder.Build(months, creditTypes, CreditsTypeChartMode.Grouped, CreditsChartType.Line);
+
+        var series = model.Series.Should().ContainSingle().Which.Should().BeOfType<LineSeries>().Subject;
+        series.Points.Should().HaveCount(2);
+        series.Points[0].Y.Should().Be(150d);
+        series.Points[1].Y.Should().Be(230d);
+    }
+
+    [Fact]
+    public void Build_LineMode_Stacked_ProducesOneSeriesPerCreditType()
+    {
+        var months = BuildMonths();
+        var creditTypes = new List<string> { "Dividend", "Rent" };
+
+        var model = CreditsChartBuilder.Build(months, creditTypes, CreditsTypeChartMode.Stacked, CreditsChartType.Line);
+
+        model.Series.Should().HaveCount(2);
+        var lineSeries = model.Series.Cast<LineSeries>().ToList();
+        var dividendSeries = lineSeries.Should().ContainSingle(s => s.Title == "Dividend").Which;
+        dividendSeries.Points.Select(p => p.Y).Should().Equal(100d, 200d);
+        var rentSeries = lineSeries.Should().ContainSingle(s => s.Title == "Rent").Which;
+        rentSeries.Points.Select(p => p.Y).Should().Equal(50d, 30d);
+    }
+
+    [Fact]
+    public void Build_EmptyMonths_ProducesNoSeries()
+    {
+        var creditTypes = new List<string> { "Dividend", "Rent" };
+
+        var model = CreditsChartBuilder.Build(
+            new List<CreditsMonthTypeTotals>(), creditTypes, CreditsTypeChartMode.Stacked, CreditsChartType.Line);
+
+        model.Series.Should().BeEmpty();
+    }
+}

--- a/docs/P04-F12-credits-chart-bar-line-toggle-wpf/plan.md
+++ b/docs/P04-F12-credits-chart-bar-line-toggle-wpf/plan.md
@@ -1,0 +1,30 @@
+# Implementation Plan: Credits Chart Bar/Line Toggle — WPF
+
+**Prerequisites:**
+- F10 (Transactions Monthly Investment Chart — WPF) already merged to `main`; its `ChartTypeMode` enum, `RectangleBarSeries`/`LineSeries` branching, and per-node chart-mode persistence are the reference pattern this feature mirrors for the Credits chart
+- F11 (Credits Chart Bar/Line Toggle — Web Frontend) already merged to `main`; its Stacked+Line/Grouped+Line semantics and toggle labelling are the cross-platform contract this feature implements on WPF
+- `OxyPlot.Wpf` is already a project dependency; `LineSeries` is already used by `TransactionsChartBuilder`, `RectangleBarSeries` is already used by `CreditsChartBuilder`
+
+### Stage 1: Chart Type State
+
+**1. Chart type enum and option view model** - Add the Bar/Line chart-type enum and its option view model for toggle-button binding, distinct from the existing Transactions chart's equivalent type. Reference the spec's Technical Decisions for the naming rationale.
+
+**2. Per-node persistence** - Extend the existing per-node persisted view-state record with the new chart type field, alongside the already-persisted period filter and Stacked/Grouped selections, so all three persist together without overwriting each other. Reference the spec's Technical Decisions for the persistence approach.
+
+### Stage 2: Chart Rendering
+
+**3. Line series construction** - Extend the chart builder to construct line series from the same monthly per-type totals the existing bar rendering already uses: a single line for the combined total when grouped, or one line per credit type when stacked. Reference the spec's Technical Decisions for the exact Grouped/Stacked line semantics.
+
+**4. Value-label rule generalization** - Extend the existing value-label annotation logic so it applies consistently across both the Stacked/Grouped and Bar/Line dimensions: single-series combinations get one total label per month, multi-series combinations get one label per credit type per month. Reference the spec's Technical Decisions for the exact rule.
+
+### Stage 3: ViewModel and UI Wiring
+
+**5. ViewModel wiring** - Wire the new chart type state, its toggle command, and its selection persistence into the asset details view model, extending the existing chart-rebuild call sites to pass the new mode through. Reference the spec's Component Overview for the exact methods being extended.
+
+**6. Toolbar toggle row** - Add the new Bar/Line toggle row to both Credits chart templates (asset-level and aggregate-level), and relabel the existing Stacked/Grouped toggle row, following the exact button styling and binding pattern the existing toggle already uses. Reference the spec's Component Overview for the exact label text and template scope.
+
+### Stage 4: Tests
+
+**7. Chart builder test coverage** - Add unit tests for the chart builder covering Bar/Line series construction and the Grouped-single-series versus Stacked-per-type-series behaviour. Reference the spec's Testing Strategy for the full list of test functions.
+
+**8. ViewModel test coverage** - Add unit tests for the view model's chart type default, persistence, and independence from the existing Stacked/Grouped and period-filter persistence, including that toggling rebuilds the chart from already-loaded data with no new fetch.

--- a/docs/P04-F12-credits-chart-bar-line-toggle-wpf/spec.md
+++ b/docs/P04-F12-credits-chart-bar-line-toggle-wpf/spec.md
@@ -1,0 +1,111 @@
+# F12. Credits Chart Bar/Line Toggle — WPF
+
+## 1. Technical Overview
+
+**What:** Add a second, independent toggle to the WPF Credits tab's chart — chart display mode (`Bar`/`Line`) — alongside the existing Stacked/Grouped grouping toggle, at all three node levels (Broker, Portfolio, Asset). Grouped + Line renders a single line for the combined monthly total; Stacked + Line renders one line per credit type (not cumulative). Unlike F11 (Web), WPF's credit-type aggregation (`CreditsMonthTypeTotals.TotalsByType`) is already dynamic — no data-shape refactor is needed here, only the chart-building and toggle-wiring work.
+
+**Why:** F11 shipped this toggle on the web frontend; this feature brings the same capability to WPF for cross-platform parity, mirroring the exact architectural pattern F10 (Transactions chart) already established for a Bar/Line toggle on this platform (`TransactionsChartBuilder`'s `ChartTypeMode`, `RectangleBarSeries`/`LineSeries` branching, and per-node-persisted mode state).
+
+**Scope:**
+- Included: a new `CreditsChartType` enum (`Bar`/`Line`, distinct from F10's `ChartTypeMode`, since a WPF enum name cannot be reused across two unrelated toggles in the same namespace) with its own `CreditsChartTypeOptionViewModel`, `CreditsChartTypes` collection, and `SelectCreditsChartTypeCommand`; `CreditsChartBuilder` extended with `LineSeries` construction (one line per type when Stacked, one line on the combined total when Grouped) and value-label annotations that follow the same one-series-one-Total-label / many-series-one-label-per-type rule Bar mode already uses, now applied across both toggle dimensions; `CreditsViewState` extended with the new chart type field so all three selections (period filter, Stacked/Grouped, Bar/Line) persist together per node; a new "View: Bar / Line" toggle row added to both Credits `DataTemplate`s (`CreditsAssetTemplate`, `CreditsAggregateTemplate`), with the existing Stacked/Grouped row relabelled "Group:"; unit test coverage.
+- Excluded: any backend change (none needed); the web equivalent (F11, already complete, merged to `main`) — this feature only covers the WPF (`Financial.App`) side; any change to the Transactions chart (F10, already shipped, untouched by this feature).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.App/ViewModels/CreditsChartType.cs` (new) — `Bar`/`Line` enum
+- `Financial.App/ViewModels/CreditsChartTypeOptionViewModel.cs` (new) — mirrors `CreditsTypeModeOptionViewModel`
+- `Financial.App/ViewModels/CreditsViewState.cs` (modified) — third field added
+- `Financial.App/ViewModels/CreditsChartBuilder.cs` (modified) — Line rendering, cross-dimension label rule
+- `Financial.App/ViewModels/AssetDetailsViewModel.cs` (modified) — chart type state, persistence, wiring
+- `Financial.App/Components/NavigationView.xaml` (modified) — new toggle row in both Credits templates
+- Test files: `Tests/Financial.Presentation.Tests/ViewModels/CreditsChartBuilderTests.cs` (new), `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelCreditsChartTests.cs` (new)
+
+```mermaid
+graph TD
+    A["User selects Broker, Portfolio, or Asset node"] --> B[AssetDetailsViewModel]
+    B --> C["Already-loaded Credits collection (unchanged fetch logic)"]
+    C --> D["RefreshCreditsByMonthChart -> CreditsMonthTypeTotals (already dynamic per-type)"]
+    D --> E{"selectedCreditsChartType"}
+    E -->|Bar| F["CreditsChartBuilder.BuildBarSeries (existing, unchanged)"]
+    E -->|Line, Grouped| G["CreditsChartBuilder.BuildLineSeries — single LineSeries on Total"]
+    E -->|Line, Stacked| H["CreditsChartBuilder.BuildLineSeries — one LineSeries per credit type"]
+    F --> I[NavigationView.xaml Credits tab]
+    G --> I
+    H --> I
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|------------------|-------------------------|-----------|
+| New enum naming | `CreditsChartType { Bar, Line }`, a new WPF enum distinct from F10's existing `ChartTypeMode` | Reuse F10's `ChartTypeMode` directly for Credits too | Reuse is not even possible without an alias, since `ChartTypeMode` already exists in the same `Financial.Presentation.App.ViewModels` namespace (unlike TypeScript modules, C# enums collide at the namespace level); a distinct name also mirrors F11 (Web)'s own precedent of keeping each chart's Bar/Line type feature-local |
+| Stacked + Line rendering | One `LineSeries` per credit type, each plotting that type's own independent monthly value — not cumulative | Cumulative stacked lines | Mirrors F11 (Web)'s confirmed decision exactly, for cross-platform consistency |
+| Grouped + Line rendering | A single `LineSeries` plotting each month's `Total` (sum across all credit types) | One line per type, unstacked (same as Stacked+Line) | Mirrors F11 (Web)'s confirmed decision exactly |
+| Value-label annotations in Line mode | Extend the existing `UpdateValueLabels`/`AddValueLabel` machinery to Line mode too, using the same rule Bar mode already follows: whichever combination renders a single visual series gets one `Total` label per month, whichever renders per-type series gets one label per type per month. Concretely: `Bar+Stacked` and `Line+Grouped` (both single-series-per-month) show the `Total` label; `Bar+Grouped` and `Line+Stacked` (both multi-series-per-month) show one label per type | Skip value-label annotations for Line mode entirely, matching F11 (Web)'s choice to rely on hover only for Line | Confirmed with the user: matches this WPF app's own established convention (F10's Transactions chart already keeps value labels for both Bar and Line) rather than the web platform's choice, since OxyPlot users in this app rely less on hover-only discovery than the web's recharts tooltips |
+| Toggle labelling | New row: "View: Bar / Line" (matches F11 Web's label exactly). Existing row relabelled: "Group: Stacked / Grouped" (was "View:") | Keep "View:" on the Stacked/Grouped row and label the new row "Chart Type:" | Matches F11 (Web)'s confirmed labelling exactly, for cross-platform UI consistency |
+| Persistence | Extend the existing `CreditsViewState` record struct (already storing `Filter` + `Mode` per node in `_creditsViewStateByKey`) with a third field, `ChartType`, rather than a second dictionary | A separate `Dictionary<string, CreditsChartType>` | Mirrors F11 (Web)'s equivalent decision to extend the single `PersistedPrefs` record rather than add a second map; minimal, consistent extension of the proven per-node-record pattern |
+| Line series colour | Reuse `CreditsChartBuilder`'s existing `BuildBluePalette` gradient (already used for Bar's per-type fill colours) for Line's per-type stroke colours, and `OxyColors.SteelBlue` (the palette's existing single-count fallback) for the Grouped+Line Total line | A new, separate colour scheme for Line mode | `BuildBluePalette` already produces exactly the colours needed (already dynamic per type count); reusing it means a type's colour doesn't change when toggling Bar/Line, consistent with F11 (Web)'s equivalent choice |
+
+## 4. Component Overview
+
+**WPF (`Financial.App`):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|---------------|---------|------------------------|
+| `Financial.App/ViewModels/CreditsChartType.cs` | New | Chart type enum | `public enum CreditsChartType { Bar, Line }` |
+| `Financial.App/ViewModels/CreditsChartTypeOptionViewModel.cs` | New | Toggle button binding | `Label`, `ChartType` (`CreditsChartType`), `IsSelected`, mirroring `CreditsTypeModeOptionViewModel` field-for-field |
+| `Financial.App/ViewModels/CreditsViewState.cs` | Modified | Per-node persisted state | Extend `internal readonly record struct CreditsViewState(PeriodFilter Filter, CreditsTypeChartMode Mode)` with a third field, `CreditsChartType ChartType` |
+| `Financial.App/ViewModels/CreditsChartBuilder.cs` | Modified | Chart rendering | `Build` gains a `CreditsChartType mode` parameter (Bar builds the existing `RectangleBarSeries` set unchanged; Line builds one `LineSeries` per type when `CreditsTypeChartMode.Stacked`, or a single `LineSeries` on `Total` when `Grouped`, reusing `BuildBluePalette`); `ApplyLabelDensity`/`UpdateValueLabels`/`AddValueLabel` extended to apply the single-series-vs-per-type labelling rule across both the Stacked/Grouped and Bar/Line dimensions, per the Technical Decisions table |
+| `Financial.App/ViewModels/AssetDetailsViewModel.cs` | Modified | Chart type state | Add `_selectedCreditsChartType` field (default `Bar`), `CreditsChartTypes` (`ObservableCollection<CreditsChartTypeOptionViewModel>`), `SelectCreditsChartTypeCommand`, `InitializeCreditsChartTypes()`, `SetCreditsChartType(CreditsChartType, bool rebuild)`, `UpdateCreditsChartTypeSelection()`; extend `GetCreditsViewState`/`ApplyCreditsViewState`/`UpdateCreditsViewState`/`SetCreditsContext` to carry the third `ChartType` field alongside the existing `Filter`/`Mode`; extend the `CreditsChartBuilder.Build`/`ApplyLabelDensity` call sites (`RefreshCreditsByMonthChart`, `UpdateCreditsPlotWidth`) to pass `_selectedCreditsChartType` |
+| `Financial.App/Components/NavigationView.xaml` | Modified | Rendering | Add a new `RowDefinition` and a "View: Bar / Line" `ItemsControl` toggle row (bound to `AssetDetails.CreditsChartTypes` / `AssetDetails.SelectCreditsChartTypeCommand`, mirroring the existing Stacked/Grouped row's exact XAML structure) to both `CreditsAssetTemplate` and `CreditsAggregateTemplate`; relabel the existing Stacked/Grouped row's `TextBlock` from "View:" to "Group:" in both templates |
+
+**Backend:** None — this feature operates entirely on already-loaded `CreditDTO[]` data via the existing `Credits` collection; no service or DTO changes.
+
+## 5. API Contracts
+
+Not applicable — no new or modified endpoint, and no HTTP call at all (WPF renders from already-loaded in-memory data).
+
+## 6. Data Model
+
+Not applicable — no database or DTO changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|-----------------|
+| `Tests/Financial.Presentation.Tests/ViewModels/CreditsChartBuilderTests.cs` (new) | Unit | `CreditsChartBuilder` | Bar/Line series construction, Grouped+Line single-series vs Stacked+Line per-type-series counts, empty-input handling |
+| `Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelCreditsChartTests.cs` (new) | Unit | `AssetDetailsViewModel` | Chart type default/persistence, independence from Stacked/Grouped and period-filter persistence, rebuild on toggle |
+
+**Test Functions:**
+
+| Test Function | Description | Assertions |
+|----------------|--------------|-------------|
+| `Build_BarMode_ProducesOneSeriesPerCreditType` | 2 credit types, `Bar` mode | `PlotModel.Series` has one `RectangleBarSeries` per type (existing behaviour, regression check) |
+| `Build_LineMode_Grouped_ProducesSingleSeriesOnTotal` | 2 credit types, `Line` mode, `CreditsTypeChartMode.Grouped` | `PlotModel.Series` has exactly one `LineSeries`, with point values matching each month's `Total` |
+| `Build_LineMode_Stacked_ProducesOneSeriesPerCreditType` | 2 credit types, `Line` mode, `CreditsTypeChartMode.Stacked` | `PlotModel.Series` has one `LineSeries` per type, each with point values matching that type's own monthly total (not cumulative) |
+| `Build_EmptyMonths_ProducesNoSeries` | Empty input | `PlotModel.Series` is empty, regardless of mode |
+| `SetCreditsChartType_DefaultsToBar` | Fresh node selection | `AssetDetailsViewModel`'s chart type is `Bar` |
+| `SetCreditsChartType_PersistsSelectionPerNode` | Set chart type on Broker A, switch to Broker B, switch back to Broker A | Broker A's chart type selection is remembered, mirroring the existing Stacked/Grouped and period-filter persistence tests |
+| `SetCreditsChartType_DoesNotAffectSelectedTypeMode_ForSameNode` | Set chart type to `Line` on a node whose grouping is `Stacked` | The Stacked/Grouped selection is unchanged, confirming the two toggles persist independently |
+| `SetCreditsChartType_RebuildsCreditsPlotModel` | Credits already loaded, then chart type changed | `CreditsPlotModel` is rebuilt (non-null, reflects the new mode) without any new data fetch |
+
+**Acceptance tests (PRD Section 9, F12):**
+- The Credits chart offers a Bar/Line toggle independent from the existing Stacked/Grouped toggle, at Broker, Portfolio, and Asset levels → covered by `SetCreditsChartType_DefaultsToBar` at the ViewModel level; the `DataTemplate` toggle-row wiring itself is verified via a manual/live smoke check per the `implement-feature` skill's Step 6.4, since WPF `ItemsControl`/`DataTemplate` rendering is not unit-testable without a running visual tree
+- Default chart display mode is Bar; existing Stacked/Grouped bar rendering is visually unchanged when Bar is selected → `SetCreditsChartType_DefaultsToBar` + `Build_BarMode_ProducesOneSeriesPerCreditType`
+- Selecting Line with Grouped selected renders a single line representing the combined total across all credit types per month → `Build_LineMode_Grouped_ProducesSingleSeriesOnTotal`
+- Selecting Line with Stacked selected renders one line per credit type, not cumulative → `Build_LineMode_Stacked_ProducesOneSeriesPerCreditType`
+- Chart values in Line mode match the Bar mode's underlying data exactly → satisfied by construction: both series types are built from the same `CreditsMonthTypeTotals` list produced by the existing (unmodified) `RefreshCreditsByMonthChart` grouping logic
+- The Bar/Line selection persists per node selection, independent from the Stacked/Grouped selection's own persistence → `SetCreditsChartType_PersistsSelectionPerNode` + `SetCreditsChartType_DoesNotAffectSelectedTypeMode_ForSameNode`
+
+**Cross-feature integration tests (PRD Section 9):**
+- F12 has no `Consumes` block (it operates on already-loaded Credits data, not on output from another Section 6 feature) — no cross-feature integration criteria apply, consistent with the PRD's rule that features without Consumes generate none.
+
+## Assumptions and Decisions (from interview)
+
+- **Line mode shows value-label annotations**, confirmed with the user, matching this WPF app's own established convention (F10's Transactions chart keeps labels for both Bar and Line) rather than F11 (Web)'s choice to rely on hover only for Line — the labelling rule is generalized from Bar mode's existing Stacked/Grouped split to also account for the new Bar/Line dimension: single-visual-series combinations (`Bar+Stacked`, `Line+Grouped`) get one `Total` label per month; multi-series combinations (`Bar+Grouped`, `Line+Stacked`) get one label per type per month.
+- **`CreditsChartType` is a new, distinct enum** rather than reusing F10's `ChartTypeMode`, both because C# namespace rules make direct reuse impossible without an alias and because it mirrors F11 (Web)'s precedent of keeping each chart's Bar/Line type feature-local.
+- **No data-shape refactor needed**, unlike F11 (Web): WPF's `CreditsMonthTypeTotals.TotalsByType` dictionary is already dynamic per credit type, so this feature is scoped to chart-building and toggle-wiring only.
+- **Stacked+Line renders separate, non-cumulative lines** (one per credit type) and **Grouped+Line renders a single Total line**, and **toggle labels are "View: Bar / Line" (new) / "Group: Stacked / Grouped" (relabelled)** — all three directly mirror F11 (Web)'s already-confirmed decisions, applied here for cross-platform consistency.


### PR DESCRIPTION
## Summary
- Adds a "View: Bar / Line" toggle to the Credits chart (WPF) at Broker, Portfolio, and Asset levels, independent from the existing "Group: Stacked / Grouped" toggle
- Line + Grouped renders a single line on the combined monthly total; Line + Stacked renders one line per credit type, reusing the existing blue color palette
- Bar/Line selection persists per node alongside the existing Stacked/Grouped and period-filter selections
- Value-label annotations are shown in Line mode too (single Total label for single-visual-series combos, one label per type otherwise), matching this app's existing labelling convention (mirrors F10's Transactions chart)

## Test plan
- [x] `CreditsChartBuilderTests` — Bar/Line series construction, Grouped+Line single-series vs Stacked+Line per-type-series, empty-input handling (4/4 passing)
- [x] `AssetDetailsViewModelCreditsChartTests` — chart type default (Bar), per-node persistence, independence from Stacked/Grouped selection, plot rebuild on toggle (4/4 passing)
- [x] Full `Financial.Presentation.Tests` suite: 131/131 passing
- [x] Full solution test suite (Application 175/175, Domain 51/51, Infrastructure 62/65 with 3 pre-existing skips, Presentation 131/131); `Financial.Api.Tests` soft-failed due to a locked DLL from a running `Financial.Api.exe` process on this machine — pre-existing environment condition, not caused by this change
- [x] Live smoke test: launched the WPF app, navigated to a Broker node's Credits tab, verified default Bar rendering, switched to Line+Stacked (per-type lines, correct labels), switched to Line+Grouped (single Total line matching Bar mode's totals exactly), confirmed toggle persistence across the Group switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)