### PR TITLE
feat(P10-F02): Active/Historic Investments Data Model & Storage

### DIFF
--- a/Financial.Application/Interfaces/IRepository.cs
+++ b/Financial.Application/Interfaces/IRepository.cs
@@ -1,13 +1,13 @@
-﻿using Financial.Domain.Entities;
+using Financial.Domain.Entities;
 
 namespace Financial.Application.Interfaces;
 
 public interface IRepository
 {
-    IEnumerable<Asset> GetAssetsByBroker(string name);
-    IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio);
-    IEnumerable<Broker> GetBrokerList();
-    Asset? GetAsset(string brokerName, string portfolioName, string assetName);
+    IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active);
+    IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active);
+    IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active);
+    Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active);
 
     Task SaveChangesAsync();
 }

--- a/Financial.Application/Interfaces/InvestmentScope.cs
+++ b/Financial.Application/Interfaces/InvestmentScope.cs
@@ -1,0 +1,3 @@
+namespace Financial.Application.Interfaces;
+
+public enum InvestmentScope { Active, Historic }

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -142,16 +142,9 @@ internal static class NavigationMapper
         return (totalBought, totalSold, totalCredits);
     }
 
-    internal static IEnumerable<T> OrderByNameWithEncerradasLast<T>(IEnumerable<T> source, Func<T, string> nameSelector)
-    {
-        return source
-            .OrderBy(item => IsEncerradas(nameSelector(item)) ? 1 : 0)
-            .ThenBy(item => nameSelector(item) ?? string.Empty, StringComparer.CurrentCultureIgnoreCase);
-    }
-
     private static IEnumerable<PortfolioNodeDTO> MapPortfolios(IEnumerable<Portfolio> portfolios)
     {
-        return OrderByNameWithEncerradasLast(portfolios, p => p.Name).Select(MapPortfolio);
+        return portfolios.OrderBy(p => p.Name, StringComparer.CurrentCultureIgnoreCase).Select(MapPortfolio);
     }
 
     private static PortfolioNodeDTO MapPortfolio(Portfolio portfolio)
@@ -161,7 +154,7 @@ internal static class NavigationMapper
             Name = portfolio.Name,
             AssetCount = portfolio.Assets.Count,
             ActiveAssetCount = portfolio.Assets.Count(a => a.Active),
-            Assets = OrderByNameWithEncerradasLast(portfolio.Assets, a => a.Name).Select(MapAsset).ToList()
+            Assets = portfolio.Assets.OrderBy(a => a.Name, StringComparer.CurrentCultureIgnoreCase).Select(MapAsset).ToList()
         };
     }
 

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -85,7 +85,7 @@ public sealed class NavigationService : INavigationService
 
     public IEnumerable<BrokerNodeDTO> GetBrokers()
     {
-        var brokers = NavigationMapper.OrderByNameWithEncerradasLast(_repository.GetBrokerList(), b => b.Name);
+        var brokers = _repository.GetBrokerList().OrderBy(b => b.Name, StringComparer.CurrentCultureIgnoreCase);
         return brokers.Select(NavigationMapper.MapBroker).ToList();
     }
 

--- a/Financial.Application/Services/PortfolioAssetSummaryService.cs
+++ b/Financial.Application/Services/PortfolioAssetSummaryService.cs
@@ -27,8 +27,8 @@ public sealed class PortfolioAssetSummaryService : IPortfolioAssetSummaryService
         var computed = assets.Select(a => ComputeAssetData(a, today)).ToList();
         var portfolioTotalInvested = computed.Sum(c => c.TotalInvested);
 
-        return NavigationMapper
-            .OrderByNameWithEncerradasLast(computed, c => c.AssetName)
+        return computed
+            .OrderBy(c => c.AssetName, StringComparer.CurrentCultureIgnoreCase)
             .Select(c => ToDTO(c, CalculateWeight(c.TotalInvested, portfolioTotalInvested)))
             .ToList();
     }

--- a/Financial.Domain/Entities/Investments.cs
+++ b/Financial.Domain/Entities/Investments.cs
@@ -1,23 +1,36 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Financial.Domain.Entities;
 
 public class Investments
 {
-    private List<Broker> _brokers = new List<Broker>();
-    public IReadOnlyCollection<Broker> Brokers { get => _brokers.AsReadOnly(); private set => SetBrokers(value); }
-    private void SetBrokers(IReadOnlyCollection<Broker> data)
+    private List<Broker> _activeBrokers = new List<Broker>();
+    public IReadOnlyCollection<Broker> ActiveBrokers { get => _activeBrokers.AsReadOnly(); private set => SetActiveBrokers(value); }
+    private void SetActiveBrokers(IReadOnlyCollection<Broker> data)
     {
-        _brokers.Clear();
-        _brokers.AddRange(data);
+        _activeBrokers.Clear();
+        _activeBrokers.AddRange(data);
+    }
+
+    private List<Broker> _historicBrokers = new List<Broker>();
+    public IReadOnlyCollection<Broker> HistoricBrokers { get => _historicBrokers.AsReadOnly(); private set => SetHistoricBrokers(value); }
+    private void SetHistoricBrokers(IReadOnlyCollection<Broker> data)
+    {
+        _historicBrokers.Clear();
+        _historicBrokers.AddRange(data);
     }
 
     private Investments() { }
 
     public static Investments Create() => new();
 
-    public void AddBroker(Broker broker)
+    public void AddActiveBroker(Broker broker)
     {
-        _brokers.Add(broker);
+        _activeBrokers.Add(broker);
+    }
+
+    public void AddHistoricBroker(Broker broker)
+    {
+        _historicBrokers.Add(broker);
     }
 }

--- a/Financial.Infrastructure/Repositories/JSONRepository.cs
+++ b/Financial.Infrastructure/Repositories/JSONRepository.cs
@@ -16,27 +16,27 @@ public sealed class JSONRepository : IRepository
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
     }
 
-    public IEnumerable<Asset> GetAssetsByBroker(string name)
+    public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active)
     {
-        return GetAssetsByBrokerInternal(name);
+        return GetAssetsByBrokerInternal(name, scope);
     }
 
