### PR TITLE
feat: arrange per-portfolio breakdown pie charts two per row

### DIFF
--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -387,14 +387,19 @@
                                         <oxy:PlotView Model="{Binding AssetDetails.OverallBreakdownPlotModel}" Height="260" Background="Transparent"/>
                                     </StackPanel>
 
-                                    <!-- Row 6: Per-portfolio asset breakdown pies -->
+                                    <!-- Row 6: Per-portfolio asset breakdown pies, two per row -->
                                     <ItemsControl Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="4"
                                                   Margin="0,15,0,0"
                                                   ItemsSource="{Binding AssetDetails.PortfolioBreakdownPieItems}"
                                                   Visibility="{Binding AssetDetails.HasBreakdownData, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <UniformGrid Columns="2"/>
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <StackPanel Margin="0,0,0,15">
+                                                <StackPanel Margin="0,0,15,15">
                                                     <TextBlock Text="{Binding PortfolioName}" FontWeight="Bold" Margin="0,0,0,5"/>
                                                     <oxy:PlotView Model="{Binding PlotModel}" Height="260" Background="Transparent"/>
                                                 </StackPanel>

--- a/Financial.Web/src/components/BrokerBreakdownCharts.css
+++ b/Financial.Web/src/components/BrokerBreakdownCharts.css
@@ -5,6 +5,12 @@
   margin-top: 24px;
 }
 
+.broker-breakdown__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+}
+
 .broker-breakdown__chart-title {
   font-size: 13px;
   font-weight: 600;

--- a/Financial.Web/src/components/BrokerBreakdownCharts.tsx
+++ b/Financial.Web/src/components/BrokerBreakdownCharts.tsx
@@ -122,15 +122,17 @@ export default function BrokerBreakdownCharts() {
   return (
     <div className="broker-breakdown">
       <BreakdownPie title="Portfolio Breakdown" data={portfolioData} />
-      {breakdown.map((portfolio) => (
-        <BreakdownPie
-          key={portfolio.portfolioName}
-          title={portfolio.portfolioName}
-          data={buildPieSliceData(
-            portfolio.assets.map((asset) => ({ name: asset.assetName, value: asset.totalInvested })),
-          )}
-        />
-      ))}
+      <div className="broker-breakdown__grid">
+        {breakdown.map((portfolio) => (
+          <BreakdownPie
+            key={portfolio.portfolioName}
+            title={portfolio.portfolioName}
+            data={buildPieSliceData(
+              portfolio.assets.map((asset) => ({ name: asset.assetName, value: asset.totalInvested })),
+            )}
+          />
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- The per-portfolio asset breakdown pies (shown under a Broker/aggregate node selection, one pie per portfolio) each stretched to fill the full available width, one per row — wasteful for a chart that doesn't need that much space.
- The single overall "Portfolio Breakdown" pie is untouched (it's a distinct chart, not part of this list).
- WPF: the per-portfolio `ItemsControl` now uses a `UniformGrid Columns="2"` as its `ItemsPanel` instead of the default vertical `StackPanel`.
- Web: the per-portfolio pies now render inside their own `.broker-breakdown__grid` (CSS grid, 2 columns), separate from the overall pie above it.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test Financial.slnx` all pass (461 tests, 3 pre-existing skips)
- [x] `npm test` all pass (347/347)
- [x] `npx tsc -b --noEmit` clean
- [x] Manually confirm the per-portfolio pies render two per row on both WPF and Web, and the overall pie stays full-width