### PR TITLE
feat: P05-F01: WPF DataGrid visual standardization

### DIFF
--- a/Financial.App/App.xaml
+++ b/Financial.App/App.xaml
@@ -116,7 +116,7 @@
         </Style>
 
         <Style x:Key="NumericColumnTextStyle" TargetType="TextBlock">
-            <Setter Property="TextAlignment" Value="Left"/>
+            <Setter Property="TextAlignment" Value="Right"/>
             <Setter Property="Padding" Value="8"/>
         </Style>
     </Application.Resources>

--- a/Financial.App/App.xaml
+++ b/Financial.App/App.xaml
@@ -2,7 +2,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:Financial.Presentation.App"
-             xmlns:converters="clr-namespace:Financial.Presentation.App.Converters">
+             xmlns:converters="clr-namespace:Financial.Presentation.App.Converters"
+             xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
     <Application.Resources>
         <!-- Value Converters -->
         <converters:BoolToIconConverter x:Key="BoolToIconConverter"/>
@@ -56,12 +57,67 @@
         <Style TargetType="DataGrid">
             <Setter Property="AutoGenerateColumns" Value="False"/>
             <Setter Property="IsReadOnly" Value="True"/>
+            <Setter Property="FontSize" Value="13"/>
             <Setter Property="AlternatingRowBackground" Value="#F5F5F5"/>
             <Setter Property="GridLinesVisibility" Value="Horizontal"/>
             <Setter Property="HeadersVisibility" Value="Column"/>
             <Setter Property="SelectionMode" Value="Single"/>
             <Setter Property="CanUserResizeRows" Value="False"/>
             <Setter Property="CanUserSortColumns" Value="True"/>
+        </Style>
+
+        <Style TargetType="DataGridColumnHeader">
+            <Setter Property="Background" Value="#F0F0F0"/>
+            <Setter Property="Foreground" Value="#333333"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Padding" Value="8"/>
+            <Setter Property="BorderBrush" Value="#CCCCCC"/>
+            <Setter Property="BorderThickness" Value="0,0,1,1"/>
+        </Style>
+
+        <Style TargetType="DataGridRow">
+            <Setter Property="Background" Value="White"/>
+            <Style.Triggers>
+                <Trigger Property="ItemsControl.AlternationIndex" Value="1">
+                    <Setter Property="Background" Value="#F5F5F5"/>
+                </Trigger>
+                <Trigger Property="IsSelected" Value="True">
+                    <Setter Property="Background" Value="LightYellow"/>
+                </Trigger>
+                <MultiTrigger>
+                    <MultiTrigger.Conditions>
+                        <Condition Property="IsSelected" Value="True"/>
+                        <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
+                    </MultiTrigger.Conditions>
+                    <Setter Property="Background" Value="LightYellow"/>
+                </MultiTrigger>
+            </Style.Triggers>
+            <Style.Resources>
+                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="#007ACC"/>
+                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="White"/>
+            </Style.Resources>
+        </Style>
+
+        <Style TargetType="DataGridCell">
+            <Style.Triggers>
+                <Trigger Property="IsSelected" Value="True">
+                    <Setter Property="Background" Value="LightYellow"/>
+                    <Setter Property="Foreground" Value="Black"/>
+                </Trigger>
+                <MultiTrigger>
+                    <MultiTrigger.Conditions>
+                        <Condition Property="IsSelected" Value="True"/>
+                        <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
+                    </MultiTrigger.Conditions>
+                    <Setter Property="Background" Value="LightYellow"/>
+                    <Setter Property="Foreground" Value="Black"/>
+                </MultiTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="NumericColumnTextStyle" TargetType="TextBlock">
+            <Setter Property="TextAlignment" Value="Left"/>
+            <Setter Property="Padding" Value="8"/>
         </Style>
     </Application.Resources>
 </Application>

--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -2,8 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:oxy="http://oxyplot.org/wpf"
              mc:Ignorable="d"
              d:DesignHeight="700" d:DesignWidth="1200">
@@ -456,40 +455,28 @@
                                         <DataGridTextColumn Header="First Investment" Binding="{Binding DisplayFirstInvestmentDate}" Width="Auto"/>
                                         <DataGridTextColumn Header="Quantity" Binding="{Binding DisplayCurrentQuantity}" Width="Auto">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                    <Setter Property="FontFamily" Value="Consolas"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Header="Total Invested" Binding="{Binding DisplayTotalInvested}" Width="Auto">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                    <Setter Property="FontFamily" Value="Consolas"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Header="% Portfolio" Binding="{Binding DisplayPortfolioWeight}" Width="Auto">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                    <Setter Property="FontFamily" Value="Consolas"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Header="Total Credits" Binding="{Binding DisplayTotalCredits}" Width="Auto">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                    <Setter Property="FontFamily" Value="Consolas"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                         <DataGridTemplateColumn Header="Current Value" Width="Auto">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
-                                                    <TextBlock FontFamily="Consolas" TextAlignment="Right">
+                                                    <TextBlock TextAlignment="Left" Padding="8">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Text" Value="{Binding DisplayCurrentValue}"/>
@@ -507,7 +494,7 @@
                                         <DataGridTemplateColumn Header="% Profit" Width="Auto">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
-                                                    <TextBlock FontFamily="Consolas" TextAlignment="Right">
+                                                    <TextBlock TextAlignment="Left" Padding="8">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Text" Value="{Binding DisplayProfitPercent}"/>
@@ -531,7 +518,7 @@
                                         <DataGridTemplateColumn Header="% Profit w/ Credits" Width="Auto">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
-                                                    <TextBlock FontFamily="Consolas" TextAlignment="Right">
+                                                    <TextBlock TextAlignment="Left" Padding="8">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Text" Value="{Binding DisplayProfitWithCreditsPercent}"/>
@@ -555,7 +542,7 @@
                                         <DataGridTemplateColumn Header="XIRR" Width="Auto">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
-                                                    <TextBlock FontFamily="Consolas" TextAlignment="Right">
+                                                    <TextBlock TextAlignment="Left" Padding="8">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Text" Value="{Binding DisplayXirr}"/>
@@ -590,42 +577,27 @@
                                                 </Style>
                                             </DataGridTextColumn.HeaderStyle>
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                    <Setter Property="FontFamily" Value="Consolas"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Header="Last Credit Month" Binding="{Binding LastCreditMonthDisplay}" Width="Auto">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                    <Setter Property="FontFamily" Value="Consolas"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Header="Last Month %" Binding="{Binding DisplayLastMonthCreditsPercent}" Width="Auto">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                    <Setter Property="FontFamily" Value="Consolas"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Header="Est. Annual Credits" Binding="{Binding DisplayEstimatedAnnualCredits}" Width="Auto">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                    <Setter Property="FontFamily" Value="Consolas"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Header="Est. Annual %" Binding="{Binding DisplayEstimatedAnnualPercent}" Width="Auto">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                    <Setter Property="FontFamily" Value="Consolas"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                     </DataGrid.Columns>
@@ -754,27 +726,21 @@
                                                             Binding="{Binding Quantity, StringFormat=N8}"
                                                             Width="Auto">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Header="Unit Price"
                                                             Binding="{Binding UnitPrice, StringFormat=N2}"
                                                             Width="Auto">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Header="Fees"
                                                             Binding="{Binding Fees, StringFormat=N2}"
                                                             Width="Auto">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
