### PR TITLE
feat: Reorder Portfolio Summary columns and add Current Price

### DIFF
--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -452,11 +452,12 @@
                                                 <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=AssetName, Converter={StaticResource DoubleToGridLengthConverter}}"/>
                                                 <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=FirstInvestment, Converter={StaticResource DoubleToGridLengthConverter}}"/>
                                                 <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=Quantity, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=TotalInvested, Converter={StaticResource DoubleToGridLengthConverter}}"/>
                                                 <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=PortfolioWeight, Converter={StaticResource DoubleToGridLengthConverter}}"/>
-                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=TotalCredits, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=TotalInvested, Converter={StaticResource DoubleToGridLengthConverter}}"/>
                                                 <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=CurrentValue, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=TotalCredits, Converter={StaticResource DoubleToGridLengthConverter}}"/>
                                                 <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=AveragePrice, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=CurrentPrice, Converter={StaticResource DoubleToGridLengthConverter}}"/>
                                                 <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=Profit, Converter={StaticResource DoubleToGridLengthConverter}}"/>
                                                 <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=ProfitWithCredits, Converter={StaticResource DoubleToGridLengthConverter}}"/>
                                                 <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=Xirr, Converter={StaticResource DoubleToGridLengthConverter}}"/>
@@ -475,14 +476,15 @@
                                             <Border Grid.Column="5" Style="{StaticResource GroupHeaderBarStyle}"/>
                                             <Border Grid.Column="6" Style="{StaticResource GroupHeaderBarStyle}"/>
                                             <Border Grid.Column="7" Style="{StaticResource GroupHeaderBarStyle}"/>
-                                            <Border Grid.Column="8" Grid.ColumnSpan="2" Style="{StaticResource GroupHeaderBarStyle}">
+                                            <Border Grid.Column="8" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="9" Grid.ColumnSpan="2" Style="{StaticResource GroupHeaderBarStyle}">
                                                 <TextBlock Text="Profit" Style="{StaticResource GroupHeaderTitleTextStyle}"/>
                                             </Border>
-                                            <Border Grid.Column="10" Style="{StaticResource GroupHeaderBarStyle}"/>
-                                            <Border Grid.Column="11" Grid.ColumnSpan="3" Style="{StaticResource GroupHeaderBarStyle}" BorderThickness="3,0,1,1" BorderBrush="#007ACC">
+                                            <Border Grid.Column="11" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="12" Grid.ColumnSpan="3" Style="{StaticResource GroupHeaderBarStyle}" BorderThickness="3,0,1,1" BorderBrush="#007ACC">
                                                 <TextBlock Text="Last Month" Style="{StaticResource GroupHeaderTitleTextStyle}"/>
                                             </Border>
-                                            <Border Grid.Column="14" Grid.ColumnSpan="2" Style="{StaticResource GroupHeaderBarStyle}">
+                                            <Border Grid.Column="15" Grid.ColumnSpan="2" Style="{StaticResource GroupHeaderBarStyle}">
                                                 <TextBlock Text="Est. Annual" Style="{StaticResource GroupHeaderTitleTextStyle}"/>
                                             </Border>
                                         </Grid>
@@ -509,17 +511,12 @@
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTextColumn Header="Total Invested" Binding="{Binding DisplayTotalInvested}" Width="{Binding Source={StaticResource ColWidths}, Path=TotalInvested, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
-                                                    <DataGridTextColumn.ElementStyle>
-                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
-                                                    </DataGridTextColumn.ElementStyle>
-                                                </DataGridTextColumn>
                                                 <DataGridTextColumn Header="% Portfolio" Binding="{Binding DisplayPortfolioWeight}" Width="{Binding Source={StaticResource ColWidths}, Path=PortfolioWeight, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
