### PR TITLE
feat(P10-F01): Position Type domain model (Long/Flat/Short)

### DIFF
--- a/Financial.Application/DTOs/AssetDetailsDTO.cs
+++ b/Financial.Application/DTOs/AssetDetailsDTO.cs
@@ -71,10 +71,10 @@ public class AssetDetailsDTO
     public bool IsActive { get; set; }
 
     /// <summary>
-    /// Position status derived from quantity sign (Long/Flat/Short)
+    /// Position type derived from quantity sign (Long/Flat/Short)
     /// </summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public Asset.PositionStatus Status { get; set; }
+    public PositionType PositionType { get; set; }
 
     /// <summary>
     /// Total amount bought

--- a/Financial.Application/DTOs/AssetDetailsDTO.cs
+++ b/Financial.Application/DTOs/AssetDetailsDTO.cs
@@ -71,6 +71,12 @@ public class AssetDetailsDTO
     public bool IsActive { get; set; }
 
     /// <summary>
+    /// Position status derived from quantity sign (Long/Flat/Short)
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public Asset.PositionStatus Status { get; set; }
+
+    /// <summary>
     /// Total amount bought
     /// </summary>
     public decimal TotalBought { get; set; }

--- a/Financial.Application/DTOs/AssetNodeDTO.cs
+++ b/Financial.Application/DTOs/AssetNodeDTO.cs
@@ -61,10 +61,10 @@ public class AssetNodeDTO
     public bool IsActive { get; set; }
 
     /// <summary>
-    /// Position status derived from quantity sign (Long/Flat/Short)
+    /// Position type derived from quantity sign (Long/Flat/Short)
     /// </summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public Asset.PositionStatus Status { get; set; }
+    public PositionType PositionType { get; set; }
 
     /// <summary>
     /// Number of transactions (buy/sell)

--- a/Financial.Application/DTOs/AssetNodeDTO.cs
+++ b/Financial.Application/DTOs/AssetNodeDTO.cs
@@ -61,6 +61,12 @@ public class AssetNodeDTO
     public bool IsActive { get; set; }
 
     /// <summary>
+    /// Position status derived from quantity sign (Long/Flat/Short)
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public Asset.PositionStatus Status { get; set; }
+
+    /// <summary>
     /// Number of transactions (buy/sell)
     /// </summary>
     public int TransactionCount { get; set; }

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -70,7 +70,7 @@ internal static class NavigationMapper
                 ["Quantity"] = asset.Quantity,
                 ["AveragePrice"] = asset.AveragePrice,
                 ["IsActive"] = asset.IsActive,
-                ["PositionStatus"] = asset.Status,
+                ["PositionType"] = asset.PositionType,
                 ["TransactionCount"] = asset.TransactionCount,
                 ["CreditCount"] = asset.CreditCount
             }
@@ -179,7 +179,7 @@ internal static class NavigationMapper
             Quantity = asset.Quantity,
             AveragePrice = asset.AveragePrice,
             IsActive = asset.Active,
-            Status = asset.Status,
+            PositionType = asset.PositionType,
             TransactionCount = asset.Transactions.Count,
             CreditCount = asset.Credits.Count
         };

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -70,6 +70,7 @@ internal static class NavigationMapper
                 ["Quantity"] = asset.Quantity,
                 ["AveragePrice"] = asset.AveragePrice,
                 ["IsActive"] = asset.IsActive,
+                ["PositionStatus"] = asset.Status,
                 ["TransactionCount"] = asset.TransactionCount,
                 ["CreditCount"] = asset.CreditCount
             }
@@ -178,6 +179,7 @@ internal static class NavigationMapper
             Quantity = asset.Quantity,
             AveragePrice = asset.AveragePrice,
             IsActive = asset.Active,
+            Status = asset.Status,
             TransactionCount = asset.Transactions.Count,
             CreditCount = asset.Credits.Count
         };

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -72,7 +72,7 @@ public sealed class NavigationService : INavigationService
             Quantity = asset.Quantity,
             AveragePrice = asset.AveragePrice,
             IsActive = asset.Active,
-            Status = asset.Status,
+            PositionType = asset.PositionType,
             TotalBought = totalBought,
             TotalSold = totalSold,
             TotalCredits = totalCredits,

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -72,6 +72,7 @@ public sealed class NavigationService : INavigationService
             Quantity = asset.Quantity,
             AveragePrice = asset.AveragePrice,
             IsActive = asset.Active,
+            Status = asset.Status,
             TotalBought = totalBought,
             TotalSold = totalSold,
             TotalCredits = totalCredits,

--- a/Financial.Domain/Entities/Asset.cs
+++ b/Financial.Domain/Entities/Asset.cs
@@ -5,6 +5,8 @@ namespace Financial.Domain.Entities;
 
 public class Asset
 {
+    public enum PositionStatus { Long, Flat, Short }
+
     public string Name { get; private set; }
 
     public string ISIN { get; private set; }
@@ -24,6 +26,13 @@ public class Asset
     public decimal Quantity { get; private set; }
 
     public bool Active => Quantity > 0;
+
+    public PositionStatus Status => Quantity switch
+    {
+        > 0 => PositionStatus.Long,
+        < 0 => PositionStatus.Short,
+        _ => PositionStatus.Flat
+    };
 
     private List<Transaction> _transactions = new List<Transaction>();
     public IReadOnlyCollection<Transaction> Transactions { get => _transactions.AsReadOnly(); private set => SetTransactions(value); }

--- a/Financial.Domain/Entities/Asset.cs
+++ b/Financial.Domain/Entities/Asset.cs
@@ -5,8 +5,6 @@ namespace Financial.Domain.Entities;
 
 public class Asset
 {
-    public enum PositionStatus { Long, Flat, Short }
-
     public string Name { get; private set; }
 
     public string ISIN { get; private set; }
@@ -27,11 +25,11 @@ public class Asset
 
     public bool Active => Quantity > 0;
 
-    public PositionStatus Status => Quantity switch
+    public PositionType PositionType => Quantity switch
     {
-        > 0 => PositionStatus.Long,
-        < 0 => PositionStatus.Short,
-        _ => PositionStatus.Flat
+        > 0 => PositionType.Long,
+        < 0 => PositionType.Short,
+        _ => PositionType.Flat
     };
 
     private List<Transaction> _transactions = new List<Transaction>();

--- a/Financial.Domain/Entities/PositionType.cs
+++ b/Financial.Domain/Entities/PositionType.cs
@@ -1,0 +1,3 @@
+namespace Financial.Domain.Entities;
+
+public enum PositionType { Long, Flat, Short }

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -50,6 +50,7 @@ export interface AssetNodeDto {
   quantity: number
   averagePrice: number
   isActive: boolean
+  status: string
   transactionCount: number
   creditCount: number
 }
@@ -91,6 +92,7 @@ export interface AssetDetailsDto {
   quantity: number
   averagePrice: number
   isActive: boolean
+  status: string
   totalBought: number
   totalSold: number
   totalCredits: number

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -50,7 +50,7 @@ export interface AssetNodeDto {
   quantity: number
   averagePrice: number
   isActive: boolean
-  status: string
+  positionType: string
   transactionCount: number
   creditCount: number
 }
@@ -92,7 +92,7 @@ export interface AssetDetailsDto {
   quantity: number
   averagePrice: number
   isActive: boolean
-  status: string
+  positionType: string
   totalBought: number
   totalSold: number
   totalCredits: number

--- a/Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx
@@ -43,7 +43,7 @@ const ASSET: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   isActive: true,
-  status: 'Long',
+  positionType: 'Long',
   totalBought: 2000,
   totalSold: 500,
   totalCredits: 50,

--- a/Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx
@@ -43,6 +43,7 @@ const ASSET: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   isActive: true,
+  status: 'Long',
   totalBought: 2000,
   totalSold: 500,
   totalCredits: 50,

--- a/Financial.Web/src/hooks/useAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/useAssetSummary.test.ts
@@ -46,6 +46,7 @@ const ASSET_DETAILS: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   isActive: true,
+  status: 'Long',
   totalBought: 2000,
   totalSold: 0,
   totalCredits: 50,

--- a/Financial.Web/src/hooks/useAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/useAssetSummary.test.ts
@@ -46,7 +46,7 @@ const ASSET_DETAILS: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   isActive: true,
-  status: 'Long',
+  positionType: 'Long',
   totalBought: 2000,
   totalSold: 0,
   totalCredits: 50,

--- a/Financial.Web/src/hooks/useCredits.test.ts
+++ b/Financial.Web/src/hooks/useCredits.test.ts
@@ -83,7 +83,7 @@ const ASSET_DETAILS: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   isActive: true,
-  status: 'Long',
+  positionType: 'Long',
   totalBought: 2000,
   totalSold: 0,
   totalCredits: 470.5,

--- a/Financial.Web/src/hooks/useCredits.test.ts
+++ b/Financial.Web/src/hooks/useCredits.test.ts
@@ -83,6 +83,7 @@ const ASSET_DETAILS: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   isActive: true,
+  status: 'Long',
   totalBought: 2000,
   totalSold: 0,
   totalCredits: 470.5,

--- a/Financial.Web/src/hooks/useTransactions.test.ts
+++ b/Financial.Web/src/hooks/useTransactions.test.ts
@@ -93,6 +93,7 @@ const ASSET_DETAILS: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   isActive: true,
+  status: 'Long',
   totalBought: 2000,
   totalSold: 0,
   totalCredits: 50,

--- a/Financial.Web/src/hooks/useTransactions.test.ts
+++ b/Financial.Web/src/hooks/useTransactions.test.ts
@@ -93,7 +93,7 @@ const ASSET_DETAILS: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   isActive: true,
-  status: 'Long',
+  positionType: 'Long',
   totalBought: 2000,
   totalSold: 0,
   totalCredits: 50,

--- a/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
@@ -40,6 +40,7 @@ const makeBroker = (
       quantity: 10,
       averagePrice: 100,
       isActive: a.isActive ?? true,
+      status: a.status ?? ((a.isActive ?? true) ? 'Long' : 'Flat'),
       transactionCount: 0,
       creditCount: 0,
     })),

--- a/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
@@ -40,7 +40,7 @@ const makeBroker = (
       quantity: 10,
       averagePrice: 100,
       isActive: a.isActive ?? true,
-      status: a.status ?? ((a.isActive ?? true) ? 'Long' : 'Flat'),
+      positionType: a.positionType ?? ((a.isActive ?? true) ? 'Long' : 'Flat'),
       transactionCount: 0,
       creditCount: 0,
     })),

