### PR TITLE
feat(P10-F03): AssetClassification Historic Portfolio Metadata

### DIFF
--- a/Integrations/GoogleFinancialSupport/AssetClassificationLookup.cs
+++ b/Integrations/GoogleFinancialSupport/AssetClassificationLookup.cs
@@ -11,10 +11,13 @@ namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 internal readonly record struct AssetClassificationEntry(
     CountryCode Country,
     string LocalTypeCode,
-    GlobalAssetClass Class);
+    GlobalAssetClass Class,
+    string HistoricPortfolio = null);
 
 internal static class AssetClassificationLookup
 {
+    internal const string UncategorizedHistoricPortfolioName = "Uncategorized";
+
     private static readonly IReadOnlyDictionary<string, AssetClassificationEntry> Entries = LoadEntries();
 
     public static bool TryGet(string assetName, out AssetClassificationEntry entry)
@@ -27,6 +30,12 @@ internal static class AssetClassificationLookup
 
         return Entries.TryGetValue(assetName.Trim(), out entry);
     }
+
+    public static string ResolveHistoricPortfolio(string assetName) =>
+        TryGet(assetName, out var entry) ? ResolveHistoricPortfolio(entry) : UncategorizedHistoricPortfolioName;
+
+    public static string ResolveHistoricPortfolio(AssetClassificationEntry entry) =>
+        string.IsNullOrWhiteSpace(entry.HistoricPortfolio) ? UncategorizedHistoricPortfolioName : entry.HistoricPortfolio;
 
     private static IReadOnlyDictionary<string, AssetClassificationEntry> LoadEntries()
     {
@@ -43,7 +52,7 @@ internal static class AssetClassificationLookup
 
         return jsonEntries.ToDictionary(
             e => e.Name,
-            e => new AssetClassificationEntry(e.Country, e.LocalTypeCode, e.AssetClass),
+            e => new AssetClassificationEntry(e.Country, e.LocalTypeCode, e.AssetClass, e.HistoricPortfolio),
             StringComparer.OrdinalIgnoreCase);
     }
 
@@ -53,5 +62,6 @@ internal static class AssetClassificationLookup
         public CountryCode Country { get; set; }
         public string LocalTypeCode { get; set; } = "";
         public GlobalAssetClass AssetClass { get; set; }
+        public string HistoricPortfolio { get; set; }
     }
 }

--- a/Tests/Financial.Infrastructure.Tests/Integrations/AssetClassificationLookupTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Integrations/AssetClassificationLookupTests.cs
@@ -17,6 +17,14 @@ public class AssetClassificationLookupTests
     }
 
     [Fact]
+    public void TryGet_Bitcoin_HistoricPortfolioIsNull()
+    {
+        AssetClassificationLookup.TryGet("Bitcoin", out var entry);
+
+        entry.HistoricPortfolio.Should().BeNull();
+    }
+
+    [Fact]
     public void TryGet_BitcoinCaseInsensitiveAndTrimmed_ReturnsCryptocurrencyClass()
     {
         var found = AssetClassificationLookup.TryGet(" bitcoin ", out var entry);
@@ -32,5 +40,41 @@ public class AssetClassificationLookupTests
 
         found.Should().BeFalse();
         entry.Should().Be(default(AssetClassificationEntry));
+    }
+
+    [Fact]
+    public void ResolveHistoricPortfolio_EntryWithHistoricPortfolio_ReturnsClassifiedValue()
+    {
+        var entry = new AssetClassificationEntry(CountryCode.UK, "REIT", GlobalAssetClass.RealEstate, "Dividend Portfolio");
+
+        var result = AssetClassificationLookup.ResolveHistoricPortfolio(entry);
+
+        result.Should().Be("Dividend Portfolio");
+    }
+
+    [Fact]
+    public void ResolveHistoricPortfolio_EntryWithoutHistoricPortfolio_ReturnsUncategorized()
+    {
+        var entry = new AssetClassificationEntry(CountryCode.UK, "REIT", GlobalAssetClass.RealEstate);
+
+        var result = AssetClassificationLookup.ResolveHistoricPortfolio(entry);
+
+        result.Should().Be(AssetClassificationLookup.UncategorizedHistoricPortfolioName);
+    }
+
+    [Fact]
+    public void ResolveHistoricPortfolio_KnownAssetWithoutHistoricPortfolio_ReturnsUncategorized()
+    {
+        var result = AssetClassificationLookup.ResolveHistoricPortfolio("Bitcoin");
+
+        result.Should().Be(AssetClassificationLookup.UncategorizedHistoricPortfolioName);
+    }
+
+    [Fact]
+    public void ResolveHistoricPortfolio_UnknownAssetName_ReturnsUncategorized()
+    {
+        var result = AssetClassificationLookup.ResolveHistoricPortfolio("NotARealAsset");
+
+        result.Should().Be(AssetClassificationLookup.UncategorizedHistoricPortfolioName);
     }
 }

