### PR TITLE
feat(P09-F02): Tesouro Direto Finance Service

### DIFF
--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IDividendDataSource, DividendDataSourceAdapter>();
         services.AddSingleton<IAssetSnapshotSource, AssetSnapshotSourceAdapter>();
         services.AddSingleton<IFinanceService, GoogleFinanceService>();
+        services.AddSingleton<TesouroDiretoFinanceService>();
         services.AddSingleton<IAssetPriceFetcher, StandardAssetPriceFetcher>();
         services.AddSingleton<IAssetPriceFetcher, CryptocurrencyAssetPriceFetcher>();
         services.AddSingleton<IRepository>(sp =>

--- a/Financial.Infrastructure/Interfaces/AssetValueNotFoundException.cs
+++ b/Financial.Infrastructure/Interfaces/AssetValueNotFoundException.cs
@@ -1,0 +1,8 @@
+namespace Financial.Infrastructure.Interfaces;
+
+public sealed class AssetValueNotFoundException : Exception
+{
+    public AssetValueNotFoundException(string message) : base(message)
+    {
+    }
+}

--- a/Financial.Infrastructure/Services/TesouroDiretoFinanceService.cs
+++ b/Financial.Infrastructure/Services/TesouroDiretoFinanceService.cs
@@ -1,0 +1,30 @@
+using Financial.Domain.ValueObjects;
+using Financial.Infrastructure.Integrations.WebPageParser;
+using Financial.Infrastructure.Interfaces;
+
+namespace Financial.Infrastructure.Services;
+
+public sealed class TesouroDiretoFinanceService : IFinanceService
+{
+    private readonly Func<string, AssetValueSnapshot?> _lookup;
+
+    public TesouroDiretoFinanceService() : this(TesouroDireto.GetRedemptionValue)
+    {
+    }
+
+    internal TesouroDiretoFinanceService(Func<string, AssetValueSnapshot?> lookup)
+    {
+        _lookup = lookup ?? throw new ArgumentNullException(nameof(lookup));
+    }
+
+    public AssetValueSnapshot GetAssetValue(AssetValueRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+        {
+            throw new ArgumentException("Name is required.", nameof(request));
+        }
+
+        return _lookup(request.Name)
+            ?? throw new AssetValueNotFoundException($"No Tesouro Direto bond found matching '{request.Name}'.");
+    }
+}

--- a/Integrations/WebPageParser/TesouroDireto.cs
+++ b/Integrations/WebPageParser/TesouroDireto.cs
@@ -1,0 +1,126 @@
+using System.Globalization;
+using Financial.Domain.ValueObjects;
+using HtmlAgilityPack;
+
+namespace Financial.Infrastructure.Integrations.WebPageParser;
+
+/// <summary>
+/// Parses the Tesouro Direto redemption-price table.
+/// Column positions are resolved by header text (not fixed indices) since the
+/// live table structure could not be verified when this scraper was written.
+/// Run TesouroDiretoVerificationTests manually to confirm it still matches production.
+/// </summary>
+public static class TesouroDireto
+{
+    private const string RedemptionPageUrl = "https://www.tesourodireto.com.br/produtos/dados-sobre-titulos/rendimento-dos-titulos";
+    private const string TitleColumnHeader = "Título";
+    private const string PriceColumnHeader = "Preço Unit.";
+    private const string BrowserUserAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+    public static AssetValueSnapshot? GetRedemptionValue(string bondTitle)
+    {
+        var htmlWeb = new HtmlWeb { UserAgent = BrowserUserAgent };
+        HtmlDocument htmlDoc = htmlWeb.Load(RedemptionPageUrl);
+
+        var table = FindRedemptionTable(htmlDoc)
+            ?? throw new InvalidOperationException("Tesouro Direto redemption table not found. The page structure may have changed.");
+
+        return FindMatchingRow(table, bondTitle);
+    }
+
+    internal static HtmlNode? FindRedemptionTable(HtmlDocument document)
+    {
+        var tables = document.DocumentNode.SelectNodes("//table");
+        if (tables == null)
+        {
+            return null;
+        }
+
+        foreach (var table in tables)
+        {
+            if (TryResolveColumns(table, out _, out _))
+            {
+                return table;
+            }
+        }
+
+        return null;
+    }
+
+    internal static AssetValueSnapshot? FindMatchingRow(HtmlNode table, string bondTitle)
+    {
+        if (!TryResolveColumns(table, out var titleColumnIndex, out var priceColumnIndex))
+        {
+            throw new InvalidOperationException("Tesouro Direto table columns not found. The page structure may have changed.");
+        }
+
+        var rows = table.SelectNodes(".//tbody/tr");
+        if (rows == null)
+        {
+            return null;
+        }
+
+        var requestedTitle = bondTitle.Trim();
+
+        foreach (var row in rows)
+        {
+            var cells = row.SelectNodes("th|td");
+            var lastColumnIndex = Math.Max(titleColumnIndex, priceColumnIndex);
+            if (cells == null || cells.Count <= lastColumnIndex)
+            {
+                continue;
+            }
+
+            var rowTitle = cells[titleColumnIndex].InnerText.Trim();
+            if (!string.Equals(rowTitle, requestedTitle, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var price = ParsePrice(cells[priceColumnIndex].InnerText);
+            return new AssetValueSnapshot(bondTitle, rowTitle, price, DateTimeOffset.Now);
+        }
+
+        return null;
+    }
+
+    internal static bool TryResolveColumns(HtmlNode table, out int titleColumnIndex, out int priceColumnIndex)
+    {
+        titleColumnIndex = -1;
+        priceColumnIndex = -1;
+
+        var headerRow = table.SelectSingleNode(".//thead/tr") ?? table.SelectSingleNode(".//tr");
+        var headerCells = headerRow?.SelectNodes("th|td");
+        if (headerCells == null)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < headerCells.Count; i++)
+        {
+            var headerText = headerCells[i].InnerText.Trim();
+            if (headerText.Contains(TitleColumnHeader, StringComparison.OrdinalIgnoreCase))
+            {
+                titleColumnIndex = i;
+            }
+            else if (headerText.Contains(PriceColumnHeader, StringComparison.OrdinalIgnoreCase))
+            {
+                priceColumnIndex = i;
+            }
+        }
+
+        return titleColumnIndex >= 0 && priceColumnIndex >= 0;
+    }
+
+    internal static decimal ParsePrice(string priceText)
+    {
+        var cleaned = priceText
+            .Replace("R$", string.Empty)
+            .Trim()
+            .Replace(".", string.Empty)
+            .Replace(",", ".");
+
+        return decimal.Parse(cleaned, CultureInfo.InvariantCulture);
+    }
+}

--- a/Tests/Financial.Infrastructure.Tests/Integrations/TesouroDiretoTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Integrations/TesouroDiretoTests.cs
@@ -1,0 +1,67 @@
+using Financial.Infrastructure.Integrations.WebPageParser;
+using FluentAssertions;
+using HtmlAgilityPack;
+
+namespace Financial.Infrastructure.Tests.Integrations;
+
+public class TesouroDiretoTests
+{
+    [Fact]
+    public void FindMatchingRow_ExactTitleMatch_ReturnsRow()
+    {
+        var table = BuildTable(
+            "<table><thead><tr><th>Título</th><th>Preço Unit.</th></tr></thead>" +
+            "<tbody><tr><td>TESOURO IPCA+ 2029</td><td>R$ 3.775,97</td></tr></tbody></table>");
+
+        var result = TesouroDireto.FindMatchingRow(table, "TESOURO IPCA+ 2029");
+
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("TESOURO IPCA+ 2029");
+        result.Price.Should().Be(3775.97m);
+    }
+
+    [Fact]
+    public void FindMatchingRow_CaseInsensitiveMatch_ReturnsRow()
+    {
+        var table = BuildTable(
+            "<table><thead><tr><th>Título</th><th>Preço Unit.</th></tr></thead>" +
+            "<tbody><tr><td>TESOURO IPCA+ 2029</td><td>R$ 3.775,97</td></tr></tbody></table>");
+
+        var result = TesouroDireto.FindMatchingRow(table, "tesouro ipca+ 2029");
+
+        result.Should().NotBeNull();
+        result!.Price.Should().Be(3775.97m);
+    }
+
+    [Fact]
+    public void FindMatchingRow_WhitespaceDifference_ReturnsRow()
+    {
+        var table = BuildTable(
+            "<table><thead><tr><th>Título</th><th>Preço Unit.</th></tr></thead>" +
+            "<tbody><tr><td>  TESOURO SELIC 2029  </td><td>R$ 15.234,10</td></tr></tbody></table>");
+
+        var result = TesouroDireto.FindMatchingRow(table, "TESOURO SELIC 2029");
+
+        result.Should().NotBeNull();
+        result!.Price.Should().Be(15234.10m);
+    }
+
+    [Fact]
+    public void FindMatchingRow_NoMatch_ReturnsNull()
+    {
+        var table = BuildTable(
+            "<table><thead><tr><th>Título</th><th>Preço Unit.</th></tr></thead>" +
+            "<tbody><tr><td>TESOURO IPCA+ 2029</td><td>R$ 3.775,97</td></tr></tbody></table>");
+
+        var result = TesouroDireto.FindMatchingRow(table, "TESOURO PREFIXADO 2027");
+
+        result.Should().BeNull();
+    }
+
+    private static HtmlNode BuildTable(string tableHtml)
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml(tableHtml);
+        return document.DocumentNode.SelectSingleNode("//table");
+    }
+}

--- a/Tests/Financial.Infrastructure.Tests/Integrations/TesouroDiretoVerificationTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Integrations/TesouroDiretoVerificationTests.cs
@@ -1,0 +1,66 @@
+using Financial.Infrastructure.Integrations.WebPageParser;
+using Xunit.Abstractions;
+
+namespace Financial.Infrastructure.Tests.Integrations;
+
+/// <summary>
+/// Manual verification tests for the Tesouro Direto redemption-table scraper.
+/// These tests make real HTTP requests and should be run manually, on a machine
+/// with normal internet access, to confirm the live table structure before this
+/// feature is relied on in production.
+/// Mark as [Fact] to run, or keep as [Fact(Skip = "Manual")] to skip in CI.
+/// </summary>
+public class TesouroDiretoVerificationTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public TesouroDiretoVerificationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact(Skip = "Manual verification test - requires internet connection")]
+    public void VerifySelectors_WithKnownBonds()
+    {
+        _output.WriteLine("Testing Tesouro Direto redemption-table scraping with live data...");
+        _output.WriteLine("");
+
+        var bondTitles = new[]
+        {
+            "TESOURO SELIC 2029",
+            "TESOURO IPCA+ 2029",
+            "TESOURO PREFIXADO 2027",
+        };
+
+        foreach (var bondTitle in bondTitles)
+        {
+            _output.WriteLine($"Testing '{bondTitle}'...");
+
+            var snapshot = TesouroDireto.GetRedemptionValue(bondTitle);
+
+            if (snapshot is null)
+            {
+                _output.WriteLine($"  ✗ Not found — either the bond title doesn't match the table, or column resolution failed.");
+                continue;
+            }
+
+            Assert.True(snapshot.Price > 0, $"Price should be positive, got {snapshot.Price}");
+
+            _output.WriteLine($"  ✓ Name: {snapshot.Name}");
+            _output.WriteLine($"  ✓ Price: {snapshot.Price:C}");
+            _output.WriteLine($"  ✓ AsOf: {snapshot.AsOf}");
+            _output.WriteLine("");
+        }
+    }
+
+    [Fact(Skip = "Manual verification test - requires internet connection")]
+    public void VerifySelectors_UnknownBond_ReturnsNull()
+    {
+        _output.WriteLine("Testing a bond title that should not exist in the table...");
+
+        var snapshot = TesouroDireto.GetRedemptionValue("NOT A REAL BOND TITLE");
+
+        Assert.Null(snapshot);
+        _output.WriteLine("  ✓ Correctly returned null for an unmatched title");
+    }
+}