--- a/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
+++ b/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
@@ -53,6 +53,64 @@ public class NavigationMapperTests
         reitNode.Metadata["GlobalAssetClass"].Should().Be(GlobalAssetClass.RealEstate);
     }
 
+    [Fact]
+    public void GetNavigationTree_AssetNode_MetadataIncludesPositionStatus()
+    {
+        _repository.Broker = BuildBrokerWithAsset("LONG1", GlobalAssetClass.Equity, quantity: 10m);
+
+        var tree = CreateService().GetNavigationTree();
+
+        var assetNode = GetFirstAssetNode(tree);
+        assetNode.Metadata["PositionStatus"].Should().Be(Asset.PositionStatus.Long);
+    }
+
+    [Theory]
+    [InlineData(10, Asset.PositionStatus.Long)]
+    [InlineData(0, Asset.PositionStatus.Flat)]
+    [InlineData(-10, Asset.PositionStatus.Short)]
+    public void GetAssetsByBrokerPortfolio_AssetNodeDto_StatusMatchesAssetStatus(decimal quantity, Asset.PositionStatus expectedStatus)
+    {
+        var broker = Broker.Create("Broker", "BRL");
+        var portfolio = broker.AddPortfolio("Portfolio");
+        portfolio.AddAsset(BuildAssetWithQuantity("ASSET1", quantity));
+        _repository.Broker = broker;
+
+        var assets = CreateService().GetAssetsByBrokerPortfolio("Broker", "Portfolio").ToList();
+
+        assets.Should().ContainSingle().Which.Status.Should().Be(expectedStatus);
+    }
+
+    [Theory]
+    [InlineData(10, Asset.PositionStatus.Long)]
+    [InlineData(0, Asset.PositionStatus.Flat)]
+    [InlineData(-10, Asset.PositionStatus.Short)]
+    public void GetAssetDetails_ReturnsStatusMatchingAsset(decimal quantity, Asset.PositionStatus expectedStatus)
+    {
+        var broker = Broker.Create("Broker", "BRL");
+        var portfolio = broker.AddPortfolio("Portfolio");
+        portfolio.AddAsset(BuildAssetWithQuantity("ASSET1", quantity));
+        _repository.Broker = broker;
+
+        var details = CreateService().GetAssetDetails("Broker", "Portfolio", "ASSET1");
+
+        details.Should().NotBeNull();
+        details!.Status.Should().Be(expectedStatus);
+    }
+
+    private static Asset BuildAssetWithQuantity(string name, decimal quantity)
+    {
+        var asset = Asset.Create(name, "ISIN", "BVMF", name, CountryCode.BR, "FII", GlobalAssetClass.Equity);
+        if (quantity > 0)
+        {
+            asset.AddTransaction(Transaction.Create(new DateTime(2024, 1, 1), Transaction.TransactionType.Buy, quantity, 10m, 0m));
+        }
+        else if (quantity < 0)
+        {
+            asset.AddTransaction(Transaction.Create(new DateTime(2024, 1, 1), Transaction.TransactionType.Sell, -quantity, 10m, 0m));
+        }
+        return asset;
+    }
+
     private static TreeNodeDTO GetFirstAssetNode(TreeNodeDTO tree) =>
         tree.Children
             .SelectMany(broker => broker.Children)
@@ -64,11 +122,20 @@ public class NavigationMapperTests
             .SelectMany(broker => broker.Children)
             .SelectMany(portfolio => portfolio.Children);
 
-    private static Broker BuildBrokerWithAsset(string assetName, GlobalAssetClass assetClass)
+    private static Broker BuildBrokerWithAsset(string assetName, GlobalAssetClass assetClass, decimal quantity = 0m)
     {
         var broker = Broker.Create("Broker", "BRL");
         var portfolio = broker.AddPortfolio("Portfolio");
-        portfolio.AddAsset(Asset.Create(assetName, "ISIN", "BVMF", "T1", CountryCode.BR, "FII", assetClass));
+        var asset = Asset.Create(assetName, "ISIN", "BVMF", "T1", CountryCode.BR, "FII", assetClass);
+        if (quantity > 0)
+        {
+            asset.AddTransaction(Transaction.Create(new DateTime(2024, 1, 1), Transaction.TransactionType.Buy, quantity, 10m, 0m));
+        }
+        else if (quantity < 0)
+        {
+            asset.AddTransaction(Transaction.Create(new DateTime(2024, 1, 1), Transaction.TransactionType.Sell, -quantity, 10m, 0m));
+        }
+        portfolio.AddAsset(asset);
         return broker;
     }
 
@@ -88,10 +155,16 @@ public class NavigationMapperTests
     {
         public Broker? Broker { get; set; }
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name) => [];
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => [];
+        public IEnumerable<Asset> GetAssetsByBroker(string name) =>
+            Broker == null ? [] : Broker.Portfolios.SelectMany(p => p.Assets);
+
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) =>
+            Broker?.Portfolios.FirstOrDefault(p => p.Name == portfolio)?.Assets ?? [];
+
         public IEnumerable<Broker> GetBrokerList() => Broker == null ? [] : [Broker];
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => null;
+
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) =>
+            Broker?.Portfolios.FirstOrDefault(p => p.Name == portfolioName)?.Assets.FirstOrDefault(a => a.Name == assetName);
         public Task SaveChangesAsync() => Task.CompletedTask;
     }
 }

--- a/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
+++ b/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
@@ -54,21 +54,21 @@ public class NavigationMapperTests
     }
 
     [Fact]