-    public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio)
+    public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
     {
-        return GetPortfoliosByBroker(broker)
+        return GetPortfoliosByBroker(broker, scope)
             .Where(p => p.Name == portfolio)
             .SelectMany(p => p.Assets);
     }
 
-    public Asset? GetAsset(string brokerName, string portfolioName, string assetName)
+    public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active)
     {
-        return GetAssetsByBrokerPortfolio(brokerName, portfolioName)
+        return GetAssetsByBrokerPortfolio(brokerName, portfolioName, scope)
             .FirstOrDefault(a => a.Name == assetName);
     }
 
-    public IEnumerable<Broker> GetBrokerList()
+    public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active)
     {
-        return _investiments.Brokers;
+        return ResolveBrokers(scope);
     }
 
     public async Task SaveChangesAsync()
@@ -45,12 +45,15 @@ public sealed class JSONRepository : IRepository
         await _storage.WriteAsync(json).ConfigureAwait(false);
     }
 
-    private IEnumerable<Broker> GetBrokersByName(string brokerName) =>
-        _investiments.Brokers.Where(b => b.Name == brokerName);
+    private IReadOnlyCollection<Broker> ResolveBrokers(InvestmentScope scope) =>
+        scope == InvestmentScope.Historic ? _investiments.HistoricBrokers : _investiments.ActiveBrokers;
 
-    private IEnumerable<Portfolio> GetPortfoliosByBroker(string brokerName) =>
-        GetBrokersByName(brokerName).SelectMany(b => b.Portfolios);
+    private IEnumerable<Broker> GetBrokersByName(string brokerName, InvestmentScope scope) =>
+        ResolveBrokers(scope).Where(b => b.Name == brokerName);
 
-    private IEnumerable<Asset> GetAssetsByBrokerInternal(string brokerName) =>
-        GetPortfoliosByBroker(brokerName).SelectMany(p => p.Assets);
+    private IEnumerable<Portfolio> GetPortfoliosByBroker(string brokerName, InvestmentScope scope) =>
+        GetBrokersByName(brokerName, scope).SelectMany(b => b.Portfolios);
+
+    private IEnumerable<Asset> GetAssetsByBrokerInternal(string brokerName, InvestmentScope scope) =>
+        GetPortfoliosByBroker(brokerName, scope).SelectMany(p => p.Assets);
 }

--- a/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
@@ -58,7 +58,7 @@ public sealed class GoogleGenerator
     private async Task ProcessBrokerAsync(Investments data, string fileName, string fileId, IProgress<string> progress)
     {
         var broker = Broker.Create(fileName, _metadataResolver.ResolveBrokerCurrency(fileName));
-        data.AddBroker(broker);
+        data.AddActiveBroker(broker);
 
         progress?.Report($"Getting spreadsheets for: {fileName}");
         var spreadSheets = await _service.GetSpreadSheetAsync(fileId);

--- a/Tests/Financial.Api.Tests/TestData/data.test.json
+++ b/Tests/Financial.Api.Tests/TestData/data.test.json
@@ -1,5 +1,5 @@
 {
-  "Brokers": [
+  "ActiveBrokers": [
     {
       "Name": "XPI",
       "Currency": "BRL",
@@ -45,5 +45,6 @@
         }
       ]
     }
-  ]
+  ],
+  "HistoricBrokers": []
 }

--- a/Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs
@@ -246,10 +246,10 @@ public class BrokerBreakdownServiceTests
         public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
         public IEnumerable<Broker> Brokers { get; set; } = [];
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name) => AssetsByBroker;
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => AssetsByBrokerPortfolio;
-        public IEnumerable<Broker> GetBrokerList() => Brokers;
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => null;
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => Brokers;
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
         public Task SaveChangesAsync() => Task.CompletedTask;
     }
 }

--- a/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
+++ b/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
@@ -155,15 +155,15 @@ public class NavigationMapperTests
     {
         public Broker? Broker { get; set; }
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name) =>
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) =>
             Broker == null ? [] : Broker.Portfolios.SelectMany(p => p.Assets);
 
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) =>
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) =>
             Broker?.Portfolios.FirstOrDefault(p => p.Name == portfolio)?.Assets ?? [];
 
-        public IEnumerable<Broker> GetBrokerList() => Broker == null ? [] : [Broker];
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => Broker == null ? [] : [Broker];
 
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) =>
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) =>
             Broker?.Portfolios.FirstOrDefault(p => p.Name == portfolioName)?.Assets.FirstOrDefault(a => a.Name == assetName);
         public Task SaveChangesAsync() => Task.CompletedTask;
     }

--- a/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs
@@ -595,10 +595,10 @@ public class PortfolioAssetSummaryServiceTests
     {
         public IEnumerable<Asset> Assets { get; set; } = [];
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name) => [];
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => Assets;
-        public IEnumerable<Broker> GetBrokerList() => [];
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => null;
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => [];
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => Assets;
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => [];
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
         public Task SaveChangesAsync() => Task.CompletedTask;
     }
 }

--- a/Tests/Financial.Application.Tests/Services/SummaryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/SummaryServiceTests.cs
@@ -313,10 +313,10 @@ public class SummaryServiceTests
         public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
         public IEnumerable<Broker> Brokers { get; set; } = [];
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name) => AssetsByBroker;
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => AssetsByBrokerPortfolio;
-        public IEnumerable<Broker> GetBrokerList() => Brokers;
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => null;
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => Brokers;
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
         public Task SaveChangesAsync() => Task.CompletedTask;
     }
 }

--- a/Tests/Financial.Application.Tests/Services/TransactionServiceQueryTests.cs
+++ b/Tests/Financial.Application.Tests/Services/TransactionServiceQueryTests.cs
@@ -154,10 +154,10 @@ public class TransactionServiceQueryTests
         public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
         public IEnumerable<Broker> Brokers { get; set; } = [];
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name) => AssetsByBroker;
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => AssetsByBrokerPortfolio;
-        public IEnumerable<Broker> GetBrokerList() => Brokers;
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => null;
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => Brokers;
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
         public Task SaveChangesAsync() => Task.CompletedTask;
     }
 }