--- a/Tests/Financial.Infrastructure.Tests/Services/TesouroDiretoFinanceServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/TesouroDiretoFinanceServiceTests.cs
@@ -1,0 +1,43 @@
+using Financial.Domain.ValueObjects;
+using Financial.Infrastructure.Interfaces;
+using Financial.Infrastructure.Services;
+using FluentAssertions;
+
+namespace Financial.Infrastructure.Tests.Services;
+
+public class TesouroDiretoFinanceServiceTests
+{
+    [Fact]
+    public void GetAssetValue_BlankName_ThrowsArgumentException()
+    {
+        var service = new TesouroDiretoFinanceService(_ => null);
+        var request = new AssetValueRequest { Name = "" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<ArgumentException>().WithMessage("Name is required.*");
+    }
+
+    [Fact]
+    public void GetAssetValue_NoMatch_ThrowsAssetValueNotFoundException()
+    {
+        var service = new TesouroDiretoFinanceService(_ => null);
+        var request = new AssetValueRequest { Name = "TESOURO PREFIXADO 2027" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<AssetValueNotFoundException>().WithMessage("*TESOURO PREFIXADO 2027*");
+    }
+
+    [Fact]
+    public void GetAssetValue_Match_ReturnsSnapshot()
+    {
+        var snapshot = new AssetValueSnapshot("TESOURO IPCA+ 2029", "TESOURO IPCA+ 2029", 3775.97m, DateTimeOffset.UtcNow);
+        var service = new TesouroDiretoFinanceService(_ => snapshot);
+        var request = new AssetValueRequest { Name = "TESOURO IPCA+ 2029" };
+
+        var result = service.GetAssetValue(request);
+
+        result.Should().Be(snapshot);
+    }
+}

--- a/docs/P09-F02-tesouro-direto-finance-service/plan.md
+++ b/docs/P09-F02-tesouro-direto-finance-service/plan.md
@@ -1,0 +1,25 @@
+# Implementation Plan: Tesouro Direto Finance Service
+
+**Prerequisites:**
+- No new tools or libraries — uses the existing HtmlAgilityPack + xUnit + FluentAssertions stack
+- Before finalizing the scraper's parsing logic, manually inspect the live tesourodireto.com.br redemption page from a machine with normal internet access (the sandboxed environment used to write this spec could not reach the site — see spec's Technical Decisions), and confirm or correct the assumed table/column structure
+
+### Stage 1: Tesouro Direto Scraper
+
+**1. TesouroDireto Scraper** - Add the static scraper that fetches the Tesouro Direto redemption-price table with a browser-like request identity, locates the relevant table by its column headers rather than a hardcoded position, and matches a bond by title. Reference the spec for the exact fetch, column-resolution, and matching approach.
+
+**2. Manual Verification Test Class** - Add a skipped-by-default test class that exercises the scraper against the real site with known bond titles, mirroring the existing Google Finance verification tests, so the live structure can be confirmed by running it manually before this feature is relied on in production.
+
+### Stage 2: Finance Service and Not-Found Signal
+
+**3. Shared Not-Found Exception** - Add the shared exception type that signals "this source doesn't have the requested value" in a way distinguishable from any other failure, since the existing finance-service contract only supports throw-on-failure. Reference the spec for its placement and intended catch-site.
+
+**4. TesouroDiretoFinanceService Implementation** - Add the finance-service implementation that validates its request, delegates to the scraper, and translates a no-match result into the shared not-found exception. Reference the spec for the exact validation and translation behavior.
+
+### Stage 3: Wiring and Test Coverage
+
+**5. Dependency Injection Registration** - Register the new finance service in the Infrastructure composition root by its own concrete type, not as the shared finance-service interface, to avoid creating an ambiguous registration for the existing Google Finance consumers. Reference the spec's Technical Decisions for why.
+
+**6. Unit Test Coverage** - Add test coverage for the scraper's row-matching logic against in-memory HTML and for the finance service's validation and not-found translation, following the existing sibling test files' structure. Reference the spec's Testing Strategy for the full list of test functions and the seam used to avoid a live network call.
+
+**7. Regression Check** - Confirm every existing test in the solution still passes unchanged, since this feature only adds new, not-yet-wired types. Run the full test suite to verify no existing behavior changed.

--- a/docs/P09-F02-tesouro-direto-finance-service/spec.md
+++ b/docs/P09-F02-tesouro-direto-finance-service/spec.md
@@ -1,0 +1,93 @@
+## Technical Overview
+
+**What:** Introduce `TesouroDiretoFinanceService` (`Financial.Infrastructure/Services/`), implementing `IFinanceService`, backed by a new static scraper `TesouroDireto` (`Integrations/WebPageParser/TesouroDireto.cs`) that fetches tesourodireto.com.br's redemption-price table and matches a bond by title. Also introduces `AssetValueNotFoundException`, a shared "expected miss" signal any `IFinanceService` implementation can throw, needed because F01's `IFinanceService.GetAssetValue` contract (non-nullable return, throws on failure) has no existing way to distinguish "not found, try the next source" from a hard failure.
+
+**Why:** F01 shipped `IFinanceService` and `GoogleFinanceService`, but Bond assets still have no real price source — that's this PRD's whole point. The PRD requires Tesouro Direto to be the authoritative source, with Status Invest (F03) as an automatic fallback when Tesouro Direto can't resolve the bond (F04 orchestrates this, not yet built). For that fallback to work, this feature needs a way to say "this bond isn't in the Tesouro Direto table" without that looking like a scrape failure — hence `AssetValueNotFoundException`, introduced here since F02 is the first feature that needs it, and shared so F03 can reuse the exact same signal.
+
+**Scope:**
+- **Included:** `TesouroDireto` static scraper (HTML fetch, table location, header-based column resolution, row matching by bond title); `TesouroDiretoFinanceService` implementing `IFinanceService`; `AssetValueNotFoundException`; DI registration of `TesouroDiretoFinanceService` by its concrete type; a manual, network-requiring verification test class mirroring `GoogleFinanceVerificationTests`, since the live page's exact table structure could not be verified from this environment (see Technical Decisions).
+- **Excluded** (deferred to later features in this PRD, per PRD Section 8): `StatusInvestFinanceService` (F03); `BondAssetPriceFetcher`, the try-TD-then-SI orchestration, and the `AssetPriceRequestDTO.Name` field addition (F04); any UI/API/DTO contract change (this feature adds an unconsumed service — nothing calls it until F04).
+- **Consumes:** none — F02's only PRD dependency is F01 (the `IFinanceService` contract it implements), which is an infrastructure dependency, not a PRD `Consumes` data relationship.
+- **Provides (per PRD):** current unit price ("Preço Unit.") and as-of date for a bond matched by title, or a not-found signal when no row matches (used by F04, not yet built).
+
+## Architecture Impact
+
+**Affected components:**
+- `Integrations/WebPageParser/TesouroDireto.cs` — Infrastructure/Integrations layer, new scraper
+- `Financial.Infrastructure/Services/TesouroDiretoFinanceService.cs` — Infrastructure layer, new `IFinanceService` implementation
+- `Financial.Infrastructure/Interfaces/AssetValueNotFoundException.cs` — Infrastructure layer, new shared exception type
+- `Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs` — modified, new registration
+- `Tests/Financial.Infrastructure.Tests/Integrations/TesouroDiretoTests.cs` — new, pure parsing unit tests (no network)
+- `Tests/Financial.Infrastructure.Tests/Services/TesouroDiretoFinanceServiceTests.cs` — new
+- `Tests/Financial.Infrastructure.Tests/Integrations/TesouroDiretoVerificationTests.cs` — new, manual/skipped, requires internet
+
+```mermaid
+graph TD
+    A[TesouroDiretoFinanceService] --> B[IFinanceService]
+    A --> C["TesouroDireto (static scraper)"]
+    C -->|"HtmlWeb + browser User-Agent"| D["tesourodireto.com.br redemption table"]
+    C --> E{"Title matches a row?"}
+    E -->|"yes"| F[AssetValueSnapshot]
+    E -->|"no"| G[AssetValueNotFoundException]
+```
+
+## Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|------------------------|-----------|
+| Live site verification | tesourodireto.com.br returned HTTP 403 to two independent fetch attempts made while writing this spec (both from a sandboxed research environment with restricted outbound network to that host); statusinvest.com.br fetched cleanly by contrast. The exact table markup, column order, and whether "Resgatar" is a CSS-only tab toggle or a separate data fetch could not be confirmed. The scraper is written defensively (header-text column resolution, not fixed indices) and ships with a `[Fact(Skip = "...")]` manual verification test — mirroring `GoogleFinanceVerificationTests`' existing convention — that must be run (unskipped) against the live site on a machine with normal internet access before this feature is considered production-ready | Block the spec until the live page is manually inspected first | Chosen approach keeps the feature moving using the same "verify before relying on it in production" convention this codebase already has for Google Finance, rather than stalling on an environment-specific network restriction |
+| Anti-bot mitigation | `TesouroDireto`'s `HtmlWeb` request sets a realistic browser `User-Agent` via `PreRequest`, unlike `GoogleFinance`/`DadosMercadoDividend`, which use `HtmlWeb`'s default | No special handling, matching the other two scrapers exactly | Addresses the observed 403 if it's User-Agent-based bot filtering; if the site instead requires a JS challenge (Cloudflare Turnstile or similar), no plain HTML fetch — with or without a User-Agent — will work, and that would need to surface as a follow-up finding once verified live, not something this spec can resolve blind |
+| Column resolution | Locate "Título" and "Preço Unit." columns by matching header-row cell text (case-insensitive, trimmed), then read body rows by the resolved index — not hardcoded column-index constants | Fixed column-index constants, matching `DadosMercadoDividend`'s pattern exactly | Since the real column order is unverified, header-text matching is resilient to the table having a different column order than assumed; `DadosMercadoDividend`'s fixed-index approach is only safe there because its structure is already confirmed working in production |
+| Not-found signaling | New `AssetValueNotFoundException` (`Financial.Infrastructure/Interfaces/`), thrown when no row's title matches `request.Name`; any other failure (network error, missing table, header columns not found) throws `InvalidOperationException`, matching `GoogleFinance`'s existing "structure may have changed" convention | Return a nullable `AssetValueSnapshot?` from `IFinanceService.GetAssetValue`, changing the interface F01 already shipped | Avoids reopening F01's interface and its already-shipped consumers/tests (`GoogleFinanceService`, `StandardAssetPriceFetcher`, `CryptocurrencyAssetPriceFetcher`); F04 (not yet built) catches specifically `AssetValueNotFoundException` to trigger its Status Invest fallback, while any other exception propagates as a genuine failure |
+| DI registration | `TesouroDiretoFinanceService` is registered in DI by its own concrete type (`services.AddSingleton<TesouroDiretoFinanceService>();`), not as `IFinanceService` | Register it as `IFinanceService` alongside `GoogleFinanceService` | `GoogleFinanceService` is the only thing that should ever be resolved when a constructor asks for a single `IFinanceService` (as `StandardAssetPriceFetcher`/`CryptocurrencyAssetPriceFetcher` do); registering a second `IFinanceService` implementation would make that resolution ambiguous (last-registered wins silently). `TesouroDiretoFinanceService` still implements `IFinanceService` for shape/testability consistency — it's just resolved by concrete type when F04 injects it directly |
+| Bond title matching | Exact, case-insensitive comparison against `request.Name`, ignoring leading/trailing whitespace (per PRD) | Fuzzy/normalized matching (strip accents, punctuation) | Matches the PRD's explicit decision; if the live table's title formatting turns out to need normalization once verified, that's a follow-up refinement to `TesouroDireto`'s row-matching helper, isolated to one method |
+
+## Component Overview
+
+**Backend (Infrastructure only — no Domain, Application, or Presentation changes):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|----------------------|
+| `Integrations/WebPageParser/TesouroDireto.cs` | New | Static scraper for the Tesouro Direto redemption table | `GetRedemptionValue(string bondTitle)` loads the page via `HtmlWeb` (browser `User-Agent` set via `PreRequest`), locates the redemption table, resolves the "Título" and "Preço Unit." column indices from the header row, and returns the matching row's price/date, or `null` if no row matches; a separate `internal static` row-matching helper (`FindMatchingRow`) is unit-testable against an in-memory `HtmlDocument` without a network call, mirroring `DadosMercadoDividend.ParseDividendRow`'s testable-without-network seam |
+| `Financial.Infrastructure/Services/TesouroDiretoFinanceService.cs` | New | `IFinanceService` implementation | `GetAssetValue(AssetValueRequest request)` validates `Name` is non-blank (`ArgumentException` otherwise), calls `TesouroDireto.GetRedemptionValue(request.Name)`, and either returns the resulting `AssetValueSnapshot` or throws `AssetValueNotFoundException` when the scraper returns no match |
+| `Financial.Infrastructure/Interfaces/AssetValueNotFoundException.cs` | New | Shared "expected miss" signal | A plain `Exception` subclass with a message constructor; thrown by any `IFinanceService` implementation (starting with this one) to mean "this source doesn't have the value, try another," as opposed to any other exception meaning a genuine failure |
+| `Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs` | Modified | DI composition root | Adds `services.AddSingleton<TesouroDiretoFinanceService>();` (registered by concrete type, not `IFinanceService` — see Technical Decisions) |
+| `Tests/Financial.Infrastructure.Tests/Integrations/TesouroDiretoTests.cs` | New | Unit tests | Covers `FindMatchingRow` against hand-built in-memory HTML: exact match, case-insensitive match, whitespace-tolerant match, no match |
+| `Tests/Financial.Infrastructure.Tests/Services/TesouroDiretoFinanceServiceTests.cs` | New | Unit tests | Covers `GetAssetValue`'s blank-`Name` validation and its not-found-to-exception translation, using a seam that lets the scraper's result be substituted in tests (see Testing Strategy) |
+| `Tests/Financial.Infrastructure.Tests/Integrations/TesouroDiretoVerificationTests.cs` | New | Manual verification tests | `[Fact(Skip = "Manual verification test - requires internet connection")]` tests that call `TesouroDireto.GetRedemptionValue` against real bond titles, mirroring `GoogleFinanceVerificationTests`; must be run unskipped on a machine with normal internet access to confirm the live table structure before this feature ships |
+
+No Domain, Application, or Presentation-layer files are touched — this feature adds a service nothing consumes yet.
+
+## Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Tests/Financial.Infrastructure.Tests/Integrations/TesouroDiretoTests.cs` | Unit | `TesouroDireto.FindMatchingRow` | Row-matching logic against in-memory HTML, no network |
+| `Tests/Financial.Infrastructure.Tests/Services/TesouroDiretoFinanceServiceTests.cs` | Unit | `TesouroDiretoFinanceService` | Validation and not-found-to-exception translation |
+| `Tests/Financial.Infrastructure.Tests/Integrations/TesouroDiretoVerificationTests.cs` | Manual (skipped in CI) | `TesouroDireto.GetRedemptionValue` | Confirms the live page's structure once run manually with internet access |
+
+**Test functions:**
+
+| Test Function | Description | Assertions |
+|----------------|--------------|------------|
+| `FindMatchingRow_ExactTitleMatch_ReturnsRow` | Builds an in-memory table with a row titled "TESOURO IPCA+ 2029" and looks up the same title | Returns the matching row |
+| `FindMatchingRow_CaseInsensitiveMatch_ReturnsRow` | Looks up `"tesouro ipca+ 2029"` against a row titled `"TESOURO IPCA+ 2029"` | Returns the matching row |
+| `FindMatchingRow_WhitespaceDifference_ReturnsRow` | Looks up a title with extra leading/trailing whitespace | Returns the matching row |
+| `FindMatchingRow_NoMatch_ReturnsNull` | Looks up a title with no matching row | Returns `null`, no exception |
+| `GetAssetValue_BlankName_ThrowsArgumentException` | Calls `GetAssetValue` with a blank `Name` | Throws `ArgumentException` |
+| `GetAssetValue_NoMatch_ThrowsAssetValueNotFoundException` | Scraper seam returns no match for the requested title | Throws `AssetValueNotFoundException` |
+| `GetAssetValue_Match_ReturnsSnapshot` | Scraper seam returns a match | Returns the corresponding `AssetValueSnapshot` unmodified |
+| `VerifySelectors_WithKnownBonds` *(manual, skipped)* | Calls `TesouroDireto.GetRedemptionValue` against real bond titles (e.g., "TESOURO SELIC 2029") with internet access | Returns a positive price and a recent `AsOf`; failure here means the table structure changed and `TesouroDireto`'s column-resolution logic needs updating |
+
+**Seam for testing `TesouroDiretoFinanceServiceTests` without network:** `TesouroDireto.GetRedemptionValue` is a `static` method wrapping a live HTTP call, the same limitation `GoogleFinance`'s static methods have. Rather than duplicating that untestable seam inside `TesouroDiretoFinanceService` too, `TesouroDiretoFinanceService`'s constructor accepts an optional `Func<string, AssetValueSnapshot?>` lookup delegate defaulting to `TesouroDireto.GetRedemptionValue`, so tests can substitute a fake delegate without needing a full interface just for this one static call — a narrower, lower-ceremony seam than introducing a new interface solely for testability, consistent with this codebase's preference for direct static delegation elsewhere (`StandardAssetPriceFetcher` still calls `GoogleFinanceService` via `IFinanceService`, since that seam already existed for DI purposes; this one doesn't need a new interface for a single internal call).
+
+**What stays untested (documented, not a gap):** `TesouroDireto.GetRedemptionValue`'s live HTTP fetch and its real table/column resolution against the actual page have no automated unit seam — same limitation already documented for `GoogleFinance`'s live calls. Covered instead by the manual `TesouroDiretoVerificationTests`, run by hand with internet access.
+
+**Acceptance criteria traceability (PRD Section 9, F02):**
+- "`TesouroDiretoFinanceService.GetAssetValue` returns a matching price and as-of date when `request.Name` matches a `Titulo` row case-insensitively (ignoring leading/trailing whitespace)" → `FindMatchingRow_ExactTitleMatch_ReturnsRow`, `FindMatchingRow_CaseInsensitiveMatch_ReturnsRow`, `FindMatchingRow_WhitespaceDifference_ReturnsRow`, `GetAssetValue_Match_ReturnsSnapshot`
+- "`TesouroDiretoFinanceService.GetAssetValue` returns a not-found result, not an exception, when no row matches" *(PRD wording predates this spec's `AssetValueNotFoundException` decision — see Technical Decisions)* → `FindMatchingRow_NoMatch_ReturnsNull`, `GetAssetValue_NoMatch_ThrowsAssetValueNotFoundException`; satisfied in substance as "a distinguishable not-found signal F04 can catch," not a literal non-exception return
+- "`TesouroDiretoFinanceService` is registered in DI as a singleton" → verified by code review of `InfrastructureServiceCollectionExtensions`, consistent with this codebase's convention of not testing DI composition roots
+
+**Cross-Feature Integration (PRD Section 9):** F02 is a provider consumed by F04 (`BondAssetPriceFetcher`), which does not exist yet at this point in the wave sequence. The Cross-Feature Integration criterion covering "a bond found on Tesouro Direto is correctly returned by `BondAssetPriceFetcher`" is validated when F04 is implemented, exactly mirroring the pattern F01's spec used for its own forward-referencing integration criteria.


### PR DESCRIPTION
## Summary
- Adds `TesouroDireto`, a static scraper for tesourodireto.com.br's redemption-price table, resolving the "Título"/"Preço Unit." columns by header text (not fixed indices) since the live table structure couldn't be verified while writing the spec.
- Adds `TesouroDiretoFinanceService` implementing `IFinanceService` (F01), registered in DI by its own concrete type — registering it as `IFinanceService` would make `StandardAssetPriceFetcher`'s injection ambiguous with `GoogleFinanceService`.
- Adds `AssetValueNotFoundException`, a shared "expected miss, try the next source" signal for `IFinanceService` implementations, since F01's contract only supports throw-on-failure with no existing way to distinguish a clean not-found from a genuine error.
- Adds a manual, skipped-by-default verification test class (`TesouroDiretoVerificationTests`, mirrors `GoogleFinanceVerificationTests`) — **please run this manually with real internet access** before relying on this in production; `tesourodireto.com.br` returned HTTP 403 to fetch attempts made from the sandboxed environment used to write the spec, so a browser `User-Agent` was set defensively, but the actual table/column structure has not been confirmed against the live site.
- This is F02 of the BR Bond Finance Service Integration PRD. Nothing consumes `TesouroDiretoFinanceService` yet — that's F04 (Bond fetcher, not yet built), which will also add F03 (Status Invest) as a fallback.

## Test plan
- [x] `dotnet build` on the full solution — 0 errors
- [x] Full test suite across all 5 test projects — 501/501 passing (5 skipped: 2 new manual TD verification tests + 3 pre-existing)
- [x] New `TesouroDiretoTests` covering row-matching (exact/case-insensitive/whitespace/no-match) against in-memory HTML, no network
- [x] New `TesouroDiretoFinanceServiceTests` covering validation and not-found-to-exception translation
- [x] Live smoke check: API host starts cleanly with the new DI registration; existing Equity price endpoint still round-trips correctly
- [ ] **Action needed from you**: run `TesouroDiretoVerificationTests` (currently `[Fact(Skip = ...)]`) against the live site from a machine with normal internet access, to confirm the assumed table structure is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)