-                                                </Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                         <DataGridTextColumn Header="Total"
@@ -782,47 +748,12 @@
                                                             Width="*"
                                                             IsReadOnly="True">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}">
                                                     <Setter Property="FontWeight" Value="Bold"/>
                                                 </Style>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                     </DataGrid.Columns>
-                                    <DataGrid.RowStyle>
-                                        <Style TargetType="DataGridRow">
-                                            <Style.Triggers>
-                                                <Trigger Property="IsSelected" Value="True">
-                                                    <Setter Property="Background" Value="LightYellow"/>
-                                                </Trigger>
-                                                <MultiTrigger>
-                                                    <MultiTrigger.Conditions>
-                                                        <Condition Property="IsSelected" Value="True"/>
-                                                        <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                                    </MultiTrigger.Conditions>
-                                                    <Setter Property="Background" Value="LightYellow"/>
-                                                </MultiTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </DataGrid.RowStyle>
-                                    <DataGrid.CellStyle>
-                                        <Style TargetType="DataGridCell">
-                                            <Style.Triggers>
-                                                <Trigger Property="IsSelected" Value="True">
-                                                    <Setter Property="Background" Value="LightYellow"/>
-                                                    <Setter Property="Foreground" Value="Black"/>
-                                                </Trigger>
-                                                <MultiTrigger>
-                                                    <MultiTrigger.Conditions>
-                                                        <Condition Property="IsSelected" Value="True"/>
-                                                        <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                                    </MultiTrigger.Conditions>
-                                                    <Setter Property="Background" Value="LightYellow"/>
-                                                    <Setter Property="Foreground" Value="Black"/>
-                                                </MultiTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </DataGrid.CellStyle>
                                 </DataGrid>
                                 <GridSplitter Grid.Row="2"
                                               Height="6"
@@ -1085,52 +1016,17 @@
                                         <DataGridTextColumn Header="Type" 
                                                             Binding="{Binding Type}" 
                                                             Width="Auto"/>
-                                        <DataGridTextColumn Header="Value" 
-                                                            Binding="{Binding Value, StringFormat=N2}" 
+                                        <DataGridTextColumn Header="Value"
+                                                            Binding="{Binding Value, StringFormat=N2}"
                                                             Width="*">
                                             <DataGridTextColumn.ElementStyle>
-                                                <Style TargetType="TextBlock">
-                                                    <Setter Property="TextAlignment" Value="Right"/>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}">
                                                     <Setter Property="FontWeight" Value="Bold"/>
                                                     <Setter Property="Foreground" Value="Black"/>
                                                 </Style>
                                             </DataGridTextColumn.ElementStyle>
                                         </DataGridTextColumn>
                                     </DataGrid.Columns>
-                                    <DataGrid.RowStyle>
-                                        <Style TargetType="DataGridRow">
-                                            <Style.Triggers>
-                                                <Trigger Property="IsSelected" Value="True">
-                                                    <Setter Property="Background" Value="LightYellow"/>
-                                                </Trigger>
-                                                <MultiTrigger>
-                                                    <MultiTrigger.Conditions>
-                                                        <Condition Property="IsSelected" Value="True"/>
-                                                        <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                                    </MultiTrigger.Conditions>
-                                                    <Setter Property="Background" Value="LightYellow"/>
-                                                </MultiTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </DataGrid.RowStyle>
-                                    <DataGrid.CellStyle>
-                                        <Style TargetType="DataGridCell">
-                                            <Style.Triggers>
-                                                <Trigger Property="IsSelected" Value="True">
-                                                    <Setter Property="Background" Value="LightYellow"/>
-                                                    <Setter Property="Foreground" Value="Black"/>
-                                                </Trigger>
-                                                <MultiTrigger>
-                                                    <MultiTrigger.Conditions>
-                                                        <Condition Property="IsSelected" Value="True"/>
-                                                        <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                                    </MultiTrigger.Conditions>
-                                                    <Setter Property="Background" Value="LightYellow"/>
-                                                    <Setter Property="Foreground" Value="Black"/>
-                                                </MultiTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </DataGrid.CellStyle>
                                 </DataGrid>
                                 <GridSplitter Grid.Row="2"
                                               Height="6"

--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -476,7 +476,7 @@
                                         <DataGridTemplateColumn Header="Current Value" Width="Auto">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
-                                                    <TextBlock TextAlignment="Left" Padding="8">
+                                                    <TextBlock TextAlignment="Right" Padding="8">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Text" Value="{Binding DisplayCurrentValue}"/>
@@ -494,7 +494,7 @@
                                         <DataGridTemplateColumn Header="% Profit" Width="Auto">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
-                                                    <TextBlock TextAlignment="Left" Padding="8">
+                                                    <TextBlock TextAlignment="Right" Padding="8">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Text" Value="{Binding DisplayProfitPercent}"/>
@@ -518,7 +518,7 @@
                                         <DataGridTemplateColumn Header="% Profit w/ Credits" Width="Auto">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
-                                                    <TextBlock TextAlignment="Left" Padding="8">
+                                                    <TextBlock TextAlignment="Right" Padding="8">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Text" Value="{Binding DisplayProfitWithCreditsPercent}"/>
@@ -542,7 +542,7 @@
                                         <DataGridTemplateColumn Header="XIRR" Width="Auto">
                                             <DataGridTemplateColumn.CellTemplate>
                                                 <DataTemplate>
-                                                    <TextBlock TextAlignment="Left" Padding="8">
+                                                    <TextBlock TextAlignment="Right" Padding="8">
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock">
                                                                 <Setter Property="Text" Value="{Binding DisplayXirr}"/>

--- a/Financial.App/Views/AssetPriceView.xaml
+++ b/Financial.App/Views/AssetPriceView.xaml
@@ -1,7 +1,6 @@
 <UserControl x:Class="Financial.Presentation.App.Views.AssetPriceView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Grid Margin="20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -69,9 +68,7 @@
                 </Grid.RowDefinitions>
                 <TextBlock Grid.Row="0" Text="Assets Current Prices" FontSize="16" FontWeight="Bold"
                            Foreground="#333333" Margin="0,0,0,10"/>
-                <DataGrid Grid.Row="1" ItemsSource="{Binding Results}" AutoGenerateColumns="False"
-                          FontSize="13" AlternatingRowBackground="#F5F5F5" IsReadOnly="True"
-                          HeadersVisibility="Column" GridLinesVisibility="Horizontal"
+                <DataGrid Grid.Row="1" ItemsSource="{Binding Results}"
                           BorderBrush="#CCCCCC" BorderThickness="1"
                           ScrollViewer.VerticalScrollBarVisibility="Auto">
                     <DataGrid.Columns>
