### PR TITLE
feat(P08-F02): Cryptocurrency Asset Price Fetcher

### DIFF
--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IDividendDataSource, DividendDataSourceAdapter>();
         services.AddSingleton<IAssetSnapshotSource, AssetSnapshotSourceAdapter>();
         services.AddSingleton<IAssetPriceFetcher, StandardAssetPriceFetcher>();
+        services.AddSingleton<IAssetPriceFetcher, CryptocurrencyAssetPriceFetcher>();
         services.AddSingleton<IRepository>(sp =>
         {
             var settings = sp.GetRequiredService<IOptions<RepositorySettingsOptions>>().Value;

--- a/Financial.Infrastructure/Services/CryptocurrencyAssetPriceFetcher.cs
+++ b/Financial.Infrastructure/Services/CryptocurrencyAssetPriceFetcher.cs
@@ -1,0 +1,41 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Domain.Entities;
+using Financial.Domain.ValueObjects;
+using Financial.Infrastructure.Integrations.WebPageParser;
+
+namespace Financial.Infrastructure.Services;
+
+public sealed class CryptocurrencyAssetPriceFetcher : IAssetPriceFetcher
+{
+    private readonly IRepository _repository;
+
+    public CryptocurrencyAssetPriceFetcher(IRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public bool Supports(GlobalAssetClass assetClass) => assetClass == GlobalAssetClass.Cryptocurrency;
+
+    public AssetValueSnapshot GetSnapshot(AssetPriceRequestDTO request)
+    {
+        if (string.IsNullOrWhiteSpace(request.BrokerName))
+        {
+            throw new ArgumentException("BrokerName is required for cryptocurrency assets.", nameof(request));
+        }
+
+        var currency = ResolveBrokerCurrency(_repository.GetBrokerList(), request.BrokerName);
+        return GoogleFinance.GetCryptocurrencyFinancialInfoSnapshot(currency, request.Ticker);
+    }
+
+    internal static string ResolveBrokerCurrency(IEnumerable<Broker> brokers, string brokerName)
+    {
+        var broker = brokers.FirstOrDefault(b => b.Name == brokerName);
+        if (broker is null)
+        {
+            throw new InvalidOperationException($"Broker '{brokerName}' not found.");
+        }
+
+        return broker.Currency;
+    }
+}

--- a/Tests/Financial.Infrastructure.Tests/Services/CryptocurrencyAssetPriceFetcherTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/CryptocurrencyAssetPriceFetcherTests.cs
@@ -1,0 +1,106 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Domain.Entities;
+using Financial.Infrastructure.Services;
+using FluentAssertions;
+
+namespace Financial.Infrastructure.Tests.Services;
+
+public class CryptocurrencyAssetPriceFetcherTests
+{
+    [Fact]
+    public void Supports_Cryptocurrency_ReturnsTrue()
+    {
+        var fetcher = new CryptocurrencyAssetPriceFetcher(new StubRepository([]));
+
+        var result = fetcher.Supports(GlobalAssetClass.Cryptocurrency);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Supports_Equity_ReturnsFalse()
+    {
+        var fetcher = new CryptocurrencyAssetPriceFetcher(new StubRepository([]));
+
+        var result = fetcher.Supports(GlobalAssetClass.Equity);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Supports_Unknown_ReturnsFalse()
+    {
+        var fetcher = new CryptocurrencyAssetPriceFetcher(new StubRepository([]));
+
+        var result = fetcher.Supports(GlobalAssetClass.Unknown);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetSnapshot_BlankBrokerName_ThrowsArgumentException()
+    {
+        var fetcher = new CryptocurrencyAssetPriceFetcher(new StubRepository([]));
+        var request = new AssetPriceRequestDTO { Exchange = "", Ticker = "BTC", AssetClass = GlobalAssetClass.Cryptocurrency, BrokerName = null };
+
+        Action act = () => fetcher.GetSnapshot(request);
+
+        act.Should().Throw<ArgumentException>().WithMessage("BrokerName is required for cryptocurrency assets.*");
+    }
+
+    [Fact]
+    public void GetSnapshot_UnknownBroker_ThrowsInvalidOperationException()
+    {
+        var fetcher = new CryptocurrencyAssetPriceFetcher(new StubRepository([]));
+        var request = new AssetPriceRequestDTO
+        {
+            Exchange = "",
+            Ticker = "BTC",
+            AssetClass = GlobalAssetClass.Cryptocurrency,
+            BrokerName = "NotABroker"
+        };
+
+        Action act = () => fetcher.GetSnapshot(request);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*NotABroker*");
+    }
+
+    [Fact]
+    public void ResolveBrokerCurrency_KnownBroker_ReturnsCurrency()
+    {
+        var brokers = new[] { Broker.Create("Coinbase", "GBP") };
+
+        var currency = CryptocurrencyAssetPriceFetcher.ResolveBrokerCurrency(brokers, "Coinbase");
+
+        currency.Should().Be("GBP");
+    }
+
+    [Fact]
+    public void ResolveBrokerCurrency_UnknownBroker_ThrowsInvalidOperationException()
+    {
+        Action act = () => CryptocurrencyAssetPriceFetcher.ResolveBrokerCurrency([], "Coinbase");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Coinbase*");
+    }
+
+    private sealed class StubRepository : IRepository
+    {
+        private readonly List<Broker> _brokers;
+
+        public StubRepository(IEnumerable<Broker> brokers)
+        {
+            _brokers = brokers.ToList();
+        }
+
+        public IEnumerable<Asset> GetAssetsByBroker(string name) => throw new NotImplementedException();
+
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => throw new NotImplementedException();
+
+        public IEnumerable<Broker> GetBrokerList() => _brokers;
+
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => throw new NotImplementedException();
+
+        public Task SaveChangesAsync() => throw new NotImplementedException();
+    }
+}

--- a/docs/P08-F02-cryptocurrency-asset-price-fetcher/plan.md
+++ b/docs/P08-F02-cryptocurrency-asset-price-fetcher/plan.md
@@ -1,0 +1,17 @@
+# Implementation Plan: Cryptocurrency Asset Price Fetcher
+
+**Prerequisites:**
+- No new tools, libraries, or configuration — uses the existing xUnit + FluentAssertions test stack and the existing `GoogleFinance` integration as-is
+- Requires F01 (`IAssetPriceFetcher`, `StandardAssetPriceFetcher`) already merged to `main`
+
+### Stage 1: Fetcher Implementation
+
+**1. CryptocurrencyAssetPriceFetcher Implementation** - Create the new Infrastructure-layer class implementing the strategy interface, relocating today's cryptocurrency-specific validation, broker-currency resolution, and Google Finance beta-quote delegation from `AssetPriceService` unchanged. Reference the spec for the exact `Supports` semantics, error messages, and the `ResolveBrokerCurrency` seam's shape.
+
+### Stage 2: Wiring and Verification
+
+**2. Dependency Injection Registration** - Register the new fetcher in the Infrastructure composition root alongside the existing `StandardAssetPriceFetcher` registration, without touching `AssetPriceService`'s own registration. Reference the spec's Component Overview for the exact registration point.
+
+**3. Unit Test Coverage** - Add a new test file covering the fetcher's asset-class matching, broker-name validation, and currency-resolution branching, following the sibling `StandardAssetPriceFetcherTests` file's structure and assertion style. Reference the spec's Testing Strategy for the full list of test functions and what stays intentionally untested.
+
+**4. Regression Check** - Confirm `AssetPriceService`, its existing branching logic (including its own copy of `GetCryptocurrencySnapshot`/`ResolveBrokerCurrency`), and its existing test file remain completely untouched and still pass, since this feature only adds a new, not-yet-wired type. Run the full test suite to verify no existing behavior changed.

--- a/docs/P08-F02-cryptocurrency-asset-price-fetcher/spec.md
+++ b/docs/P08-F02-cryptocurrency-asset-price-fetcher/spec.md
@@ -1,0 +1,82 @@
+## Technical Overview
+
+**What:** Extract `AssetPriceService`'s existing cryptocurrency-specific price-fetch logic — broker-currency resolution plus the Google Finance beta-quote URL fetch — into a new `CryptocurrencyAssetPriceFetcher` (`Financial.Infrastructure/Services/`), the second implementation of the `IAssetPriceFetcher` strategy contract introduced in F01. Register it in DI alongside `StandardAssetPriceFetcher`.
+
+**Why:** `AssetPriceService.GetCurrentPrice` still contains its original `AssetClass == Cryptocurrency ? : ` branching (F01 only added the contract and the default-path implementation; it did not touch `AssetPriceService`). This feature relocates the crypto-specific half of that branch into its own strategy so that F03 has both concrete fetchers available to dispatch between, and so the `IRepository` dependency — needed only for broker-currency resolution — moves out of `AssetPriceService` and lives exclusively where it's actually used.
+
+**Scope:**
+- Included: `CryptocurrencyAssetPriceFetcher` class implementing `IAssetPriceFetcher`; relocated `BrokerName` validation and `ResolveBrokerCurrency` logic (kept `internal static`, independently tested, per interview); delegation to `GoogleFinance.GetCryptocurrencyFinancialInfoSnapshot` unchanged; DI registration in `InfrastructureServiceCollectionExtensions`.
+- Excluded (deferred to F03, per PRD Section 8): any change to `AssetPriceService` itself — its existing branching, `GetCryptocurrencySnapshot`, and its own copy of `ResolveBrokerCurrency` all stay in place and keep being the only thing callers exercise until F03; `AssetPriceService`'s constructor keeps its `IRepository` dependency until F03 removes it; any API, DTO, or UI change (this feature adds an unconsumed type only, exactly like F01).
+- Consumes: none — F02 has no PRD `Consumes` block; its only PRD dependency (F01, the `IAssetPriceFetcher` contract) is an infrastructure/contract dependency, already implemented and merged.
+- Provides (per PRD): asset value snapshot for `Cryptocurrency`-class assets, consumed by F03 once that dispatcher exists.
+
+## Architecture Impact
+
+**Affected components:**
+- `Financial.Infrastructure/Services/CryptocurrencyAssetPriceFetcher.cs` — Infrastructure layer, new cryptocurrency fetch strategy
+- `Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs` — Infrastructure layer, DI registration
+- `Integrations/WebPageParser/GoogleFinance.cs` — Infrastructure/Integrations, consumed unchanged (no modification)
+- `Financial.Application/Interfaces/IAssetPriceFetcher.cs` — Application layer, existing contract (F01), implemented but not modified
+
+```mermaid
+graph TD
+    A["AssetPriceService (unchanged in F02)"] -.->|"wired in F03"| B[IAssetPriceFetcher]
+    B --> C[CryptocurrencyAssetPriceFetcher]
+    C -->|"BrokerName"| D["IRepository.GetBrokerList()"]
+    D --> E["ResolveBrokerCurrency"]
+    E -->|"Currency, Ticker"| F["GoogleFinance.GetCryptocurrencyFinancialInfoSnapshot"]
+    F --> G[AssetValueSnapshot]
+```
+
+## Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|------------------------|-----------|
+| File/folder layout | Flat: `CryptocurrencyAssetPriceFetcher.cs` in `Financial.Infrastructure/Services/`, test in `Tests/Financial.Infrastructure.Tests/Services/` — mirrors `StandardAssetPriceFetcher.cs`'s established sibling layout from F01 | A `Services/SnapshotFetchers/` subfolder | Same reasoning already settled in F01: keeps the diff minimal, consistent with the now-established flat `Services/` convention |
+| `ResolveBrokerCurrency` shape | Kept `internal static string ResolveBrokerCurrency(IEnumerable<Broker> brokers, string brokerName)` on the new class, with its own dedicated unit tests (mirroring today's `AssetPriceServiceTests.ResolveBrokerCurrency_*` pair) | Fold it into a private instance method, covered only indirectly via `GetSnapshot` tests | Matches the PRD's "relocated here unchanged" wording literally; preserves the same pure/testable seam this exact logic already had, consistent with F01's precedent of keeping validation/lookup logic independently testable |
+| Validation ownership | `GetSnapshot` validates only `BrokerName` (its unique precondition); `Ticker` validation remains solely `AssetPriceService`'s responsibility, unchanged | The fetcher independently re-validates `Ticker` too | Directly carries forward F01's settled decision — avoids duplicating the same blank-check across every fetcher |
+| XML documentation | No XML doc comments | XML summary comments | Directly carries forward F01's settled decision, keeping the fetcher family's documentation style consistent |
+| Constructor dependency | `IRepository`, injected exactly as `AssetPriceService` injects it today | A narrower broker-lookup-only interface | PRD explicitly describes this as `IRepository` "moved here from `AssetPriceService`" — no new abstraction introduced, matching the "no over-engineering" project guidance for a personal-use codebase |
+
+## Component Overview
+
+**Backend (Infrastructure):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|----------------------|
+| `Financial.Infrastructure/Services/CryptocurrencyAssetPriceFetcher.cs` | New | Cryptocurrency-class fetch strategy | Implements `IAssetPriceFetcher`; `Supports` returns `true` only for `GlobalAssetClass.Cryptocurrency`; `GetSnapshot` validates `BrokerName` is non-blank (`ArgumentException`, message `"BrokerName is required for cryptocurrency assets."`, matching today's `GetCryptocurrencySnapshot`), resolves currency via `ResolveBrokerCurrency`, then delegates to `GoogleFinance.GetCryptocurrencyFinancialInfoSnapshot(currency, ticker)`; exposes `internal static string ResolveBrokerCurrency(IEnumerable<Broker> brokers, string brokerName)` throwing `InvalidOperationException` (message containing the broker name) when no match is found, identical to today's implementation |
+| `Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs` | Modified | DI composition root | Adds `services.AddSingleton<IAssetPriceFetcher, CryptocurrencyAssetPriceFetcher>();` alongside the existing `StandardAssetPriceFetcher` registration; `AssetPriceService`'s own registration is untouched in this feature |
+| `Tests/Financial.Infrastructure.Tests/Services/CryptocurrencyAssetPriceFetcherTests.cs` | New | Unit tests | Covers `Supports`, `GetSnapshot`'s `BrokerName` validation, and `ResolveBrokerCurrency`'s known/unknown broker branching |
+
+No Presentation-layer (API/WPF/Web) or Domain-layer files are touched — `AssetPriceService`, `AssetPriceRequestDTO`, `IAssetPriceService`, and every caller are unmodified by this feature, exactly as in F01.
+
+## Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Tests/Financial.Infrastructure.Tests/Services/CryptocurrencyAssetPriceFetcherTests.cs` | Unit | `CryptocurrencyAssetPriceFetcher` | Full `Supports`/`GetSnapshot`/`ResolveBrokerCurrency` branching |
+
+**Test functions:**
+
+| Test Function | Description | Assertions |
+|----------------|--------------|------------|
+| `Supports_Cryptocurrency_ReturnsTrue` | Calls `Supports(GlobalAssetClass.Cryptocurrency)` | Returns `true` |
+| `Supports_Equity_ReturnsFalse` | Calls `Supports(GlobalAssetClass.Equity)` | Returns `false` |
+| `Supports_Unknown_ReturnsFalse` | Calls `Supports(GlobalAssetClass.Unknown)` | Returns `false` |
+| `GetSnapshot_BlankBrokerName_ThrowsArgumentException` | Calls `GetSnapshot` with a request whose `BrokerName` is `null` | Throws `ArgumentException` with message `"BrokerName is required for cryptocurrency assets."` |
+| `GetSnapshot_UnknownBroker_ThrowsInvalidOperationException` | Calls `GetSnapshot` with `BrokerName = "NotABroker"` against an empty broker list | Throws `InvalidOperationException` with message containing `"NotABroker"`, before any network call is attempted |
+| `ResolveBrokerCurrency_KnownBroker_ReturnsCurrency` | Calls `CryptocurrencyAssetPriceFetcher.ResolveBrokerCurrency([Broker.Create("Coinbase", "GBP")], "Coinbase")` | Returns `"GBP"` |
+| `ResolveBrokerCurrency_UnknownBroker_ThrowsInvalidOperationException` | Calls `ResolveBrokerCurrency([], "Coinbase")` | Throws `InvalidOperationException` with message containing `"Coinbase"` |
+
+**What stays untested (documented, not a gap):** `GetSnapshot`'s success path (`GoogleFinance.GetCryptocurrencyFinancialInfoSnapshot`'s live `HtmlWeb.Load` call) has no unit seam to intercept — the same limitation already documented for `StandardAssetPriceFetcher` in F01 and for this exact code path in `docs/P07-F03-cryptocurrency-price-fetch-strategy/spec.md`. Verified by code review that the delegation is a direct pass-through of `(currency, ticker)`, unmodified from today's `GetCryptocurrencySnapshot`. The DI registration line is also not unit-tested, consistent with F01 and this codebase's existing convention.
+
+**Acceptance criteria traceability (PRD Section 9, F02):**
+- "`CryptocurrencyAssetPriceFetcher.Supports` returns `true` only for `GlobalAssetClass.Cryptocurrency`, `false` for every other value" → `Supports_Cryptocurrency_ReturnsTrue`, `Supports_Equity_ReturnsFalse`, `Supports_Unknown_ReturnsFalse`
+- "`CryptocurrencyAssetPriceFetcher.GetSnapshot` throws `ArgumentException` when `BrokerName` is blank" → `GetSnapshot_BlankBrokerName_ThrowsArgumentException`
+- "`CryptocurrencyAssetPriceFetcher.GetSnapshot` throws `InvalidOperationException` when `BrokerName` matches no broker returned by `IRepository.GetBrokerList()`" → `GetSnapshot_UnknownBroker_ThrowsInvalidOperationException`
+- "`CryptocurrencyAssetPriceFetcher.GetSnapshot` resolves the matching broker's `Currency` and calls `GoogleFinance.GetCryptocurrencyFinancialInfoSnapshot(currency, ticker)`" → `ResolveBrokerCurrency_KnownBroker_ReturnsCurrency` covers the currency-resolution half; the delegation itself is not unit-tested (live network call, see "What stays untested" above), verified by code review
+- "`CryptocurrencyAssetPriceFetcher` is registered in DI as an `IAssetPriceFetcher`" → not unit-tested, verified by code review of `InfrastructureServiceCollectionExtensions`, consistent with F01's precedent
+
+**Cross-Feature Integration (PRD Section 9):** F02 is a provider consumed by F03 (`AssetPriceService` dispatcher), which does not exist yet at this point in the wave sequence. The Cross-Feature Integration criterion covering "a Cryptocurrency request dispatches to the snapshot provided by `CryptocurrencyAssetPriceFetcher`" and the DI-collection-count criterion are both validated when F03 is implemented; F02's testing scope is limited to the acceptance criteria above, exactly mirroring the pattern F01 used for its own forward-referencing integration criteria.

--- a/docs/prd/P08-prd-asset-snapshot-fetch-strategy/prd-asset-snapshot-fetch-strategy.md
+++ b/docs/prd/P08-prd-asset-snapshot-fetch-strategy/prd-asset-snapshot-fetch-strategy.md
@@ -68,7 +68,7 @@ This is a maintainability investment, not a user-facing change: no API contract,
 - As the system, I want a common `IAssetPriceFetcher` contract so that any future asset-class-specific fetch strategy can be added without modifying existing dispatch code
 - As the developer, I want today's non-cryptocurrency price-fetch logic (the Google Finance stock-quote path) extracted into a `StandardAssetPriceFetcher` implementing that contract, so today's default behavior becomes one strategy among many instead of being hardwired into `AssetPriceService`
 
-### F02. Cryptocurrency Snapshot Fetcher
+### F02. Cryptocurrency Asset Price Fetcher
 - As the system, I want the cryptocurrency-specific price-fetch logic (broker-currency resolution plus the Google Finance beta-quote URL) extracted into a `CryptocurrencyAssetPriceFetcher` implementing the same contract, so its logic is fully independent of the standard strategy and of any future asset class
 - As the developer, I want the existing `ResolveBrokerCurrency` logic and the crypto branch's `BrokerName`-required validation moved into this fetcher unchanged, so behavior stays identical to today, only relocated
 
@@ -97,7 +97,7 @@ This is a maintainability investment, not a user-facing change: no API contract,
 - No caller-visible change: this feature only introduces new types and DI registrations that nothing consumes yet
 - Once consumed by F03, a request whose asset class is not `Cryptocurrency` produces the exact same Google Finance stock-quote fetch, response shape, and failure behavior as today
 
-### F02. Cryptocurrency Snapshot Fetcher
+### F02. Cryptocurrency Asset Price Fetcher
 
 **Provides:**
 - Asset value snapshot (ticker, display name, price, as-of timestamp) for `Cryptocurrency`-class assets, using the currency resolved from the asset's broker (used by F03)
@@ -159,7 +159,7 @@ This is a maintainability investment, not a user-facing change: no API contract,
 | # | Feature | Priority | Dependencies |
 |---|---------|----------|--------------|
 | F01 | Asset Snapshot Fetcher Contract & Standard Fetcher | 1 | None |
-| F02 | Cryptocurrency Snapshot Fetcher | 1 | F01 |
+| F02 | Cryptocurrency Asset Price Fetcher | 1 | F01 |
 | F03 | Strategy Dispatch in AssetPriceService | 1 | F01, F02 |
 
 ### Execution Waves
@@ -192,7 +192,7 @@ graph TD
 - [ ] `StandardAssetPriceFetcher.GetSnapshot` calls `GoogleFinance.GetFinancialInfoSnapshot(exchange, ticker)` and returns its result unmodified
 - [ ] `StandardAssetPriceFetcher` is registered in DI as an `IAssetPriceFetcher`
 
-### F02. Cryptocurrency Snapshot Fetcher
+### F02. Cryptocurrency Asset Price Fetcher
 - [ ] `CryptocurrencyAssetPriceFetcher.Supports` returns `true` only for `GlobalAssetClass.Cryptocurrency`, `false` for every other value
 - [ ] `CryptocurrencyAssetPriceFetcher.GetSnapshot` throws `ArgumentException` when `BrokerName` is blank
 - [ ] `CryptocurrencyAssetPriceFetcher.GetSnapshot` throws `InvalidOperationException` when `BrokerName` matches no broker returned by `IRepository.GetBrokerList()`


### PR DESCRIPTION
## Summary
- Adds `CryptocurrencyAssetPriceFetcher` (`Financial.Infrastructure/Services/`), the second `IAssetPriceFetcher` strategy, relocating `AssetPriceService`'s cryptocurrency-specific broker-currency resolution and Google Finance beta-quote fetch **unchanged**
- Registers it in DI alongside `StandardAssetPriceFetcher`; `AssetPriceService` itself is **not modified** in this PR — its existing branching logic, including its own copy of `GetCryptocurrencySnapshot`/`ResolveBrokerCurrency`, stays in place until F03 wires the dispatcher in
- Also fixes the F02 PRD section title (`Cryptocurrency Snapshot Fetcher` → `Cryptocurrency Asset Price Fetcher`) to match the `IAssetSnapshotFetcher` → `IAssetPriceFetcher` rename that landed in F01
- Second piece of the P08 "Asset Snapshot Fetch Strategy" refactor (see `docs/prd/P08-prd-asset-snapshot-fetch-strategy/`) — F03 (the `AssetPriceService` dispatcher) is next

## Test plan
- [x] `dotnet build Financial.slnx` — succeeds, no new warnings
- [x] New unit tests in `CryptocurrencyAssetPriceFetcherTests.cs` cover `Supports` (Cryptocurrency/Equity/Unknown), `GetSnapshot`'s blank-`BrokerName` and unknown-broker validation, and `ResolveBrokerCurrency`'s known/unknown broker branching
- [x] Existing `AssetPriceServiceTests` and `StandardAssetPriceFetcherTests` pass unmodified
- [x] Full solution test suite green: Domain 51, Application 169, Infrastructure 89 passed + 3 pre-existing skipped (live-network verification tests), Api 37, Presentation 141 — zero failures, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)