-    public void GetNavigationTree_AssetNode_MetadataIncludesPositionStatus()
+    public void GetNavigationTree_AssetNode_MetadataIncludesPositionType()
     {
         _repository.Broker = BuildBrokerWithAsset("LONG1", GlobalAssetClass.Equity, quantity: 10m);
 
         var tree = CreateService().GetNavigationTree();
 
         var assetNode = GetFirstAssetNode(tree);
-        assetNode.Metadata["PositionStatus"].Should().Be(Asset.PositionStatus.Long);
+        assetNode.Metadata["PositionType"].Should().Be(PositionType.Long);
     }
 
     [Theory]
-    [InlineData(10, Asset.PositionStatus.Long)]
-    [InlineData(0, Asset.PositionStatus.Flat)]
-    [InlineData(-10, Asset.PositionStatus.Short)]
-    public void GetAssetsByBrokerPortfolio_AssetNodeDto_StatusMatchesAssetStatus(decimal quantity, Asset.PositionStatus expectedStatus)
+    [InlineData(10, PositionType.Long)]
+    [InlineData(0, PositionType.Flat)]
+    [InlineData(-10, PositionType.Short)]
+    public void GetAssetsByBrokerPortfolio_AssetNodeDto_PositionTypeMatchesAssetPositionType(decimal quantity, PositionType expectedPositionType)
     {
         var broker = Broker.Create("Broker", "BRL");
         var portfolio = broker.AddPortfolio("Portfolio");
@@ -77,14 +77,14 @@ public class NavigationMapperTests
 
         var assets = CreateService().GetAssetsByBrokerPortfolio("Broker", "Portfolio").ToList();
 
-        assets.Should().ContainSingle().Which.Status.Should().Be(expectedStatus);
+        assets.Should().ContainSingle().Which.PositionType.Should().Be(expectedPositionType);
     }
 
     [Theory]
-    [InlineData(10, Asset.PositionStatus.Long)]
-    [InlineData(0, Asset.PositionStatus.Flat)]
-    [InlineData(-10, Asset.PositionStatus.Short)]
-    public void GetAssetDetails_ReturnsStatusMatchingAsset(decimal quantity, Asset.PositionStatus expectedStatus)
+    [InlineData(10, PositionType.Long)]
+    [InlineData(0, PositionType.Flat)]
+    [InlineData(-10, PositionType.Short)]
+    public void GetAssetDetails_ReturnsPositionTypeMatchingAsset(decimal quantity, PositionType expectedPositionType)
     {
         var broker = Broker.Create("Broker", "BRL");
         var portfolio = broker.AddPortfolio("Portfolio");
@@ -94,7 +94,7 @@ public class NavigationMapperTests
         var details = CreateService().GetAssetDetails("Broker", "Portfolio", "ASSET1");
 
         details.Should().NotBeNull();
-        details!.Status.Should().Be(expectedStatus);
+        details!.PositionType.Should().Be(expectedPositionType);
     }
 
     private static Asset BuildAssetWithQuantity(string name, decimal quantity)

--- a/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
@@ -68,6 +68,33 @@ public class AssetTests
     }
 
     [Fact]
+    public void Status_PositiveQuantity_ReturnsLong()
+    {
+        var asset = Asset.Create("Asset A", "ISIN123", "NYSE", "AAA");
+        asset.AddTransaction(Transaction.Create(new DateTime(2024, 1, 1), Transaction.TransactionType.Buy, 10m, 5m, 0m));
+
+        asset.Status.Should().Be(Asset.PositionStatus.Long);
+    }
+
+    [Fact]
+    public void Status_ZeroQuantity_ReturnsFlat()
+    {
+        var asset = Asset.Create("Asset A", "ISIN123", "NYSE", "AAA");
+
+        asset.Status.Should().Be(Asset.PositionStatus.Flat);
+    }
+
+    [Fact]
+    public void Status_NegativeQuantity_ReturnsShort()
+    {
+        var asset = Asset.Create("Asset A", "ISIN123", "NYSE", "AAA");
+        asset.AddTransaction(Transaction.Create(new DateTime(2024, 1, 1), Transaction.TransactionType.Sell, 5m, 10m, 0m));
+
+        asset.Quantity.Should().Be(-5m);
+        asset.Status.Should().Be(Asset.PositionStatus.Short);
+    }
+
+    [Fact]
     public void UpdateTransaction_RebuildsTransactionsAndRecalculates()
     {
         var asset = Asset.Create("Asset A", "ISIN123", "NYSE", "AAA");

--- a/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
@@ -68,30 +68,30 @@ public class AssetTests
     }
 
     [Fact]
-    public void Status_PositiveQuantity_ReturnsLong()
+    public void PositionType_PositiveQuantity_ReturnsLong()
     {
         var asset = Asset.Create("Asset A", "ISIN123", "NYSE", "AAA");
         asset.AddTransaction(Transaction.Create(new DateTime(2024, 1, 1), Transaction.TransactionType.Buy, 10m, 5m, 0m));
 
-        asset.Status.Should().Be(Asset.PositionStatus.Long);
+        asset.PositionType.Should().Be(PositionType.Long);
     }
 
     [Fact]
-    public void Status_ZeroQuantity_ReturnsFlat()
+    public void PositionType_ZeroQuantity_ReturnsFlat()
     {
         var asset = Asset.Create("Asset A", "ISIN123", "NYSE", "AAA");
 
-        asset.Status.Should().Be(Asset.PositionStatus.Flat);
+        asset.PositionType.Should().Be(PositionType.Flat);
     }
 
     [Fact]
-    public void Status_NegativeQuantity_ReturnsShort()
+    public void PositionType_NegativeQuantity_ReturnsShort()
     {
         var asset = Asset.Create("Asset A", "ISIN123", "NYSE", "AAA");
         asset.AddTransaction(Transaction.Create(new DateTime(2024, 1, 1), Transaction.TransactionType.Sell, 5m, 10m, 0m));
 
         asset.Quantity.Should().Be(-5m);
-        asset.Status.Should().Be(Asset.PositionStatus.Short);
+        asset.PositionType.Should().Be(PositionType.Short);
     }
 
     [Fact]

--- a/docs/P10-F01-position-status-domain-model/plan.md
+++ b/docs/P10-F01-position-status-domain-model/plan.md
@@ -6,22 +6,22 @@
 
 ### Stage 1: Domain Layer
 
-**1. PositionStatus Enum and Asset.Status Property** - Add the `PositionStatus` enum (`Long`, `Flat`, `Short`) nested inside `Asset`, and a computed `Status` property that derives its value purely from `Asset.Quantity`'s sign. Leave `Asset.Active` untouched. Reference the spec's Section 3 decision on enum placement.
+**1. PositionType Enum and Asset.PositionType Property** - Add a top-level `PositionType` enum (`Long`, `Flat`, `Short`) in `Financial.Domain.Entities`, and a computed `PositionType` property on `Asset` that derives its value purely from `Asset.Quantity`'s sign. Leave `Asset.Active` untouched. Reference the spec's Section 3 decision on enum placement (top-level, not nested, due to the property/type name matching).
 
-**2. Domain Unit Tests** - Extend `AssetTests.cs` with cases covering an asset with positive, zero, and negative quantity, asserting `Status` resolves to `Long`, `Flat`, and `Short` respectively.
+**2. Domain Unit Tests** - Extend `AssetTests.cs` with cases covering an asset with positive, zero, and negative quantity, asserting `PositionType` resolves to `Long`, `Flat`, and `Short` respectively.
 
 ### Stage 2: Application Layer
 
-**3. DTO Updates** - Add a `Status` property to `AssetNodeDTO` and `AssetDetailsDTO`, following the existing enum-serialization pattern already used for `Country` and `Class` on those same DTOs.
+**3. DTO Updates** - Add a `PositionType` property to `AssetNodeDTO` and `AssetDetailsDTO`, following the existing enum-serialization pattern already used for `Country` and `Class` on those same DTOs.
 
-**4. Mapping Updates** - Update `NavigationMapper.MapAsset` to populate the new `Status` field, update `NavigationMapper.BuildAssetTreeNode` to add a `PositionStatus` entry to the tree node's `Metadata` dictionary alongside the existing `IsActive` entry, and update `NavigationService.GetAssetDetails` to populate `Status` on the returned `AssetDetailsDTO`.
+**4. Mapping Updates** - Update `NavigationMapper.MapAsset` to populate the new `PositionType` field, update `NavigationMapper.BuildAssetTreeNode` to add a `PositionType` entry to the tree node's `Metadata` dictionary alongside the existing `IsActive` entry, and update `NavigationService.GetAssetDetails` to populate `PositionType` on the returned `AssetDetailsDTO`.
 
