### PR TITLE
fix: handle invalid/empty ticker in Shared Dividend Check without crashing

### DIFF
--- a/Financial.App/ViewModels/DividendCheckViewModel.cs
+++ b/Financial.App/ViewModels/DividendCheckViewModel.cs
@@ -18,6 +18,7 @@ public class DividendCheckViewModel : ViewModelBase
     private string _summaryDividendYield = string.Empty;
     private string _summaryPriceMaxBuy = string.Empty;
     private bool _isPriceGood;
+    private string _errorMessage = string.Empty;
 
     public string Ticker
     {
@@ -61,6 +62,18 @@ public class DividendCheckViewModel : ViewModelBase
         private set => SetProperty(ref _isPriceGood, value);
     }
 
+    public string ErrorMessage
+    {
+        get => _errorMessage;
+        private set
+        {
+            if (SetProperty(ref _errorMessage, value))
+                OnPropertyChanged(nameof(HasError));
+        }
+    }
+
+    public bool HasError => !string.IsNullOrEmpty(ErrorMessage);
+
     public ObservableCollection<DividendHistoryItemDTO> History { get; } = new();
     public ObservableCollection<DividendYearTotalDTO> YearTotals { get; } = new();
     public RelayCommand CheckCommand { get; }
@@ -75,22 +88,52 @@ public class DividendCheckViewModel : ViewModelBase
 
     private void Check()
     {
-        var request = new DividendLookupRequestDTO { Exchange = _defaultExchange, Ticker = Ticker.ToUpperInvariant() };
-        var summary = _dividendService.GetDividendSummary(request);
+        ErrorMessage = string.Empty;
 
+        if (string.IsNullOrWhiteSpace(Ticker))
+        {
+            ErrorMessage = "Enter a ticker before checking.";
+            ClearResults();
+            return;
+        }
+
+        try
+        {
+            var request = new DividendLookupRequestDTO { Exchange = _defaultExchange, Ticker = Ticker.ToUpperInvariant() };
+            var summary = _dividendService.GetDividendSummary(request);
+
+            History.Clear();
+            foreach (var item in summary.History)
+                History.Add(item);
+
+            YearTotals.Clear();
+            foreach (var item in summary.YearTotals)
+                YearTotals.Add(item);
+
+            SummaryName = $"{summary.Ticker} - {summary.Name}";
+            SummaryPrice = $"Current price: {summary.CurrentPrice:N2}";
+            SummaryAverageDividend = $"Average Dividend: {summary.AverageDividendLastFiveYears:F2} (last {DividendValuationRules.DividendYearsLookback} years)";
+            SummaryDividendYield = $"Dividend Yield: {summary.DividendYieldPercent:F2}% (annual avg / current price)";
+            SummaryPriceMaxBuy = $"Price max buy: {summary.PriceMaxBuy:F2}   Discount {summary.DiscountPercent:F2}%";
+            IsPriceGood = summary.PriceMaxBuy > summary.CurrentPrice;
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = $"Could not find dividend data for '{Ticker}'. Check the ticker and try again.";
+            ClearResults();
+            System.Diagnostics.Debug.WriteLine($"Dividend check failed for ticker '{Ticker}': {ex}");
+        }
+    }
+
+    private void ClearResults()
+    {
         History.Clear();
-        foreach (var item in summary.History)
-            History.Add(item);
-
         YearTotals.Clear();
-        foreach (var item in summary.YearTotals)
-            YearTotals.Add(item);
-
-        SummaryName = $"{summary.Ticker} - {summary.Name}";
-        SummaryPrice = $"Current price: {summary.CurrentPrice:N2}";
-        SummaryAverageDividend = $"Average Dividend: {summary.AverageDividendLastFiveYears:F2} (last {DividendValuationRules.DividendYearsLookback} years)";
-        SummaryDividendYield = $"Dividend Yield: {summary.DividendYieldPercent:F2}% (annual avg / current price)";
-        SummaryPriceMaxBuy = $"Price max buy: {summary.PriceMaxBuy:F2}   Discount {summary.DiscountPercent:F2}%";
-        IsPriceGood = summary.PriceMaxBuy > summary.CurrentPrice;
+        SummaryName = string.Empty;
+        SummaryPrice = string.Empty;
+        SummaryAverageDividend = string.Empty;
+        SummaryDividendYield = string.Empty;
+        SummaryPriceMaxBuy = string.Empty;
+        IsPriceGood = false;
     }
 }

--- a/Financial.App/Views/DividendCheckView.xaml
+++ b/Financial.App/Views/DividendCheckView.xaml
@@ -6,6 +6,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
@@ -72,7 +73,12 @@
             </StackPanel>
         </Border>
 
-        <Border Grid.Row="2" BorderBrush="#CCCCCC" BorderThickness="1" Padding="15" Margin="0,0,0,20">
+        <Border Grid.Row="2" BorderBrush="#D32F2F" BorderThickness="1" Padding="10" Margin="0,0,0,20"
+                Background="#FDECEA" Visibility="{Binding HasError, Converter={StaticResource BoolToVisibilityConverter}}">
+            <TextBlock Text="{Binding ErrorMessage}" Foreground="#D32F2F" FontWeight="Bold" TextWrapping="Wrap"/>
+        </Border>
+
+        <Border Grid.Row="3" BorderBrush="#CCCCCC" BorderThickness="1" Padding="15" Margin="0,0,0,20">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -105,7 +111,7 @@
             </Grid>
         </Border>
 
-        <Grid Grid.Row="3">
+        <Grid Grid.Row="4">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*" MinWidth="300"/>
                 <ColumnDefinition Width="10"/>

