### PR TITLE
fix: show friendly error for invalid dividend ticker on web

### DIFF
--- a/Financial.Api/Controllers/DividendsController.cs
+++ b/Financial.Api/Controllers/DividendsController.cs
@@ -22,6 +22,7 @@ public sealed class DividendsController : ControllerBase
     [HttpGet("{ticker}/history")]
     [ProducesResponseType(typeof(IReadOnlyList<DividendHistoryItemDTO>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult<IReadOnlyList<DividendHistoryItemDTO>> GetDividendHistory(
         string ticker,
         [FromQuery] string? exchange = null)
@@ -32,13 +33,21 @@ public sealed class DividendsController : ControllerBase
         }
 
         var request = BuildRequest(ticker, exchange);
-        var history = _dividendService.GetDividendHistory(request);
-        return Ok(history);
+        try
+        {
+            var history = _dividendService.GetDividendHistory(request);
+            return Ok(history);
+        }
+        catch (Exception)
+        {
+            return DividendNotFound(ticker);
+        }
     }
 
     [HttpGet("{ticker}/summary")]
     [ProducesResponseType(typeof(DividendSummaryDTO), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult<DividendSummaryDTO> GetDividendSummary(
         string ticker,
         [FromQuery] string? exchange = null)
@@ -49,9 +58,22 @@ public sealed class DividendsController : ControllerBase
         }
 
         var request = BuildRequest(ticker, exchange);
-        var summary = _dividendService.GetDividendSummary(request);
-        return Ok(summary);
+        try
+        {
+            var summary = _dividendService.GetDividendSummary(request);
+            return Ok(summary);
+        }
+        catch (Exception)
+        {
+            return DividendNotFound(ticker);
+        }
     }
+
+    private ObjectResult DividendNotFound(string ticker) =>
+        Problem(
+            title: "Dividend data not found",
+            detail: $"Could not find dividend data for '{ticker.Trim().ToUpperInvariant()}'. Check the ticker and try again.",
+            statusCode: StatusCodes.Status404NotFound);
 
     private DividendLookupRequestDTO BuildRequest(string ticker, string? exchange)
     {

--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -19,6 +19,14 @@ const errorResponse = () =>
     json: async () => ({}),
   }) as Response
 
+const problemDetailsResponse = (detail: string) =>
+  ({
+    ok: false,
+    status: 404,
+    statusText: 'Not Found',
+    text: async () => JSON.stringify({ title: 'Dividend data not found', detail, status: 404 }),
+  }) as Response
+
 describe('financialApiClient', () => {
   it('calls navigation tree endpoint', async () => {
     const responseBody: TreeNodeDto = {
@@ -142,5 +150,19 @@ describe('financialApiClient', () => {
     })
 
     await expect(client.getNavigationTree()).rejects.toThrow('API request failed')
+  })
+
+  it('throws the problem-details "detail" message when the API returns one', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(problemDetailsResponse("Could not find dividend data for 'ASDF'. Check the ticker and try again."))
+    const client = createFinancialApiClient({
+      baseUrl: API_BASE_URL,
+      fetch: fetchMock,
+    })
+
+    await expect(client.getDividendSummary('ASDF', 'BVMF')).rejects.toThrow(
+      "Could not find dividend data for 'ASDF'. Check the ticker and try again.",
+    )
   })
 })

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -51,6 +51,32 @@ export interface FinancialApiClientOptions {
   fetch?: typeof fetch
 }
 
+interface ProblemDetailsBody {
+  detail?: string
+  title?: string
+}
+
+async function buildErrorMessage(response: Response, method: string, url: string): Promise<string> {
+  let body = ''
+  try {
+    body = await response.text()
+  } catch {
+    // Ignore response body failures; fall back to the generic message below.
+  }
+
+  if (body) {
+    try {
+      const problem = JSON.parse(body) as ProblemDetailsBody
+      if (problem.detail) return problem.detail
+      if (problem.title) return problem.title
+    } catch {
+      // Not a JSON problem-details body; fall through to the generic message.
+    }
+  }
+
+  return `API request failed: ${method} ${url} (${response.status} ${body || response.statusText})`
+}
+
 export function createFinancialApiClient(options: FinancialApiClientOptions = {}): FinancialApiClient {
   const baseUrl = options.baseUrl !== undefined
     ? options.baseUrl.replace(/\/$/, '')
@@ -73,17 +99,8 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
     })
 
     if (!response.ok) {
-      let errorDetail = response.statusText
-      try {
-        const body = await response.text()
-        if (body) {
-          errorDetail = body
-        }
-      } catch {
-        // Ignore response body failures; status text is enough.
-      }
       const method = init?.method ?? 'GET'
-      throw new Error(`API request failed: ${method} ${url} (${response.status} ${errorDetail})`)
+      throw new Error(await buildErrorMessage(response, method, url))
     }
 
     return (await response.json()) as T