-**5. Application Unit Tests** - Extend `NavigationMapperTests.cs` to verify the navigation tree's asset metadata includes the correct `PositionStatus`, and that both `AssetNodeDTO.Status` and `AssetDetailsDTO.Status` match the source asset's computed status across long, flat, and short cases.
+**5. Application Unit Tests** - Extend `NavigationMapperTests.cs` to verify the navigation tree's asset metadata includes the correct `PositionType`, and that both `AssetNodeDTO.PositionType` and `AssetDetailsDTO.PositionType` match the source asset's computed value across long, flat, and short cases.
 
 ### Stage 3: Web Types and Fixtures
 
-**6. TypeScript Type Updates** - Add a required `status` field to the `AssetNodeDto` and `AssetDetailsDto` interfaces in `types.ts`, matching the existing `isActive` field's requiredness.
+**6. TypeScript Type Updates** - Add a required `positionType` field to the `AssetNodeDto` and `AssetDetailsDto` interfaces in `types.ts`, matching the existing `isActive` field's requiredness.
 
-**7. Test Fixture Updates** - Update the asset-literal fixtures in the five affected test files (`CurrentValuesPage.test.tsx`, `useAssetSummary.test.ts`, `useCredits.test.ts`, `useTransactions.test.ts`, `AssetSummaryTab.test.tsx`) to include a `status` value consistent with each fixture's existing `isActive`/`quantity` value.
+**7. Test Fixture Updates** - Update the asset-literal fixtures in the five affected test files (`CurrentValuesPage.test.tsx`, `useAssetSummary.test.ts`, `useCredits.test.ts`, `useTransactions.test.ts`, `AssetSummaryTab.test.tsx`) to include a `positionType` value consistent with each fixture's existing `isActive`/`quantity` value.
 
 **8. Build and Test Verification** - Run the TypeScript build (`tsc -b --noEmit`) and the existing Vitest and .NET test suites to confirm the new required field introduces no compilation or test regressions.

--- a/docs/P10-F01-position-status-domain-model/plan.md
+++ b/docs/P10-F01-position-status-domain-model/plan.md
@@ -1,0 +1,27 @@
+# Implementation Plan: F01. Position Status Domain Model
+
+**Prerequisites:**
+- No new tools, libraries, or environment variables required
+- Builds on the existing `Financial.Domain`, `Financial.Application`, and `Financial.Web` projects as they stand on `main`
+
+### Stage 1: Domain Layer
+
+**1. PositionStatus Enum and Asset.Status Property** - Add the `PositionStatus` enum (`Long`, `Flat`, `Short`) nested inside `Asset`, and a computed `Status` property that derives its value purely from `Asset.Quantity`'s sign. Leave `Asset.Active` untouched. Reference the spec's Section 3 decision on enum placement.
+
+**2. Domain Unit Tests** - Extend `AssetTests.cs` with cases covering an asset with positive, zero, and negative quantity, asserting `Status` resolves to `Long`, `Flat`, and `Short` respectively.
+
+### Stage 2: Application Layer
+
+**3. DTO Updates** - Add a `Status` property to `AssetNodeDTO` and `AssetDetailsDTO`, following the existing enum-serialization pattern already used for `Country` and `Class` on those same DTOs.
+
+**4. Mapping Updates** - Update `NavigationMapper.MapAsset` to populate the new `Status` field, update `NavigationMapper.BuildAssetTreeNode` to add a `PositionStatus` entry to the tree node's `Metadata` dictionary alongside the existing `IsActive` entry, and update `NavigationService.GetAssetDetails` to populate `Status` on the returned `AssetDetailsDTO`.
+
+**5. Application Unit Tests** - Extend `NavigationMapperTests.cs` to verify the navigation tree's asset metadata includes the correct `PositionStatus`, and that both `AssetNodeDTO.Status` and `AssetDetailsDTO.Status` match the source asset's computed status across long, flat, and short cases.
+
+### Stage 3: Web Types and Fixtures
+
+**6. TypeScript Type Updates** - Add a required `status` field to the `AssetNodeDto` and `AssetDetailsDto` interfaces in `types.ts`, matching the existing `isActive` field's requiredness.
+
+**7. Test Fixture Updates** - Update the asset-literal fixtures in the five affected test files (`CurrentValuesPage.test.tsx`, `useAssetSummary.test.ts`, `useCredits.test.ts`, `useTransactions.test.ts`, `AssetSummaryTab.test.tsx`) to include a `status` value consistent with each fixture's existing `isActive`/`quantity` value.
+
+**8. Build and Test Verification** - Run the TypeScript build (`tsc -b --noEmit`) and the existing Vitest and .NET test suites to confirm the new required field introduces no compilation or test regressions.

--- a/docs/P10-F01-position-status-domain-model/spec.md
+++ b/docs/P10-F01-position-status-domain-model/spec.md
@@ -2,24 +2,25 @@
 
 ## 1. Technical Overview
 
