### PR TITLE
feat: allow resizing Portfolio Summary columns again

### DIFF
--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:oxy="http://oxyplot.org/wpf"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:vm="clr-namespace:Financial.Presentation.App.ViewModels"
              mc:Ignorable="d"
              d:DesignHeight="700" d:DesignWidth="1200">
     <Grid>
@@ -411,22 +412,7 @@
                         </DataTemplate>
                         <DataTemplate x:Key="PortfolioSummaryTemplate">
                             <DataTemplate.Resources>
-                                <sys:Double x:Key="ColW_AssetName">160</sys:Double>
-                                <sys:Double x:Key="ColW_FirstInvestment">110</sys:Double>
-                                <sys:Double x:Key="ColW_Quantity">110</sys:Double>
-                                <sys:Double x:Key="ColW_TotalInvested">110</sys:Double>
-                                <sys:Double x:Key="ColW_PortfolioWeight">90</sys:Double>
-                                <sys:Double x:Key="ColW_TotalCredits">100</sys:Double>
-                                <sys:Double x:Key="ColW_CurrentValue">100</sys:Double>
-                                <sys:Double x:Key="ColW_AveragePrice">100</sys:Double>
-                                <sys:Double x:Key="ColW_Profit">70</sys:Double>
-                                <sys:Double x:Key="ColW_ProfitWithCredits">110</sys:Double>
-                                <sys:Double x:Key="ColW_Xirr">70</sys:Double>
-                                <sys:Double x:Key="ColW_LastMonthCredits">100</sys:Double>
-                                <sys:Double x:Key="ColW_LastCreditMonth">90</sys:Double>
-                                <sys:Double x:Key="ColW_LastMonthPercent">70</sys:Double>
-                                <sys:Double x:Key="ColW_EstAnnualCredits">100</sys:Double>
-                                <sys:Double x:Key="ColW_EstAnnualPercent">70</sys:Double>
+                                <vm:PortfolioSummaryColumnWidths x:Key="ColWidths"/>
                             </DataTemplate.Resources>
                             <Grid Margin="10">
                                 <Grid.RowDefinitions>
@@ -463,22 +449,22 @@
                                         <!-- Group title bar: merges related columns under one spanning header -->
                                         <Grid Grid.Row="0">
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_AssetName}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_FirstInvestment}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_Quantity}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_TotalInvested}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_PortfolioWeight}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_TotalCredits}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_CurrentValue}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_AveragePrice}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_Profit}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_ProfitWithCredits}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_Xirr}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_LastMonthCredits}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_LastCreditMonth}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_LastMonthPercent}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_EstAnnualCredits}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColW_EstAnnualPercent}, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=AssetName, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=FirstInvestment, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=Quantity, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=TotalInvested, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=PortfolioWeight, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=TotalCredits, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=CurrentValue, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=AveragePrice, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=Profit, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=ProfitWithCredits, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=Xirr, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=LastMonthCredits, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=LastCreditMonth, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=LastMonthPercent, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=EstAnnualCredits, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=EstAnnualPercent, Converter={StaticResource DoubleToGridLengthConverter}}"/>
                                             </Grid.ColumnDefinitions>
 
                                             <Border Grid.Column="0" Style="{StaticResource GroupHeaderBarStyle}"/>
@@ -505,41 +491,40 @@
                                                   ItemsSource="{Binding AssetDetails.PortfolioAssetSummaryRows}"
                                                   AutoGenerateColumns="False"
                                                   CanUserAddRows="False"
-                                                  CanUserResizeColumns="False"
                                                   IsReadOnly="True"
                                                   ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                                             <DataGrid.Columns>