--- a/Tests/Financial.Api.Tests/DividendEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/DividendEndpointsTests.cs
@@ -58,22 +58,55 @@ public class DividendEndpointsTests
             .Should().BeTrue("the frontend expects the property to be named 'averageDividendLastFiveYears'");
     }
 
-    private static WebApplicationFactory<Program> CreateFactory()
+    [Fact]
+    public async Task GetDividendSummary_WhenServiceThrows_ReturnsNotFoundWithFriendlyDetail()
+    {
+        await using var factory = CreateFactory(throwOnLookup: true);
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/financial/dividends/ASDF/summary?exchange=BVMF");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("detail").GetString().Should().Contain("ASDF");
+    }
+
+    [Fact]
+    public async Task GetDividendHistory_WhenServiceThrows_ReturnsNotFoundWithFriendlyDetail()
+    {
+        await using var factory = CreateFactory(throwOnLookup: true);
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/financial/dividends/ASDF/history?exchange=BVMF");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("detail").GetString().Should().Contain("ASDF");
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(bool throwOnLookup = false)
     {
         return new ApiTestFactory().WithWebHostBuilder(builder =>
         {
             builder.ConfigureServices(services =>
             {
                 services.RemoveAll<IDividendService>();
-                services.AddSingleton<IDividendService>(new DividendServiceStub());
+                services.AddSingleton<IDividendService>(new DividendServiceStub(throwOnLookup));
             });
         });
     }
 
-    private sealed class DividendServiceStub : IDividendService
+    private sealed class DividendServiceStub(bool throwOnLookup = false) : IDividendService
     {
         public IReadOnlyList<DividendHistoryItemDTO> GetDividendHistory(DividendLookupRequestDTO request)
         {
+            if (throwOnLookup)
+            {
+                throw new InvalidOperationException("Ticker not found.");
+            }
+
             return new[]
             {
                 new DividendHistoryItemDTO
@@ -87,6 +120,11 @@ public class DividendEndpointsTests
 
         public DividendSummaryDTO GetDividendSummary(DividendLookupRequestDTO request)
         {
+            if (throwOnLookup)
+            {
+                throw new InvalidOperationException("Ticker not found.");
+            }
+
             return new DividendSummaryDTO
             {
                 Exchange = request.Exchange,


### PR DESCRIPTION
## Summary
- `DividendsController` let exceptions from the dividend/asset-snapshot lookup (e.g. the scraper failing to find an unknown ticker's page) propagate to ASP.NET's generic exception handler, returning a bare 500 ProblemDetails with no useful message.
- The web API client (`financialApiClient.ts`) then dumped that raw response — method, URL, status, and JSON body — straight into the `DividendCheckPage` error banner, e.g. `API request failed: GET /api/v1/financial/dividends/ASDF/summary?exchange=BVMF (500 {"type":"...","title":"An error occurred...","status":500,"traceId":"..."})`.
- `DividendsController.GetDividendHistory`/`GetDividendSummary` now catch the lookup failure at the API boundary and return a 404 with a friendly `detail` message ("Could not find dividend data for 'ASDF'. Check the ticker and try again."), mirroring the WPF fix from #132.
- `financialApiClient`'s shared `request()` helper now parses ProblemDetails-shaped error bodies and surfaces the `detail` (or `title`) field as the thrown error message, instead of the raw dump. Falls back to the previous behavior for non-ProblemDetails errors, so unexpected failures elsewhere in the app still surface full debugging detail.
- Empty-ticker validation on the web was already handled client-side ("Ticker is required.") before this change — untouched.

## Test plan
- [x] Added `DividendEndpointsTests`: `GetDividendSummary_WhenServiceThrows_ReturnsNotFoundWithFriendlyDetail`, `GetDividendHistory_WhenServiceThrows_ReturnsNotFoundWithFriendlyDetail`.
- [x] Added `financialApiClient.test.ts`: throws the ProblemDetails `detail` message when the API returns one.
- [x] `dotnet test` — full solution passes (462+ tests).
- [x] `npm test -- --run` — all 349 frontend tests pass.
- [x] `npx tsc -b --noEmit` — no type errors.