--- a/docs/P10-F03-assetclassification-historic-portfolio-metadata/plan.md
+++ b/docs/P10-F03-assetclassification-historic-portfolio-metadata/plan.md
@@ -1,0 +1,17 @@
+# Implementation Plan: F03. AssetClassification Historic Portfolio Metadata
+
+**Prerequisites:**
+- No new tools, libraries, or environment variables required
+- Builds on `Integrations/GoogleFinancialSupport` as it stands on `main`
+
+### Stage 1: AssetClassification Data Model
+
+**1. HistoricPortfolio Field** - Add an optional `HistoricPortfolio` member to `AssetClassificationEntry` (defaulting to null, so existing construction call sites keep compiling unmodified) and a matching optional property to the internal `AssetClassificationJson` deserialization model.
+
+**2. Resolution Method** - Add an `UncategorizedHistoricPortfolioName` constant and a `ResolveHistoricPortfolio` method to `AssetClassificationLookup` that returns the classified value when present, or the fallback name otherwise.
+
+### Stage 2: Tests
+
+**3. Resolution and Fallback Tests** - Extend `AssetClassificationLookupTests` to cover a classified value resolving correctly, an unclassified-but-known asset falling back to the default name, and an unknown asset name falling back to the same default.
+
+**4. Backward-Compatibility Test** - Add a test confirming that an existing classification entry without the new field still deserializes successfully.