@@ -91,67 +88,13 @@
                         </DataGridTextColumn>
                         <DataGridTextColumn Binding="{Binding Price, StringFormat=N2}" Header="Price" Width="120">
                             <DataGridTextColumn.ElementStyle>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="HorizontalAlignment" Value="Right"/>
-                                    <Setter Property="Padding" Value="8"/>
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}">
                                     <Setter Property="FontWeight" Value="Bold"/>
                                     <Setter Property="Foreground" Value="Black"/>
                                 </Style>
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>
                     </DataGrid.Columns>
-                    <DataGrid.ColumnHeaderStyle>
-                        <Style TargetType="DataGridColumnHeader">
-                            <Setter Property="Background" Value="#F0F0F0"/>
-                            <Setter Property="Foreground" Value="#333333"/>
-                            <Setter Property="FontWeight" Value="Bold"/>
-                            <Setter Property="Padding" Value="8"/>
-                            <Setter Property="BorderBrush" Value="#CCCCCC"/>
-                            <Setter Property="BorderThickness" Value="0,0,1,1"/>
-                        </Style>
-                    </DataGrid.ColumnHeaderStyle>
-                    <DataGrid.RowStyle>
-                        <Style TargetType="DataGridRow">
-                            <Setter Property="Background" Value="White"/>
-                            <Style.Triggers>
-                                <Trigger Property="ItemsControl.AlternationIndex" Value="1">
-                                    <Setter Property="Background" Value="#F5F5F5"/>
-                                </Trigger>
-                                <Trigger Property="IsSelected" Value="True">
-                                    <Setter Property="Background" Value="LightYellow"/>
-                                </Trigger>
-                                <MultiTrigger>
-                                    <MultiTrigger.Conditions>
-                                        <Condition Property="IsSelected" Value="True"/>
-                                        <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                    </MultiTrigger.Conditions>
-                                    <Setter Property="Background" Value="LightYellow"/>
-                                </MultiTrigger>
-                            </Style.Triggers>
-                            <Style.Resources>
-                                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="#007ACC"/>
-                                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="White"/>
-                            </Style.Resources>
-                        </Style>
-                    </DataGrid.RowStyle>
-                    <DataGrid.CellStyle>
-                        <Style TargetType="DataGridCell">
-                            <Style.Triggers>
-                                <Trigger Property="IsSelected" Value="True">
-                                    <Setter Property="Background" Value="LightYellow"/>
-                                    <Setter Property="Foreground" Value="Black"/>
-                                </Trigger>
-                                <MultiTrigger>
-                                    <MultiTrigger.Conditions>
-                                        <Condition Property="IsSelected" Value="True"/>
-                                        <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                    </MultiTrigger.Conditions>
-                                    <Setter Property="Background" Value="LightYellow"/>
-                                    <Setter Property="Foreground" Value="Black"/>
-                                </MultiTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </DataGrid.CellStyle>
                 </DataGrid>
             </Grid>
         </Border>

--- a/Financial.App/Views/DividendCheckView.xaml
+++ b/Financial.App/Views/DividendCheckView.xaml
@@ -1,7 +1,6 @@
 <UserControl x:Class="Financial.Presentation.App.Views.DividendCheckView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Grid Margin="20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -123,63 +122,8 @@
                                Foreground="#333333" Margin="0,0,0,10"/>
                     <DataGrid Grid.Row="1" Name="dividendDataGrid" ItemsSource="{Binding History}"
                               AutoGenerateColumns="True" AutoGeneratingColumn="DividendDataGrid_AutoGeneratingColumn"
-                              FontSize="13" AlternatingRowBackground="#F5F5F5" IsReadOnly="True"
-                              HeadersVisibility="Column" GridLinesVisibility="Horizontal"
                               BorderBrush="#CCCCCC" BorderThickness="1"
-                              ScrollViewer.VerticalScrollBarVisibility="Auto">
-                        <DataGrid.ColumnHeaderStyle>
-                            <Style TargetType="DataGridColumnHeader">
-                                <Setter Property="Background" Value="#F0F0F0"/>
-                                <Setter Property="Foreground" Value="#333333"/>
-                                <Setter Property="FontWeight" Value="Bold"/>
-                                <Setter Property="Padding" Value="8"/>
-                                <Setter Property="BorderBrush" Value="#CCCCCC"/>
-                                <Setter Property="BorderThickness" Value="0,0,1,1"/>
-                            </Style>
-                        </DataGrid.ColumnHeaderStyle>
-                        <DataGrid.RowStyle>
-                            <Style TargetType="DataGridRow">
-                                <Setter Property="Background" Value="White"/>
-                                <Style.Triggers>
-                                    <Trigger Property="ItemsControl.AlternationIndex" Value="1">
-                                        <Setter Property="Background" Value="#F5F5F5"/>
-                                    </Trigger>
-                                    <Trigger Property="IsSelected" Value="True">
-                                        <Setter Property="Background" Value="LightYellow"/>
-                                    </Trigger>
-                                    <MultiTrigger>
-                                        <MultiTrigger.Conditions>
-                                            <Condition Property="IsSelected" Value="True"/>
-                                            <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                        </MultiTrigger.Conditions>
-                                        <Setter Property="Background" Value="LightYellow"/>
-                                    </MultiTrigger>
-                                </Style.Triggers>
-                                <Style.Resources>
-                                    <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="#007ACC"/>
-                                    <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="White"/>
-                                </Style.Resources>
-                            </Style>
-                        </DataGrid.RowStyle>
-                        <DataGrid.CellStyle>
-                            <Style TargetType="DataGridCell">
-                                <Style.Triggers>
-                                    <Trigger Property="IsSelected" Value="True">
-                                        <Setter Property="Background" Value="LightYellow"/>
-                                        <Setter Property="Foreground" Value="Black"/>
-                                    </Trigger>
-                                    <MultiTrigger>
-                                        <MultiTrigger.Conditions>
-                                            <Condition Property="IsSelected" Value="True"/>
-                                            <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                        </MultiTrigger.Conditions>
-                                        <Setter Property="Background" Value="LightYellow"/>
-                                        <Setter Property="Foreground" Value="Black"/>
-                                    </MultiTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </DataGrid.CellStyle>
-                    </DataGrid>
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                 </Grid>
             </Border>
 
@@ -193,63 +137,8 @@
                                Foreground="#333333" Margin="0,0,0,10"/>
                     <DataGrid Grid.Row="1" Name="dividendByYearDataGrid" ItemsSource="{Binding YearTotals}"
                               AutoGenerateColumns="True" AutoGeneratingColumn="DividendByYearDataGrid_AutoGeneratingColumn"
-                              FontSize="13" AlternatingRowBackground="#F5F5F5" IsReadOnly="True"
-                              HeadersVisibility="Column" GridLinesVisibility="Horizontal"
                               BorderBrush="#CCCCCC" BorderThickness="1"
