### PR TITLE
chore: Add XIRR to asset summary (WPF + Web)

### DIFF
--- a/Financial.Api/Controllers/XirrController.cs
+++ b/Financial.Api/Controllers/XirrController.cs
@@ -1,0 +1,32 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Financial.Api.Controllers;
+
+[ApiController]
+[Route("xirr")]
+public sealed class XirrController : ControllerBase
+{
+    private readonly IXirrCalculationService _xirrCalculationService;
+
+    public XirrController(IXirrCalculationService xirrCalculationService)
+    {
+        _xirrCalculationService = xirrCalculationService ?? throw new ArgumentNullException(nameof(xirrCalculationService));
+    }
+
+    [HttpPost("calculate")]
+    [ProducesResponseType(typeof(XirrResultDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public ActionResult<XirrResultDTO> Calculate([FromBody] CalculateXirrRequestDTO? request)
+    {
+        if (request is null)
+        {
+            return BadRequest();
+        }
+
+        var xirr = _xirrCalculationService.Calculate(request.CashFlows, request.TerminalValue);
+
+        return Ok(new XirrResultDTO { Xirr = xirr });
+    }
+}

--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -187,6 +187,7 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
                                     <!-- Row 0: Quantity & Average Price -->
@@ -298,9 +299,29 @@
                                                Margin="10,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-                                    <!-- Row 11: Status/Error -->
-                                    <TextBlock Grid.Row="11" Grid.Column="0" Text="Status:" FontWeight="Bold" Margin="0,5"/>
-                                    <TextBlock Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="3"
+                                    <!-- Row 11: XIRR & XIRR w/ Credits -->
+                                    <TextBlock Grid.Row="11" Grid.Column="0" Text="XIRR:" FontWeight="Bold" Margin="0,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="11" Grid.Column="1"
+                                               Text="{Binding AssetDetails.Xirr, Mode=OneWay, StringFormat=P2, TargetNullValue='—'}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Foreground="{Binding AssetDetails.Xirr, Converter={StaticResource SignedValueToBrushConverter}}"
+                                               Margin="10,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="11" Grid.Column="2" Text="XIRR w/ Credits:" FontWeight="Bold" Margin="20,5,0,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="11" Grid.Column="3"
+                                               Text="{Binding AssetDetails.XirrWithCredits, Mode=OneWay, StringFormat=P2, TargetNullValue='—'}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Foreground="{Binding AssetDetails.XirrWithCredits, Converter={StaticResource SignedValueToBrushConverter}}"
+                                               Margin="10,5"
+                                               Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+                                    <!-- Row 12: Status/Error -->
+                                    <TextBlock Grid.Row="12" Grid.Column="0" Text="Status:" FontWeight="Bold" Margin="0,5"/>
+                                    <TextBlock Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="3"
                                                Text="{Binding AssetDetails.TodayInfoMessage, Mode=OneWay}"
                                                Margin="10,5"
                                                Foreground="DarkRed"/>

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -17,6 +17,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private readonly IAssetPriceService _assetPriceService;
     private readonly IBrokerBreakdownService _brokerBreakdownService;
     private readonly ITransactionQueryService _transactionQueryService;
+    private readonly IXirrCalculationService _xirrCalculationService;
     private readonly TodayInfoTracker _todayInfo;
     private readonly TransactionActions _transactionActions;
     private readonly CreditActions _creditActions;
@@ -91,6 +92,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private CancellationTokenSource? _transactionsCts;
     private IReadOnlyList<TransactionSummaryItemDTO> _brokerPortfolioTransactions = Array.Empty<TransactionSummaryItemDTO>();
     private IReadOnlyList<TransactionMonthNet> _transactionsChartMonths = Array.Empty<TransactionMonthNet>();
+    private IReadOnlyList<AssetCashFlowDTO> _cashFlowsWithCredits = Array.Empty<AssetCashFlowDTO>();
+    private IReadOnlyList<AssetCashFlowDTO> _cashFlowsWithoutCredits = Array.Empty<AssetCashFlowDTO>();
 
     public string AssetName { get => _assetName; private set => SetProperty(ref _assetName, value); }
     public string BrokerName { get => _brokerName; private set => SetProperty(ref _brokerName, value); }
@@ -171,6 +174,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public decimal TotalCurrentValueWithCredits => TotalCurrentValue + TotalCredits;
     public decimal ResultPercentWithCredits => AssetDetailsCalculations.CalculateResultPercentWithCredits(AveragePrice, Quantity, TotalCurrentValueWithCredits);
     public bool HasAveragePrice => AssetDetailsCalculations.HasAveragePrice(AveragePrice, Quantity);
+    public decimal? Xirr => _xirrCalculationService.Calculate(_cashFlowsWithoutCredits, TotalCurrentValue);
+    public decimal? XirrWithCredits => _xirrCalculationService.Calculate(_cashFlowsWithCredits, TotalCurrentValueWithCredits);
 
     public bool IsPortfolioView
     {
@@ -310,13 +315,15 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         ICreditService creditService,
         IAssetPriceService assetPriceService,
         IBrokerBreakdownService brokerBreakdownService,
-        ITransactionQueryService transactionQueryService)
+        ITransactionQueryService transactionQueryService,
+        IXirrCalculationService xirrCalculationService)
     {
         _transactionService = transactionService ?? throw new ArgumentNullException(nameof(transactionService));
         _creditService = creditService ?? throw new ArgumentNullException(nameof(creditService));
         _assetPriceService = assetPriceService ?? throw new ArgumentNullException(nameof(assetPriceService));
         _brokerBreakdownService = brokerBreakdownService ?? throw new ArgumentNullException(nameof(brokerBreakdownService));
         _transactionQueryService = transactionQueryService ?? throw new ArgumentNullException(nameof(transactionQueryService));
+        _xirrCalculationService = xirrCalculationService ?? throw new ArgumentNullException(nameof(xirrCalculationService));
         _todayInfo = new TodayInfoTracker(ApplyTodayInfo, ResetTodayInfo, UpdateCommandStates);
         _transactionActions = new TransactionActions(
             _transactionService,
@@ -363,7 +370,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
 
         PortfolioAssetSummaryRows.Clear();
         foreach (var item in assetItems)
-            PortfolioAssetSummaryRows.Add(new PortfolioAssetSummaryRowViewModel(item));
+            PortfolioAssetSummaryRows.Add(new PortfolioAssetSummaryRowViewModel(item, _xirrCalculationService));
 
         FooterTotalInvested = assetItems.Sum(i => i.TotalInvested);
         FooterTotalCredits = assetItems.Sum(i => i.TotalCredits);
@@ -393,6 +400,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         CancelAndResetTransactionsFetch();
         var assetKey = BuildAssetKey(details.BrokerName, details.PortfolioName, details.Name);
         _todayInfo.UpdateAssetKey(assetKey);
+        _cashFlowsWithCredits = details.CashFlowsWithCredits;
+        _cashFlowsWithoutCredits = details.CashFlowsWithoutCredits;
 
         AssetName = details.Name;
         BrokerName = details.BrokerName;
@@ -599,6 +608,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         OnPropertyChanged(nameof(HasAveragePrice));
         OnPropertyChanged(nameof(TotalCurrentValueWithCredits));
         OnPropertyChanged(nameof(ResultPercentWithCredits));
+        OnPropertyChanged(nameof(Xirr));
+        OnPropertyChanged(nameof(XirrWithCredits));
     }
 
     private void LoadAggregateCredits(string contextKey, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
@@ -770,6 +781,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         TotalBought = 0;
         TotalSold = 0;
         TotalCredits = 0;
+        _cashFlowsWithCredits = Array.Empty<AssetCashFlowDTO>();
+        _cashFlowsWithoutCredits = Array.Empty<AssetCashFlowDTO>();
         _todayInfo.Clear();
         Transactions.Clear();
     }

--- a/Financial.App/ViewModels/MainNavigationViewModel.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModel.cs
@@ -16,7 +16,8 @@ public class MainNavigationViewModel : MainNavigationViewModelBase<AssetDetailsV
         ICreditService creditService,
         IAssetPriceService assetPriceService,
         IBrokerBreakdownService brokerBreakdownService,
-        ITransactionQueryService transactionQueryService)
+        ITransactionQueryService transactionQueryService,
+        IXirrCalculationService xirrCalculationService)
         : base(
             navigationService ?? throw new ArgumentNullException(nameof(navigationService)),
             creditQueryService ?? throw new ArgumentNullException(nameof(creditQueryService)),
@@ -27,7 +28,8 @@ public class MainNavigationViewModel : MainNavigationViewModelBase<AssetDetailsV
                 creditService ?? throw new ArgumentNullException(nameof(creditService)),
                 assetPriceService ?? throw new ArgumentNullException(nameof(assetPriceService)),
                 brokerBreakdownService ?? throw new ArgumentNullException(nameof(brokerBreakdownService)),
-                transactionQueryService ?? throw new ArgumentNullException(nameof(transactionQueryService))))
+                transactionQueryService ?? throw new ArgumentNullException(nameof(transactionQueryService)),
+                xirrCalculationService ?? throw new ArgumentNullException(nameof(xirrCalculationService))))
     {
     }
 }