--- a/Tests/Financial.Domain.Tests/Domain/InvestmentsTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/InvestmentsTests.cs
@@ -6,13 +6,38 @@ namespace Financial.Domain.Tests;
 public class InvestmentsTests
 {
     [Fact]
-    public void AddBroker_AddsBrokerToCollection()
+    public void AddActiveBroker_AddsBrokerToActiveCollection()
     {
         var investments = Investments.Create();
         var broker = Broker.Create("Broker A", "USD");
 
-        investments.AddBroker(broker);
+        investments.AddActiveBroker(broker);
 
-        investments.Brokers.Should().ContainSingle().Which.Name.Should().Be("Broker A");
+        investments.ActiveBrokers.Should().ContainSingle().Which.Name.Should().Be("Broker A");
+        investments.HistoricBrokers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddHistoricBroker_AddsBrokerToHistoricCollection()
+    {
+        var investments = Investments.Create();
+        var broker = Broker.Create("Broker A", "USD");
+
+        investments.AddHistoricBroker(broker);
+
+        investments.HistoricBrokers.Should().ContainSingle().Which.Name.Should().Be("Broker A");
+        investments.ActiveBrokers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ActiveAndHistoricBrokers_AreIndependentCollections()
+    {
+        var investments = Investments.Create();
+
+        investments.AddActiveBroker(Broker.Create("Active Broker", "USD"));
+        investments.AddHistoricBroker(Broker.Create("Historic Broker", "USD"));
+
+        investments.ActiveBrokers.Should().ContainSingle().Which.Name.Should().Be("Active Broker");
+        investments.HistoricBrokers.Should().ContainSingle().Which.Name.Should().Be("Historic Broker");
     }
 }

--- a/Tests/Financial.Infrastructure.Tests/Persistence/InvestmentsJsonSerializerTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Persistence/InvestmentsJsonSerializerTests.cs
@@ -9,32 +9,69 @@ public class InvestmentsJsonSerializerTests
     private static readonly InvestmentsSerializerAdapter Serializer = new();
 
     [Fact]
-    public void SerializeDeserialize_RoundTripPreservesStructure()
+    public void SerializeDeserialize_RoundTripPreservesActiveAndHistoricStructure()
     {
         var investments = Investments.Create();
-        var broker = Broker.Create("Broker A", "USD");
-        var portfolio = broker.AddPortfolio("Default");
-        portfolio.AddAsset(Asset.Create("Asset A", "ISIN123", "NYSE", "AAA"));
-        investments.AddBroker(broker);
+
+        var activeBroker = Broker.Create("Broker A", "USD");
+        var activePortfolio = activeBroker.AddPortfolio("Default");
+        activePortfolio.AddAsset(Asset.Create("Asset A", "ISIN123", "NYSE", "AAA"));
+        investments.AddActiveBroker(activeBroker);
+
+        var historicBroker = Broker.Create("Broker B", "USD");
+        var historicPortfolio = historicBroker.AddPortfolio("Uncategorized");
+        historicPortfolio.AddAsset(Asset.Create("Asset B", "ISIN456", "NYSE", "BBB"));
+        investments.AddHistoricBroker(historicBroker);
 
         var json = Serializer.Serialize(investments);
         var result = Serializer.Deserialize(json);
 
         result.Should().NotBeNull();
-        var brokerResult = result.Brokers.Should().ContainSingle().Which;
-        var portfolioResult = brokerResult.Portfolios.Should().ContainSingle().Which;
-        portfolioResult.Assets.Should().ContainSingle();
+
+        var activeBrokerResult = result.ActiveBrokers.Should().ContainSingle().Which;
+        var activePortfolioResult = activeBrokerResult.Portfolios.Should().ContainSingle().Which;
+        activePortfolioResult.Assets.Should().ContainSingle().Which.Name.Should().Be("Asset A");
+
+        var historicBrokerResult = result.HistoricBrokers.Should().ContainSingle().Which;
+        var historicPortfolioResult = historicBrokerResult.Portfolios.Should().ContainSingle().Which;
+        historicPortfolioResult.Assets.Should().ContainSingle().Which.Name.Should().Be("Asset B");
     }
 
     [Fact]
     public void Serialize_ProducesValidJson()
     {
         var investments = Investments.Create();
-        investments.AddBroker(Broker.Create("Broker A", "BRL"));
+        investments.AddActiveBroker(Broker.Create("Broker A", "BRL"));
 
         var json = Serializer.Serialize(investments);
 
         json.Should().NotBeNullOrWhiteSpace();
         json.Should().Contain("Broker A");
+    }
+
+    [Fact]
+    public void Deserialize_MissingHistoricBrokersKey_ResultsInEmptyHistoricCollection()
+    {
+        const string json = """
+            { "ActiveBrokers": [ { "Name": "Broker A", "Currency": "USD", "Portfolios": [] } ] }
+            """;
+
+        var result = Serializer.Deserialize(json);
+
+        result.ActiveBrokers.Should().ContainSingle();
+        result.HistoricBrokers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Deserialize_MissingActiveBrokersKey_ResultsInEmptyActiveCollection()
+    {
+        const string json = """
+            { "HistoricBrokers": [ { "Name": "Broker A", "Currency": "USD", "Portfolios": [] } ] }
+            """;
+
+        var result = Serializer.Deserialize(json);
+
+        result.HistoricBrokers.Should().ContainSingle();
+        result.ActiveBrokers.Should().BeEmpty();
     }
 }

--- a/Tests/Financial.Infrastructure.Tests/Repositories/JsonRepositoryTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Repositories/JsonRepositoryTests.cs
@@ -1,3 +1,5 @@
+using Financial.Application.Interfaces;
+using Financial.Domain.Entities;
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
 using FluentAssertions;
@@ -26,5 +28,52 @@ public class JsonRepositoryTests
         result.Should().HaveCount(records);
     }
 
-}
+    [Fact]
+    public void GetAssetsByBroker_DefaultScope_ReturnsActiveOnly()
+    {
+        var repository = CreateRepositoryWithBothScopes(out _, out _);
 
+        var result = repository.GetAssetsByBroker("XPI");
+
+        result.Should().ContainSingle().Which.Name.Should().Be("ACTIVE_ASSET");
+    }
+
+    [Fact]
+    public void GetAssetsByBroker_HistoricScope_ReturnsHistoricOnly()
+    {
+        var repository = CreateRepositoryWithBothScopes(out _, out _);
+
+        var result = repository.GetAssetsByBroker("XPI", InvestmentScope.Historic);
+
+        result.Should().ContainSingle().Which.Name.Should().Be("HISTORIC_ASSET");
+    }
+
+    [Fact]
+    public void GetBrokerList_ActiveAndHistoricScopes_ReturnIndependentLists()
+    {
+        var repository = CreateRepositoryWithBothScopes(out var activeBroker, out var historicBroker);
+
+        var activeResult = repository.GetBrokerList();
+        var historicResult = repository.GetBrokerList(InvestmentScope.Historic);
+
+        activeResult.Should().ContainSingle().Which.Should().BeSameAs(activeBroker);
+        historicResult.Should().ContainSingle().Which.Should().BeSameAs(historicBroker);
+    }
+
+    private static JSONRepository CreateRepositoryWithBothScopes(out Broker activeBroker, out Broker historicBroker)
+    {
+        var investments = Investments.Create();
+
+        activeBroker = Broker.Create("XPI", "BRL");
+        activeBroker.AddPortfolio("Default").AddAsset(Asset.Create("ACTIVE_ASSET", "ISIN1", "BVMF", "ACTIVE_ASSET"));
+        investments.AddActiveBroker(activeBroker);
+
+        historicBroker = Broker.Create("XPI", "BRL");
+        historicBroker.AddPortfolio("Uncategorized").AddAsset(Asset.Create("HISTORIC_ASSET", "ISIN2", "BVMF", "HISTORIC_ASSET"));
+        investments.AddHistoricBroker(historicBroker);
+
+        var storage = new LocalJsonStorage(TestDataPaths.DataJsonFile);
+        var serializer = new InvestmentsSerializerAdapter();
+        return new JSONRepository(investments, storage, serializer);
+    }
+}

