### PR TITLE
feat: color the Active/Inactive circle green/red in front of asset name

### DIFF
--- a/Financial.App/App.xaml
+++ b/Financial.App/App.xaml
@@ -7,6 +7,7 @@
     <Application.Resources>
         <!-- Value Converters -->
         <converters:BoolToIconConverter x:Key="BoolToIconConverter"/>
+        <converters:BoolToActiveColorConverter x:Key="BoolToActiveColorConverter"/>
         <converters:DateFormatConverter x:Key="DateFormatConverter"/>
         <converters:TransactionTypeToColorConverter x:Key="TransactionTypeToColorConverter"/>
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>

--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -65,6 +65,7 @@
                         <StackPanel Orientation="Horizontal">
                             <!-- Icon for Asset nodes based on Active status -->
                             <TextBlock Text="{Binding Metadata[IsActive], Converter={StaticResource BoolToIconConverter}}"
+                                       Foreground="{Binding Metadata[IsActive], Converter={StaticResource BoolToActiveColorConverter}}"
                                        Visibility="{Binding NodeType, Converter={StaticResource NodeTypeToVisibilityConverter}}"
                                        Margin="0,0,5,0"
                                        FontSize="14"

--- a/Financial.App/Converters/BoolToActiveColorConverter.cs
+++ b/Financial.App/Converters/BoolToActiveColorConverter.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace Financial.Presentation.App.Converters;
+
+/// <summary>
+/// Converts boolean active status to a brush: green for active, red for inactive.
+/// </summary>
+public class BoolToActiveColorConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is true ? Brushes.Green : Brushes.Red;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/Financial.Web/src/components/InvestmentTree.css
+++ b/Financial.Web/src/components/InvestmentTree.css
@@ -86,6 +86,14 @@
   padding-left: 12px;
 }
 
+.investment-tree__status-icon--active {
+  color: #2e7d32;
+}
+
+.investment-tree__status-icon--inactive {
+  color: #c62828;
+}
+
 .investment-tree__node--broker {
   font-weight: 500;
 }

--- a/Financial.Web/src/components/InvestmentTree.tsx
+++ b/Financial.Web/src/components/InvestmentTree.tsx
@@ -78,7 +78,7 @@ function AssetNode({ node, brokerName, portfolioName, filterClass }: AssetNodePr
         onClick={handleClick}
         type="button"
       >
-        {prefix} {node.displayName}
+        <span className={`investment-tree__status-icon investment-tree__status-icon--${isActive ? 'active' : 'inactive'}`}>{prefix}</span> {node.displayName}
       </button>
     </li>
   )

--- a/Financial.Web/src/components/__tests__/InvestmentTree.test.tsx
+++ b/Financial.Web/src/components/__tests__/InvestmentTree.test.tsx
@@ -112,7 +112,7 @@ describe('InvestmentTree', () => {
     await screen.findByText('XPI (BRL)')
     const expandBtn = screen.getAllByLabelText('Expand')[0]
     fireEvent.click(expandBtn)
-    expect(screen.getByText('● KLBN4')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '● KLBN4' })).toBeInTheDocument()
   })
 
   it('renders inactive asset with empty circle prefix', async () => {
@@ -120,7 +120,16 @@ describe('InvestmentTree', () => {
     await screen.findByText('XPI (BRL)')
     const expandBtn = screen.getAllByLabelText('Expand')[0]
     fireEvent.click(expandBtn)
-    expect(screen.getByText('○ TRPL4')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '○ TRPL4' })).toBeInTheDocument()
+  })
+
+  it('renders active asset status icon in green and inactive in red', async () => {
+    renderTree()
+    await screen.findByText('XPI (BRL)')
+    const expandBtn = screen.getAllByLabelText('Expand')[0]
+    fireEvent.click(expandBtn)
+    expect(screen.getByText('●')).toHaveClass('investment-tree__status-icon--active')
+    expect(screen.getByText('○')).toHaveClass('investment-tree__status-icon--inactive')
   })
 
   it('clicking asset node sets selectedNode in context', async () => {
@@ -128,7 +137,7 @@ describe('InvestmentTree', () => {
     await screen.findByText('XPI (BRL)')
     const expandBtn = screen.getAllByLabelText('Expand')[0]
     fireEvent.click(expandBtn)
-    fireEvent.click(screen.getByText('● KLBN4'))
+    fireEvent.click(screen.getByRole('button', { name: '● KLBN4' }))
     expect(screen.getByTestId('selected').textContent).toBe('Asset:XPI:Acoes:KLBN4')
   })
 
@@ -168,8 +177,8 @@ describe('InvestmentTree', () => {
     fireEvent.click(expandBtn)
 
     fireEvent.change(screen.getByLabelText('Asset class'), { target: { value: '1' } })
-    expect(screen.getByText('● KLBN4')).toBeInTheDocument()
-    expect(screen.queryByText('● TREA3')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '● KLBN4' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '● TREA3' })).not.toBeInTheDocument()
   })
 
   it('asset class filter All restores full tree', async () => {
@@ -195,8 +204,8 @@ describe('InvestmentTree', () => {
 
     fireEvent.change(screen.getByLabelText('Asset class'), { target: { value: '1' } })
     fireEvent.change(screen.getByLabelText('Asset class'), { target: { value: 'all' } })
-    expect(screen.getByText('● KLBN4')).toBeInTheDocument()
-    expect(screen.getByText('● TREA3')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '● KLBN4' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '● TREA3' })).toBeInTheDocument()
   })
 
   it('broker node is retained in tree when filter is active', async () => {

--- a/Financial.Web/src/pages/__tests__/PortfolioNavigatorPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/PortfolioNavigatorPage.test.tsx
@@ -84,8 +84,8 @@ describe('PortfolioNavigatorPage', () => {
     renderPage()
     await screen.findByText('XPI (BRL)')
     fireEvent.click(screen.getAllByLabelText('Expand')[0])
-    fireEvent.click(screen.getByText('● KLBN4'))
-    expect(screen.getByText('KLBN4')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '● KLBN4' }))
+    expect(screen.getByText('KLBN4', { selector: '.detail-panel__name' })).toBeInTheDocument()
     expect(screen.getByText('KLBN4 · BVMF · XPI · Acoes')).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary
- The tree's circle prefix (filled ● for active, hollow ○ for inactive) rendered in the default text color on both WPF and Web, making the active/inactive distinction easy to miss.
- WPF: adds `BoolToActiveColorConverter`, bound to the tree item's `Foreground` alongside the existing icon binding.
- Web: wraps the circle prefix in a `<span>` with an active/inactive modifier class, styled green/red in `InvestmentTree.css` (reusing the same hex values already used for profit/loss coloring in `PortfolioSummaryTab`).

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test Financial.slnx` all pass (461 tests, 3 pre-existing skips)
- [x] `npm test` all pass (347/347), including updated assertions where wrapping the circle in a span changed how Testing Library reads the button's text
- [x] `npx tsc -b --noEmit` clean
- [x] Manually confirm the circle renders green for active assets and red for inactive assets in both apps