--- a/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
+++ b/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using System.Globalization;
 
@@ -6,8 +7,7 @@ namespace Financial.Presentation.App.ViewModels;
 
 public class PortfolioAssetSummaryRowViewModel : ViewModelBase
 {
-    private const int XirrMaxIterations = 100;
-    private const double XirrTolerance = 1e-7;
+    private readonly IXirrCalculationService _xirrCalculationService;
 
     private bool _isLoadingPrice = true;
     private bool _priceFetchFailed;
@@ -92,8 +92,9 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
     public bool XirrIsPositive => _xirr > 0;
     public bool XirrIsNegative => _xirr < 0;
 
-    public PortfolioAssetSummaryRowViewModel(PortfolioAssetSummaryItemDTO dto)
+    public PortfolioAssetSummaryRowViewModel(PortfolioAssetSummaryItemDTO dto, IXirrCalculationService xirrCalculationService)
     {
+        _xirrCalculationService = xirrCalculationService ?? throw new ArgumentNullException(nameof(xirrCalculationService));
         AssetName = dto.AssetName;
         Ticker = dto.Ticker;
         Exchange = dto.Exchange;
@@ -126,7 +127,8 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
             ? (_currentValue.Value + TotalCredits - TotalInvested) / TotalInvested * 100
             : (decimal?)null;
 
-        _xirr = ComputeXirr(_currentValue.Value);
+        var xirrFraction = _xirrCalculationService.Calculate(CashFlows, _currentValue.Value);
+        _xirr = xirrFraction.HasValue ? xirrFraction.Value * 100 : null;
         _isLoadingPrice = false;
 
         OnPropertyChanged(nameof(IsLoadingPrice));
@@ -162,47 +164,4 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
         OnPropertyChanged(nameof(DisplayXirr));
     }
 
-    private decimal? ComputeXirr(decimal terminalValue)
-    {
-        var cashFlows = BuildCashFlowSeries(terminalValue);
-        if (cashFlows.Count < 2)
-            return null;
-
-        var t0 = cashFlows[0].date;
-        double rate = 0.1;
-
-        for (int i = 0; i < XirrMaxIterations; i++)
-        {
-            double f = 0;
-            double df = 0;
-
-            foreach (var (date, amount) in cashFlows)
-            {
-                double years = (date - t0).TotalDays / 365.0;
-                double denom = Math.Pow(1 + rate, years);
-                double c = (double)amount;
-                f += c / denom;
-                df -= years * c / (denom * (1 + rate));
-            }
-
-            if (df == 0)
-                return null;
-
-            double next = rate - f / df;
-
-            if (Math.Abs(f) < XirrTolerance)
-                return (decimal)(rate * 100);
-
-            rate = next;
-        }
-
-        return null;
-    }
-
-    private List<(DateTime date, decimal amount)> BuildCashFlowSeries(decimal terminalValue)
-    {
-        var series = CashFlows.Select(cf => (cf.Date, cf.Amount)).ToList();
-        series.Add((DateTime.Today, terminalValue));
-        return series;
-    }
 }

--- a/Financial.Application/DTOs/AssetDetailsDTO.cs
+++ b/Financial.Application/DTOs/AssetDetailsDTO.cs
@@ -94,5 +94,15 @@ public class AssetDetailsDTO
     /// List of all credits (dividends/rent)
     /// </summary>
     public List<CreditDTO> Credits { get; set; } = new();
+
+    /// <summary>
+    /// Cash flows (transactions + credits) used to compute XIRR with credits
+    /// </summary>
+    public IReadOnlyList<AssetCashFlowDTO> CashFlowsWithCredits { get; set; } = [];
+
+    /// <summary>
+    /// Cash flows (transactions only) used to compute XIRR without credits
+    /// </summary>
+    public IReadOnlyList<AssetCashFlowDTO> CashFlowsWithoutCredits { get; set; } = [];
 }
 

--- a/Financial.Application/DTOs/CalculateXirrRequestDTO.cs
+++ b/Financial.Application/DTOs/CalculateXirrRequestDTO.cs
@@ -1,0 +1,7 @@
+namespace Financial.Application.DTOs;
+
+public sealed class CalculateXirrRequestDTO
+{
+    public IReadOnlyList<AssetCashFlowDTO> CashFlows { get; init; } = [];
+    public decimal TerminalValue { get; init; }
+}