-**What:** Add a three-state `PositionStatus` enum (`Long`, `Flat`, `Short`) nested inside `Asset`, expose it as a computed `Asset.Status` property derived purely from `Asset.Quantity`'s sign, and surface that value through the existing asset DTOs (`AssetNodeDTO`, `AssetDetailsDTO`) and their TypeScript counterparts (`AssetNodeDto`, `AssetDetailsDto`) via the current mapping paths (`NavigationMapper.MapAsset`, `NavigationMapper.BuildAssetTreeNode`, `NavigationService.GetAssetDetails`).
+**What:** Add a three-state `PositionType` enum (`Long`, `Flat`, `Short` — standard industry terminology for a position's directional state) as a top-level type in `Financial.Domain.Entities`, expose it as a computed `Asset.PositionType` property derived purely from `Asset.Quantity`'s sign, and surface that value through the existing asset DTOs (`AssetNodeDTO`, `AssetDetailsDTO`) and their TypeScript counterparts (`AssetNodeDto`, `AssetDetailsDto`) via the current mapping paths (`NavigationMapper.MapAsset`, `NavigationMapper.BuildAssetTreeNode`, `NavigationService.GetAssetDetails`).
 
 **Why:** `Asset.Active => Quantity > 0` is a boolean today, so a closed position (`Quantity = 0`) and an open short (`Quantity < 0`) both evaluate to `false` and render identically in the WPF status converter. This feature replaces that binary signal with a genuine three-state one, computed the same way `Active` already is (a pure function of `Quantity`), with no new persisted state and no schema change.
 
 **Scope:**
-- **Included:** `PositionStatus` enum; `Asset.Status` computed property; `Status`/`status` field added to `AssetNodeDTO`/`AssetDetailsDTO` (C#) and `AssetNodeDto`/`AssetDetailsDto` (TS); mapping updates in `NavigationMapper` and `NavigationService`; a matching `PositionStatus` entry in the WPF tree's `Metadata` dictionary; Domain and Application unit tests; updates to existing Web test fixtures that construct these DTOs as literals.
-- **Excluded:** Any UI rendering of the new status (color converters, tree/detail panel visuals) — that belongs to F08 (Web) and F10 (WPF). Any API scope selector (`?scope=active|historic`) — that belongs to F05. Any change to `Asset.Active` or its existing consumers (`SummaryService`, `CreditService`, `BrokerBreakdownService` all filter with `.Where(a => a.Active)` for real aggregation logic, not just display) — `Active` stays exactly as it is today; `Status` is additive, not a replacement.
+- **Included:** `PositionType` enum; `Asset.PositionType` computed property; `PositionType`/`positionType` field added to `AssetNodeDTO`/`AssetDetailsDTO` (C#) and `AssetNodeDto`/`AssetDetailsDto` (TS); mapping updates in `NavigationMapper` and `NavigationService`; a matching `PositionType` entry in the WPF tree's `Metadata` dictionary; Domain and Application unit tests; updates to existing Web test fixtures that construct these DTOs as literals.
+- **Excluded:** Any UI rendering of the new position type (color converters, tree/detail panel visuals) — that belongs to F08 (Web) and F10 (WPF). Any API scope selector (`?scope=active|historic`) — that belongs to F05. Any change to `Asset.Active` or its existing consumers (`SummaryService`, `CreditService`, `BrokerBreakdownService` all filter with `.Where(a => a.Active)` for real aggregation logic, not just display) — `Active` stays exactly as it is today; `PositionType` is additive, not a replacement.
 
 ## 2. Architecture Impact
 
 **Affected components:**
-- `Financial.Domain/Entities/Asset.cs` — new nested `PositionStatus` enum, new `Status` computed property
-- `Financial.Application/DTOs/AssetNodeDTO.cs` — new `Status` property
-- `Financial.Application/DTOs/AssetDetailsDTO.cs` — new `Status` property
-- `Financial.Application/Services/NavigationMapper.cs` — `MapAsset` populates `Status`; `BuildAssetTreeNode` adds a `PositionStatus` entry to `Metadata`
-- `Financial.Application/Services/NavigationService.cs` — `GetAssetDetails` populates `Status` on the returned `AssetDetailsDTO`
-- `Financial.Web/src/api/types.ts` — `AssetNodeDto`/`AssetDetailsDto` gain a required `status: string` field
-- Five existing Web test files gain a `status` value in their `AssetNodeDto`/`AssetDetailsDto` literals (see Section 4)
+- `Financial.Domain/Entities/PositionType.cs` — new top-level enum (`Long`, `Flat`, `Short`)
+- `Financial.Domain/Entities/Asset.cs` — new `PositionType` computed property
+- `Financial.Application/DTOs/AssetNodeDTO.cs` — new `PositionType` property
+- `Financial.Application/DTOs/AssetDetailsDTO.cs` — new `PositionType` property
+- `Financial.Application/Services/NavigationMapper.cs` — `MapAsset` populates `PositionType`; `BuildAssetTreeNode` adds a `PositionType` entry to `Metadata`
+- `Financial.Application/Services/NavigationService.cs` — `GetAssetDetails` populates `PositionType` on the returned `AssetDetailsDTO`
+- `Financial.Web/src/api/types.ts` — `AssetNodeDto`/`AssetDetailsDto` gain a required `positionType: string` field
+- Five existing Web test files gain a `positionType` value in their `AssetNodeDto`/`AssetDetailsDto` literals (see Section 4)
 - `Tests/Financial.Domain.Tests/Domain/AssetTests.cs` — new/extended tests
 - `Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs` — new/extended tests
 
@@ -27,25 +28,26 @@
 
 ```mermaid
 graph TD
-    A["Asset.Quantity"] --> B["Asset.Status (computed)"]
+    A["Asset.Quantity"] --> B["Asset.PositionType (computed)"]
     B --> C["NavigationMapper.MapAsset"]
     B --> D["NavigationService.GetAssetDetails"]
-    C --> E["AssetNodeDTO.Status"]
-    C --> F["NavigationMapper.BuildAssetTreeNode Metadata[PositionStatus]"]
-    D --> G["AssetDetailsDTO.Status"]
-    E --> H["AssetNodeDto.status (TS, via JSON)"]
-    G --> I["AssetDetailsDto.status (TS, via JSON)"]
+    C --> E["AssetNodeDTO.PositionType"]
+    C --> F["NavigationMapper.BuildAssetTreeNode Metadata[PositionType]"]
+    D --> G["AssetDetailsDTO.PositionType"]
+    E --> H["AssetNodeDto.positionType (TS, via JSON)"]
+    G --> I["AssetDetailsDto.positionType (TS, via JSON)"]
 ```
 
 ## 3. Technical Decisions
 
 | Decision | Chosen Approach | Alternative Considered | Trade-off |
 |----------|-----------------|-------------------------|-----------|
-| Enum placement | Nest `PositionStatus` inside `Asset` (`Asset.PositionStatus`), matching the existing `Transaction.TransactionType` / `Credit.CreditType` convention | Standalone top-level enum next to `CountryCode`/`GlobalAssetClass` in `AssetClassification.cs` | `PositionStatus` describes a single-entity state, not a cross-cutting classification value shared by multiple entities, so the nested-enum convention fits better |
-| Relationship to `Active` | Keep `Asset.Active` unchanged; `Status` is a second, independent computed property | Remove/rename `Active` in favor of `Status` everywhere | `Active` is load-bearing business-logic filtering in `SummaryService`, `CreditService`, and `BrokerBreakdownService` (all outside this PRD's scope) — changing it would silently alter aggregation behavior those services rely on today |
-| `Metadata` dictionary key for WPF tree | Add a new `"PositionStatus"` key alongside the existing `"IsActive"` key in `BuildAssetTreeNode` | Replace `"IsActive"` with `"PositionStatus"` | F10 (not this feature) owns switching the WPF converter/binding over; keeping `"IsActive"` prevents breaking today's binding until F10 lands |
-| TS field requiredness | `status: string` required, matching `isActive`'s existing required-field convention | `status?: string` optional, to avoid touching existing test fixtures | User decision: consistency with `isActive` outweighs the one-time cost of updating 5 test fixture files |
-| DTO property type | `AssetNodeDTO.Status`/`AssetDetailsDTO.Status` typed directly as the domain `Asset.PositionStatus` enum (serialized via `[JsonConverter(typeof(JsonStringEnumConverter))]`), mirroring how `Country`/`Class` are typed directly as `CountryCode`/`GlobalAssetClass` | Introduce a separate Application-layer `PositionStatus` enum decoupled from Domain | Matches the codebase's existing convention of DTOs referencing Domain enums directly; introducing a parallel Application enum would require an extra mapping step for no benefit in this codebase |
+| Naming | `PositionType` (industry term for Long/Flat/Short), not `PositionStatus`/`Status` | `PositionStatus`/`Status` | User correction mid-implementation: "Position Type" is the term the industry actually uses for this concept |
+| Enum placement | Top-level `PositionType` enum in `Financial.Domain.Entities` (own file `PositionType.cs`), not nested inside `Asset` | Nest inside `Asset` as `Asset.PositionType`, matching `Transaction.TransactionType` / `Credit.CreditType` | C# does not allow a class to declare both a nested type and a property with the identical name (`CS0102`); since the property is named `PositionType` to match the enum's name exactly (mirroring how `CountryCode Country`/`GlobalAssetClass Class` reference top-level Domain enums), the enum must live outside `Asset`, following the `CountryCode`/`GlobalAssetClass` convention instead |
+| Relationship to `Active` | Keep `Asset.Active` unchanged; `PositionType` is a second, independent computed property | Remove/rename `Active` in favor of `PositionType` everywhere | `Active` is load-bearing business-logic filtering in `SummaryService`, `CreditService`, and `BrokerBreakdownService` (all outside this PRD's scope) — changing it would silently alter aggregation behavior those services rely on today |
+| `Metadata` dictionary key for WPF tree | Add a new `"PositionType"` key alongside the existing `"IsActive"` key in `BuildAssetTreeNode` | Replace `"IsActive"` with `"PositionType"` | F10 (not this feature) owns switching the WPF converter/binding over; keeping `"IsActive"` prevents breaking today's binding until F10 lands |
+| TS field requiredness | `positionType: string` required, matching `isActive`'s existing required-field convention | `positionType?: string` optional, to avoid touching existing test fixtures | User decision: consistency with `isActive` outweighs the one-time cost of updating 5 test fixture files |
+| DTO property type | `AssetNodeDTO.PositionType`/`AssetDetailsDTO.PositionType` typed directly as the domain `PositionType` enum (serialized via `[JsonConverter(typeof(JsonStringEnumConverter))]`), mirroring how `Country`/`Class` are typed directly as `CountryCode`/`GlobalAssetClass` | Introduce a separate Application-layer enum decoupled from Domain | Matches the codebase's existing convention of DTOs referencing Domain enums directly; introducing a parallel Application enum would require an extra mapping step for no benefit in this codebase |
 
 ## 4. Component Overview
 
@@ -53,34 +55,35 @@ graph TD
 
 | File Path | New/Modified | Purpose | Key Responsibilities |
 |-----------|--------------|---------|------------------------|
-| `Financial.Domain/Entities/Asset.cs` | Modified | Domain state | Nested `PositionStatus` enum; `Status` computed property (`Quantity > 0` → `Long`, `< 0` → `Short`, else `Flat`) |
-| `Financial.Application/DTOs/AssetNodeDTO.cs` | Modified | Tree node DTO | New `Status` property (`[JsonConverter(typeof(JsonStringEnumConverter))]`) |
-| `Financial.Application/DTOs/AssetDetailsDTO.cs` | Modified | Asset details DTO | New `Status` property (same converter) |
-| `Financial.Application/Services/NavigationMapper.cs` | Modified | Mapping | `MapAsset` sets `Status = asset.Status`; `BuildAssetTreeNode` adds `Metadata["PositionStatus"] = asset.Status` (reads from the already-mapped `AssetNodeDTO`) |
-| `Financial.Application/Services/NavigationService.cs` | Modified | Mapping | `GetAssetDetails` sets `Status = asset.Status` on the constructed `AssetDetailsDTO` |
+| `Financial.Domain/Entities/PositionType.cs` | New | Domain enum | `PositionType { Long, Flat, Short }`, top-level in `Financial.Domain.Entities` |
+| `Financial.Domain/Entities/Asset.cs` | Modified | Domain state | `PositionType` computed property (`Quantity > 0` → `Long`, `< 0` → `Short`, else `Flat`) |
+| `Financial.Application/DTOs/AssetNodeDTO.cs` | Modified | Tree node DTO | New `PositionType` property (`[JsonConverter(typeof(JsonStringEnumConverter))]`) |
+| `Financial.Application/DTOs/AssetDetailsDTO.cs` | Modified | Asset details DTO | New `PositionType` property (same converter) |
+| `Financial.Application/Services/NavigationMapper.cs` | Modified | Mapping | `MapAsset` sets `PositionType = asset.PositionType`; `BuildAssetTreeNode` adds `Metadata["PositionType"] = asset.PositionType` (reads from the already-mapped `AssetNodeDTO`) |
+| `Financial.Application/Services/NavigationService.cs` | Modified | Mapping | `GetAssetDetails` sets `PositionType = asset.PositionType` on the constructed `AssetDetailsDTO` |
 
 **Frontend:**
 
 | File Path | New/Modified | Purpose | Key Responsibilities |
 |-----------|--------------|---------|------------------------|
-| `Financial.Web/src/api/types.ts` | Modified | Type contracts | `AssetNodeDto`/`AssetDetailsDto` gain required `status: string` |
-| `Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx` | Modified | Test fixture | `makeBroker`'s nested asset literal gains a `status` value |
-| `Financial.Web/src/hooks/useAssetSummary.test.ts` | Modified | Test fixture | `ASSET_DETAILS` literal gains a `status` value |
-| `Financial.Web/src/hooks/useCredits.test.ts` | Modified | Test fixture | `ASSET_DETAILS` literal gains a `status` value |
-| `Financial.Web/src/hooks/useTransactions.test.ts` | Modified | Test fixture | `ASSET_DETAILS` literal gains a `status` value |
-| `Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx` | Modified | Test fixture | `ASSET` literal gains a `status` value |
+| `Financial.Web/src/api/types.ts` | Modified | Type contracts | `AssetNodeDto`/`AssetDetailsDto` gain required `positionType: string` |
+| `Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx` | Modified | Test fixture | `makeBroker`'s nested asset literal gains a `positionType` value |
+| `Financial.Web/src/hooks/useAssetSummary.test.ts` | Modified | Test fixture | `ASSET_DETAILS` literal gains a `positionType` value |
+| `Financial.Web/src/hooks/useCredits.test.ts` | Modified | Test fixture | `ASSET_DETAILS` literal gains a `positionType` value |
+| `Financial.Web/src/hooks/useTransactions.test.ts` | Modified | Test fixture | `ASSET_DETAILS` literal gains a `positionType` value |
+| `Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx` | Modified | Test fixture | `ASSET` literal gains a `positionType` value |
 
-No other Web test file needs changes: `InvestmentTree.test.tsx` builds `TreeNodeDto.metadata` as a loosely-typed `Record<string, unknown>` (no compile-time requirement to add the new key), and `DetailPanel.test.tsx`/`useAssetSummary.test.ts`'s other fixtures build `SelectedNode`, whose `isActive` field is already optional and which does not gain a `status` field in this feature.
+No other Web test file needs changes: `InvestmentTree.test.tsx` builds `TreeNodeDto.metadata` as a loosely-typed `Record<string, unknown>` (no compile-time requirement to add the new key), and `DetailPanel.test.tsx`/`useAssetSummary.test.ts`'s other fixtures build `SelectedNode`, whose `isActive` field is already optional and which does not gain a `positionType` field in this feature.
 
-**Database:** None — `Status` is computed at read time from `Quantity`; no schema or `data.json` shape change.
+**Database:** None — `PositionType` is computed at read time from `Quantity`; no schema or `data.json` shape change.
 
 ## 5. API Contracts
 
-Not applicable — this feature has no new or modified endpoints. Existing `GET` endpoints that already return `AssetNodeDTO`/`AssetDetailsDTO` will include the new `status` field automatically once the DTOs are updated (F05 later adds the `scope` query parameter to these same endpoints).
+Not applicable — this feature has no new or modified endpoints. Existing `GET` endpoints that already return `AssetNodeDTO`/`AssetDetailsDTO` will include the new `positionType` field automatically once the DTOs are updated (F05 later adds the `scope` query parameter to these same endpoints).
 
 ## 6. Data Model
 
-Not applicable — no persisted schema change. `PositionStatus` is a computed, in-memory value derived from `Asset.Quantity` on every read, exactly like `Asset.Active` today.
+Not applicable — no persisted schema change. `PositionType` is a computed, in-memory value derived from `Asset.Quantity` on every read, exactly like `Asset.Active` today.
 
 ## 7. Testing Strategy
 
@@ -88,20 +91,20 @@ Not applicable — no persisted schema change. `PositionStatus` is a computed, i
 
 | Test File | Test Type | Target | Coverage Goal |
 |-----------|-----------|--------|----------------|
-| `Tests/Financial.Domain.Tests/Domain/AssetTests.cs` | Unit | `Asset.Status` | All three states |
-| `Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs` | Unit | `NavigationMapper.MapAsset`, `NavigationService.GetAssetDetails` | `Status` correctly mapped onto both DTOs and into tree `Metadata` |
+| `Tests/Financial.Domain.Tests/Domain/AssetTests.cs` | Unit | `Asset.PositionType` | All three states |
+| `Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs` | Unit | `NavigationMapper.MapAsset`, `NavigationService.GetAssetDetails` | `PositionType` correctly mapped onto both DTOs and into tree `Metadata` |
 
 **Test Functions:**
 
 | Test Function | Description | Assertions |
 |----------------|-------------|------------|
-| `Status_PositiveQuantity_ReturnsLong` | Asset with `Quantity > 0` (e.g., after a buy) | `asset.Status.Should().Be(Asset.PositionStatus.Long)` — covers PRD acceptance criterion "Quantity > 0 → Long" |
-| `Status_ZeroQuantity_ReturnsFlat` | Newly created asset, or fully sold down to zero | `asset.Status.Should().Be(Asset.PositionStatus.Flat)` — covers "Quantity = 0 → Flat" |
-| `Status_NegativeQuantity_ReturnsShort` | Asset sold without a prior matching buy (net short) | `asset.Status.Should().Be(Asset.PositionStatus.Short)` — covers "Quantity < 0 → Short" |
-| `GetNavigationTree_AssetNode_MetadataIncludesPositionStatus` | Extend the existing `NavigationMapperTests` pattern | `assetNode.Metadata["PositionStatus"].Should().Be(Asset.PositionStatus.Long)` for a long asset |
-| `GetAssetsByBrokerPortfolio_AssetNodeDto_StatusMatchesAssetStatus` | Build assets with Long/Flat/Short quantities via `StubRepository` | Each returned `AssetNodeDTO.Status` matches the source asset's `Status` — covers "Status is present on Active-scoped AssetNodeDTO" |
-| `GetAssetDetails_ReturnsStatusMatchingAsset` | Build a single asset via `StubRepository`, call `GetAssetDetails` | Returned `AssetDetailsDTO.Status` matches `asset.Status` — covers "Status is present on ... AssetDetailsDto" |
+| `PositionType_PositiveQuantity_ReturnsLong` | Asset with `Quantity > 0` (e.g., after a buy) | `asset.PositionType.Should().Be(PositionType.Long)` — covers PRD acceptance criterion "Quantity > 0 → Long" |
+| `PositionType_ZeroQuantity_ReturnsFlat` | Newly created asset, or fully sold down to zero | `asset.PositionType.Should().Be(PositionType.Flat)` — covers "Quantity = 0 → Flat" |
+| `PositionType_NegativeQuantity_ReturnsShort` | Asset sold without a prior matching buy (net short) | `asset.PositionType.Should().Be(PositionType.Short)` — covers "Quantity < 0 → Short" |
+| `GetNavigationTree_AssetNode_MetadataIncludesPositionType` | Extend the existing `NavigationMapperTests` pattern | `assetNode.Metadata["PositionType"].Should().Be(PositionType.Long)` for a long asset |
+| `GetAssetsByBrokerPortfolio_AssetNodeDto_PositionTypeMatchesAssetPositionType` | Build assets with Long/Flat/Short quantities via `StubRepository` | Each returned `AssetNodeDTO.PositionType` matches the source asset's `PositionType` — covers "PositionType is present on Active-scoped AssetNodeDTO" |
+| `GetAssetDetails_ReturnsPositionTypeMatchingAsset` | Build a single asset via `StubRepository`, call `GetAssetDetails` | Returned `AssetDetailsDTO.PositionType` matches `asset.PositionType` — covers "PositionType is present on ... AssetDetailsDto" |
 
-**Web side:** No new test files — the existing fixture updates (Section 4) are what keep `npm run typecheck`/`tsc -b --noEmit` and the existing Vitest suites green with the now-required `status` field. No new Web behavior is introduced by this feature, so no new Web test assertions are needed.
+**Web side:** No new test files — the existing fixture updates (Section 4) are what keep `npm run typecheck`/`tsc -b --noEmit` and the existing Vitest suites green with the now-required `positionType` field. No new Web behavior is introduced by this feature, so no new Web test assertions are needed.
 
-**Deferred cross-feature integration:** PRD Section 9's Cross-Feature Integration criterion "Position status computed by F01 appears correctly on every Active-scoped asset returned by F05" cannot be tested yet — F05 (the `scope=active|historic` selector) does not exist. The unit tests above establish that `Status` is correctly computed and correctly present on both DTOs today; F05's own spec should add the actual end-to-end assertion once its scoped endpoints exist.
+**Deferred cross-feature integration:** PRD Section 9's Cross-Feature Integration criterion "Position status computed by F01 appears correctly on every Active-scoped asset returned by F05" cannot be tested yet — F05 (the `scope=active|historic` selector) does not exist. The unit tests above establish that `PositionType` is correctly computed and correctly present on both DTOs today; F05's own spec should add the actual end-to-end assertion once its scoped endpoints exist. Note for whoever specs F05/F08/F10 next: the PRD text still says "Status"/"status" — read that as `PositionType`/`positionType`, the name this feature actually shipped with.

--- a/docs/P10-F01-position-status-domain-model/spec.md
+++ b/docs/P10-F01-position-status-domain-model/spec.md
@@ -1,0 +1,107 @@
+# Feature Spec: F01. Position Status Domain Model
+
+## 1. Technical Overview
+
+**What:** Add a three-state `PositionStatus` enum (`Long`, `Flat`, `Short`) nested inside `Asset`, expose it as a computed `Asset.Status` property derived purely from `Asset.Quantity`'s sign, and surface that value through the existing asset DTOs (`AssetNodeDTO`, `AssetDetailsDTO`) and their TypeScript counterparts (`AssetNodeDto`, `AssetDetailsDto`) via the current mapping paths (`NavigationMapper.MapAsset`, `NavigationMapper.BuildAssetTreeNode`, `NavigationService.GetAssetDetails`).
+
+**Why:** `Asset.Active => Quantity > 0` is a boolean today, so a closed position (`Quantity = 0`) and an open short (`Quantity < 0`) both evaluate to `false` and render identically in the WPF status converter. This feature replaces that binary signal with a genuine three-state one, computed the same way `Active` already is (a pure function of `Quantity`), with no new persisted state and no schema change.
+
+**Scope:**
+- **Included:** `PositionStatus` enum; `Asset.Status` computed property; `Status`/`status` field added to `AssetNodeDTO`/`AssetDetailsDTO` (C#) and `AssetNodeDto`/`AssetDetailsDto` (TS); mapping updates in `NavigationMapper` and `NavigationService`; a matching `PositionStatus` entry in the WPF tree's `Metadata` dictionary; Domain and Application unit tests; updates to existing Web test fixtures that construct these DTOs as literals.
+- **Excluded:** Any UI rendering of the new status (color converters, tree/detail panel visuals) — that belongs to F08 (Web) and F10 (WPF). Any API scope selector (`?scope=active|historic`) — that belongs to F05. Any change to `Asset.Active` or its existing consumers (`SummaryService`, `CreditService`, `BrokerBreakdownService` all filter with `.Where(a => a.Active)` for real aggregation logic, not just display) — `Active` stays exactly as it is today; `Status` is additive, not a replacement.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Domain/Entities/Asset.cs` — new nested `PositionStatus` enum, new `Status` computed property
+- `Financial.Application/DTOs/AssetNodeDTO.cs` — new `Status` property
+- `Financial.Application/DTOs/AssetDetailsDTO.cs` — new `Status` property
+- `Financial.Application/Services/NavigationMapper.cs` — `MapAsset` populates `Status`; `BuildAssetTreeNode` adds a `PositionStatus` entry to `Metadata`
+- `Financial.Application/Services/NavigationService.cs` — `GetAssetDetails` populates `Status` on the returned `AssetDetailsDTO`
+- `Financial.Web/src/api/types.ts` — `AssetNodeDto`/`AssetDetailsDto` gain a required `status: string` field
+- Five existing Web test files gain a `status` value in their `AssetNodeDto`/`AssetDetailsDto` literals (see Section 4)
+- `Tests/Financial.Domain.Tests/Domain/AssetTests.cs` — new/extended tests
+- `Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs` — new/extended tests
+
+**Data flow:**
+
+```mermaid
+graph TD
+    A["Asset.Quantity"] --> B["Asset.Status (computed)"]
+    B --> C["NavigationMapper.MapAsset"]
+    B --> D["NavigationService.GetAssetDetails"]
+    C --> E["AssetNodeDTO.Status"]
+    C --> F["NavigationMapper.BuildAssetTreeNode Metadata[PositionStatus]"]
+    D --> G["AssetDetailsDTO.Status"]
+    E --> H["AssetNodeDto.status (TS, via JSON)"]
+    G --> I["AssetDetailsDto.status (TS, via JSON)"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Enum placement | Nest `PositionStatus` inside `Asset` (`Asset.PositionStatus`), matching the existing `Transaction.TransactionType` / `Credit.CreditType` convention | Standalone top-level enum next to `CountryCode`/`GlobalAssetClass` in `AssetClassification.cs` | `PositionStatus` describes a single-entity state, not a cross-cutting classification value shared by multiple entities, so the nested-enum convention fits better |
+| Relationship to `Active` | Keep `Asset.Active` unchanged; `Status` is a second, independent computed property | Remove/rename `Active` in favor of `Status` everywhere | `Active` is load-bearing business-logic filtering in `SummaryService`, `CreditService`, and `BrokerBreakdownService` (all outside this PRD's scope) — changing it would silently alter aggregation behavior those services rely on today |
+| `Metadata` dictionary key for WPF tree | Add a new `"PositionStatus"` key alongside the existing `"IsActive"` key in `BuildAssetTreeNode` | Replace `"IsActive"` with `"PositionStatus"` | F10 (not this feature) owns switching the WPF converter/binding over; keeping `"IsActive"` prevents breaking today's binding until F10 lands |
+| TS field requiredness | `status: string` required, matching `isActive`'s existing required-field convention | `status?: string` optional, to avoid touching existing test fixtures | User decision: consistency with `isActive` outweighs the one-time cost of updating 5 test fixture files |
+| DTO property type | `AssetNodeDTO.Status`/`AssetDetailsDTO.Status` typed directly as the domain `Asset.PositionStatus` enum (serialized via `[JsonConverter(typeof(JsonStringEnumConverter))]`), mirroring how `Country`/`Class` are typed directly as `CountryCode`/`GlobalAssetClass` | Introduce a separate Application-layer `PositionStatus` enum decoupled from Domain | Matches the codebase's existing convention of DTOs referencing Domain enums directly; introducing a parallel Application enum would require an extra mapping step for no benefit in this codebase |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|------------------------|
+| `Financial.Domain/Entities/Asset.cs` | Modified | Domain state | Nested `PositionStatus` enum; `Status` computed property (`Quantity > 0` → `Long`, `< 0` → `Short`, else `Flat`) |
+| `Financial.Application/DTOs/AssetNodeDTO.cs` | Modified | Tree node DTO | New `Status` property (`[JsonConverter(typeof(JsonStringEnumConverter))]`) |
+| `Financial.Application/DTOs/AssetDetailsDTO.cs` | Modified | Asset details DTO | New `Status` property (same converter) |
+| `Financial.Application/Services/NavigationMapper.cs` | Modified | Mapping | `MapAsset` sets `Status = asset.Status`; `BuildAssetTreeNode` adds `Metadata["PositionStatus"] = asset.Status` (reads from the already-mapped `AssetNodeDTO`) |
+| `Financial.Application/Services/NavigationService.cs` | Modified | Mapping | `GetAssetDetails` sets `Status = asset.Status` on the constructed `AssetDetailsDTO` |
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|------------------------|
+| `Financial.Web/src/api/types.ts` | Modified | Type contracts | `AssetNodeDto`/`AssetDetailsDto` gain required `status: string` |
+| `Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx` | Modified | Test fixture | `makeBroker`'s nested asset literal gains a `status` value |
+| `Financial.Web/src/hooks/useAssetSummary.test.ts` | Modified | Test fixture | `ASSET_DETAILS` literal gains a `status` value |
+| `Financial.Web/src/hooks/useCredits.test.ts` | Modified | Test fixture | `ASSET_DETAILS` literal gains a `status` value |
+| `Financial.Web/src/hooks/useTransactions.test.ts` | Modified | Test fixture | `ASSET_DETAILS` literal gains a `status` value |
+| `Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx` | Modified | Test fixture | `ASSET` literal gains a `status` value |
+
+No other Web test file needs changes: `InvestmentTree.test.tsx` builds `TreeNodeDto.metadata` as a loosely-typed `Record<string, unknown>` (no compile-time requirement to add the new key), and `DetailPanel.test.tsx`/`useAssetSummary.test.ts`'s other fixtures build `SelectedNode`, whose `isActive` field is already optional and which does not gain a `status` field in this feature.
+
+**Database:** None — `Status` is computed at read time from `Quantity`; no schema or `data.json` shape change.
+
+## 5. API Contracts
+
+Not applicable — this feature has no new or modified endpoints. Existing `GET` endpoints that already return `AssetNodeDTO`/`AssetDetailsDTO` will include the new `status` field automatically once the DTOs are updated (F05 later adds the `scope` query parameter to these same endpoints).
+
+## 6. Data Model
+
+Not applicable — no persisted schema change. `PositionStatus` is a computed, in-memory value derived from `Asset.Quantity` on every read, exactly like `Asset.Active` today.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Tests/Financial.Domain.Tests/Domain/AssetTests.cs` | Unit | `Asset.Status` | All three states |
+| `Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs` | Unit | `NavigationMapper.MapAsset`, `NavigationService.GetAssetDetails` | `Status` correctly mapped onto both DTOs and into tree `Metadata` |
+
+**Test Functions:**
+
+| Test Function | Description | Assertions |
+|----------------|-------------|------------|
+| `Status_PositiveQuantity_ReturnsLong` | Asset with `Quantity > 0` (e.g., after a buy) | `asset.Status.Should().Be(Asset.PositionStatus.Long)` — covers PRD acceptance criterion "Quantity > 0 → Long" |
+| `Status_ZeroQuantity_ReturnsFlat` | Newly created asset, or fully sold down to zero | `asset.Status.Should().Be(Asset.PositionStatus.Flat)` — covers "Quantity = 0 → Flat" |
+| `Status_NegativeQuantity_ReturnsShort` | Asset sold without a prior matching buy (net short) | `asset.Status.Should().Be(Asset.PositionStatus.Short)` — covers "Quantity < 0 → Short" |
+| `GetNavigationTree_AssetNode_MetadataIncludesPositionStatus` | Extend the existing `NavigationMapperTests` pattern | `assetNode.Metadata["PositionStatus"].Should().Be(Asset.PositionStatus.Long)` for a long asset |
+| `GetAssetsByBrokerPortfolio_AssetNodeDto_StatusMatchesAssetStatus` | Build assets with Long/Flat/Short quantities via `StubRepository` | Each returned `AssetNodeDTO.Status` matches the source asset's `Status` — covers "Status is present on Active-scoped AssetNodeDTO" |
+| `GetAssetDetails_ReturnsStatusMatchingAsset` | Build a single asset via `StubRepository`, call `GetAssetDetails` | Returned `AssetDetailsDTO.Status` matches `asset.Status` — covers "Status is present on ... AssetDetailsDto" |
+
+**Web side:** No new test files — the existing fixture updates (Section 4) are what keep `npm run typecheck`/`tsc -b --noEmit` and the existing Vitest suites green with the now-required `status` field. No new Web behavior is introduced by this feature, so no new Web test assertions are needed.
+
+**Deferred cross-feature integration:** PRD Section 9's Cross-Feature Integration criterion "Position status computed by F01 appears correctly on every Active-scoped asset returned by F05" cannot be tested yet — F05 (the `scope=active|historic` selector) does not exist. The unit tests above establish that `Status` is correctly computed and correctly present on both DTOs today; F05's own spec should add the actual end-to-end assertion once its scoped endpoints exist.


### PR DESCRIPTION
## Summary
- Adds a `PositionType` enum (`Long`/`Flat`/`Short`) computed from `Asset.Quantity`'s sign, additive to the existing `Active` bool (which stays untouched since it's load-bearing filtering logic in `SummaryService`/`CreditService`/`BrokerBreakdownService`).
- Surfaces `PositionType` on `AssetNodeDTO`/`AssetDetailsDTO` (C#) and `AssetNodeDto`/`AssetDetailsDto` (TS, required field), via `NavigationMapper`/`NavigationService`, plus a matching `Metadata["PositionType"]` entry in the WPF tree.
- No UI rendering of the new value in this PR — that's F08 (Web) and F10 (WPF), per the PRD's feature split. No API scope selector — that's F05.
- Implements `docs/P10-F01-position-status-domain-model/spec.md` and `plan.md` against `docs/prd/P10-prd-historic-investments/prd-historic-investments.md`.

## Test plan
- [x] `Financial.Domain.Tests` — 62 passed (incl. new Long/Flat/Short cases)
- [x] `Financial.Application.Tests` — 179 passed (incl. new DTO/Metadata mapping cases)
- [x] `Financial.Api.Tests` — 42 passed (real HTTP round-trip through `NavigationEndpointsTests`)
- [x] `Financial.Infrastructure.Tests` — 108 passed, 5 pre-existing skips (external network tests)
- [x] `Financial.Presentation.Tests` (WPF) — 150 passed
- [x] Web: `tsc -b --noEmit` clean, `vitest run` — 365 passed, `eslint .` clean

## Note
Mid-implementation, the field was renamed from `Status`/`PositionStatus` to `PositionType` per industry terminology — reflected throughout code, tests, and the spec/plan docs. The PRD's F05/F08/F10 sections still say "Status"; read that as `PositionType` when those are spec'd next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)