--- a/Tests/Financial.Infrastructure.Tests/Services/AssetPriceServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/AssetPriceServiceTests.cs
@@ -141,13 +141,13 @@ public class AssetPriceServiceTests
             _brokers = brokers.ToList();
         }
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name) => throw new NotImplementedException();
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
 
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => throw new NotImplementedException();
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
 
-        public IEnumerable<Broker> GetBrokerList() => _brokers;
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => _brokers;
 
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => throw new NotImplementedException();
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
 
         public Task SaveChangesAsync() => throw new NotImplementedException();
     }

--- a/Tests/Financial.Infrastructure.Tests/Services/CryptocurrencyAssetPriceFetcherTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/CryptocurrencyAssetPriceFetcherTests.cs
@@ -114,13 +114,13 @@ public class CryptocurrencyAssetPriceFetcherTests
             _brokers = brokers.ToList();
         }
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name) => throw new NotImplementedException();
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
 
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => throw new NotImplementedException();
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
 
-        public IEnumerable<Broker> GetBrokerList() => _brokers;
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => _brokers;
 
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => throw new NotImplementedException();
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
 
         public Task SaveChangesAsync() => throw new NotImplementedException();
     }

--- a/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs
@@ -410,7 +410,7 @@ public class NavigationServiceTests
     }
 
     [Fact]
-    public void GetBrokers_ShouldOrderByNameWithEncerradasLast()
+    public void GetBrokers_ShouldOrderByNameAlphabetically()
     {
         // Arrange
         var repository = new StubRepository(new[]
@@ -425,11 +425,11 @@ public class NavigationServiceTests
         var brokerNames = sut.GetBrokers().Select(broker => broker.Name).ToList();
 
         // Assert
-        brokerNames.Should().ContainInOrder("Alpha", "Zeta", "Encerradas");
+        brokerNames.Should().ContainInOrder("Alpha", "Encerradas", "Zeta");
     }
 
     [Fact]
-    public void GetBrokers_PortfoliosShouldOrderByNameWithEncerradasLast()
+    public void GetBrokers_PortfoliosShouldOrderByNameAlphabetically()
     {
         // Arrange
         var broker = BuildBroker("Broker", "USD",
@@ -443,11 +443,11 @@ public class NavigationServiceTests
         var portfolioNames = sut.GetBrokers().Single().Portfolios.Select(portfolio => portfolio.Name).ToList();
 
         // Assert
-        portfolioNames.Should().ContainInOrder("Alpha", "Zeta", "Encerradas");
+        portfolioNames.Should().ContainInOrder("Alpha", "Encerradas", "Zeta");
     }
 
     [Fact]
-    public void GetBrokers_AssetsShouldOrderByNameWithEncerradasLast()
+    public void GetBrokers_AssetsShouldOrderByNameAlphabetically()
     {
         // Arrange
         var broker = BuildBroker("Broker", "USD",
@@ -463,7 +463,7 @@ public class NavigationServiceTests
             .ToList();
 
         // Assert
-        assetNames.Should().ContainInOrder("Alpha", "Zeta", "Encerradas");
+        assetNames.Should().ContainInOrder("Alpha", "Encerradas", "Zeta");
     }
 
     private static Broker BuildBroker(string name, string currency = "USD",
@@ -492,13 +492,13 @@ public class NavigationServiceTests
             _brokers = brokers.ToList();
         }
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name) => throw new NotImplementedException();
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
 
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio) => throw new NotImplementedException();
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
 
-        public IEnumerable<Broker> GetBrokerList() => _brokers;
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => _brokers;
 
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName) => throw new NotImplementedException();
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
 
         public Task SaveChangesAsync() => throw new NotImplementedException();
     }