--- a/Financial.Application/DTOs/XirrResultDTO.cs
+++ b/Financial.Application/DTOs/XirrResultDTO.cs
@@ -1,0 +1,6 @@
+namespace Financial.Application.DTOs;
+
+public sealed class XirrResultDTO
+{
+    public decimal? Xirr { get; init; }
+}

--- a/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<IBrokerBreakdownService, BrokerBreakdownService>();
         services.AddSingleton<IPortfolioAssetSummaryService, PortfolioAssetSummaryService>();
         services.AddSingleton<ISummaryService, SummaryService>();
+        services.AddSingleton<IXirrCalculationService, XirrCalculationService>();
 
         return services;
     }

--- a/Financial.Application/Interfaces/IXirrCalculationService.cs
+++ b/Financial.Application/Interfaces/IXirrCalculationService.cs
@@ -1,0 +1,8 @@
+using Financial.Application.DTOs;
+
+namespace Financial.Application.Interfaces;
+
+public interface IXirrCalculationService
+{
+    decimal? Calculate(IReadOnlyList<AssetCashFlowDTO> cashFlows, decimal terminalValue);
+}

--- a/Financial.Application/Services/AssetCashFlowBuilder.cs
+++ b/Financial.Application/Services/AssetCashFlowBuilder.cs
@@ -1,0 +1,38 @@
+using Financial.Application.DTOs;
+using Financial.Domain.Entities;
+
+namespace Financial.Application.Services;
+
+internal static class AssetCashFlowBuilder
+{
+    public static IReadOnlyList<AssetCashFlowDTO> BuildWithCredits(Asset asset)
+    {
+        var flows = BuildFromTransactions(asset);
+
+        foreach (var c in asset.Credits)
+            flows.Add(new AssetCashFlowDTO { Date = c.Date, Amount = c.Value });
+
+        flows.Sort((a, b) => a.Date.CompareTo(b.Date));
+        return flows;
+    }
+
+    public static IReadOnlyList<AssetCashFlowDTO> BuildWithoutCredits(Asset asset)
+    {
+        var flows = BuildFromTransactions(asset);
+        flows.Sort((a, b) => a.Date.CompareTo(b.Date));
+        return flows;
+    }
+
+    private static List<AssetCashFlowDTO> BuildFromTransactions(Asset asset)
+    {
+        var flows = new List<AssetCashFlowDTO>();
+
+        foreach (var t in asset.Transactions)
+        {
+            var amount = t.Type == Transaction.TransactionType.Buy ? -t.TotalPrice : t.TotalPrice;
+            flows.Add(new AssetCashFlowDTO { Date = t.Date, Amount = amount });
+        }
+
+        return flows;
+    }
+}

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -76,7 +76,9 @@ public sealed class NavigationService : INavigationService
             TotalSold = totalSold,
             TotalCredits = totalCredits,
             Transactions = transactions,
-            Credits = credits
+            Credits = credits,
+            CashFlowsWithCredits = AssetCashFlowBuilder.BuildWithCredits(asset),
+            CashFlowsWithoutCredits = AssetCashFlowBuilder.BuildWithoutCredits(asset)
         };
     }
 

--- a/Financial.Application/Services/PortfolioAssetSummaryService.cs
+++ b/Financial.Application/Services/PortfolioAssetSummaryService.cs
@@ -42,7 +42,7 @@ public sealed class PortfolioAssetSummaryService : IPortfolioAssetSummaryService
             .DefaultIfEmpty(null)
             .Min();
 
-        var cashFlows = BuildCashFlows(asset);
+        var cashFlows = AssetCashFlowBuilder.BuildWithCredits(asset);
         var creditsAnalysis = ComputeCreditsAnalysis(asset, totalBought - totalSold, today);
 
         return new AssetComputedData(
@@ -122,23 +122,6 @@ public sealed class PortfolioAssetSummaryService : IPortfolioAssetSummaryService
             <= 5.0 => 3,
             _ => null
         };
-    }
-
-    private static IReadOnlyList<AssetCashFlowDTO> BuildCashFlows(Asset asset)
-    {
-        var flows = new List<AssetCashFlowDTO>();
-
-        foreach (var t in asset.Transactions)
-        {
-            var amount = t.Type == Transaction.TransactionType.Buy ? -t.TotalPrice : t.TotalPrice;
-            flows.Add(new AssetCashFlowDTO { Date = t.Date, Amount = amount });
-        }
-
-        foreach (var c in asset.Credits)
-            flows.Add(new AssetCashFlowDTO { Date = c.Date, Amount = c.Value });
-
-        flows.Sort((a, b) => a.Date.CompareTo(b.Date));
-        return flows;
     }
 
     private static PortfolioAssetSummaryItemDTO ToDTO(AssetComputedData c, decimal weight) =>

--- a/Financial.Application/Services/XirrCalculationService.cs
+++ b/Financial.Application/Services/XirrCalculationService.cs
@@ -1,0 +1,17 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Domain.Rules;
+
+namespace Financial.Application.Services;
+
+public sealed class XirrCalculationService : IXirrCalculationService
+{
+    public decimal? Calculate(IReadOnlyList<AssetCashFlowDTO> cashFlows, decimal terminalValue)
+    {
+        var series = new List<(DateTime Date, decimal Amount)>(cashFlows.Count + 1);
+        series.AddRange(cashFlows.Select(cf => (cf.Date, cf.Amount)));
+        series.Add((DateTime.Today, terminalValue));
+
+        return XirrCalculator.Calculate(series);
+    }
+}

--- a/Financial.Domain/Rules/XirrCalculator.cs
+++ b/Financial.Domain/Rules/XirrCalculator.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Financial.Domain.Rules;
+
+public static class XirrCalculator
+{
+    private const int MaxIterations = 100;
+    private const double Tolerance = 1e-7;
+    private const double InitialRateGuess = 0.1;
+    private const double DaysPerYear = 365.0;
+
+    public static decimal? Calculate(IReadOnlyList<(DateTime Date, decimal Amount)> cashFlows)
+    {
+        if (cashFlows.Count < 2)
+        {
+            return null;
+        }
+
+        var ordered = cashFlows.OrderBy(cf => cf.Date).ToList();
+        var startDate = ordered[0].Date;
+        var rate = InitialRateGuess;
+
+        for (var iteration = 0; iteration < MaxIterations; iteration++)
+        {
+            double presentValue = 0;
+            double derivative = 0;
+
+            foreach (var (date, amount) in ordered)
+            {
+                var years = (date - startDate).TotalDays / DaysPerYear;
+                var discountFactor = Math.Pow(1 + rate, years);
+                var amountAsDouble = (double)amount;
+
+                presentValue += amountAsDouble / discountFactor;
+                derivative -= years * amountAsDouble / (discountFactor * (1 + rate));
+            }
+
+            if (Math.Abs(presentValue) < Tolerance)
+            {
+                return (decimal)rate;
+            }
+
+            if (derivative == 0)
+            {
+                return null;
+            }
+
+            rate -= presentValue / derivative;
+        }
+
+        return null;
+    }
+}