--- a/docs/P10-F03-assetclassification-historic-portfolio-metadata/spec.md
+++ b/docs/P10-F03-assetclassification-historic-portfolio-metadata/spec.md
@@ -1,0 +1,114 @@
+# Feature Spec: F03. AssetClassification Historic Portfolio Metadata
+
+## 1. Technical Overview
+
+**What:** Add an optional `historicPortfolio` field to `AssetClassifications.json` entries, expose it through `AssetClassificationEntry`, and add a `ResolveHistoricPortfolio` resolution method on `AssetClassificationLookup` that returns the classified value when present, or a fallback `"Uncategorized"` name otherwise.
+
+**Why:** When an asset closes, F04 needs to know which portfolio to file it under in Historic Investments. Without this feature, a closed asset would have no way to preserve its original strategy grouping (e.g., "Dividend Portfolio") — it would always land in a single generic bucket instead.
+
+**Scope:**
+- **Included:** `historicPortfolio` optional field on `AssetClassifications.json` entries (schema support only — no real entries in the file are populated with values, since that's user-supplied classification data, not something this feature can know); `AssetClassificationEntry` gains a `HistoricPortfolio` member; `AssetClassificationLookup` gains a `ResolveHistoricPortfolio` method and an `UncategorizedHistoricPortfolioName` constant; unit tests.
+- **Excluded:** Anything that actually routes a closed asset to a historic broker/portfolio at import time, or calls `ResolveHistoricPortfolio` — that's F04. Populating real entries in `AssetClassifications.json` with actual `historicPortfolio` values — that's the user's own classification data entry, done as needed once F04 exists. The per-broker separation of "Uncategorized" portfolios (each broker gets its own) — that emerges for free from `Broker.AddPortfolio`'s existing per-broker scoping (already true and already tested in F02), not from anything this feature adds.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Integrations/GoogleFinancialSupport/AssetClassificationLookup.cs` — `AssetClassificationEntry` gains a 4th member (`HistoricPortfolio`, nullable, defaults to `null`); the internal `AssetClassificationJson` model gains a matching optional property; new `UncategorizedHistoricPortfolioName` constant; new `ResolveHistoricPortfolio` method (two overloads: by asset name, and by an already-resolved entry)
+- `Tests/Financial.Infrastructure.Tests/Integrations/AssetClassificationLookupTests.cs` — extended with resolution/fallback test cases
+
+**Data flow:**
+
+```mermaid
+graph TD
+    A["AssetClassifications.json (historicPortfolio, optional)"] --> B["AssetClassificationLookup.LoadEntries"]
+    B --> C["AssetClassificationEntry.HistoricPortfolio"]
+    D["ResolveHistoricPortfolio(assetName)"] --> E["TryGet(assetName)"]
+    E -->|"found, HistoricPortfolio set"| F["classified value"]
+    E -->|"found, HistoricPortfolio null/blank"| G["\"Uncategorized\""]
+    E -->|"not found"| G
+    F --> H["Future F04 consumer"]
+    G --> H
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Fallback ownership | `AssetClassificationLookup.ResolveHistoricPortfolio(assetName)` applies the `"Uncategorized"` fallback itself, always returning a non-null name | Expose only the raw nullable `HistoricPortfolio` field via `TryGet`, leaving the fallback to the caller (matching how `AssetMetadataResolver.ResolveAssetClassification` already applies its own fallback for `Country`/`LocalTypeCode`/`Class` today) | User decision: one resolution method with the fallback rule in a single place is simpler for F04 to consume (one call, always valid) than every future caller reimplementing the same null-check |
+| `AssetClassificationEntry` compile compatibility | Give the new `HistoricPortfolio` positional record member a `= null` default, so the one existing 3-arg construction call in `AssetMetadataResolver.cs` (F04's territory, not yet implemented) keeps compiling unmodified | Make `HistoricPortfolio` a required 4th positional parameter and update that call site as a compile-keeping fix (the pattern used in F02 for `GoogleGenerator.AddBroker`) | The project targets `net10.0` (C# supports default values on record positional parameters), so the default-value escape hatch is available here and avoids touching a file outside this feature's boundary at all — cleaner than F02's situation, where no such default was possible for a renamed method |
+| Real `AssetClassifications.json` entries | No existing entries are given real `historicPortfolio` values as part of this feature | Add a real value to one entry as a demonstration (mirroring the PRD's illustrative example) | Which portfolio a specific closed asset originally belonged to is the user's own classification knowledge, not something this feature can correctly infer; inventing a value would pollute real personal data |
+| Method placement | `ResolveHistoricPortfolio` added to the existing `AssetClassificationLookup` static class | New dedicated class | It operates on the exact same embedded lookup table `TryGet` already exposes; a new class would split one cohesive concern across two files for no benefit |
+
+## 4. Component Overview
+
+**Infrastructure:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|------------------------|
+| `Integrations/GoogleFinancialSupport/AssetClassificationLookup.cs` | Modified | Asset classification lookup | `AssetClassificationEntry` gains `HistoricPortfolio` (nullable `string`, default `null`); `AssetClassificationJson` gains matching optional property; `LoadEntries` passes the new field through; new `internal const string UncategorizedHistoricPortfolioName = "Uncategorized"`; new `ResolveHistoricPortfolio(string assetName)` (applies the fallback, always returns a non-null name) and `ResolveHistoricPortfolio(AssetClassificationEntry entry)` (pure resolution logic, directly unit-testable without going through the embedded resource) |
+
+**Tests:**
+
+| File Path | New/Modified | Purpose |
+|-----------|--------------|---------|
+| `Tests/Financial.Infrastructure.Tests/Integrations/AssetClassificationLookupTests.cs` | Modified | Cover resolution with a classified value, fallback to `"Uncategorized"` for both a known-but-unclassified asset and an unknown asset name, and that existing entries without the field still deserialize |
+
+**Not touched (explicitly out of scope):** `AssetMetadataResolver.cs`, `GoogleGenerator.cs`, and `AssetClassifications.json`'s real entry data — all F04's territory or the user's own data-entry task.
+
+## 5. API Contracts
+
+Not applicable — this feature has no endpoints. `ResolveHistoricPortfolio` is a plain internal-assembly method consumed by F04's import logic once that exists.
+
+## 6. Data Model
+
+**`AssetClassifications.json` entry shape — before:**
+```json
+{ "name": "AGNC INVESTMENT CORP. (AGNC)", "country": "UK", "localTypeCode": "REIT", "assetClass": "RealEstate" }
+```
+
+**`AssetClassifications.json` entry shape — after (field is optional; existing entries need no change):**
+```json
+{ "name": "AGNC INVESTMENT CORP. (AGNC)", "country": "UK", "localTypeCode": "REIT", "assetClass": "RealEstate", "historicPortfolio": "Dividend Portfolio" }
+```
+
+`AssetClassificationJson` (internal deserialization model) gains `public string? HistoricPortfolio { get; set; }` — no `required` modifier, so an entry that omits the key deserializes with `HistoricPortfolio == null`, exactly like `LocalTypeCode`/`Country`/`AssetClass` already behave when a real-world entry doesn't specify them.
+
+`AssetClassificationEntry` (the `internal readonly record struct` returned by `TryGet`) changes from:
+```csharp
+internal readonly record struct AssetClassificationEntry(
+    CountryCode Country,
+    string LocalTypeCode,
+    GlobalAssetClass Class);
+```
+to:
+```csharp
+internal readonly record struct AssetClassificationEntry(
+    CountryCode Country,
+    string LocalTypeCode,
+    GlobalAssetClass Class,
+    string? HistoricPortfolio = null);
+```
+
+No changes to the actual `Integrations/GoogleFinancialSupport/AssetClassifications.json` production file's 152 existing entries — the schema supports the new key, but no entry is given a value as part of this feature.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Tests/Financial.Infrastructure.Tests/Integrations/AssetClassificationLookupTests.cs` | Unit | `AssetClassificationLookup.ResolveHistoricPortfolio` | Classified value, fallback for unclassified-but-known asset, fallback for unknown asset, existing entries remain valid |
+
+**Test Functions:**
+
+| Test Function | Description | Assertions |
+|----------------|-------------|------------|
+| `ResolveHistoricPortfolio_EntryWithHistoricPortfolio_ReturnsClassifiedValue` | Call the entry-based overload with a manually constructed `AssetClassificationEntry` whose `HistoricPortfolio` is set (e.g., `"Dividend Portfolio"`) | Returns `"Dividend Portfolio"` — covers PRD AC "an entry with a `historicPortfolio` value resolves to that value when looked up" |
+| `ResolveHistoricPortfolio_EntryWithoutHistoricPortfolio_ReturnsUncategorized` | Call the entry-based overload with a constructed entry whose `HistoricPortfolio` is `null` | Returns `"Uncategorized"` |
+| `ResolveHistoricPortfolio_KnownAssetWithoutHistoricPortfolio_ReturnsUncategorized` | Call the name-based overload with `"Bitcoin"` (a real entry in the embedded resource that has no `historicPortfolio`) | Returns `"Uncategorized"` — covers PRD AC "an entry without `historicPortfolio` resolves to ... `\"Uncategorized\"`" using real, unmodified data |
+| `ResolveHistoricPortfolio_UnknownAssetName_ReturnsUncategorized` | Call the name-based overload with an asset name not in the classification table | Returns `"Uncategorized"` — covers "an asset with no classification entry ... resolves to ... `\"Uncategorized\"`" |
+| `TryGet_Bitcoin_HistoricPortfolioIsNull` | Extend the existing `TryGet_Bitcoin_ReturnsCryptocurrencyClass` assertion (or add alongside it) | `entry.HistoricPortfolio.Should().BeNull()` — confirms an existing entry without the new key deserializes successfully with no exception, covers "existing entries without `historicPortfolio` remain valid" |
+
+**Scope clarification for the AC "resolves to that broker's own `\"Uncategorized\"` portfolio (not a bucket shared across brokers)":** the "per broker" separation is not something `ResolveHistoricPortfolio` itself can test or guarantee — it takes only an asset name, no broker context. That guarantee comes from `Broker.AddPortfolio` always scoping a `Portfolio` to the `Broker` it's created on (already true today, already covered by F02's `InvestmentsTests`/`JsonRepositoryTests`). F03's own test coverage is limited to the portion it controls: that the resolved *name* is correct. F04's own spec should verify the per-broker application once it exists.
+
+**Deferred cross-feature integration:** no PRD Section 9 Cross-Feature Integration criterion references F03 directly (F04's own criteria will consume `ResolveHistoricPortfolio` once F04 exists).


### PR DESCRIPTION
## Summary
- Adds an optional `historicPortfolio` field to `AssetClassifications.json` entries, exposed via `AssetClassificationEntry`.
- Adds `AssetClassificationLookup.ResolveHistoricPortfolio` (two overloads: by asset name, and by an already-resolved entry) which returns the classified value when present, or falls back to `"Uncategorized"` otherwise — the fallback rule lives in one place instead of every future caller reimplementing it.
- No real entries in `AssetClassifications.json` are populated with values — that's the user's own classification data, added as needed once F04 exists.
- `AssetMetadataResolver.cs` (F04's territory, not yet implemented) is untouched: the new `HistoricPortfolio` record member defaults to `null`, so its existing 3-arg construction call keeps compiling as-is.
- Implements `docs/P10-F03-assetclassification-historic-portfolio-metadata/spec.md` and `plan.md` against `docs/prd/P10-prd-historic-investments/prd-historic-investments.md`.

## Note
The spec called for `string?` nullable annotations, but `GoogleFinancialSupport.csproj` doesn't have `Nullable` enabled (unlike `Financial.Application`) and has no existing nullable-annotation usage — so I used plain `string` instead (behaviorally identical; null is still valid without the annotation) to keep the build at 0 warnings, matching this project's actual convention.

## Test plan
- [x] `Financial.Domain.Tests` — 64 passed
- [x] `Financial.Application.Tests` — 179 passed
- [x] `Financial.Infrastructure.Tests` — 118 passed, 5 pre-existing skips (incl. 5 new `AssetClassificationLookup` tests)
- [x] `Financial.Api.Tests` — 42 passed
- [x] `Financial.Presentation.Tests` (WPF) — 150 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)