-                                                <DataGridTextColumn Header="Total Credits" Binding="{Binding DisplayTotalCredits}" Width="{Binding Source={StaticResource ColWidths}, Path=TotalCredits, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                <DataGridTextColumn Header="Total Invested" Binding="{Binding DisplayTotalInvested}" Width="{Binding Source={StaticResource ColWidths}, Path=TotalInvested, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
@@ -542,11 +539,34 @@
                                                         </DataTemplate>
                                                     </DataGridTemplateColumn.CellTemplate>
                                                 </DataGridTemplateColumn>
+                                                <DataGridTextColumn Header="Total Credits" Binding="{Binding DisplayTotalCredits}" Width="{Binding Source={StaticResource ColWidths}, Path=TotalCredits, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
                                                 <DataGridTextColumn Header="Average Price" Binding="{Binding DisplayAveragePrice}" Width="{Binding Source={StaticResource ColWidths}, Path=AveragePrice, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
+                                                <DataGridTemplateColumn Header="Current Price" Width="{Binding Source={StaticResource ColWidths}, Path=CurrentPrice, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTemplateColumn.CellTemplate>
+                                                        <DataTemplate>
+                                                            <TextBlock TextAlignment="Right" Padding="8" VerticalAlignment="Center">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Setter Property="Text" Value="{Binding DisplayCurrentPrice}"/>
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding IsLoadingPrice}" Value="True">
+                                                                                <Setter Property="Text" Value="..."/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                        </DataTemplate>
+                                                    </DataGridTemplateColumn.CellTemplate>
+                                                </DataGridTemplateColumn>
                                                 <DataGridTemplateColumn Header="%" Width="{Binding Source={StaticResource ColWidths}, Path=Profit, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
                                                     <DataGridTemplateColumn.CellTemplate>
                                                         <DataTemplate>

--- a/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
+++ b/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
@@ -11,6 +11,7 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
 
     private bool _isLoadingPrice = true;
     private bool _priceFetchFailed;
+    private decimal? _currentPrice;
     private decimal? _currentValue;
     private decimal? _profitPercent;
     private decimal? _profitWithCreditsPercent;
@@ -36,6 +37,7 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
 
     public bool IsLoadingPrice => _isLoadingPrice;
     public bool PriceFetchFailed => _priceFetchFailed;
+    public decimal? CurrentPrice => _currentPrice;
     public decimal? CurrentValue => _currentValue;
     public decimal? ProfitPercent => _profitPercent;
     public decimal? ProfitWithCreditsPercent => _profitWithCreditsPercent;
@@ -70,6 +72,9 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
 
     public string DisplayCurrentValue =>
         _isLoadingPrice || _priceFetchFailed ? "—" : _currentValue?.ToString("N2") ?? "—";
+
+    public string DisplayCurrentPrice =>
+        _isLoadingPrice || _priceFetchFailed ? "—" : _currentPrice?.ToString("N2") ?? "—";
 
     public string DisplayProfitPercent =>
         _isLoadingPrice || _priceFetchFailed || !_profitPercent.HasValue ? "—" : $"{_profitPercent.Value:F2}%";