-                              ScrollViewer.VerticalScrollBarVisibility="Auto">
-                        <DataGrid.ColumnHeaderStyle>
-                            <Style TargetType="DataGridColumnHeader">
-                                <Setter Property="Background" Value="#F0F0F0"/>
-                                <Setter Property="Foreground" Value="#333333"/>
-                                <Setter Property="FontWeight" Value="Bold"/>
-                                <Setter Property="Padding" Value="8"/>
-                                <Setter Property="BorderBrush" Value="#CCCCCC"/>
-                                <Setter Property="BorderThickness" Value="0,0,1,1"/>
-                            </Style>
-                        </DataGrid.ColumnHeaderStyle>
-                        <DataGrid.RowStyle>
-                            <Style TargetType="DataGridRow">
-                                <Setter Property="Background" Value="White"/>
-                                <Style.Triggers>
-                                    <Trigger Property="ItemsControl.AlternationIndex" Value="1">
-                                        <Setter Property="Background" Value="#F5F5F5"/>
-                                    </Trigger>
-                                    <Trigger Property="IsSelected" Value="True">
-                                        <Setter Property="Background" Value="LightYellow"/>
-                                    </Trigger>
-                                    <MultiTrigger>
-                                        <MultiTrigger.Conditions>
-                                            <Condition Property="IsSelected" Value="True"/>
-                                            <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                        </MultiTrigger.Conditions>
-                                        <Setter Property="Background" Value="LightYellow"/>
-                                    </MultiTrigger>
-                                </Style.Triggers>
-                                <Style.Resources>
-                                    <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="#007ACC"/>
-                                    <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="White"/>
-                                </Style.Resources>
-                            </Style>
-                        </DataGrid.RowStyle>
-                        <DataGrid.CellStyle>
-                            <Style TargetType="DataGridCell">
-                                <Style.Triggers>
-                                    <Trigger Property="IsSelected" Value="True">
-                                        <Setter Property="Background" Value="LightYellow"/>
-                                        <Setter Property="Foreground" Value="Black"/>
-                                    </Trigger>
-                                    <MultiTrigger>
-                                        <MultiTrigger.Conditions>
-                                            <Condition Property="IsSelected" Value="True"/>
-                                            <Condition Property="primitives:Selector.IsSelectionActive" Value="False"/>
-                                        </MultiTrigger.Conditions>
-                                        <Setter Property="Background" Value="LightYellow"/>
-                                        <Setter Property="Foreground" Value="Black"/>
-                                    </MultiTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </DataGrid.CellStyle>
-                    </DataGrid>
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                 </Grid>
             </Border>
         </Grid>

--- a/Financial.App/Views/DividendCheckView.xaml.cs
+++ b/Financial.App/Views/DividendCheckView.xaml.cs
@@ -49,7 +49,7 @@ public partial class DividendCheckView : UserControl
             col.Binding = new System.Windows.Data.Binding(propertyName) { StringFormat = "N2" };
 
         var style = new System.Windows.Style(typeof(TextBlock));
-        style.Setters.Add(new Setter(TextBlock.TextAlignmentProperty, TextAlignment.Right));
+        style.Setters.Add(new Setter(TextBlock.TextAlignmentProperty, TextAlignment.Left));
         style.Setters.Add(new Setter(TextBlock.FontWeightProperty, FontWeights.Bold));
         style.Setters.Add(new Setter(TextBlock.ForegroundProperty, System.Windows.Media.Brushes.Black));
         col.ElementStyle = style;

--- a/Financial.App/Views/DividendCheckView.xaml.cs
+++ b/Financial.App/Views/DividendCheckView.xaml.cs
@@ -49,7 +49,7 @@ public partial class DividendCheckView : UserControl
             col.Binding = new System.Windows.Data.Binding(propertyName) { StringFormat = "N2" };
 
         var style = new System.Windows.Style(typeof(TextBlock));
-        style.Setters.Add(new Setter(TextBlock.TextAlignmentProperty, TextAlignment.Left));
+        style.Setters.Add(new Setter(TextBlock.TextAlignmentProperty, TextAlignment.Right));
         style.Setters.Add(new Setter(TextBlock.FontWeightProperty, FontWeights.Bold));
         style.Setters.Add(new Setter(TextBlock.ForegroundProperty, System.Windows.Media.Brushes.Black));
         col.ElementStyle = style;