--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { API_BASE_URL } from './config'
 import { createFinancialApiClient } from './financialApiClient'
-import type { AssetDetailsDto, AssetPriceDto, TreeNodeDto } from './types'
+import type { AssetDetailsDto, AssetPriceDto, TreeNodeDto, XirrResultDto } from './types'
 
 const okResponse = <T,>(payload: T) =>
   ({
@@ -186,6 +186,24 @@ describe('financialApiClient', () => {
     expect(result).toEqual(responseBody)
     const [url] = fetchMock.mock.calls[0]
     expect(url).toBe(`${API_BASE_URL}/asset-price-fetch`)
+  })
+
+  it('posts a calculate xirr request', async () => {
+    const responseBody: XirrResultDto = { xirr: 0.1234 }
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({
+      baseUrl: API_BASE_URL,
+      fetch: fetchMock,
+    })
+
+    const cashFlows = [{ date: '2024-01-01T00:00:00', amount: -1000 }]
+    const result = await client.calculateXirr(cashFlows, 1100)
+
+    expect(result).toEqual(responseBody)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/xirr/calculate`)
+    expect(init?.method).toBe('POST')
+    expect(init?.body).toBe(JSON.stringify({ cashFlows, terminalValue: 1100 }))
   })
 
   it('throws when the API returns an error', async () => {

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -1,6 +1,7 @@
 import { API_BASE_URL } from './config'
 import type {
   AggregatedSummaryDto,
+  AssetCashFlowDto,
   AssetDetailsDto,
   AssetPriceDto,
   BrokerNodeDto,
@@ -19,6 +20,7 @@ import type {
   TransactionUpdateDto,
   TreeNodeDto,
   WatchlistItemDto,
+  XirrResultDto,
 } from './types'
 
 export interface FinancialApiClient {
@@ -50,6 +52,7 @@ export interface FinancialApiClient {
   getWatchlist: () => Promise<WatchlistItemDto[]>
   getAssetPriceFetchScope: () => Promise<PortfolioReferenceDto[]>
   getPortfolioAssetsSummary: (brokerName: string, portfolioName: string) => Promise<PortfolioAssetSummaryItemDto[]>
+  calculateXirr: (cashFlows: AssetCashFlowDto[], terminalValue: number) => Promise<XirrResultDto>
 }
 
 export interface FinancialApiClientOptions {
@@ -196,5 +199,10 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       request<PortfolioAssetSummaryItemDto[]>(
         `/summary/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}/assets`,
       ),
+    calculateXirr: (cashFlows, terminalValue) =>
+      request<XirrResultDto>('/xirr/calculate', {
+        method: 'POST',
+        body: JSON.stringify({ cashFlows, terminalValue }),
+      }),
   }
 }

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -96,6 +96,8 @@ export interface AssetDetailsDto {
   totalCredits: number
   transactions: TransactionDto[]
   credits: CreditDto[]
+  cashFlowsWithCredits: AssetCashFlowDto[]
+  cashFlowsWithoutCredits: AssetCashFlowDto[]
 }
 
 export interface TransactionCreateDto {
@@ -217,6 +219,15 @@ export interface PortfolioReferenceDto {
 export interface AssetCashFlowDto {
   date: string
   amount: number
+}
+
+export interface CalculateXirrRequestDto {
+  cashFlows: AssetCashFlowDto[]
+  terminalValue: number
+}
+
+export interface XirrResultDto {
+  xirr: number | null
 }
 
 export interface PortfolioAssetSummaryItemDto {

--- a/Financial.Web/src/components/AssetSummaryTab.tsx
+++ b/Financial.Web/src/components/AssetSummaryTab.tsx
@@ -35,6 +35,8 @@ export default function AssetSummaryTab() {
     resultPercent,
     totalCurrentPlusCredits,
     resultWithCreditsPercent,
+    xirr,
+    xirrWithCredits,
   } = useAssetSummary()
 
   if (isLoadingAsset) {
@@ -53,6 +55,9 @@ export default function AssetSummaryTab() {
     resultPercent >= 0 ? 'asset-summary__value--green' : 'asset-summary__value--red'
   const resultWithCreditsClass =
     resultWithCreditsPercent >= 0 ? 'asset-summary__value--green' : 'asset-summary__value--red'
+  const xirrClass = xirr === null ? '' : xirr >= 0 ? 'asset-summary__value--green' : 'asset-summary__value--red'
+  const xirrWithCreditsClass =
+    xirrWithCredits === null ? '' : xirrWithCredits >= 0 ? 'asset-summary__value--green' : 'asset-summary__value--red'
 
   return (
     <div className="asset-summary">
@@ -156,6 +161,19 @@ export default function AssetSummaryTab() {
                   <span className="asset-summary__label">Result % with Credits</span>
                   <span className={`asset-summary__value ${resultWithCreditsClass}`}>
                     {formatPercent(resultWithCreditsPercent)}
+                  </span>
+                </div>
+
+                <div className="asset-summary__field">
+                  <span className="asset-summary__label">XIRR</span>
+                  <span className={`asset-summary__value ${xirrClass}`}>
+                    {xirr === null ? '—' : formatPercent(xirr)}
+                  </span>
+                </div>
+                <div className="asset-summary__field">
+                  <span className="asset-summary__label">XIRR w/ Credits</span>
+                  <span className={`asset-summary__value ${xirrWithCreditsClass}`}>
+                    {xirrWithCredits === null ? '—' : formatPercent(xirrWithCredits)}
                   </span>
                 </div>
               </>

--- a/Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx
@@ -22,6 +22,8 @@ const mockHookValue: AssetSummaryData = {
   resultPercent: 0,
   totalCurrentPlusCredits: 0,
   resultWithCreditsPercent: 0,
+  xirr: null,
+  xirrWithCredits: null,
 }
 
 vi.mock('../../hooks/useAssetSummary', () => ({
@@ -46,6 +48,8 @@ const ASSET: AssetDetailsDto = {
   totalCredits: 50,
   transactions: [],
   credits: [],
+  cashFlowsWithCredits: [],
+  cashFlowsWithoutCredits: [],
 }
 
 const PRICE: AssetPriceDto = {
@@ -77,6 +81,8 @@ describe('AssetSummaryTab', () => {
       resultPercent: 0,
       totalCurrentPlusCredits: 0,
       resultWithCreditsPercent: 0,
+      xirr: null,
+      xirrWithCredits: null,
     })
   })
 
@@ -225,5 +231,52 @@ describe('AssetSummaryTab', () => {
     render(<AssetSummaryTab />)
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
     expect(mockRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders_dash_for_xirr_while_not_yet_computed', () => {
+    setMock({
+      asset: ASSET,
+      price: PRICE,
+      showCurrentSection: true,
+      totalCurrentValue: 2500,
+      totalCurrentPlusCredits: 2550,
+      xirr: null,
+      xirrWithCredits: null,
+    })
+    render(<AssetSummaryTab />)
+    const xirrLabel = screen.getByText('XIRR')
+    expect(xirrLabel.nextElementSibling?.textContent).toBe('—')
+    const xirrWithCreditsLabel = screen.getByText('XIRR w/ Credits')
+    expect(xirrWithCreditsLabel.nextElementSibling?.textContent).toBe('—')
+  })
+
+  it('renders_positive_xirr_in_green', () => {
+    setMock({
+      asset: ASSET,
+      price: PRICE,
+      showCurrentSection: true,
+      totalCurrentValue: 2500,
+      totalCurrentPlusCredits: 2550,
+      xirr: 0.1234,
+      xirrWithCredits: 0.15,
+    })
+    render(<AssetSummaryTab />)
+    const xirrLabel = screen.getByText('XIRR')
+    expect(xirrLabel.nextElementSibling).toHaveClass('asset-summary__value--green')
+  })
+
+  it('renders_negative_xirr_in_red', () => {
+    setMock({
+      asset: ASSET,
+      price: PRICE,
+      showCurrentSection: true,
+      totalCurrentValue: 1500,
+      totalCurrentPlusCredits: 1550,
+      xirr: -0.1234,
+      xirrWithCredits: -0.1,
+    })
+    render(<AssetSummaryTab />)
+    const xirrLabel = screen.getByText('XIRR')
+    expect(xirrLabel.nextElementSibling).toHaveClass('asset-summary__value--red')
   })
 })

--- a/Financial.Web/src/hooks/useAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/useAssetSummary.test.ts
@@ -1,17 +1,19 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FinancialApiClient } from '../api/financialApiClient'
-import type { AssetDetailsDto, AssetPriceDto, SelectedNode } from '../api/types'
+import type { AssetDetailsDto, AssetPriceDto, SelectedNode, XirrResultDto } from '../api/types'
 import { createSelectedNodeWrapper } from '../test-utils/selectedNodeTestWrapper'
 import { useAssetSummary } from './useAssetSummary'
 
 const getAssetDetailsMock = vi.fn<FinancialApiClient['getAssetDetails']>()
 const getCurrentPriceMock = vi.fn<FinancialApiClient['getCurrentPrice']>()
+const calculateXirrMock = vi.fn<FinancialApiClient['calculateXirr']>()
 
 vi.mock('../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
     getAssetDetails: getAssetDetailsMock,
     getCurrentPrice: getCurrentPriceMock,
+    calculateXirr: calculateXirrMock,
   }),
 }))
 
@@ -49,6 +51,8 @@ const ASSET_DETAILS: AssetDetailsDto = {
   totalCredits: 50,
   transactions: [],
   credits: [],
+  cashFlowsWithCredits: [{ date: '2024-01-01T00:00:00', amount: -2000 }],
+  cashFlowsWithoutCredits: [{ date: '2024-01-01T00:00:00', amount: -2000 }],
 }
 
 const PRICE: AssetPriceDto = {
@@ -63,6 +67,8 @@ describe('useAssetSummary', () => {
   beforeEach(() => {
     getAssetDetailsMock.mockReset()
     getCurrentPriceMock.mockReset()
+    calculateXirrMock.mockReset()
+    calculateXirrMock.mockResolvedValue({ xirr: null })
   })
 
   it('fetches_asset_details_on_asset_selection', async () => {
@@ -195,6 +201,39 @@ describe('useAssetSummary', () => {
     const tcc = tcv + ASSET_DETAILS.totalCredits
     const expected = (tcc - ASSET_DETAILS.totalBought) / ASSET_DETAILS.totalBought
     expect(result.current.resultWithCreditsPercent).toBeCloseTo(expected, 5)
+  })
+
+  it('fetches_xirr_for_both_totals_once_asset_and_price_are_loaded', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    getCurrentPriceMock.mockResolvedValue(PRICE)
+    const responses: XirrResultDto[] = [{ xirr: 0.12 }, { xirr: 0.15 }]
+    calculateXirrMock.mockImplementation(() => Promise.resolve(responses.shift() ?? { xirr: null }))
+    const { wrapper, setNode } = createSelectedNodeWrapper()
+    const { result } = renderHook(() => useAssetSummary(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.xirr).toBe(0.12))
+    expect(result.current.xirrWithCredits).toBe(0.15)
+    expect(calculateXirrMock).toHaveBeenCalledWith(
+      ASSET_DETAILS.cashFlowsWithoutCredits,
+      PRICE.price * ASSET_DETAILS.quantity,
+    )
+    expect(calculateXirrMock).toHaveBeenCalledWith(
+      ASSET_DETAILS.cashFlowsWithCredits,
+      PRICE.price * ASSET_DETAILS.quantity + ASSET_DETAILS.totalCredits,
+    )
+  })
+
+  it('resets_xirr_to_null_when_xirr_calculation_fails', async () => {
+    getAssetDetailsMock.mockResolvedValue(ASSET_DETAILS)
+    getCurrentPriceMock.mockResolvedValue(PRICE)
+    calculateXirrMock.mockRejectedValue(new Error('XIRR unavailable'))
+    const { wrapper, setNode } = createSelectedNodeWrapper()
+    const { result } = renderHook(() => useAssetSummary(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.price).not.toBeNull())
+    await waitFor(() => expect(calculateXirrMock).toHaveBeenCalled())
+    expect(result.current.xirr).toBeNull()
+    expect(result.current.xirrWithCredits).toBeNull()
   })
 
   it('sets_asset_error_on_load_failure', async () => {

--- a/Financial.Web/src/hooks/useAssetSummary.ts
+++ b/Financial.Web/src/hooks/useAssetSummary.ts
@@ -11,6 +11,8 @@ interface SummaryState {
   price: AssetPriceDto | null
   isLoadingPrice: boolean
   priceError: string | null
+  xirr: number | null
+  xirrWithCredits: number | null
 }
 
 type SummaryAction =
@@ -22,6 +24,8 @@ type SummaryAction =
   | { type: 'PRICE_FETCH_START' }
   | { type: 'PRICE_FETCH_SUCCESS'; payload: AssetPriceDto }
   | { type: 'PRICE_FETCH_ERROR'; payload: string }
+  | { type: 'XIRR_RESET' }
+  | { type: 'XIRR_FETCH_SUCCESS'; xirr: number | null; xirrWithCredits: number | null }
 
 const INITIAL_STATE: SummaryState = {
   asset: null,
@@ -31,6 +35,8 @@ const INITIAL_STATE: SummaryState = {
   price: null,
   isLoadingPrice: false,
   priceError: null,
+  xirr: null,
+  xirrWithCredits: null,
 }
 
 function reducer(state: SummaryState, action: SummaryAction): SummaryState {
@@ -46,11 +52,15 @@ function reducer(state: SummaryState, action: SummaryAction): SummaryState {
     case 'ASSET_RETRY':
       return { ...state, assetRetryCount: state.assetRetryCount + 1 }
     case 'PRICE_FETCH_START':
-      return { ...state, isLoadingPrice: true, priceError: null, price: null }
+      return { ...state, isLoadingPrice: true, priceError: null, price: null, xirr: null, xirrWithCredits: null }
     case 'PRICE_FETCH_SUCCESS':
       return { ...state, isLoadingPrice: false, price: action.payload }
     case 'PRICE_FETCH_ERROR':
       return { ...state, isLoadingPrice: false, priceError: action.payload, price: null }
+    case 'XIRR_RESET':
+      return { ...state, xirr: null, xirrWithCredits: null }
+    case 'XIRR_FETCH_SUCCESS':
+      return { ...state, xirr: action.xirr, xirrWithCredits: action.xirrWithCredits }
     default:
       return state
   }
@@ -71,6 +81,8 @@ export interface AssetSummaryData {
   resultPercent: number
   totalCurrentPlusCredits: number
   resultWithCreditsPercent: number
+  xirr: number | null
+  xirrWithCredits: number | null
 }
 
 export function useAssetSummary(): AssetSummaryData {
@@ -144,6 +156,33 @@ export function useAssetSummary(): AssetSummaryData {
     )
   }, [isAsset, selectedNode, fetchPrice])
 
+  useEffect(() => {
+    if (!state.asset || !state.price) {
+      dispatch({ type: 'XIRR_RESET' })
+      return
+    }
+
+    const currentValue = state.price.price * state.asset.quantity
+    const currentValueWithCredits = currentValue + state.asset.totalCredits
+    let cancelled = false
+
+    void Promise.all([
+      apiClient.calculateXirr(state.asset.cashFlowsWithoutCredits, currentValue),
+      apiClient.calculateXirr(state.asset.cashFlowsWithCredits, currentValueWithCredits),
+    ])
+      .then(([withoutCredits, withCredits]) => {
+        if (cancelled) return
+        dispatch({ type: 'XIRR_FETCH_SUCCESS', xirr: withoutCredits.xirr, xirrWithCredits: withCredits.xirr })
+      })
+      .catch(() => {
+        if (!cancelled) dispatch({ type: 'XIRR_RESET' })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [state.asset, state.price, apiClient])
+
   const canRefresh = !state.isLoadingPrice
 
   const showCurrentSection =
@@ -179,5 +218,7 @@ export function useAssetSummary(): AssetSummaryData {
     resultPercent,
     totalCurrentPlusCredits,
     resultWithCreditsPercent,
+    xirr: state.xirr,
+    xirrWithCredits: state.xirrWithCredits,
   }
 }

--- a/Financial.Web/src/hooks/useCredits.test.ts
+++ b/Financial.Web/src/hooks/useCredits.test.ts
@@ -88,6 +88,8 @@ const ASSET_DETAILS: AssetDetailsDto = {
   totalCredits: 470.5,
   transactions: [],
   credits: [CREDIT_A, CREDIT_B],
+  cashFlowsWithCredits: [],
+  cashFlowsWithoutCredits: [],
 }
 
 describe('useCredits', () => {

--- a/Financial.Web/src/hooks/useTransactions.test.ts
+++ b/Financial.Web/src/hooks/useTransactions.test.ts
@@ -98,6 +98,8 @@ const ASSET_DETAILS: AssetDetailsDto = {
   totalCredits: 50,
   transactions: [TRANSACTION_A, TRANSACTION_B],
   credits: [],
+  cashFlowsWithCredits: [],
+  cashFlowsWithoutCredits: [],
 }
 
 describe('useTransactions', () => {

--- a/Tests/Financial.Api.Tests/XirrEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/XirrEndpointsTests.cs
@@ -1,0 +1,58 @@
+using Financial.Application.DTOs;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace Financial.Api.Tests;
+
+public class XirrEndpointsTests
+{
+    [Fact]
+    public async Task Calculate_ValidRequest_ReturnsOk()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var request = new CalculateXirrRequestDTO
+        {
+            CashFlows = [new AssetCashFlowDTO { Date = DateTime.Today.AddYears(-1), Amount = -1000m }],
+            TerminalValue = 1100m
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/xirr/calculate", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<XirrResultDTO>();
+        result.Should().NotBeNull();
+        result!.Xirr.Should().NotBeNull();
+        result.Xirr!.Value.Should().BeApproximately(0.10m, 0.01m);
+    }
+
+    [Fact]
+    public async Task Calculate_EmptyBody_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync<CalculateXirrRequestDTO?>("/api/v1/financial/xirr/calculate", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Calculate_InsufficientCashFlows_ReturnsOkWithNullXirr()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var request = new CalculateXirrRequestDTO { CashFlows = [], TerminalValue = 0m };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/xirr/calculate", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<XirrResultDTO>();
+        result.Should().NotBeNull();
+        result!.Xirr.Should().BeNull();
+    }
+}

--- a/Tests/Financial.Application.Tests/Services/XirrCalculationServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/XirrCalculationServiceTests.cs
@@ -1,0 +1,48 @@
+using Financial.Application.DTOs;
+using Financial.Application.Services;
+using FluentAssertions;
+
+namespace Financial.Application.Tests.Services;
+
+public class XirrCalculationServiceTests
+{
+    private readonly XirrCalculationService _sut = new();
+
+    [Fact]
+    public void Calculate_SingleInvestmentGrowingTenPercent_ReturnsApproximatelyTenPercent()
+    {
+        var oneYearAgo = DateTime.Today.AddYears(-1);
+        var cashFlows = new List<AssetCashFlowDTO>
+        {
+            new() { Date = oneYearAgo, Amount = -1000m }
+        };
+
+        var result = _sut.Calculate(cashFlows, 1100m);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().BeApproximately(0.10m, 0.01m);
+    }
+
+    [Fact]
+    public void Calculate_NoCashFlows_ReturnsNull()
+    {
+        var result = _sut.Calculate([], 1000m);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Calculate_AppendsTerminalValueAsTodaysCashFlow()
+    {
+        var oneYearAgo = DateTime.Today.AddYears(-1);
+        var cashFlows = new List<AssetCashFlowDTO>
+        {
+            new() { Date = oneYearAgo, Amount = -1000m }
+        };
+
+        var result = _sut.Calculate(cashFlows, 900m);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().BeLessThan(0m);
+    }
+}

--- a/Tests/Financial.Domain.Tests/Domain/XirrCalculatorTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/XirrCalculatorTests.cs
@@ -1,0 +1,81 @@
+using Financial.Domain.Rules;
+using FluentAssertions;
+
+namespace Financial.Domain.Tests;
+
+public class XirrCalculatorTests
+{
+    [Fact]
+    public void Calculate_FewerThanTwoCashFlows_ReturnsNull()
+    {
+        var result = XirrCalculator.Calculate([(new DateTime(2024, 1, 1), -1000m)]);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Calculate_TenPercentGrowthOverOneYear_ReturnsApproximatelyTenPercent()
+    {
+        var cashFlows = new List<(DateTime Date, decimal Amount)>
+        {
+            (new DateTime(2023, 1, 1), -1000m),
+            (new DateTime(2024, 1, 1), 1100m)
+        };
+
+        var result = XirrCalculator.Calculate(cashFlows);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().BeApproximately(0.10m, 0.001m);
+    }
+
+    [Fact]
+    public void Calculate_LossOverOneYear_ReturnsNegativeRate()
+    {
+        var cashFlows = new List<(DateTime Date, decimal Amount)>
+        {
+            (new DateTime(2023, 1, 1), -1000m),
+            (new DateTime(2024, 1, 1), 900m)
+        };
+
+        var result = XirrCalculator.Calculate(cashFlows);
+
+        result.Should().NotBeNull();
+        result!.Value.Should().BeLessThan(0m);
+    }
+
+    [Fact]
+    public void Calculate_UnorderedCashFlows_MatchesResultOfOrderedCashFlows()
+    {
+        var ordered = new List<(DateTime Date, decimal Amount)>
+        {
+            (new DateTime(2022, 1, 1), -1000m),
+            (new DateTime(2023, 1, 1), 100m),
+            (new DateTime(2024, 1, 1), 1100m)
+        };
+        var unordered = new List<(DateTime Date, decimal Amount)>
+        {
+            (new DateTime(2024, 1, 1), 1100m),
+            (new DateTime(2022, 1, 1), -1000m),
+            (new DateTime(2023, 1, 1), 100m)
+        };
+
+        var orderedResult = XirrCalculator.Calculate(ordered);
+        var unorderedResult = XirrCalculator.Calculate(unordered);
+
+        unorderedResult.Should().Be(orderedResult);
+    }
+
+    [Fact]
+    public void Calculate_AllPositiveCashFlows_ReturnsNull()
+    {
+        var cashFlows = new List<(DateTime Date, decimal Amount)>
+        {
+            (new DateTime(2023, 1, 1), 500m),
+            (new DateTime(2024, 1, 1), 500m)
+        };
+
+        var result = XirrCalculator.Calculate(cashFlows);
+
+        result.Should().BeNull();
+    }
+}

--- a/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
@@ -230,6 +230,38 @@ public class NavigationServiceTests
     }
 
     [Fact]
+    public void GetAssetDetails_ShouldIncludeCashFlowsWithCredits()
+    {
+        // Arrange
+        const string brokerName = "XPI";
+        const string portfolioName = "Default";
+        const string assetName = "BCIA11";
+
+        // Act
+        var result = _sut.GetAssetDetails(brokerName, portfolioName, assetName);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.CashFlowsWithCredits.Should().HaveCount(result.Transactions.Count + result.Credits.Count);
+    }
+
+    [Fact]
+    public void GetAssetDetails_ShouldIncludeCashFlowsWithoutCredits_ExcludingCredits()
+    {
+        // Arrange
+        const string brokerName = "XPI";
+        const string portfolioName = "Default";
+        const string assetName = "BCIA11";
+
+        // Act
+        var result = _sut.GetAssetDetails(brokerName, portfolioName, assetName);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.CashFlowsWithoutCredits.Should().HaveCount(result.Transactions.Count);
+    }
+
+    [Fact]
     public void GetAssetDetails_ShouldCalculateTotalsCorrectly()
     {
         // Arrange

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
@@ -1,5 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
+using Financial.Application.Services;
 using Financial.Presentation.App.ViewModels;
 using FluentAssertions;
 
@@ -16,7 +17,8 @@ public class AssetDetailsViewModelBrokerSummaryTests
             new StubCreditService(),
             new StubAssetPriceService(),
             brokerBreakdownService ?? new StubBrokerBreakdownService(),
-            transactionQueryService ?? new StubTransactionQueryService());
+            transactionQueryService ?? new StubTransactionQueryService(),
+            new XirrCalculationService());
     }
 
     [Fact]

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelCreditsChartTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelCreditsChartTests.cs
@@ -1,5 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
+using Financial.Application.Services;
 using Financial.Presentation.App.ViewModels;
 using FluentAssertions;
 
@@ -14,7 +15,8 @@ public class AssetDetailsViewModelCreditsChartTests
             new StubCreditService(),
             new StubAssetPriceService(),
             new StubBrokerBreakdownService(),
-            new StubTransactionQueryService());
+            new StubTransactionQueryService(),
+            new XirrCalculationService());
     }
 
     [Fact]

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
@@ -1,5 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
+using Financial.Application.Services;
 using Financial.Domain.Entities;
 using Financial.Presentation.App.ViewModels;
 using FluentAssertions;
@@ -15,7 +16,8 @@ public class AssetDetailsViewModelPortfolioSummaryTests
             new StubCreditService(),
             priceService ?? new NeverResolvingPriceService(),
             new StubBrokerBreakdownService(),
-            new StubTransactionQueryService());
+            new StubTransactionQueryService(),
+            new XirrCalculationService());
     }
 
     private static IReadOnlyList<PortfolioAssetSummaryItemDTO> BuildItems(int count = 2)

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelTransactionsChartTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelTransactionsChartTests.cs
@@ -1,5 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
+using Financial.Application.Services;
 using Financial.Presentation.App.Helpers;
 using Financial.Presentation.App.ViewModels;
 using FluentAssertions;
@@ -17,7 +18,8 @@ public class AssetDetailsViewModelTransactionsChartTests
             new StubCreditService(),
             new StubAssetPriceService(),
             brokerBreakdownService ?? new StubBrokerBreakdownService(),
-            transactionQueryService ?? new StubTransactionQueryService());
+            transactionQueryService ?? new StubTransactionQueryService(),
+            new XirrCalculationService());
     }
 
     private static AssetDetailsDTO BuildAssetDetails(List<TransactionDTO> transactions) => new()

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelXirrTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelXirrTests.cs
@@ -1,0 +1,110 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Application.Services;
+using Financial.Domain.Entities;
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class AssetDetailsViewModelXirrTests
+{
+    private static AssetDetailsViewModel BuildViewModel(IAssetPriceService? priceService = null)
+    {
+        return new AssetDetailsViewModel(
+            new StubTransactionService(),
+            new StubCreditService(),
+            priceService ?? new FixedPriceService(0m),
+            new StubBrokerBreakdownService(),
+            new StubTransactionQueryService(),
+            new XirrCalculationService());
+    }
+
+    private static AssetDetailsDTO BuildAssetDetails(
+        IReadOnlyList<AssetCashFlowDTO> cashFlowsWithoutCredits,
+        IReadOnlyList<AssetCashFlowDTO> cashFlowsWithCredits,
+        decimal totalCredits = 0m) => new()
+    {
+        Name = "TEST",
+        BrokerName = "XPI",
+        PortfolioName = "Default",
+        Ticker = "TEST",
+        Exchange = "BVMF",
+        Quantity = 1m,
+        AveragePrice = 1000m,
+        TotalCredits = totalCredits,
+        CashFlowsWithoutCredits = cashFlowsWithoutCredits,
+        CashFlowsWithCredits = cashFlowsWithCredits
+    };
+
+    [Fact]
+    public void Xirr_BeforeAssetLoaded_IsNull()
+    {
+        var vm = BuildViewModel();
+
+        vm.Xirr.Should().BeNull();
+        vm.XirrWithCredits.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Xirr_AfterLoadAssetDetailsAndPriceFetched_ComputesApproximateRate()
+    {
+        var buyDate = DateTime.Today.AddYears(-1);
+        var cashFlows = new List<AssetCashFlowDTO> { new() { Date = buyDate, Amount = -1000m } };
+        var vm = BuildViewModel(new FixedPriceService(1100m));
+
+        vm.LoadAssetDetails(BuildAssetDetails(cashFlows, cashFlows));
+        await vm.EnsureTodayInfoLoadedAsync();
+
+        vm.Xirr.Should().NotBeNull();
+        vm.Xirr!.Value.Should().BeApproximately(0.10m, 0.01m);
+    }
+
+    [Fact]
+    public async Task XirrWithCredits_UsesCreditsCashFlowsAndTotalWithCredits()
+    {
+        var buyDate = DateTime.Today.AddYears(-1);
+        var creditDate = DateTime.Today.AddMonths(-6);
+        var withoutCredits = new List<AssetCashFlowDTO> { new() { Date = buyDate, Amount = -1000m } };
+        var withCredits = new List<AssetCashFlowDTO>
+        {
+            new() { Date = buyDate, Amount = -1000m },
+            new() { Date = creditDate, Amount = 50m }
+        };
+        var vm = BuildViewModel(new FixedPriceService(1000m));
+
+        vm.LoadAssetDetails(BuildAssetDetails(withoutCredits, withCredits, totalCredits: 50m));
+        await vm.EnsureTodayInfoLoadedAsync();
+
+        vm.Xirr.Should().NotBeNull();
+        vm.XirrWithCredits.Should().NotBeNull();
+        vm.XirrWithCredits!.Value.Should().BeGreaterThan(vm.Xirr!.Value);
+    }
+
+    [Fact]
+    public void Clear_ResetsXirrToNull()
+    {
+        var buyDate = DateTime.Today.AddYears(-1);
+        var cashFlows = new List<AssetCashFlowDTO> { new() { Date = buyDate, Amount = -1000m } };
+        var vm = BuildViewModel(new FixedPriceService(1100m));
+        vm.LoadAssetDetails(BuildAssetDetails(cashFlows, cashFlows));
+
+        vm.Clear();
+
+        vm.Xirr.Should().BeNull();
+        vm.XirrWithCredits.Should().BeNull();
+    }
+
+    private sealed class FixedPriceService : IAssetPriceService
+    {
+        private readonly decimal _price;
+
+        public FixedPriceService(decimal price)
+        {
+            _price = price;
+        }
+
+        public AssetPriceDTO GetCurrentPrice(AssetPriceRequestDTO request) =>
+            new() { Exchange = request.Exchange, Ticker = request.Ticker, Price = _price, AsOf = DateTimeOffset.UtcNow };
+    }
+}

--- a/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Services;
 using Financial.Presentation.App.ViewModels;
 using FluentAssertions;
 
@@ -42,7 +43,7 @@ public class PortfolioAssetSummaryRowViewModelTests
             EstimatedAnnualPercent = estimatedAnnualPercent,
             CurrentMonthCredits = currentMonthCredits
         };
-        return new PortfolioAssetSummaryRowViewModel(dto);
+        return new PortfolioAssetSummaryRowViewModel(dto, new XirrCalculationService());
     }
 
     [Fact]
@@ -89,7 +90,7 @@ public class PortfolioAssetSummaryRowViewModelTests
             CurrentQuantity = 1m, TotalBought = 1m, TotalSold = 0m,
             TotalInvested = 1m, PortfolioWeight = 23.4567m
         };
-        var row = new PortfolioAssetSummaryRowViewModel(dto);
+        var row = new PortfolioAssetSummaryRowViewModel(dto, new XirrCalculationService());
         row.DisplayPortfolioWeight.Should().Be("23.5%");
     }
 


### PR DESCRIPTION
## Summary
- Asset Summary previously showed two totals (Total Current Value, and Total Current Value + Credits) with no rate-of-return figure alongside them. This adds the corresponding XIRR for each total.
- The XIRR calculation moves out of the two duplicated client-side implementations (WPF's private Newton-Raphson in `PortfolioAssetSummaryRowViewModel`, Web's `utils/xirr.ts`) into a single Domain-layer `XirrCalculator`, exposed through a new `IXirrCalculationService` (Application layer) and a `POST /xirr/calculate` endpoint (Api layer) for the browser-based Web SPA. WPF calls the service directly in-process, matching its existing composition-root pattern.
- `AssetDetailsDTO` gains `CashFlowsWithCredits`/`CashFlowsWithoutCredits`, built by a shared `AssetCashFlowBuilder` extracted from `PortfolioAssetSummaryService`'s previously-private cash-flow logic.
- WPF: new row in the Asset Summary panel (`XIRR:` / `XIRR w/ Credits:`), and `PortfolioAssetSummaryRowViewModel`'s existing multi-asset XIRR column now delegates to the same shared service instead of its own duplicate calculator.
- Web: `useAssetSummary` fetches both XIRR values asynchronously from the new endpoint once price and asset data are loaded; `AssetSummaryTab` renders them next to the existing totals.
- Out of scope (left as-is, by design): `PortfolioSummaryTab`'s per-row XIRR column keeps its existing synchronous client-side `utils/xirr.ts` calculation — that table wasn't part of this ask, and migrating it would trade a working calculation for N extra network round trips per portfolio view.

This is out of scope for the P09 PRD (BR Bond Finance Service Integration), hence the separate branch.

## Test plan
- [x] `dotnet test` green across all 5 .NET test projects (531 passed, 5 pre-existing skips, 0 failures)
- [x] `npx vitest run` green (365 passed)
- [x] `npx tsc -b --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] Live smoke test: started the API locally and POSTed to `/xirr/calculate`, confirmed the returned rate matches the expected annualized return for the given cash flow and terminal value

🤖 Generated with [Claude Code](https://claude.com/claude-code)