-                                                <DataGridTextColumn Header="Asset Name" Binding="{Binding AssetName}" Width="{Binding Source={StaticResource ColW_AssetName}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="Asset Name" Binding="{Binding AssetName}" Width="{Binding Source={StaticResource ColWidths}, Path=AssetName, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource PlainColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTextColumn Header="First Investment" Binding="{Binding DisplayFirstInvestmentDate}" Width="{Binding Source={StaticResource ColW_FirstInvestment}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="First Investment" Binding="{Binding DisplayFirstInvestmentDate}" Width="{Binding Source={StaticResource ColWidths}, Path=FirstInvestment, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource PlainColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTextColumn Header="Quantity" Binding="{Binding DisplayCurrentQuantity}" Width="{Binding Source={StaticResource ColW_Quantity}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="Quantity" Binding="{Binding DisplayCurrentQuantity}" Width="{Binding Source={StaticResource ColWidths}, Path=Quantity, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTextColumn Header="Total Invested" Binding="{Binding DisplayTotalInvested}" Width="{Binding Source={StaticResource ColW_TotalInvested}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="Total Invested" Binding="{Binding DisplayTotalInvested}" Width="{Binding Source={StaticResource ColWidths}, Path=TotalInvested, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTextColumn Header="% Portfolio" Binding="{Binding DisplayPortfolioWeight}" Width="{Binding Source={StaticResource ColW_PortfolioWeight}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="% Portfolio" Binding="{Binding DisplayPortfolioWeight}" Width="{Binding Source={StaticResource ColWidths}, Path=PortfolioWeight, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTextColumn Header="Total Credits" Binding="{Binding DisplayTotalCredits}" Width="{Binding Source={StaticResource ColW_TotalCredits}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="Total Credits" Binding="{Binding DisplayTotalCredits}" Width="{Binding Source={StaticResource ColWidths}, Path=TotalCredits, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTemplateColumn Header="Current Value" Width="{Binding Source={StaticResource ColW_CurrentValue}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTemplateColumn Header="Current Value" Width="{Binding Source={StaticResource ColWidths}, Path=CurrentValue, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTemplateColumn.CellTemplate>
                                                         <DataTemplate>
                                                             <TextBlock TextAlignment="Right" Padding="8" VerticalAlignment="Center">
@@ -557,12 +542,12 @@
                                                         </DataTemplate>
                                                     </DataGridTemplateColumn.CellTemplate>
                                                 </DataGridTemplateColumn>
-                                                <DataGridTextColumn Header="Average Price" Binding="{Binding DisplayAveragePrice}" Width="{Binding Source={StaticResource ColW_AveragePrice}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="Average Price" Binding="{Binding DisplayAveragePrice}" Width="{Binding Source={StaticResource ColWidths}, Path=AveragePrice, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTemplateColumn Header="%" Width="{Binding Source={StaticResource ColW_Profit}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTemplateColumn Header="%" Width="{Binding Source={StaticResource ColWidths}, Path=Profit, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTemplateColumn.CellTemplate>
                                                         <DataTemplate>
                                                             <TextBlock TextAlignment="Right" Padding="8" VerticalAlignment="Center">
@@ -586,7 +571,7 @@
                                                         </DataTemplate>
                                                     </DataGridTemplateColumn.CellTemplate>
                                                 </DataGridTemplateColumn>
-                                                <DataGridTemplateColumn Header="w/ Credits" Width="{Binding Source={StaticResource ColW_ProfitWithCredits}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTemplateColumn Header="w/ Credits" Width="{Binding Source={StaticResource ColWidths}, Path=ProfitWithCredits, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTemplateColumn.CellTemplate>
                                                         <DataTemplate>
                                                             <TextBlock TextAlignment="Right" Padding="8" VerticalAlignment="Center">
@@ -610,7 +595,7 @@
                                                         </DataTemplate>
                                                     </DataGridTemplateColumn.CellTemplate>
                                                 </DataGridTemplateColumn>
-                                                <DataGridTemplateColumn Header="XIRR" Width="{Binding Source={StaticResource ColW_Xirr}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTemplateColumn Header="XIRR" Width="{Binding Source={StaticResource ColWidths}, Path=Xirr, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTemplateColumn.CellTemplate>
                                                         <DataTemplate>
                                                             <TextBlock TextAlignment="Right" Padding="8" VerticalAlignment="Center">
@@ -634,7 +619,7 @@
                                                         </DataTemplate>
                                                     </DataGridTemplateColumn.CellTemplate>
                                                 </DataGridTemplateColumn>
-                                                <DataGridTextColumn Header="Credits" Binding="{Binding DisplayLastMonthCredits}" Width="{Binding Source={StaticResource ColW_LastMonthCredits}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="Credits" Binding="{Binding DisplayLastMonthCredits}" Width="{Binding Source={StaticResource ColWidths}, Path=LastMonthCredits, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.CellStyle>
                                                         <Style TargetType="DataGridCell">
                                                             <Setter Property="BorderThickness" Value="3,0,0,0"/>
@@ -651,22 +636,22 @@
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTextColumn Header="Month" Binding="{Binding LastCreditMonthDisplay}" Width="{Binding Source={StaticResource ColW_LastCreditMonth}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="Month" Binding="{Binding LastCreditMonthDisplay}" Width="{Binding Source={StaticResource ColWidths}, Path=LastCreditMonth, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTextColumn Header="%" Binding="{Binding DisplayLastMonthCreditsPercent}" Width="{Binding Source={StaticResource ColW_LastMonthPercent}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="%" Binding="{Binding DisplayLastMonthCreditsPercent}" Width="{Binding Source={StaticResource ColWidths}, Path=LastMonthPercent, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTextColumn Header="Credits" Binding="{Binding DisplayEstimatedAnnualCredits}" Width="{Binding Source={StaticResource ColW_EstAnnualCredits}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="Credits" Binding="{Binding DisplayEstimatedAnnualCredits}" Width="{Binding Source={StaticResource ColWidths}, Path=EstAnnualCredits, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTextColumn Header="%" Binding="{Binding DisplayEstimatedAnnualPercent}" Width="{Binding Source={StaticResource ColW_EstAnnualPercent}, Converter={StaticResource DoubleToDataGridLengthConverter}}">
+                                                <DataGridTextColumn Header="%" Binding="{Binding DisplayEstimatedAnnualPercent}" Width="{Binding Source={StaticResource ColWidths}, Path=EstAnnualPercent, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>

--- a/Financial.App/Converters/DoubleToDataGridLengthConverter.cs
+++ b/Financial.App/Converters/DoubleToDataGridLengthConverter.cs
@@ -6,7 +6,10 @@ namespace Financial.Presentation.App.Converters;
 
 /// <summary>
 /// Converts a pixel-width double resource into a DataGridLength for DataGridColumn.Width,
-/// which does not accept a raw double via StaticResource.
+/// which does not accept a raw double via StaticResource. Supports TwoWay so resizing a
+/// column (which sets Width to a new pixel-mode DataGridLength) writes the new pixel value
+/// back to the shared source, keeping any other bound consumer (e.g. a group-header overlay)
+/// in sync.
 /// </summary>
 public class DoubleToDataGridLengthConverter : IValueConverter
 {
@@ -17,6 +20,6 @@ public class DoubleToDataGridLengthConverter : IValueConverter
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotSupportedException();
+        return value is DataGridLength length ? length.Value : Binding.DoNothing;
     }
 }

--- a/Financial.App/ViewModels/PortfolioSummaryColumnWidths.cs
+++ b/Financial.App/ViewModels/PortfolioSummaryColumnWidths.cs
@@ -1,0 +1,43 @@
+namespace Financial.Presentation.App.ViewModels;
+
+/// <summary>
+/// Shared pixel widths for the Portfolio Summary grid's columns, bound TwoWay from the
+/// DataGrid's own columns (so user resizing updates them) and OneWay into the group-header
+/// overlay bar's ColumnDefinitions (so the overlay stays aligned with the resized columns).
+/// </summary>
+public class PortfolioSummaryColumnWidths : ViewModelBase
+{
+    private double _assetName = 160;
+    private double _firstInvestment = 110;
+    private double _quantity = 110;
+    private double _totalInvested = 110;
+    private double _portfolioWeight = 90;
+    private double _totalCredits = 100;
+    private double _currentValue = 100;
+    private double _averagePrice = 100;
+    private double _profit = 70;
+    private double _profitWithCredits = 110;
+    private double _xirr = 70;
+    private double _lastMonthCredits = 100;
+    private double _lastCreditMonth = 90;
+    private double _lastMonthPercent = 70;
+    private double _estAnnualCredits = 100;
+    private double _estAnnualPercent = 70;
+
+    public double AssetName { get => _assetName; set => SetProperty(ref _assetName, value); }
+    public double FirstInvestment { get => _firstInvestment; set => SetProperty(ref _firstInvestment, value); }
+    public double Quantity { get => _quantity; set => SetProperty(ref _quantity, value); }
+    public double TotalInvested { get => _totalInvested; set => SetProperty(ref _totalInvested, value); }
+    public double PortfolioWeight { get => _portfolioWeight; set => SetProperty(ref _portfolioWeight, value); }
+    public double TotalCredits { get => _totalCredits; set => SetProperty(ref _totalCredits, value); }
+    public double CurrentValue { get => _currentValue; set => SetProperty(ref _currentValue, value); }
+    public double AveragePrice { get => _averagePrice; set => SetProperty(ref _averagePrice, value); }
+    public double Profit { get => _profit; set => SetProperty(ref _profit, value); }
+    public double ProfitWithCredits { get => _profitWithCredits; set => SetProperty(ref _profitWithCredits, value); }
+    public double Xirr { get => _xirr; set => SetProperty(ref _xirr, value); }
+    public double LastMonthCredits { get => _lastMonthCredits; set => SetProperty(ref _lastMonthCredits, value); }
+    public double LastCreditMonth { get => _lastCreditMonth; set => SetProperty(ref _lastCreditMonth, value); }
+    public double LastMonthPercent { get => _lastMonthPercent; set => SetProperty(ref _lastMonthPercent, value); }
+    public double EstAnnualCredits { get => _estAnnualCredits; set => SetProperty(ref _estAnnualCredits, value); }
+    public double EstAnnualPercent { get => _estAnnualPercent; set => SetProperty(ref _estAnnualPercent, value); }
+}


### PR DESCRIPTION
## Summary
- Column resize on the Portfolio Summary grid was disabled when the group-header overlay bar was added (#136), because the overlay's `Grid.ColumnDefinitions` and the `DataGrid`'s own columns were two independent, unsynced width sources — resizing one would silently desync the overlay from the actual columns.
- Replaces the 16 static per-column width resources with one shared `PortfolioSummaryColumnWidths` object. Each `DataGridColumn.Width` now binds `TwoWay` into it; the overlay's `ColumnDefinition.Width` binds `OneWay` to the same property. Resizing a column now flows through the shared source and keeps the overlay aligned automatically — no extra sync code needed.
- `DoubleToDataGridLengthConverter.ConvertBack` (previously a stub) now actually converts the resized `DataGridLength` back to a `double`, which is what makes the `TwoWay` binding work.
- `CanUserResizeColumns` is no longer disabled.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test Financial.slnx` all pass (461 tests, 3 pre-existing skips)
- [x] Manually confirm dragging a column's edge resizes it and the group-header bar above stays aligned