--- a/Tests/Financial.Presentation.Tests/ViewModels/DividendCheckViewModelTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/DividendCheckViewModelTests.cs
@@ -1,0 +1,137 @@
+using Financial.Application.Configuration;
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class DividendCheckViewModelTests
+{
+    private readonly StubDividendService _dividendService = new();
+
+    [Fact]
+    public void Check_WithEmptyTicker_SetsErrorMessageAndDoesNotThrow()
+    {
+        var vm = BuildViewModel();
+        vm.Ticker = string.Empty;
+
+        Action act = () => vm.CheckCommand.Execute(null);
+
+        act.Should().NotThrow();
+        vm.HasError.Should().BeTrue();
+        vm.ErrorMessage.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Check_WithWhitespaceTicker_SetsErrorMessage()
+    {
+        var vm = BuildViewModel();
+        vm.Ticker = "   ";
+
+        vm.CheckCommand.Execute(null);
+
+        vm.HasError.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Check_WhenServiceThrows_SetsErrorMessageInsteadOfCrashing()
+    {
+        _dividendService.ThrowOnGetSummary = new InvalidOperationException("Ticker not found.");
+        var vm = BuildViewModel();
+        vm.Ticker = "INVALIDTICKER";
+
+        Action act = () => vm.CheckCommand.Execute(null);
+
+        act.Should().NotThrow();
+        vm.HasError.Should().BeTrue();
+        vm.ErrorMessage.Should().Contain("INVALIDTICKER");
+    }
+
+    [Fact]
+    public void Check_WhenServiceThrows_ClearsPreviousResults()
+    {
+        _dividendService.Summary = MakeSummary();
+        var vm = BuildViewModel();
+        vm.Ticker = "GOOD";
+        vm.CheckCommand.Execute(null);
+        vm.History.Should().NotBeEmpty();
+
+        _dividendService.ThrowOnGetSummary = new InvalidOperationException("boom");
+        vm.Ticker = "BAD";
+        vm.CheckCommand.Execute(null);
+
+        vm.History.Should().BeEmpty();
+        vm.YearTotals.Should().BeEmpty();
+        vm.SummaryName.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Check_WithValidTicker_ClearsPreviousError()
+    {
+        _dividendService.ThrowOnGetSummary = new InvalidOperationException("boom");
+        var vm = BuildViewModel();
+        vm.Ticker = "BAD";
+        vm.CheckCommand.Execute(null);
+        vm.HasError.Should().BeTrue();
+
+        _dividendService.ThrowOnGetSummary = null;
+        _dividendService.Summary = MakeSummary();
+        vm.Ticker = "GOOD";
+        vm.CheckCommand.Execute(null);
+
+        vm.HasError.Should().BeFalse();
+        vm.ErrorMessage.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Check_WithValidTicker_PopulatesSummary()
+    {
+        _dividendService.Summary = MakeSummary();
+        var vm = BuildViewModel();
+        vm.Ticker = "TICK";
+
+        vm.CheckCommand.Execute(null);
+
+        vm.HasError.Should().BeFalse();
+        vm.SummaryName.Should().Contain("TICK");
+        vm.History.Should().HaveCount(1);
+        vm.YearTotals.Should().HaveCount(1);
+    }
+
+    private DividendCheckViewModel BuildViewModel() =>
+        new(_dividendService, Options.Create(new DividendOptions { DefaultExchange = "BVMF" }));
+
+    private static DividendSummaryDTO MakeSummary() => new()
+    {
+        Exchange = "BVMF",
+        Ticker = "TICK",
+        Name = "Sample Asset",
+        CurrentPrice = 10m,
+        PriceAsOf = DateTimeOffset.UtcNow,
+        AverageDividendLastFiveYears = 1m,
+        DividendYieldPercent = 10m,
+        PriceMaxBuy = 12m,
+        DiscountPercent = 5m,
+        History = [new DividendHistoryItemDTO { Type = "Dividend", Date = DateTime.Today, Value = 1m }],
+        YearTotals = [new DividendYearTotalDTO { Year = DateTime.Today.Year, Total = 1m }]
+    };
+
+    private sealed class StubDividendService : IDividendService
+    {
+        public DividendSummaryDTO? Summary { get; set; }
+        public Exception? ThrowOnGetSummary { get; set; }
+
+        public IReadOnlyList<DividendHistoryItemDTO> GetDividendHistory(DividendLookupRequestDTO request) =>
+            Summary?.History ?? [];
+
+        public DividendSummaryDTO GetDividendSummary(DividendLookupRequestDTO request)
+        {
+            if (ThrowOnGetSummary is not null)
+                throw ThrowOnGetSummary;
+
+            return Summary ?? throw new InvalidOperationException("No summary configured.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `DividendCheckViewModel.Check()` called the dividend/asset-snapshot services with no error handling. An empty ticker (`ArgumentException`) or an unknown ticker (scraper throws `InvalidOperationException` when the expected page structure isn't found) propagated unhandled on the UI thread, crashing the whole WPF app since there's no global exception handler.
- The view model now validates the ticker before calling the service, wraps the lookup in a try/catch, and exposes an `ErrorMessage`/`HasError` pair. Previous results are cleared on failure so stale data isn't shown alongside the error.
- `DividendCheckView.xaml` now shows a red banner with the error message when `HasError` is true, using the existing app-wide `BoolToVisibilityConverter`.

## Test plan
- [x] Added `DividendCheckViewModelTests` covering: empty ticker, whitespace ticker, service throwing (invalid ticker), error clearing previous results, error clearing on next successful check, and the happy path.
- [x] `dotnet test` — full solution passes (Domain, Application, Infrastructure, Presentation, Api).