--- a/Tests/Financial.Infrastructure.Tests/TestData/data.test.json
+++ b/Tests/Financial.Infrastructure.Tests/TestData/data.test.json
@@ -1,5 +1,5 @@
 {
-  "Brokers": [
+  "ActiveBrokers": [
     {
       "Name": "XPI",
       "Currency": "BRL",
@@ -45,5 +45,6 @@
         }
       ]
     }
-  ]
+  ],
+  "HistoricBrokers": []
 }

--- a/docs/P10-F02-active-historic-investments-data-model-storage/plan.md
+++ b/docs/P10-F02-active-historic-investments-data-model-storage/plan.md
@@ -1,0 +1,31 @@
+# Implementation Plan: F02. Active/Historic Investments Data Model & Storage
+
+**Prerequisites:**
+- No new tools, libraries, or environment variables required
+- Builds on `Financial.Domain`, `Financial.Application`, `Financial.Infrastructure`, and `Integrations/GoogleFinancialSupport` as they stand on `main` (including F01's `PositionType` work)
+
+### Stage 1: Domain Layer
+
+**1. Investments Active/Historic Split** - Replace `Investments`'s single `Brokers` collection with two independent collections, `ActiveBrokers` and `HistoricBrokers`, each backed the same way `Brokers` is today. Replace the single `AddBroker` method with `AddActiveBroker` and `AddHistoricBroker`. `Broker`/`Portfolio`/`Asset` entities are untouched.
+
+**2. Domain Unit Tests** - Update `InvestmentsTests.cs` to cover `AddActiveBroker` and `AddHistoricBroker`, confirming the two collections populate independently of each other.
+
+### Stage 2: Repository Abstraction and Infrastructure
+
+**3. InvestmentScope Enum and IRepository Signature** - Add a new `InvestmentScope` enum (`Active`/`Historic`) and give `IRepository`'s four query methods an optional scope parameter defaulting to `Active`, so every existing caller keeps compiling and keeps today's behavior unchanged.
+
+**4. JSONRepository Scope Resolution** - Update `JSONRepository` to resolve each query against `ActiveBrokers` or `HistoricBrokers` based on the scope argument. `SaveChangesAsync` continues to serialize the whole `Investments` instance unchanged.
+
+**5. Import Tool Compile Fix** - Update `GoogleGenerator`'s one call to the old `AddBroker` to call `AddActiveBroker` instead, purely to keep the import tool compiling until F04 implements real routing logic there.
+
+**6. Test-Stub Signature Updates** - Update the 8 test files that implement `IRepository` directly with an in-file stub, adding the new scope parameter to each stub's method signatures.
+
+**7. Test Data Fixture Migration** - Update both copies of `data.test.json` (Infrastructure and Api test projects) from the old `{ "Brokers": [...] }` shape to the new `{ "ActiveBrokers": [...], "HistoricBrokers": [...] }` shape, preserving the existing broker/asset content under `ActiveBrokers`.
+
+**8. Infrastructure Unit Tests** - Extend `InvestmentsJsonSerializerTests` to cover round-tripping both collections and the missing-key-defaults-to-empty behavior. Extend `JsonRepositoryTests` to cover scope-parameterized queries returning only the requested collection's data.
+
+### Stage 3: Application Layer Cleanup
+
+**9. Remove Sort-Last Special-Casing** - Remove `NavigationMapper.OrderByNameWithEncerradasLast` and replace its three call sites (portfolios within a broker, assets within a portfolio, brokers in `NavigationService.GetBrokers`) with plain alphabetical ordering. Leave `NavigationMapper.IsEncerradas` itself in place, since other services still depend on it.
+
+**10. Application Test Updates** - Rewrite the three existing "sort Encerradas last" tests in `NavigationServiceTests` to assert plain alphabetical ordering instead, confirming the special-casing no longer exists.

--- a/docs/P10-F02-active-historic-investments-data-model-storage/spec.md
+++ b/docs/P10-F02-active-historic-investments-data-model-storage/spec.md
@@ -1,0 +1,156 @@
+# Feature Spec: F02. Active/Historic Investments Data Model & Storage
+
+## 1. Technical Overview
+
+**What:** Split `Investments` from a single `Brokers` collection into two independent `Broker` collections — `ActiveBrokers` and `HistoricBrokers` — update `data.json`'s persisted shape to match, and make `IRepository` scope-aware (`InvestmentScope.Active`/`.Historic`) so Application services can query either collection through the existing single abstraction.
+
+**Why:** Today, a closed asset lives inside a normal portfolio (`"Encerradas"`) mixed into the same `Brokers` list as active holdings, so every summary/chart feature has to remember to filter it out. This feature makes the separation structural: two physically distinct collections, so a query against one can never leak data from the other, by construction rather than by convention.
+
+**Scope:**
+- **Included:** `Investments` domain entity split (`ActiveBrokers`/`HistoricBrokers`, `AddActiveBroker`/`AddHistoricBroker`); `IRepository`'s 4 query methods gain an `InvestmentScope` parameter defaulting to `Active`; `JSONRepository` resolves queries against the correct collection; the one production caller of the old `AddBroker` (`GoogleGenerator.ProcessBrokerAsync`) is updated to keep compiling; the `OrderByNameWithEncerradasLast` sort-last helper is removed (no longer needed once historic data is physically separate) and its 3 call sites use plain alphabetical ordering instead; the 8 test-stub `IRepository` implementations gain the new parameter; the 2 real `data.test.json` fixtures move to the new shape; Domain/Application/Infrastructure unit tests updated and extended.
+- **Excluded:** Anything that decides *which* assets go into which collection at import time — that is F04. `AssetClassification.json`'s `historicPortfolio` field — that is F03. The `scope=active|historic` API query parameter and any endpoint change — that is F05. `NavigationMapper.IsEncerradas` itself and `BrokerBreakdownService`'s/`SummaryService`'s `.Where(a => a.Active)`/`.Where(p => !IsEncerradas(...))` filters — those stay exactly as they are today; removing them is F05's stated cleanup once real scoped queries exist, and removing `IsEncerradas` now would break `BrokerBreakdownService.cs`, which this feature does not touch. Migrating the real, currently-running `data.json` — per the PRD, re-running the (future) import is the migration path, not a script this feature writes.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Domain/Entities/Investments.cs` — `ActiveBrokers`/`HistoricBrokers` collections, `AddActiveBroker`/`AddHistoricBroker` methods (replacing `AddBroker`)
+- `Financial.Application/Interfaces/InvestmentScope.cs` — new enum
+- `Financial.Application/Interfaces/IRepository.cs` — 4 methods gain `InvestmentScope scope = InvestmentScope.Active`
+- `Financial.Infrastructure/Repositories/JSONRepository.cs` — resolves each query against `ActiveBrokers` or `HistoricBrokers` based on the scope argument
+- `Financial.Application/Services/NavigationMapper.cs` — `OrderByNameWithEncerradasLast` removed; `MapPortfolios`/`MapPortfolio` use plain alphabetical ordering
+- `Financial.Application/Services/NavigationService.cs` — `GetBrokers()` uses plain alphabetical ordering
+- `Integrations/GoogleFinancialSupport/GoogleGenerator.cs` — one-line call-site fix (`AddBroker` → `AddActiveBroker`) to keep the import tool compiling; no routing/color-detection logic added (that's F04)
+- 8 test files with an in-file `StubRepository : IRepository` gain the new parameter (see Section 4)
+- `Tests/Financial.Infrastructure.Tests/TestData/data.test.json` and `Tests/Financial.Api.Tests/TestData/data.test.json` — move to the new shape
+- `Tests/Financial.Domain.Tests/Domain/InvestmentsTests.cs`, `Tests/Financial.Infrastructure.Tests/Persistence/InvestmentsJsonSerializerTests.cs`, `Tests/Financial.Infrastructure.Tests/Repositories/JsonRepositoryTests.cs`, `Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs` — updated/extended tests
+
+**Data flow:**
+
+```mermaid
+graph TD
+    A["data.json (ActiveBrokers / HistoricBrokers keys)"] --> B["InvestmentsSerializerAdapter.Deserialize"]
+    B --> C["Investments.ActiveBrokers / .HistoricBrokers"]
+    C --> D["JSONRepository"]
+    D -->|"scope = Active (default)"| E["Application services (unchanged callers)"]
+    D -->|"scope = Historic"| F["Future F05/F06/F07 consumers"]
+    G["GoogleGenerator (import tool)"] -->|"AddActiveBroker"| C
+    C --> H["InvestmentsSerializerAdapter.Serialize"]
+    H --> A
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Repository scope mechanism | Add an optional `InvestmentScope scope = InvestmentScope.Active` parameter to all 4 `IRepository` methods | Split into two repository interfaces (`IActiveRepository`/`IHistoricRepository`) | User decision: every existing Application-layer caller keeps compiling and keeps today's behavior unchanged (default = Active); only the 8 test stubs need a mechanical signature update, versus every consumer's constructor changing under the split-interface alternative |
+| `Investments.AddBroker` replacement | Rename to `AddActiveBroker`/`AddHistoricBroker`; fix the one production call site (`GoogleGenerator.ProcessBrokerAsync`, `AddBroker` → `AddActiveBroker`) as a compile-keeping change only | Keep `AddBroker` as a permanent alias for `AddActiveBroker` | User decision: a permanent alias whose name doesn't reveal it's active-only would be a lingering confusion; the one-line fix in `GoogleGenerator.cs` is not F04's actual routing logic, just keeps the build green until F04 replaces it properly |
+| `IsEncerradas`/sort-last cleanup scope | Remove only `OrderByNameWithEncerradasLast` (the sort-last helper) and inline plain ordering at its 3 call sites; leave the `IsEncerradas(name)` helper method itself in place | Delete `IsEncerradas` entirely now, and also fix `BrokerBreakdownService.cs`'s remaining usage | User decision: `BrokerBreakdownService` (and `SummaryService`, which has the same filter pattern) still call `IsEncerradas` directly; deleting it now would break their compile. That cleanup is explicitly F05's, once real scoped queries make the filter redundant |
+| Property naming (`Investments`) | `ActiveBrokers`/`HistoricBrokers` (both `List<Broker>`) | `ActiveInvestments`/`HistoricInvestments` (the PRD's illustrative JSON key names) | The PRD explicitly offers "`ActiveBrokers` and `HistoricBrokers` (or equivalent names)" as its primary suggestion; naming the property after the collection's element type matches the existing `Investments.Brokers` convention exactly, whereas `Investments.ActiveInvestments` reads as redundant with the enclosing class name |
+| `data.json` key casing | `ActiveBrokers`/`HistoricBrokers` (PascalCase, matching the property name exactly) | `activeInvestments`/`historicInvestments` (camelCase, as illustrated in the PRD's example JSON snippet) | `InvestmentsSerializerAdapter`'s `JsonSerializerOptions` has no camelCase naming policy — confirmed against the real test fixture, every existing key (`"Brokers"`, `"Name"`, `"ISIN"`, etc.) is PascalCase, matching C# member names verbatim. The PRD's snippet was illustrative; this follows the codebase's actual, observed convention |
+| `InvestmentScope` enum location | `Financial.Application/Interfaces/InvestmentScope.cs`, alongside `IRepository` | A new `Enums` folder | It exists solely to parameterize `IRepository`'s signature; co-locating it with the interface it serves avoids introducing a new folder for one small type |
+
+## 4. Component Overview
+
+**Domain:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|------------------------|
+| `Financial.Domain/Entities/Investments.cs` | Modified | Root aggregate | `ActiveBrokers`/`HistoricBrokers` (`IReadOnlyCollection<Broker>`, backed by private `List<Broker>` fields, same pattern as today's `Brokers`); `AddActiveBroker(Broker)`/`AddHistoricBroker(Broker)` replace `AddBroker(Broker)` |
+
+**Application:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|------------------------|
+| `Financial.Application/Interfaces/InvestmentScope.cs` | New | Query parameter | `enum InvestmentScope { Active, Historic }` |
+| `Financial.Application/Interfaces/IRepository.cs` | Modified | Repository contract | `GetAssetsByBroker`, `GetAssetsByBrokerPortfolio`, `GetBrokerList`, `GetAsset` each gain `InvestmentScope scope = InvestmentScope.Active` |
+| `Financial.Application/Services/NavigationMapper.cs` | Modified | Mapping | `OrderByNameWithEncerradasLast<T>` removed; `MapPortfolios` and `MapPortfolio` order by name with `StringComparer.CurrentCultureIgnoreCase` directly |
+| `Financial.Application/Services/NavigationService.cs` | Modified | Mapping | `GetBrokers()` orders `_repository.GetBrokerList()` by name directly, no longer via the removed helper |
+
+**Infrastructure:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|------------------------|
+| `Financial.Infrastructure/Repositories/JSONRepository.cs` | Modified | Repository implementation | Each method resolves `_investments.ActiveBrokers` or `.HistoricBrokers` based on the `scope` argument before filtering by broker/portfolio/asset name; `SaveChangesAsync` unchanged (still serializes the whole `Investments` instance, both collections) |
+| `Integrations/GoogleFinancialSupport/GoogleGenerator.cs` | Modified | Import tool (compile-keeping fix only) | `ProcessBrokerAsync`'s `data.AddBroker(broker)` → `data.AddActiveBroker(broker)`; no routing logic added |
+
+**Tests (mechanical `IRepository` signature updates — add `InvestmentScope scope = InvestmentScope.Active`, unused in the stub body):**
+
+| File Path | New/Modified |
+|-----------|--------------|
+| `Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs` | Modified |
+| `Tests/Financial.Application.Tests/Services/SummaryServiceTests.cs` | Modified |
+| `Tests/Financial.Application.Tests/Services/TransactionServiceQueryTests.cs` | Modified |
+| `Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs` | Modified |
+| `Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs` | Modified |
+| `Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs` | Modified (stub signature, plus the 3 sort-order tests below) |
+| `Tests/Financial.Infrastructure.Tests/Services/CryptocurrencyAssetPriceFetcherTests.cs` | Modified |
+| `Tests/Financial.Infrastructure.Tests/Services/AssetPriceServiceTests.cs` | Modified |
+
+**Tests (behavior updates):**
+
+| File Path | New/Modified | Purpose |
+|-----------|--------------|---------|
+| `Tests/Financial.Domain.Tests/Domain/InvestmentsTests.cs` | Modified | Cover `AddActiveBroker`/`AddHistoricBroker` and their independence |
+| `Tests/Financial.Infrastructure.Tests/Persistence/InvestmentsJsonSerializerTests.cs` | Modified | Round-trip both collections; missing-key defaults to empty |
+| `Tests/Financial.Infrastructure.Tests/Repositories/JsonRepositoryTests.cs` | Modified | Scope-parameterized queries return only the requested collection |
+| `Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs` | Modified | The 3 existing "sort Encerradas last" tests are rewritten to assert plain alphabetical order (`"Alpha", "Encerradas", "Zeta"`), proving the special-casing is gone |
+| `Tests/Financial.Infrastructure.Tests/TestData/data.test.json` | Modified | `"Brokers"` → `"ActiveBrokers"`; add empty `"HistoricBrokers": []` |
+| `Tests/Financial.Api.Tests/TestData/data.test.json` | Modified | Same change (kept identical to the Infrastructure copy, as today) |
+
+**Not touched (explicitly out of scope):** `BrokerBreakdownService.cs`, `SummaryService.cs`, `CreditService.cs`, and their existing `Encerradas`-filter tests — all still call `NavigationMapper.IsEncerradas` for filtering, unrelated to the sort-last behavior this feature removes.
+
+## 5. API Contracts
+
+Not applicable — this feature has no new or modified endpoints. F05 adds the `scope=active|historic` query parameter to existing endpoints, built on top of this feature's `InvestmentScope`.
+
+## 6. Data Model
+
+**`data.json` root shape — before:**
+```json
+{
+  "Brokers": [ /* Broker[] */ ]
+}
+```
+
+**`data.json` root shape — after:**
+```json
+{
+  "ActiveBrokers": [ /* Broker[] */ ],
+  "HistoricBrokers": [ /* Broker[] */ ]
+}
+```
+
+`Broker`/`Portfolio`/`Asset`/`Transaction`/`Credit` element shapes are unchanged — the split happens only at the `Investments` root. Serialization continues to go through `InvestmentsSerializerAdapter`'s existing `JsonSerializerOptions` (`JsonStringEnumConverter`, `WriteIndented`, `InvestmentsTypeInfoResolver` for private-setter wiring) — no changes needed there, since `ActiveBrokers`/`HistoricBrokers` are ordinary public properties on an already-`ManagedTypes`-registered type (`Investments`), reflected and wired exactly like today's `Brokers`.
+
+**Compatibility / no migration script:** A `data.json` written before this feature (still shaped `{ "Brokers": [...] }`) deserializes with **both** `ActiveBrokers` and `HistoricBrokers` empty, since the old `"Brokers"` key doesn't match either new property name — no exception, no data loss (the file itself is untouched on disk), just an empty tree until the file is regenerated. Per the PRD, regenerating `data.json` via the (future) import tool is the intended path, not a migration script this feature writes.
+
+**Cross-cutting note:** Every existing `IRepository` caller that doesn't pass a `scope` argument keeps resolving against `ActiveBrokers`, identical to today's single-collection behavior — this is what makes the change non-breaking for every already-implemented feature.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Tests/Financial.Domain.Tests/Domain/InvestmentsTests.cs` | Unit | `Investments.AddActiveBroker`/`.AddHistoricBroker` | Both collections populate independently |
+| `Tests/Financial.Infrastructure.Tests/Persistence/InvestmentsJsonSerializerTests.cs` | Unit | `InvestmentsSerializerAdapter` | Round-trip both collections; missing-key error handling |
+| `Tests/Financial.Infrastructure.Tests/Repositories/JsonRepositoryTests.cs` | Unit | `JSONRepository` | Scope-parameterized queries return only the requested collection |
+| `Tests/Financial.Infrastructure.Tests/Services/NavigationServiceTests.cs` | Unit | `NavigationService.GetBrokers()` | Plain alphabetical ordering (no more sort-last special-casing) |
+
+**Test Functions:**
+
+| Test Function | Description | Assertions |
+|----------------|-------------|------------|
+| `AddActiveBroker_AddsBrokerToActiveCollection` | Add a broker via `AddActiveBroker` | `investments.ActiveBrokers.Should().ContainSingle()`; `investments.HistoricBrokers.Should().BeEmpty()` |
+| `AddHistoricBroker_AddsBrokerToHistoricCollection` | Add a broker via `AddHistoricBroker` | `investments.HistoricBrokers.Should().ContainSingle()`; `investments.ActiveBrokers.Should().BeEmpty()` |
+| `SerializeDeserialize_RoundTripPreservesActiveAndHistoricStructure` | Populate both `ActiveBrokers` and `HistoricBrokers`, serialize, deserialize | Both collections round-trip with correct broker/portfolio/asset counts — covers PRD AC "`data.json` round-trips with both top-level arrays" |
+| `Deserialize_MissingHistoricBrokersKey_ResultsInEmptyHistoricCollection` | Deserialize JSON containing only `"ActiveBrokers"` | `result.HistoricBrokers.Should().BeEmpty()`, no exception — covers PRD AC "missing one of the two top-level keys succeeds with that collection empty" |
+| `GetAssetsByBroker_DefaultScope_ReturnsActiveOnly` | Call `GetAssetsByBroker(name)` with no scope argument against a repository with both Active and Historic data for the same broker name | Only the Active-side assets are returned — covers "omitting the scope preserves today's behavior" and "a repository query scoped to Active never returns an asset from `HistoricBrokers`" |
+| `GetAssetsByBroker_HistoricScope_ReturnsHistoricOnly` | Same setup, call with `InvestmentScope.Historic` | Only the Historic-side assets are returned, and vice versa |
+| `GetBrokers_ShouldOrderByNameAlphabetically` | Brokers named "Zeta", "Encerradas", "Alpha" | `ContainInOrder("Alpha", "Encerradas", "Zeta")` — replaces the old sort-last assertion, proving `OrderByNameWithEncerradasLast` no longer exists |
+| `GetBrokers_PortfoliosShouldOrderByNameAlphabetically` | Portfolios named "Zeta", "Encerradas", "Alpha" within one broker | Same alphabetical assertion at the portfolio level |
+| `GetBrokers_AssetsShouldOrderByNameAlphabetically` | Assets named "Zeta", "Encerradas", "Alpha" within one portfolio | Same alphabetical assertion at the asset level |
+
+**Deferred cross-feature integration:** PRD Section 9's Cross-Feature Integration criterion "Data written by import (F04) into `activeInvestments`/`historicInvestments` (F02's structure) is correctly returned by the scoped navigation API (F05)" cannot be tested yet — neither F04 nor F05 exist. The unit tests above establish that `ActiveBrokers`/`HistoricBrokers` round-trip correctly and that scoped repository queries correctly isolate one collection from the other; F04's and F05's own specs should add the actual end-to-end assertions once those exist.
+
+**Scope clarification for the AC "`NavigationMapper.IsEncerradas`/its 'sort last' special-casing no longer exists":** per the resolved decision in Section 3, only the sort-last special-casing (`OrderByNameWithEncerradasLast`) is removed in this feature; `IsEncerradas(name)` itself remains, since `BrokerBreakdownService`/`SummaryService` still call it directly and removing it now would break their compile. That remaining cleanup is F05's.


### PR DESCRIPTION
## Summary
- Splits `Investments` from a single `Brokers` list into two independent collections, `ActiveBrokers`/`HistoricBrokers`, and makes `IRepository`'s 4 query methods scope-aware via an optional `InvestmentScope` parameter defaulting to `Active` — every existing caller keeps compiling and keeps today's behavior unchanged.
- `data.json` root shape changes from `{ "Brokers": [...] }` to `{ "ActiveBrokers": [...], "HistoricBrokers": [...] }` (PascalCase, matching the codebase's existing serialization convention, not the PRD's illustrative camelCase).
- Removes `NavigationMapper.OrderByNameWithEncerradasLast` (no longer needed once historic data is physically separate) across all 4 call sites, including one in `PortfolioAssetSummaryService.cs` not caught during spec review. `IsEncerradas` itself stays, since `BrokerBreakdownService`/`SummaryService` still depend on it until F05.
- `GoogleGenerator`'s one call to the old `AddBroker` is updated to `AddActiveBroker` to keep the import tool compiling (no F04 routing logic added).
- Implements `docs/P10-F02-active-historic-investments-data-model-storage/spec.md` and `plan.md` against `docs/prd/P10-prd-historic-investments/prd-historic-investments.md`.

## Heads-up
The real, currently-running `data.json` still uses the old `{ "Brokers": [...] }` shape. Until it's regenerated via the (future) F04 import, the running app will show **zero** active investments — this is the expected, documented behavior (missing keys deserialize to empty collections rather than throwing), not a bug.

## Test plan
- [x] `Financial.Domain.Tests` — 64 passed (incl. `AddActiveBroker`/`AddHistoricBroker` independence)
- [x] `Financial.Application.Tests` — 179 passed (incl. 8 test-stub `IRepository` signature updates)
- [x] `Financial.Infrastructure.Tests` — 113 passed, 5 pre-existing skips (incl. round-trip, missing-key, and scope-isolation tests)
- [x] `Financial.Api.Tests` — 42 passed (real HTTP round-trip against the new-shape fixture)
- [x] `Financial.Presentation.Tests` (WPF) — 150 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)