@@ -110,6 +115,7 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
 
     public void ApplyPrice(decimal price)
     {
+        _currentPrice = price;
         _currentValue = price * CurrentQuantity;
 
         _profitPercent = TotalInvested != 0
@@ -124,6 +130,8 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
         _isLoadingPrice = false;
 
         OnPropertyChanged(nameof(IsLoadingPrice));
+        OnPropertyChanged(nameof(CurrentPrice));
+        OnPropertyChanged(nameof(DisplayCurrentPrice));
         OnPropertyChanged(nameof(CurrentValue));
         OnPropertyChanged(nameof(DisplayCurrentValue));
         OnPropertyChanged(nameof(ProfitPercent));
@@ -147,6 +155,7 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
 
         OnPropertyChanged(nameof(IsLoadingPrice));
         OnPropertyChanged(nameof(PriceFetchFailed));
+        OnPropertyChanged(nameof(DisplayCurrentPrice));
         OnPropertyChanged(nameof(DisplayCurrentValue));
         OnPropertyChanged(nameof(DisplayProfitPercent));
         OnPropertyChanged(nameof(DisplayProfitWithCreditsPercent));

--- a/Financial.App/ViewModels/PortfolioSummaryColumnWidths.cs
+++ b/Financial.App/ViewModels/PortfolioSummaryColumnWidths.cs
@@ -15,6 +15,7 @@ public class PortfolioSummaryColumnWidths : ViewModelBase
     private double _totalCredits = 100;
     private double _currentValue = 100;
     private double _averagePrice = 100;
+    private double _currentPrice = 100;
     private double _profit = 70;
     private double _profitWithCredits = 110;
     private double _xirr = 70;
@@ -32,6 +33,7 @@ public class PortfolioSummaryColumnWidths : ViewModelBase
     public double TotalCredits { get => _totalCredits; set => SetProperty(ref _totalCredits, value); }
     public double CurrentValue { get => _currentValue; set => SetProperty(ref _currentValue, value); }
     public double AveragePrice { get => _averagePrice; set => SetProperty(ref _averagePrice, value); }
+    public double CurrentPrice { get => _currentPrice; set => SetProperty(ref _currentPrice, value); }
     public double Profit { get => _profit; set => SetProperty(ref _profit, value); }
     public double ProfitWithCredits { get => _profitWithCredits; set => SetProperty(ref _profitWithCredits, value); }
     public double Xirr { get => _xirr; set => SetProperty(ref _xirr, value); }

--- a/Financial.Web/src/components/PortfolioSummaryTab.tsx
+++ b/Financial.Web/src/components/PortfolioSummaryTab.tsx
@@ -59,9 +59,8 @@ function AssetRow({ item, rowPrice }: AssetRowProps) {
       <td>{item.assetName}</td>
       <td>{formatShortDate(item.firstInvestmentDate)}</td>
       <td>{formatN8(item.currentQuantity)}</td>
-      <td>{formatN2(item.totalInvested)}</td>
       <td>{formatPortfolioWeight(item.portfolioWeight)}</td>
-      <td>{formatN2(item.totalCredits)}</td>
+      <td>{formatN2(item.totalInvested)}</td>
       <td>
         {rowPrice.isLoading ? (
           <span className="portfolio-summary__loading-cell">...</span>
@@ -71,7 +70,17 @@ function AssetRow({ item, rowPrice }: AssetRowProps) {
           formatN2(currentValue)
         )}
       </td>
+      <td>{formatN2(item.totalCredits)}</td>
       <td>{formatN2(item.averagePrice)}</td>
+      <td>
+        {rowPrice.isLoading ? (
+          <span className="portfolio-summary__loading-cell">...</span>
+        ) : rowPrice.fetchFailed || rowPrice.currentPrice === null ? (
+          '—'
+        ) : (
+          formatN2(rowPrice.currentPrice)
+        )}
+      </td>
       <td>
         {rowPrice.isLoading ? (
           <span className="portfolio-summary__loading-cell">...</span>
@@ -171,11 +180,12 @@ export default function PortfolioSummaryTab() {
                 <th rowSpan={2}>Asset Name</th>
                 <th rowSpan={2}>First Investment</th>
                 <th rowSpan={2}>Quantity</th>
-                <th rowSpan={2}>Total Invested</th>
                 <th rowSpan={2}>% Portfolio</th>
-                <th rowSpan={2}>Total Credits</th>
+                <th rowSpan={2}>Total Invested</th>
                 <th rowSpan={2}>Current Value</th>
+                <th rowSpan={2}>Total Credits</th>
                 <th rowSpan={2}>Average Price</th>
+                <th rowSpan={2}>Current Price</th>
                 <th colSpan={2} className="portfolio-summary__group-header">Profit</th>
                 <th rowSpan={2}>XIRR</th>
                 <th colSpan={3} className="portfolio-summary__group-header portfolio-summary__credits-separator">Last Month</th>

--- a/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
@@ -153,6 +153,7 @@ describe('PortfolioSummaryTab', () => {
     expect(screen.getAllByText('Total Credits').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('Current Value')).toBeInTheDocument()
     expect(screen.getByText('Average Price')).toBeInTheDocument()
+    expect(screen.getByText('Current Price')).toBeInTheDocument()
     expect(screen.getByText('Profit')).toBeInTheDocument()
     expect(screen.getAllByText('%').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('w/ Credits')).toBeInTheDocument()
@@ -193,7 +194,7 @@ describe('PortfolioSummaryTab', () => {
     setPortfolioMock({ items: [ITEM_1], rowPrices: [LOADING_ROW_PRICE] })
     renderComponent()
     const loadingCells = screen.getAllByText('...')
-    expect(loadingCells).toHaveLength(4)
+    expect(loadingCells).toHaveLength(5)
   })
 
   it('renders_current_value_when_price_resolves', () => {
@@ -202,6 +203,22 @@ describe('PortfolioSummaryTab', () => {
     setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
     renderComponent()
     expect(screen.getByText(/262[.,]50/)).toBeInTheDocument()
+  })
+
+  it('renders_current_price_when_price_resolves', () => {
+    const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [rowPrice] })
+    renderComponent()
+    expect(screen.getByText(/10[.,]50/)).toBeInTheDocument()
+  })
+
+  it('renders_dash_in_current_price_when_price_fetch_fails', () => {
+    setAggregatedMock({ summary: SUMMARY })
+    setPortfolioMock({ items: [ITEM_1], rowPrices: [FAILED_ROW_PRICE] })
+    renderComponent()
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(5)
   })
 
   it('renders_correct_profit_percent', () => {
@@ -249,7 +266,7 @@ describe('PortfolioSummaryTab', () => {
     setPortfolioMock({ items: [ITEM_1], rowPrices: [FAILED_ROW_PRICE] })
     renderComponent()
     const dashes = screen.getAllByText('—')
-    expect(dashes.length).toBeGreaterThanOrEqual(4)
+    expect(dashes.length).toBeGreaterThanOrEqual(5)
   })
 
   it('renders_dash_in_profit_when_total_invested_is_zero', () => {

--- a/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
@@ -125,6 +125,30 @@ public class PortfolioAssetSummaryRowViewModelTests
     }
 
     [Fact]
+    public void DisplayCurrentPrice_WhenIsLoadingPrice_ReturnsDash()
+    {
+        var row = BuildRow();
+        row.IsLoadingPrice.Should().BeTrue();
+        row.DisplayCurrentPrice.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayCurrentPrice_WhenPriceFetchFailed_ReturnsDash()
+    {
+        var row = BuildRow();
+        row.MarkPriceFailed();
+        row.DisplayCurrentPrice.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayCurrentPrice_AfterApplyPrice_ReturnsPriceN2()
+    {
+        var row = BuildRow();
+        row.ApplyPrice(10.50m);
+        row.DisplayCurrentPrice.Should().Be("10.50");
+    }
+
+    [Fact]
     public void DisplayProfitPercent_WhenIsLoadingPrice_ReturnsDash()
     {
         var row = BuildRow();
@@ -335,6 +359,7 @@ public class PortfolioAssetSummaryRowViewModelTests
 
         row.ApplyPrice(10.50m);
 
+        raised.Should().Contain(nameof(row.DisplayCurrentPrice));
         raised.Should().Contain(nameof(row.DisplayCurrentValue));
         raised.Should().Contain(nameof(row.DisplayProfitPercent));
         raised.Should().Contain(nameof(row.DisplayProfitWithCreditsPercent));
@@ -357,6 +382,7 @@ public class PortfolioAssetSummaryRowViewModelTests
 
         row.MarkPriceFailed();
 
+        raised.Should().Contain(nameof(row.DisplayCurrentPrice));
         raised.Should().Contain(nameof(row.DisplayCurrentValue));
         raised.Should().Contain(nameof(row.DisplayProfitPercent));
         raised.Should().Contain(nameof(row.DisplayProfitWithCreditsPercent));


### PR DESCRIPTION
## Summary
- Move **% Portfolio** to immediately after **Quantity** (was after Total Invested).
- Move **Current Value** to immediately after **Total Invested** (was after Total Credits).
- Add a new **Current Price** column right after **Average Price**, showing the per-unit price fetched for pricing the row (same loading/failure states as Current Value).
- Applied consistently to the Web frontend (`PortfolioSummaryTab.tsx`) and the WPF Desktop app (`NavigationView.xaml`, `PortfolioAssetSummaryRowViewModel`, `PortfolioSummaryColumnWidths`).

New column order: Asset Name → First Investment → Quantity → % Portfolio → Total Invested → Current Value → Total Credits → Average Price → **Current Price** → Profit % / w/ Credits → XIRR → Last Month group → Est. Annual group.

## Test plan
- [x] `npx tsc -b --noEmit` — clean
- [x] `npx vitest run` (Financial.Web) — 356/356 passed, including updated/new PortfolioSummaryTab tests
- [x] `dotnet build Financial.App.csproj` — succeeded
- [x] `dotnet test Financial.Presentation.Tests.csproj` — 141/141 passed, including new `DisplayCurrentPrice` viewmodel tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)