### PR TITLE
feat(P07-F04): Cryptocurrency filter — Web frontend

### DIFF
--- a/Financial.Web/src/components/InvestmentTree.tsx
+++ b/Financial.Web/src/components/InvestmentTree.tsx
@@ -15,6 +15,7 @@ const ASSET_CLASS_OPTIONS: { value: number; label: string }[] = [
   { value: 6, label: 'Cash' },
   { value: 7, label: 'Pension' },
   { value: 8, label: 'Other' },
+  { value: 9, label: 'Cryptocurrency' },
 ]
 
 const ALL_CLASSES = 'all'

--- a/Financial.Web/src/components/__tests__/InvestmentTree.test.tsx
+++ b/Financial.Web/src/components/__tests__/InvestmentTree.test.tsx
@@ -208,6 +208,39 @@ describe('InvestmentTree', () => {
     expect(screen.getByRole('button', { name: '● TREA3' })).toBeInTheDocument()
   })
 
+  it('asset class filter shows Cryptocurrency option', async () => {
+    renderTree()
+    await screen.findByText('XPI (BRL)')
+    const option = screen.getByRole('option', { name: 'Cryptocurrency' }) as HTMLOptionElement
+    expect(option.value).toBe('9')
+  })
+
+  it('asset class filter hides non-matching assets when Cryptocurrency selected', async () => {
+    const tree: TreeNodeDto = {
+      nodeType: 'Investments',
+      displayName: 'Investments',
+      metadata: {},
+      children: [
+        makeBroker('Coinbase', 'GBP', [
+          makePortfolio('Cryptocurrency', [makeAsset('BTC', true, 9), makeAsset('TREA3', true, 3)]),
+        ]),
+      ],
+    }
+    getNavigationTreeMock.mockResolvedValue(tree)
+    render(
+      <SelectedNodeProvider>
+        <InvestmentTree />
+      </SelectedNodeProvider>,
+    )
+    await screen.findByText('Coinbase (GBP)')
+    const expandBtn = screen.getAllByLabelText('Expand')[0]
+    fireEvent.click(expandBtn)
+
+    fireEvent.change(screen.getByLabelText('Asset class'), { target: { value: '9' } })
+    expect(screen.getByRole('button', { name: '● BTC' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '● TREA3' })).not.toBeInTheDocument()
+  })
+
   it('broker node is retained in tree when filter is active', async () => {
     renderTree()
     await screen.findByText('XPI (BRL)')

--- a/docs/P07-F04-cryptocurrency-filter-web-frontend/plan.md
+++ b/docs/P07-F04-cryptocurrency-filter-web-frontend/plan.md
@@ -1,0 +1,11 @@
+# Implementation Plan: Cryptocurrency Filter — Web Frontend
+
+**Prerequisites:**
+- Node/npm toolchain already configured for `Financial.Web` (Vite, Vitest, ESLint)
+- No new dependencies
+
+### Stage 1: Asset Class Filter
+
+**1. Cryptocurrency Filter Option** - Add a new "Cryptocurrency" entry to the Investment Tree's asset-class filter options, appended after the existing 8 entries, using the value already assigned to it on the backend.
+
+**2. Filter Test Coverage** - Extend the Investment Tree's existing test suite with coverage confirming the new option renders in the dropdown and correctly filters the tree to only cryptocurrency assets, following the same pattern as the suite's existing asset-class filter tests.

--- a/docs/P07-F04-cryptocurrency-filter-web-frontend/spec.md
+++ b/docs/P07-F04-cryptocurrency-filter-web-frontend/spec.md
@@ -1,0 +1,53 @@
+## Technical Overview
+
+**What:** Add "Cryptocurrency" (value `9`) as a new option in the Web Investment Tree's "Asset class" filter dropdown.
+
+**Why:** F01 (merged) added `GlobalAssetClass.Cryptocurrency` (int value `9`) to the backend domain enum. The Web frontend's asset-class filter is a hardcoded literal array with no central TypeScript enum mirroring the backend — it simply needs the one new entry to let users filter the Investment Tree down to cryptocurrency holdings.
+
+**Scope:**
+- Included: one new entry in the `ASSET_CLASS_OPTIONS` array; a test case covering it.
+- Excluded: any icon/color system (none exists for asset classes today — the only per-node visual cue is the unrelated active/inactive status icon); any shared TypeScript enum/type for `GlobalAssetClass` (none exists — the value is read ad hoc at runtime via `getMetaNumber(node.metadata, 'GlobalAssetClass')`, not modeled as a typed enum on the frontend, and introducing one now is out of scope for this single-entry addition).
+- Consumes (per PRD): `GlobalAssetClass.Cryptocurrency` and its underlying integer value (`9`), provided by F01.
+
+## Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/components/InvestmentTree.tsx` — the `ASSET_CLASS_OPTIONS` literal array and its consuming `<select>` dropdown (lines 9-18, 244-261)
+
+No other component is affected — filtering logic (`String(assetClass) !== filterClass` at the `AssetNode`/`PortfolioNode`/`BrokerNode` levels) is entirely generic over the numeric value and requires no change to support a 9th option.
+
+## Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Where to add the new value | Append `{ value: 9, label: 'Cryptocurrency' }` as the last entry in the existing `ASSET_CLASS_OPTIONS` array, matching backend enum declaration order | Insert alphabetically among existing labels | Matches the existing array's ordering convention (declaration order, not alphabetical — e.g. "Real Estate" isn't alphabetically placed today) and the PRD's explicit instruction to add it "alongside the existing 8 options" |
+
+## Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/components/InvestmentTree.tsx` | Modified | Investment Tree asset-class filter | Add `{ value: 9, label: 'Cryptocurrency' }` to `ASSET_CLASS_OPTIONS`; no other code path changes since filtering is generic over the numeric value |
+
+## Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/components/__tests__/InvestmentTree.test.tsx` | Unit/Component | `ASSET_CLASS_OPTIONS` dropdown + filtering | Cryptocurrency option renders and filters correctly |
+
+**Test functions:**
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `asset class filter shows Cryptocurrency option` | Renders the tree, opens the "Asset class" dropdown | The `<select>` contains an `<option>` with value `"9"` and label `"Cryptocurrency"` |
+| `asset class filter hides non-matching assets when Cryptocurrency selected` | Builds a tree with a mix of assets including one `makeAsset('BTC', true, 9)`, fires `fireEvent.change` on the filter with value `'9'` | Only the Cryptocurrency asset (BTC) remains visible; other assets are hidden, following the exact pattern of the existing "asset class filter hides non-matching assets" test |
+
+**Acceptance criteria traceability (PRD Section 9, F04):**
+- "The Web asset-class filter dropdown includes a 'Cryptocurrency' option with value 9" → `asset class filter shows Cryptocurrency option`
+- "Selecting 'Cryptocurrency' filters the investment tree to show only assets with Class = Cryptocurrency" → `asset class filter hides non-matching assets when Cryptocurrency selected`
+- "The 8 pre-existing filter options remain unchanged in label, value, and order" → verified by the existing, unmodified tests in `InvestmentTree.test.tsx` continuing to pass (no existing test assertions are changed by this feature)
+
+**Cross-Feature Integration (PRD Section 9):** F04 has no Consumes/Provides relationships beyond F01 (already merged); no new integration criteria apply.


### PR DESCRIPTION
## Summary
- Adds "Cryptocurrency" (value `9`) as a new option in the Web Investment Tree's "Asset class" filter dropdown, matching the `GlobalAssetClass.Cryptocurrency` value added to the backend in F01
- No other code path changes needed — filtering logic is already generic over the numeric class value

This is F04 of the Cryptocurrency Asset Type PRD (`docs/prd/P07-prd-cryptocurrency-asset-type/`), building on F01–F03 (merged, #142–#144).

Spec/plan: `docs/P07-F04-cryptocurrency-filter-web-frontend/`

## Acceptance Criteria (PRD Section 9, F04)
- [x] Web asset-class filter dropdown includes a "Cryptocurrency" option with value 9 — covered by `asset class filter shows Cryptocurrency option`
- [x] Selecting "Cryptocurrency" filters the investment tree to show only assets with Class = Cryptocurrency — covered by `asset class filter hides non-matching assets when Cryptocurrency selected`
- [x] The 8 pre-existing filter options remain unchanged in label, value, and order — verified by all existing filter tests passing unmodified

## Test plan
- [x] `tsc -b --noEmit` — clean
- [x] `eslint .` — clean
- [x] `vitest run` — 349/349 tests pass (2 new)
- [x] Dev server smoke test: confirmed the change is live in the served bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)