--- a/docs/F01-wpf-datagrid-visual-standardization/plan.md
+++ b/docs/F01-wpf-datagrid-visual-standardization/plan.md
@@ -1,0 +1,27 @@
+# F01. WPF DataGrid Visual Standardization — Implementation Plan
+
+## Prerequisites
+
+- None (Wave 1, no feature dependencies).
+
+## Phase 1: Centralize the shared DataGrid style in App.xaml
+
+1. **DataGrid base style** - Update the existing unkeyed `Style TargetType="DataGrid"` in `Financial.App/App.xaml` to add `FontSize="13"`, keeping all its current setters unchanged.
+2. **DataGridRow style** - Add a new unkeyed `Style TargetType="DataGridRow"` in `App.xaml` reproducing the reference grid's zebra pattern (`AlternationIndex` trigger to `#F5F5F5`, `White` default, `LightYellow` on selection including inactive-selection resource overrides).
+3. **DataGridCell style** - Add a new unkeyed `Style TargetType="DataGridCell"` in `App.xaml` reproducing the reference grid's selection highlight behavior.
+4. **DataGridColumnHeader style** - Add a new unkeyed `Style TargetType="DataGridColumnHeader"` in `App.xaml` reproducing the reference grid's header look (background, foreground, bold, padding, border).
+5. **NumericColumnTextStyle** - Add a new keyed `Style x:Key="NumericColumnTextStyle" TargetType="TextBlock"` in `App.xaml` with `TextAlignment="Right"` (preserving the existing convention) and `Padding="8"`, for explicit use by numeric/currency columns.
+
+## Phase 2: Apply the standard across all six grids
+
+1. **Reference grid (AssetPriceView.xaml)** - Remove its local `ColumnHeaderStyle`/`RowStyle`/`CellStyle` blocks (now inherited from `App.xaml`); change the Price column's `ElementStyle` to `BasedOn="{StaticResource NumericColumnTextStyle}"`, keeping its `FontWeight="Bold"`/`Foreground="Black"` setters and dropping the now-redundant duplicate right-alignment/padding declaration (alignment itself stays right).
+2. **Portfolio Summary grid (NavigationView.xaml)** - Switch its 4 numeric `DataGridTextColumn`s (Quantity, Total Invested, % Portfolio, Total Credits) from the inline `Right`+`Consolas` style to `BasedOn="{StaticResource NumericColumnTextStyle}"` (still right-aligned, Consolas dropped); update its 4 `DataGridTemplateColumn` numeric cells (Current Value, % Profit, % Profit w/ Credits, XIRR) to drop `FontFamily="Consolas"` while keeping `TextAlignment="Right"`, preserving all existing `DataTrigger` coloring logic untouched.
+3. **Assets Transactions grid (NavigationView.xaml)** - Remove its local selection-only `RowStyle`/`CellStyle` (now inherited with zebra added); switch its 4 numeric columns (Quantity, Unit Price, Fees, Total) to `BasedOn="{StaticResource NumericColumnTextStyle}"`, keeping the Total column's extra `FontWeight="Bold"` setter and the Type column's existing color-converter binding untouched.
+4. **Assets Credits grid (NavigationView.xaml)** - Remove its local selection-only `RowStyle`/`CellStyle`; switch its Value column to `BasedOn="{StaticResource NumericColumnTextStyle}"`, keeping its `FontWeight="Bold"`/`Foreground="Black"` setters.
+5. **Dividend History and By Year grids (DividendCheckView.xaml)** - Remove their local `ColumnHeaderStyle`/`RowStyle`/`CellStyle`/`FontSize` (now inherited from `App.xaml`).
+6. **Auto-generated column alignment (DividendCheckView.xaml.cs)** - No change needed; `ApplyValueColumnStyle` already right-aligns generated numeric columns, consistent with the shared convention.
+
+## Phase 3: Verification
+
+1. **Build and full test suite** - Run `dotnet build` and `dotnet test` across the solution to confirm no markup compile errors and no regression in the existing ViewModel/helper/builder test suite.
+2. **Manual visual pass** - Launch the WPF app and visually confirm all 6 grids share the same font/size/zebra pattern, all numeric columns remain right-aligned (including the reference grid's Price column, with the Consolas override gone), and all existing conditional coloring, selection highlighting, sorting, and action buttons still work as before.

--- a/docs/F01-wpf-datagrid-visual-standardization/spec.md
+++ b/docs/F01-wpf-datagrid-visual-standardization/spec.md
@@ -1,0 +1,80 @@
+# F01. WPF DataGrid Visual Standardization — Technical Specification
+
+## 1. Scope
+
+**Included:**
+- Centralizing the DataGrid visual standard (font, zebra row striping, column header style, cell selection style) as implicit, unkeyed WPF styles in `Financial.App/App.xaml`, so every `DataGrid`, `DataGridRow`, `DataGridCell`, and `DataGridColumnHeader` in the app inherits it automatically without per-view duplication
+- Adding one keyed `TextBlock` style (`NumericColumnTextStyle`) in `App.xaml` for right-aligned numeric/currency columns (preserving the existing right-alignment convention already used across the app), referenced explicitly by every numeric column across the 6 grids in scope
+- Applying the standardized style to: Assets Current Prices grid (reference), Portfolio Summary grid, Assets Transactions grid, Assets Credits grid, Dividend History grid, By Year grid
+- Removing the now-redundant locally-duplicated `RowStyle`/`CellStyle`/`ColumnHeaderStyle`/`FontSize` XAML blocks from `AssetPriceView.xaml`, `DividendCheckView.xaml` (both grids), and `NavigationView.xaml` (Transactions and Credits grids), since they duplicate what the new implicit App.xaml styles already provide
+- `DividendCheckView.xaml.cs`'s `ApplyValueColumnStyle` method (used by both grids' `AutoGeneratingColumn` handlers) keeps right-aligning generated numeric columns, consistent with the shared convention
+- Preserving all existing conditional formatting: profit/loss green/red coloring (Portfolio Summary's % Profit, % Profit w/ Credits, XIRR columns), `SignedValueToBrushConverter` coloring on Total Invested, transaction-type coloring and bold Total column (Assets Transactions), bold black Value column (Assets Credits)
+
+**Out of scope (per PRD Section 7):**
+- New columns, filters, sorting, export, or pagination behavior
+- Non-DataGrid controls (buttons, ComboBoxes, OxyPlot charts)
+- The React web frontend
+- Dark mode / theming system
+- Any Domain, Application, or Infrastructure layer change
+- Any change to numeric column alignment (already right-aligned everywhere; this feature keeps it that way, just via one shared style instead of per-grid duplication)
+
+## 2. Component Overview
+
+| File | Role |
+|---|---|
+| `Financial.App/App.xaml` | Replaces the existing weak, unkeyed `DataGrid` style with a complete one (adds `FontSize="13"`); adds new unkeyed styles for `DataGridRow` (zebra `AlternationIndex` trigger + selection highlight), `DataGridCell` (selection highlight), and `DataGridColumnHeader` (header look). Adds one keyed style, `NumericColumnTextStyle` (`TargetType="TextBlock"`, `TextAlignment="Right"`, `Padding="8"`), for numeric column cell content. |
+| `Financial.App/Views/AssetPriceView.xaml` | Reference grid. Removes its local `ColumnHeaderStyle`/`RowStyle`/`CellStyle` (now inherited from `App.xaml`). Price column's `ElementStyle` changes to `BasedOn="{StaticResource NumericColumnTextStyle}"`, dropping its own duplicate right-alignment/padding declaration (alignment itself is unchanged). |
+| `Financial.App/Components/NavigationView.xaml` | Portfolio Summary grid: no local row/cell/header styles exist today (nothing to remove) — it starts inheriting zebra/font/header automatically once `App.xaml` changes land. Its 4 `DataGridTextColumn` numeric columns switch from an inline `Right`+`Consolas` style to `BasedOn="{StaticResource NumericColumnTextStyle}"` (still right-aligned, Consolas dropped); its 4 `DataGridTemplateColumn` numeric cells (Current Value, % Profit, % Profit w/ Credits, XIRR) drop `FontFamily="Consolas"` from their inline `TextBlock` while keeping `TextAlignment="Right"` and their existing `DataTrigger`-based coloring untouched. Assets Transactions grid: removes its local selection-only `RowStyle`/`CellStyle` (now inherited with zebra added); its 4 numeric `DataGridTextColumn`s switch to `BasedOn="{StaticResource NumericColumnTextStyle}"` (Total column keeps its extra `FontWeight="Bold"` setter layered on top). Assets Credits grid: removes its local selection-only `RowStyle`/`CellStyle`; its Value column switches to `BasedOn="{StaticResource NumericColumnTextStyle}"`, keeping its `FontWeight="Bold"`/`Foreground="Black"` setters layered on top. |
+| `Financial.App/Views/DividendCheckView.xaml` | Both grids (Dividend History, By Year) remove their local `ColumnHeaderStyle`/`RowStyle`/`CellStyle`/`FontSize` (now inherited from `App.xaml`). |
+| `Financial.App/Views/DividendCheckView.xaml.cs` | `ApplyValueColumnStyle` is unchanged in behavior — its generated `Style` keeps `TextBlock.TextAlignmentProperty` set to `TextAlignment.Right`, consistent with the shared convention. |
+
+No Domain, Application, or Infrastructure files are touched.
+
+## 3. Requirements / Business Rules
+
+- The `App.xaml` `DataGrid` style keeps every existing setter (`AutoGenerateColumns="False"`, `IsReadOnly="True"`, `AlternatingRowBackground="#F5F5F5"`, `GridLinesVisibility="Horizontal"`, `HeadersVisibility="Column"`, `SelectionMode="Single"`, `CanUserResizeRows="False"`, `CanUserSortColumns="True"`) and adds `FontSize="13"` — matching the reference grid's current value.
+- The `DataGridRow` style zebra pattern uses the same rule already used by the reference grid: `Background="White"` by default, `Background="#F5F5F5"` when `ItemsControl.AlternationIndex=1`, and `Background="LightYellow"` on selection (both active and inactive selection states), including the `InactiveSelectionHighlightBrushKey`/`InactiveSelectionHighlightTextBrushKey` resource overrides already used by the reference grid.
+- The `DataGridColumnHeader` style matches the reference grid exactly: `Background="#F0F0F0"`, `Foreground="#333333"`, `FontWeight="Bold"`, `Padding="8"`, `BorderBrush="#CCCCCC"`, `BorderThickness="0,0,1,1"`.
+- The `DataGridCell` style matches the reference grid's selection behavior: `Background="LightYellow"`, `Foreground="Black"` on selection (active and inactive).
+- Because these four styles are unkeyed (`TargetType` only, no `x:Key`), WPF's implicit style resolution applies them automatically to every `DataGrid`, `DataGridRow`, `DataGridCell`, and `DataGridColumnHeader` in the app that does not set its own local `Style`/`RowStyle`/`CellStyle`. No grid needs to reference them explicitly — the fix is to stop overriding them locally, not to add new references.
+- `NumericColumnTextStyle` is deliberately keyed (not implicit) because an app-wide implicit `TextBlock` style would affect every label, button caption, and header text in the app, not just grid numeric cells. Every numeric/currency column must reference it explicitly via `ElementStyle`. It sets `TextAlignment="Right"`, preserving the alignment convention every grid already uses today — this feature does not change numeric alignment, only consolidates its definition into one shared resource and removes the stray `Consolas` font override.
+- Numeric columns that need additional formatting beyond alignment (bold totals, conditional profit/loss colors, `SignedValueToBrushConverter`) apply `BasedOn="{StaticResource NumericColumnTextStyle}"` and layer their own `Setter`/`Trigger`/`DataTrigger` elements on top, exactly as they do today for their existing formatting — only the font source changes (alignment stays right, as before).
+- `DataGridTemplateColumn`-based numeric cells (Portfolio Summary's Current Value, % Profit, % Profit w/ Credits, XIRR) cannot use `ElementStyle`/`BasedOn` the same way since their `TextBlock` is defined inline inside a `DataTemplate` with its own `Style`; for these, `FontFamily="Consolas"` is removed while `TextAlignment="Right"` stays on the `TextBlock` unchanged, and the inline `Style`'s `Text` binding and `DataTrigger`s (loading indicator, green/red coloring) are left unchanged.
+- `DividendCheckView.xaml.cs`'s dynamically-built `Style` (used because those two grids have `AutoGenerateColumns="True"`) is unchanged: `FontWeight="Bold"`, `Foreground="Black"`, and `TextAlignment.Right` all stay as they are today.
+- No column changes width, header text, sort behavior, alignment, or data binding — only font source and row background pattern change.
+
+## 4. UX Flow
+
+1. User opens the Read Assets Current Values screen, Portfolio Summary tab, Asset Transactions tab, Asset Credits tab, or Shares Dividend Check tab.
+2. Every `DataGrid` renders with `FontSize="13"` in the app's default font (no monospace override), a `#F0F0F0` bold column header, and alternating `White`/`#F5F5F5` row backgrounds.
+3. Every numeric/currency column's text remains right-aligned, exactly as before, including the reference grid's own Price column — only the font and zebra pattern become consistent.
+4. Existing behaviors are visually unchanged aside from the above: row selection still highlights `LightYellow`, sorting still works by clicking headers, update/delete action buttons in Transactions/Credits grids still function, and all conditional coloring (profit/loss green/red, transaction type colors, bold totals) still renders exactly as before.
+5. No new interaction is introduced; this is a pure re-render of existing data with a consistent visual style.
+
+## 5. Error Handling
+
+Not applicable — this is a read-only, presentation-only styling change with no data mutation, network call, or state transition that can fail. Per the PRD's Error Handling inclusion criteria (auth, payments, data loss risk, security, long-running/irreversible operations), none apply here.
+
+## 6. Testing Strategy
+
+The existing test suite (`Tests/Financial.Presentation.Tests`) covers ViewModels, chart builders, and helpers — it contains no XAML/view-rendering tests, and this change introduces no new C# business logic. Consistent with that pattern, this feature's testing strategy is:
+
+- **Build verification:** `dotnet build` on `Financial.App` (and the full solution) must succeed after the `App.xaml` resource changes and every touched `.xaml`/`.xaml.cs` file, catching any XAML resource-lookup or markup compile error (e.g., a missing `StaticResource` key, an invalid `BasedOn` target).
+- **Full existing test suite regression:** `dotnet test` across the solution must remain green — this change touches no ViewModel or business logic, so no existing test should be affected; a failure would indicate an unintended side effect.
+- **Manual visual verification (acceptance test surrogate):** since there is no automated visual/UI test harness in this codebase, run the WPF app and visually confirm, for each of the 6 grids, against the PRD's Section 9 acceptance criteria:
+  - Same font/size/zebra pattern across all 6 grids
+  - Every numeric column still right-aligned, including the reference grid's Price column, with the `Consolas` override gone from Portfolio Summary
+  - Profit/loss coloring, transaction-type coloring, and bold totals still render correctly
+  - Row selection highlighting and sorting still work
+  - Update/delete action buttons in Transactions and Credits grids still work
+
+## 7. Assumptions / Decisions
+
+(Auto-accepted per the Batch Mode policy at PRD-interview time; documented here for traceability.)
+
+- **Font family:** drop the `Consolas` monospace override entirely; all grids use the WPF default font, matching the reference grid. *(Locked in during the PRD-stage clarification interview.)*
+- **Numeric column alignment:** stays right-aligned everywhere, matching the convention every grid already used before this feature. *(An earlier draft of this spec incorrectly proposed switching to left-alignment; corrected after user review — right-alignment is the standard, consistent with decimal-point alignment conventions for financial figures.)*
+- **Style reuse mechanism:** centralize as unkeyed/implicit WPF styles in `App.xaml` for `DataGrid`, `DataGridRow`, `DataGridCell`, `DataGridColumnHeader` (auto-applied everywhere, no per-grid reference needed), plus one keyed style for the numeric-column text style (must stay keyed to avoid affecting all `TextBlock`s app-wide). This is a refinement of the PRD-stage decision "centralize as named resources in App.xaml" — using implicit (unkeyed) styles for the row/cell/header/grid-level styling is the simplest mechanism that achieves zero per-grid duplication, consistent with "avoid overengineering."
+- **Conditional formatting preserved exactly:** confirmed during PRD-stage interview — profit/loss coloring, `SignedValueToBrushConverter`, transaction-type coloring, and bold totals are untouched; only font/zebra change.
+- **`DataGridTemplateColumn` cells:** since these can't consume `ElementStyle`/`BasedOn` the same way as `DataGridTextColumn`, the font-family fix is applied directly on their inline `TextBlock` declarations rather than forcing them onto the shared resource — documented here since the PRD didn't specify this mechanical detail.
+- **`DividendCheckView.xaml.cs` code-behind:** left unchanged — it already right-aligns generated numeric columns, consistent with the shared convention.

--- a/docs/prd/P05-prd-wpf-datagrid-visual-consistency/prd-wpf-datagrid-visual-consistency.md
+++ b/docs/prd/P05-prd-wpf-datagrid-visual-consistency/prd-wpf-datagrid-visual-consistency.md
@@ -1,0 +1,152 @@
+# WPF DataGrid Visual Consistency
+
+## 1. Executive Summary
+
+WPF DataGrid Visual Consistency is a presentation-only fix for the Financial application's WPF desktop app (Financial.App). Today, DataGrids across different screens do not share a consistent visual language: some grids have no zebra row striping at all, and one grid applies a monospace font to its numeric columns while the rest of the app uses the default font. Numeric columns are already right-aligned everywhere, which is the correct convention and stays unchanged — but the surrounding font and row-striping inconsistency still makes the desktop app feel visually inconsistent as the user navigates between the Portfolio Summary, Transactions, Credits, and Shares Dividend Check screens.
+
+This feature establishes the existing "Assets Current Prices" grid on the Read Assets Current Values screen as the canonical visual standard and brings five other grids — Portfolio Summary, Assets Transactions, Assets Credits, and the Shares Dividend Check tab's Dividend History and By Year grids — into alignment with it: same font family and size, the same alternating-row zebra pattern, and the same right-aligned numeric column convention already used across the app (including the reference grid's own Price column, which stays right-aligned). The shared visual style is centralized as reusable named resources in `App.xaml` so all six grids reference the same style definitions instead of duplicating XAML, removing existing copy-paste duplication in the process.
+
+No business logic, data, or layer boundaries change. This is purely a WPF Presentation-layer styling change.
+
+---
+
+## 2. Problem and Opportunity
+
+### The Problem
+
+**Inconsistent zebra striping across grids**
+- The Portfolio Summary grid and the Assets Transactions and Assets Credits grids have no alternating-row background at all — their `RowStyle`/`CellStyle` only handle selection highlighting, not zebra striping
+- The Dividend History, By Year, and Assets Current Prices grids do have zebra striping, but its definition is copy-pasted identically into three separate XAML files, risking future drift
+
+**Inconsistent font usage**
+- The Portfolio Summary grid's numeric columns use a monospace font (`Consolas`) while the reference grid and most other grids use the app's default font, so numbers visually stand out differently depending on which screen the user is viewing
+
+**Style duplication increases maintenance risk**
+- The row/column-header/cell style XAML block is duplicated verbatim across `NavigationView.xaml` and `DividendCheckView.xaml`, meaning any future visual tweak must be applied in multiple places or grids will silently drift out of sync again
+
+### The Opportunity
+
+- Inconsistent zebra striping → apply one shared zebra `RowStyle` resource to every grid, including the three that currently have none
+- Inconsistent font usage → drop the `Consolas` override so every grid uses the same default font, matching the reference grid exactly
+- Style duplication → extract the shared `RowStyle`, `ColumnHeaderStyle`, `CellStyle`, and a numeric-column base style (right-aligned, matching the existing convention) into named resources in `App.xaml`, referenced via `StaticResource` from every grid, so there is a single source of truth for the visual standard going forward
+
+---
+
+## 3. Target Audience
+
+### Primary Users
+
+**Personal Investor (WPF desktop user)**
+- Uses the WPF desktop app to review portfolio data across multiple screens in the same session (Portfolio Summary, Transactions, Credits, Dividend Check, Read Assets Current Values)
+- Notices visual inconsistency between screens as a polish/quality signal, even though it has no functional impact
+- Expects the desktop app to feel like one coherent product rather than a set of independently styled screens
+
+---
+
+## 4. Objectives
+
+**Establish one visual standard for all WPF DataGrids**
+- Metric: all 6 grids in scope (Assets Current Prices, Portfolio Summary, Assets Transactions, Assets Credits, Dividend History, By Year) use the same `FontFamily`, `FontSize`, and `FontWeight` for their base text
+
+**Apply consistent zebra row striping everywhere**
+- Metric: all 6 grids render an alternating row background using the same shared `RowStyle` resource, verified by all six grids referencing the same `StaticResource` key
+
+**Keep numeric columns consistently right-aligned**
+- Metric: 100% of numeric/currency-formatted columns across all 6 grids use `TextAlignment="Right"` via one shared style, including the reference grid's own Price column
+
+**Eliminate style duplication**
+- Metric: the row/header/cell style XAML exists exactly once, in `App.xaml`, and is referenced by `StaticResource` from every grid definition — zero duplicated style blocks remain in `NavigationView.xaml`, `DividendCheckView.xaml`, or `AssetPriceView.xaml`
+
+---
+
+## 5. User Stories
+
+### F01. WPF DataGrid Visual Standardization
+
+- As a user, I want every DataGrid in the WPF app to use the same font, size, and style so that the app feels visually consistent as I move between screens
+- As a user, I want every DataGrid to show the same alternating row striping so that long rows of data remain easy to scan on every screen, not just some
+- As a user, I want numeric and currency values to stay right-aligned consistently across every grid, using one shared style instead of ad-hoc per-grid definitions, so decimal points line up and I don't have to re-adjust my scanning pattern from screen to screen
+- As a user, I want the existing color-coding (profit green/red, transaction type colors, bold totals) to keep working exactly as it does today, since only the font and row-striping consistency is changing, not the information itself or its alignment
+
+---
+
+## 6. Functionalities
+
+### F01. WPF DataGrid Visual Standardization
+
+**Capabilities:**
+- A shared `DataGrid` base style, `RowStyle` (zebra striping via `AlternationIndex` + selection highlighting), `ColumnHeaderStyle`, `CellStyle`, and a numeric-column `TextBlock` element style are defined once as keyed resources in `Financial.App/App.xaml`, replacing the existing weak, incomplete global `DataGrid` style already present there
+- All values in the shared resources match the current "Assets Current Prices" grid's visual definition (`FontSize="13"`, `AlternatingRowBackground="#F5F5F5"`, header background `#F0F0F0` with bold `#333333` text and `8`px padding, `LightYellow` selection highlight, numeric columns right-aligned) — this feature changes no alignment anywhere, only consolidates the already-consistent right-alignment convention into one shared resource
+- The default `FontFamily` used across all shared resources is the WPF default (no explicit override), replacing the `Consolas` monospace override currently applied to the Portfolio Summary grid's numeric columns
+- Every numeric/currency-formatted column across the 6 grids in scope — Price (Assets Current Prices), Quantity/Total Invested/% Portfolio/Total Credits/Current Value/% Profit/% Profit w/ Credits/XIRR (Portfolio Summary), Quantity/Unit Price/Fees/Total (Assets Transactions), Value (Assets Credits), and any numeric columns auto-generated in Dividend History and By Year — references the shared numeric-column style (right-aligned) via `ElementStyle`/`BasedOn`, or an equivalent per-column override where the column is defined via `DataGridTemplateColumn` (which cannot directly reference the shared `ElementStyle` resource)
+- The Dividend History and By Year grids (`DividendCheckView.xaml`) use `AutoGenerateColumns="True"` with a code-behind `AutoGeneratingColumn` handler; that handler keeps generating numeric columns as right-aligned, consistent with the shared convention
+- All existing conditional formatting is preserved unchanged: profit/loss green-red coloring on % Profit, % Profit w/ Credits, and XIRR in the Portfolio Summary grid; transaction-type coloring and bold Total column in the Assets Transactions grid; Total Invested's `SignedValueToBrushConverter`-based coloring; and any credit-type coloring in the Assets Credits grid
+- Non-numeric columns (names, dates, types, action buttons) are unaffected and keep their current left alignment / existing behavior
+- `Financial.App/Views/AssetPriceView.xaml` (the reference grid) is updated to consume the new shared resources instead of its own locally-defined styles; its Price column stays right-aligned, so the reference grid itself is 100% consistent with the new standard
+
+**Experience:**
+1. User opens any of the 6 screens in scope (Read Assets Current Values, Portfolio Summary, Asset Transactions tab, Asset Credits tab, Shares Dividend Check tab)
+2. Every grid renders with the same font, same zebra row striping, and the same right-aligned numeric columns as before
+3. Existing interactions (row selection highlight, sorting, update/delete action buttons, color-coded profit/loss and transaction-type text) behave exactly as before — only font and zebra striping consistency change; numeric alignment is unchanged
+4. No new user-facing controls, no new data, no change to what information is shown — purely visual consistency
+
+---
+
+## 7. Out of Scope
+
+**New grid features**
+- No new columns, filters, sorting behavior, export, or pagination are introduced by this change
+
+**Non-DataGrid controls**
+- Buttons, ComboBoxes, charts (OxyPlot), and other non-DataGrid controls elsewhere in the app are not restyled by this feature
+
+**React web frontend**
+- This feature is WPF-only; the web app's tables/grids are not in scope
+
+**Dark mode or theming system**
+- No configurable theme or dark mode is introduced; the shared style resources use the same fixed color palette the reference grid already uses today
+
+**Domain/Application/Infrastructure changes**
+- No business logic, DTOs, services, or repository code changes; this is a Presentation-layer-only change
+
+---
+
+## 8. Dependency Graph
+
+| # | Feature | Priority | Dependencies |
+|---|---------|----------|--------------|
+| F01 | WPF DataGrid Visual Standardization | 3 | None |
+
+### Execution Waves
+Features within the same wave can be built in parallel. A wave starts only after every feature in earlier waves is complete.
+
+- **Wave 1**: F01
+
+### Priority levels
+- **1** = Essential — product does not work without it
+- **2** = Important — significant value addition
+- **3** = Desirable — incremental improvement
+
+```mermaid
+graph TD
+  F01[DataGrid Standardization]
+```
+
+---
+
+## 9. Acceptance Criteria
+
+### F01. WPF DataGrid Visual Standardization
+- [ ] Assets Current Prices, Portfolio Summary, Assets Transactions, Assets Credits, Dividend History, and By Year grids all use the same `FontFamily`, `FontSize`, and `FontWeight` for base row text
+- [ ] All 6 grids render alternating row background striping using the same shared `RowStyle` resource (verified by identical `StaticResource` key usage)
+- [ ] All 6 grids use the same `ColumnHeaderStyle` (background, foreground, font weight, padding, border)
+- [ ] Every numeric/currency column across all 6 grids is right-aligned (`TextAlignment="Right"`) via the shared numeric-column style, including the Assets Current Prices grid's own Price column
+- [ ] The `Consolas` font override on the Portfolio Summary grid's numeric columns is removed; those columns use the same default font as the rest of the app
+- [ ] Profit/loss green-red coloring (% Profit, % Profit w/ Credits, XIRR, Total Invested) in the Portfolio Summary grid renders identically to before this change, with only font/zebra differing
+- [ ] Transaction-type coloring and the bold Total column in the Assets Transactions grid render identically to before this change
+- [ ] Selection highlighting (`LightYellow` background) behaves identically across all 6 grids
+- [ ] The shared row/header/cell/numeric styles exist exactly once, as keyed resources in `Financial.App/App.xaml`; no duplicated style blocks remain in `NavigationView.xaml`, `DividendCheckView.xaml`, or `AssetPriceView.xaml`
+- [ ] Existing sorting, row selection, and action-button (update/delete) behavior in Assets Transactions and Assets Credits grids is unaffected (regression check)
+
+### Cross-Feature Integration
+- [ ] N/A — this PRD has a single feature with no functional data dependencies on other features


### PR DESCRIPTION
## Summary
- Standardizes font, size, and alternating-row (zebra) striping across all WPF DataGrids, using the existing "Assets Current Prices" grid (Read Assets Current Values screen) as the reference standard.
- Centralizes the shared style (font, zebra `RowStyle`, `ColumnHeaderStyle`, `CellStyle`, and a numeric-column `TextBlock` style) as implicit/keyed resources in `Financial.App/App.xaml`, removing the copy-pasted style blocks previously duplicated across `NavigationView.xaml`, `DividendCheckView.xaml`, and `AssetPriceView.xaml`.
- Drops the stray `Consolas` monospace font override on the Portfolio Summary grid's numeric columns so every grid uses the same default font.
- Numeric/currency columns remain **right-aligned** everywhere (unchanged from before — this was already consistent across grids; only font and zebra striping needed fixing).
- Preserves all existing conditional formatting: profit/loss green/red coloring, `SignedValueToBrushConverter` on Total Invested, transaction-type coloring, bold totals.
- Presentation-layer-only change (WPF/Financial.App); no Domain, Application, or Infrastructure changes.

Grids affected: Assets Current Prices (reference), Portfolio Summary, Assets Transactions, Assets Credits, Dividend History, By Year.

Docs: `docs/prd/P05-prd-wpf-datagrid-visual-consistency/`, `docs/F01-wpf-datagrid-visual-standardization/` (spec + plan).

## Test plan
- [x] `dotnet build` succeeds for `Financial.App` and the full solution (aside from a pre-existing, unrelated file-lock issue on `Financial.Api` caused by a stray already-running `Financial.Api.exe` process on the dev machine — not caused by this change)
- [x] Full test suite passes: Domain (51), Application (175), Infrastructure (65, 3 skipped), Presentation (131) — 422 tests, 0 failed
- [x] Manually launched the WPF app and visually verified the Portfolio Summary grid: consistent font, visible zebra striping, numeric columns right-aligned, no more Consolas font
- [x] Verified existing conditional coloring (Total Bought/Sold/Credits/Invested colors) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)