### PR TITLE
feat(P10-F05): Scoped Navigation & Summary API

### DIFF
--- a/Financial.Api/Controllers/AssetsController.cs
+++ b/Financial.Api/Controllers/AssetsController.cs
@@ -1,5 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
+using Financial.Application.Validation;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Financial.Api.Controllers;
@@ -21,9 +22,10 @@ public sealed class AssetsController : ControllerBase
     public ActionResult<AssetDetailsDTO> GetAssetDetails(
         string brokerName,
         string portfolioName,
-        string assetName)
+        string assetName,
+        [FromQuery] string? scope)
     {
-        var asset = _navigationService.GetAssetDetails(brokerName, portfolioName, assetName);
+        var asset = _navigationService.GetAssetDetails(brokerName, portfolioName, assetName, InvestmentScopeParser.ParseOrDefault(scope));
         if (asset is null)
         {
             return NotFound();

--- a/Financial.Api/Controllers/NavigationController.cs
+++ b/Financial.Api/Controllers/NavigationController.cs
@@ -1,5 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
+using Financial.Application.Validation;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Financial.Api.Controllers;
@@ -17,17 +18,17 @@ public sealed class NavigationController : ControllerBase
 
     [HttpGet("tree")]
     [ProducesResponseType(typeof(TreeNodeDTO), StatusCodes.Status200OK)]
-    public ActionResult<TreeNodeDTO> GetNavigationTree()
+    public ActionResult<TreeNodeDTO> GetNavigationTree([FromQuery] string? scope)
     {
-        var tree = _navigationService.GetNavigationTree();
+        var tree = _navigationService.GetNavigationTree(InvestmentScopeParser.ParseOrDefault(scope));
         return Ok(tree);
     }
 
     [HttpGet("brokers")]
     [ProducesResponseType(typeof(IEnumerable<BrokerNodeDTO>), StatusCodes.Status200OK)]
-    public ActionResult<IEnumerable<BrokerNodeDTO>> GetBrokers()
+    public ActionResult<IEnumerable<BrokerNodeDTO>> GetBrokers([FromQuery] string? scope)
     {
-        var brokers = _navigationService.GetBrokers();
+        var brokers = _navigationService.GetBrokers(InvestmentScopeParser.ParseOrDefault(scope));
         return Ok(brokers);
     }
 }

--- a/Financial.Api/Controllers/SummaryController.cs
+++ b/Financial.Api/Controllers/SummaryController.cs
@@ -1,5 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
+using Financial.Application.Validation;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Financial.Api.Controllers;
@@ -25,9 +26,9 @@ public sealed class SummaryController : ControllerBase
     [HttpGet("broker/{brokerName}")]
     [ProducesResponseType(typeof(AggregatedSummaryDTO), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public ActionResult<AggregatedSummaryDTO> GetBrokerSummary(string brokerName)
+    public ActionResult<AggregatedSummaryDTO> GetBrokerSummary(string brokerName, [FromQuery] string? scope)
     {
-        var dto = _summaryService.GetBrokerSummary(brokerName);
+        var dto = _summaryService.GetBrokerSummary(brokerName, InvestmentScopeParser.ParseOrDefault(scope));
         return Ok(dto);
     }
 
@@ -36,9 +37,10 @@ public sealed class SummaryController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public ActionResult<AggregatedSummaryDTO> GetPortfolioSummary(
         string brokerName,
-        string portfolioName)
+        string portfolioName,
+        [FromQuery] string? scope)
     {
-        var dto = _summaryService.GetPortfolioSummary(brokerName, portfolioName);
+        var dto = _summaryService.GetPortfolioSummary(brokerName, portfolioName, InvestmentScopeParser.ParseOrDefault(scope));
         return Ok(dto);
     }
 
@@ -47,24 +49,25 @@ public sealed class SummaryController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public ActionResult<IReadOnlyList<PortfolioAssetSummaryItemDTO>> GetPortfolioAssetsSummary(
         string brokerName,
-        string portfolioName)
+        string portfolioName,
+        [FromQuery] string? scope)
     {
         if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
             return BadRequest();
 
-        var result = _portfolioAssetSummaryService.GetPortfolioAssetsSummary(brokerName, portfolioName);
+        var result = _portfolioAssetSummaryService.GetPortfolioAssetsSummary(brokerName, portfolioName, InvestmentScopeParser.ParseOrDefault(scope));
         return Ok(result);
     }
 
     [HttpGet("broker/{brokerName}/breakdown")]
     [ProducesResponseType(typeof(IReadOnlyList<PortfolioBreakdownItemDTO>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public ActionResult<IReadOnlyList<PortfolioBreakdownItemDTO>> GetBrokerBreakdown(string brokerName)
+    public ActionResult<IReadOnlyList<PortfolioBreakdownItemDTO>> GetBrokerBreakdown(string brokerName, [FromQuery] string? scope)
     {
         if (string.IsNullOrWhiteSpace(brokerName))
             return BadRequest();
 
-        var result = _brokerBreakdownService.GetBrokerBreakdown(brokerName);
+        var result = _brokerBreakdownService.GetBrokerBreakdown(brokerName, InvestmentScopeParser.ParseOrDefault(scope));
         return Ok(result);
     }
 }

--- a/Financial.Application/Interfaces/IBrokerBreakdownService.cs
+++ b/Financial.Application/Interfaces/IBrokerBreakdownService.cs
@@ -4,5 +4,5 @@ namespace Financial.Application.Interfaces;
 
 public interface IBrokerBreakdownService
 {
-    IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName);
+    IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName, InvestmentScope scope = InvestmentScope.Active);
 }

--- a/Financial.Application/Interfaces/INavigationService.cs
+++ b/Financial.Application/Interfaces/INavigationService.cs
@@ -4,8 +4,8 @@ namespace Financial.Application.Interfaces;
 
 public interface INavigationService
 {
-    TreeNodeDTO GetNavigationTree();
-    AssetDetailsDTO? GetAssetDetails(string brokerName, string portfolioName, string assetName);
-    IEnumerable<BrokerNodeDTO> GetBrokers();
+    TreeNodeDTO GetNavigationTree(InvestmentScope scope = InvestmentScope.Active);
+    AssetDetailsDTO? GetAssetDetails(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active);
+    IEnumerable<BrokerNodeDTO> GetBrokers(InvestmentScope scope = InvestmentScope.Active);
     IEnumerable<AssetNodeDTO> GetAssetsByBrokerPortfolio(string brokerName, string portfolioName);
 }

--- a/Financial.Application/Interfaces/IPortfolioAssetSummaryService.cs
+++ b/Financial.Application/Interfaces/IPortfolioAssetSummaryService.cs
@@ -4,5 +4,5 @@ namespace Financial.Application.Interfaces;
 
 public interface IPortfolioAssetSummaryService
 {
-    IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName);
+    IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active);
 }

--- a/Financial.Application/Interfaces/ISummaryService.cs
+++ b/Financial.Application/Interfaces/ISummaryService.cs
@@ -4,6 +4,6 @@ namespace Financial.Application.Interfaces;
 
 public interface ISummaryService
 {
-    AggregatedSummaryDTO GetBrokerSummary(string brokerName);
-    AggregatedSummaryDTO GetPortfolioSummary(string brokerName, string portfolioName);
+    AggregatedSummaryDTO GetBrokerSummary(string brokerName, InvestmentScope scope = InvestmentScope.Active);
+    AggregatedSummaryDTO GetPortfolioSummary(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active);
 }

--- a/Financial.Application/Services/BrokerBreakdownService.cs
+++ b/Financial.Application/Services/BrokerBreakdownService.cs
@@ -13,17 +13,16 @@ public sealed class BrokerBreakdownService : IBrokerBreakdownService
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
     }
 
-    public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName)
+    public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName, InvestmentScope scope = InvestmentScope.Active)
     {
         if (string.IsNullOrWhiteSpace(brokerName))
             return [];
 
-        var broker = _repository.GetBrokerList().FirstOrDefault(b => b.Name == brokerName);
+        var broker = _repository.GetBrokerList(scope).FirstOrDefault(b => b.Name == brokerName);
         if (broker is null)
             return [];
 
         return broker.Portfolios
-            .Where(p => !NavigationMapper.IsEncerradas(p.Name))
             .Select(BuildPortfolioBreakdown)
             .Where(p => p.Assets.Count > 0)
             .OrderBy(p => p.PortfolioName, StringComparer.CurrentCultureIgnoreCase)
@@ -33,7 +32,6 @@ public sealed class BrokerBreakdownService : IBrokerBreakdownService
     private static PortfolioBreakdownItemDTO BuildPortfolioBreakdown(Portfolio portfolio)
     {
         var assets = portfolio.Assets
-            .Where(a => a.Active)
             .Select(BuildAssetBreakdown)
             .Where(a => a.TotalInvested > 0)
             .OrderBy(a => a.AssetName, StringComparer.CurrentCultureIgnoreCase)

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 
 namespace Financial.Application.Services;
@@ -77,9 +78,9 @@ internal static class NavigationMapper
         };
     }
 
-    internal static BrokerNodeDTO MapBroker(Broker broker)
+    internal static BrokerNodeDTO MapBroker(Broker broker, InvestmentScope scope)
     {
-        var portfolios = MapPortfolios(broker.Portfolios).ToList();
+        var portfolios = MapPortfolios(broker.Portfolios, scope).ToList();
         return new BrokerNodeDTO
         {
             Name = broker.Name,
@@ -142,23 +143,23 @@ internal static class NavigationMapper
         return (totalBought, totalSold, totalCredits);
     }
 
-    private static IEnumerable<PortfolioNodeDTO> MapPortfolios(IEnumerable<Portfolio> portfolios)
+    private static IEnumerable<PortfolioNodeDTO> MapPortfolios(IEnumerable<Portfolio> portfolios, InvestmentScope scope)
     {
-        return portfolios.OrderBy(p => p.Name, StringComparer.CurrentCultureIgnoreCase).Select(MapPortfolio);
+        return portfolios.OrderBy(p => p.Name, StringComparer.CurrentCultureIgnoreCase).Select(portfolio => MapPortfolio(portfolio, scope));
     }
 
-    private static PortfolioNodeDTO MapPortfolio(Portfolio portfolio)
+    private static PortfolioNodeDTO MapPortfolio(Portfolio portfolio, InvestmentScope scope)
     {
         return new PortfolioNodeDTO
         {
             Name = portfolio.Name,
             AssetCount = portfolio.Assets.Count,
             ActiveAssetCount = portfolio.Assets.Count(a => a.Active),
-            Assets = portfolio.Assets.OrderBy(a => a.Name, StringComparer.CurrentCultureIgnoreCase).Select(MapAsset).ToList()
+            Assets = portfolio.Assets.OrderBy(a => a.Name, StringComparer.CurrentCultureIgnoreCase).Select(asset => MapAsset(asset, scope)).ToList()
         };
     }
 
-    internal static AssetNodeDTO MapAsset(Asset asset)
+    internal static AssetNodeDTO MapAsset(Asset asset, InvestmentScope scope)
     {
         return new AssetNodeDTO
         {
@@ -172,7 +173,7 @@ internal static class NavigationMapper
             Quantity = asset.Quantity,
             AveragePrice = asset.AveragePrice,
             IsActive = asset.Active,
-            PositionType = asset.PositionType,
+            PositionType = scope == InvestmentScope.Historic ? PositionType.Flat : asset.PositionType,
             TransactionCount = asset.Transactions.Count,
             CreditCount = asset.Credits.Count
         };

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -1,5 +1,6 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
+using Financial.Domain.Entities;
 
 namespace Financial.Application.Services;
 
@@ -12,9 +13,9 @@ public sealed class NavigationService : INavigationService
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
     }
 
-    public TreeNodeDTO GetNavigationTree()
+    public TreeNodeDTO GetNavigationTree(InvestmentScope scope = InvestmentScope.Active)
     {
-        var brokers = GetBrokers();
+        var brokers = GetBrokers(scope);
 
         var rootNode = new TreeNodeDTO
         {
@@ -30,7 +31,7 @@ public sealed class NavigationService : INavigationService
         return rootNode;
     }
 
-    public AssetDetailsDTO? GetAssetDetails(string brokerName, string portfolioName, string assetName)
+    public AssetDetailsDTO? GetAssetDetails(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active)
     {
         if (string.IsNullOrWhiteSpace(brokerName) ||
             string.IsNullOrWhiteSpace(portfolioName) ||
@@ -39,7 +40,7 @@ public sealed class NavigationService : INavigationService
             return null;
         }
 
-        var asset = _repository.GetAsset(brokerName, portfolioName, assetName);
+        var asset = _repository.GetAsset(brokerName, portfolioName, assetName, scope);
 
         if (asset == null)
         {
@@ -72,7 +73,7 @@ public sealed class NavigationService : INavigationService
             Quantity = asset.Quantity,
             AveragePrice = asset.AveragePrice,
             IsActive = asset.Active,
-            PositionType = asset.PositionType,
+            PositionType = scope == InvestmentScope.Historic ? PositionType.Flat : asset.PositionType,
             TotalBought = totalBought,
             TotalSold = totalSold,
             TotalCredits = totalCredits,
@@ -83,16 +84,16 @@ public sealed class NavigationService : INavigationService
         };
     }
 
-    public IEnumerable<BrokerNodeDTO> GetBrokers()
+    public IEnumerable<BrokerNodeDTO> GetBrokers(InvestmentScope scope = InvestmentScope.Active)
     {
-        var brokers = _repository.GetBrokerList().OrderBy(b => b.Name, StringComparer.CurrentCultureIgnoreCase);
-        return brokers.Select(NavigationMapper.MapBroker).ToList();
+        var brokers = _repository.GetBrokerList(scope).OrderBy(b => b.Name, StringComparer.CurrentCultureIgnoreCase);
+        return brokers.Select(broker => NavigationMapper.MapBroker(broker, scope)).ToList();
     }
 
     public IEnumerable<AssetNodeDTO> GetAssetsByBrokerPortfolio(string brokerName, string portfolioName)
     {
         return _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName)
-            .Select(NavigationMapper.MapAsset)
+            .Select(asset => NavigationMapper.MapAsset(asset, InvestmentScope.Active))
             .ToList();
     }
 

--- a/Financial.Application/Services/PortfolioAssetSummaryService.cs
+++ b/Financial.Application/Services/PortfolioAssetSummaryService.cs
@@ -13,12 +13,12 @@ public sealed class PortfolioAssetSummaryService : IPortfolioAssetSummaryService
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
     }
 
-    public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName)
+    public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active)
     {
         if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
             return [];
 
-        var assets = _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName).ToList();
+        var assets = _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName, scope).ToList();
 
         if (assets.Count == 0)
             return [];

--- a/Financial.Application/Services/SummaryService.cs
+++ b/Financial.Application/Services/SummaryService.cs
@@ -12,29 +12,26 @@ public sealed class SummaryService : ISummaryService
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
     }
 
-    public AggregatedSummaryDTO GetBrokerSummary(string brokerName)
+    public AggregatedSummaryDTO GetBrokerSummary(string brokerName, InvestmentScope scope = InvestmentScope.Active)
     {
         if (string.IsNullOrWhiteSpace(brokerName))
             return new AggregatedSummaryDTO();
 
-        var broker = _repository.GetBrokerList().FirstOrDefault(b => b.Name == brokerName);
+        var broker = _repository.GetBrokerList(scope).FirstOrDefault(b => b.Name == brokerName);
         if (broker is null)
             return new AggregatedSummaryDTO();
 
-        var assets = broker.Portfolios
-            .Where(p => !NavigationMapper.IsEncerradas(p.Name))
-            .SelectMany(p => p.Assets)
-            .Where(a => a.Active);
+        var assets = broker.Portfolios.SelectMany(p => p.Assets);
 
         return Aggregate(assets);
     }
 
-    public AggregatedSummaryDTO GetPortfolioSummary(string brokerName, string portfolioName)
+    public AggregatedSummaryDTO GetPortfolioSummary(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active)
     {
         if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
             return new AggregatedSummaryDTO();
 
-        var assets = _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName).Where(a => a.Active);
+        var assets = _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName, scope);
         return Aggregate(assets);
     }
 

--- a/Financial.Application/Validation/InvestmentScopeParser.cs
+++ b/Financial.Application/Validation/InvestmentScopeParser.cs
@@ -1,0 +1,15 @@
+using Financial.Application.Interfaces;
+
+namespace Financial.Application.Validation;
+
+public static class InvestmentScopeParser
+{
+    public static bool TryNormalize(string? value, out string normalized) =>
+        EnumParser.TryNormalize<InvestmentScope>(value, out normalized);
+
+    public static bool TryParse(string? value, out InvestmentScope scope) =>
+        EnumParser.TryParseEnum(value, out scope);
+
+    public static InvestmentScope ParseOrDefault(string? value) =>
+        TryParse(value, out var scope) ? scope : InvestmentScope.Active;
+}

--- a/Tests/Financial.Api.Tests/AssetEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/AssetEndpointsTests.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Domain.Entities;
 using FluentAssertions;
 using System.Net;
 using System.Net.Http.Json;
@@ -21,5 +22,30 @@ public class AssetEndpointsTests
         asset!.Name.Should().Be("BCIA11");
         asset.BrokerName.Should().Be("XPI");
         asset.PortfolioName.Should().Be("Default");
+    }
+
+    [Fact]
+    public async Task GetAssetDetails_ScopeHistoric_ResolvesHistoricAsset()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/financial/assets/XPI/Uncategorized/CLOSEDASSET?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var asset = await response.Content.ReadFromJsonAsync<AssetDetailsDTO>();
+        asset.Should().NotBeNull();
+        asset!.Name.Should().Be("CLOSEDASSET");
+        asset.PositionType.Should().Be(PositionType.Flat);
+    }
+
+    [Fact]
+    public async Task GetAssetDetails_ScopeActive_HistoricAssetNotFound()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/financial/assets/XPI/Uncategorized/CLOSEDASSET?scope=active");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 }

--- a/Tests/Financial.Api.Tests/NavigationEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/NavigationEndpointsTests.cs
@@ -36,4 +36,63 @@ public class NavigationEndpointsTests
         brokers!.Length.Should().BeGreaterThan(0);
     }
 
+    [Fact]
+    public async Task GetNavigationTree_ScopeOmitted_PreservesActiveOnlyBehavior()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/financial/navigation/tree");
+
+        var tree = await response.Content.ReadFromJsonAsync<TreeNodeDTO>();
+
+        var assetNames = GetAllAssetNodes(tree!).Select(a => a.DisplayName).ToList();
+        assetNames.Should().Contain("BCIA11");
+        assetNames.Should().NotContain("CLOSEDASSET");
+    }
+
+    [Fact]
+    public async Task GetNavigationTree_ScopeActive_AssetNode_IncludesPositionType()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/financial/navigation/tree?scope=active");
+
+        var tree = await response.Content.ReadFromJsonAsync<TreeNodeDTO>();
+
+        var assetNode = GetAllAssetNodes(tree!).Single(a => a.DisplayName == "BCIA11");
+        assetNode.Metadata.Should().ContainKey("PositionType");
+    }
+
+    [Fact]
+    public async Task GetNavigationTree_ScopeHistoric_ReturnsOnlyHistoricBroker()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/financial/navigation/tree?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var tree = await response.Content.ReadFromJsonAsync<TreeNodeDTO>();
+        var assetNames = GetAllAssetNodes(tree!).Select(a => a.DisplayName).ToList();
+
+        assetNames.Should().Contain("CLOSEDASSET");
+        assetNames.Should().NotContain("BCIA11");
+    }
+
+    [Fact]
+    public async Task GetBrokers_ScopeHistoric_ReturnsOnlyHistoricBroker()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/v1/financial/navigation/brokers?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var brokers = await response.Content.ReadFromJsonAsync<BrokerNodeDTO[]>();
+        brokers.Should().NotBeNull();
+        brokers!.Should().ContainSingle(b => b.Portfolios.Any(p => p.Assets.Any(a => a.Name == "CLOSEDASSET")));
+    }
+
+    private static IEnumerable<TreeNodeDTO> GetAllAssetNodes(TreeNodeDTO tree) =>
+        tree.Children.SelectMany(broker => broker.Children).SelectMany(portfolio => portfolio.Children);
 }

--- a/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
@@ -115,4 +115,67 @@ public class SummaryEndpointsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    [Fact]
+    public async Task GetBrokerSummary_ScopeHistoric_ReturnsRealizedFromHistoricBrokerOnly()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/broker/XPI?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var dto = await response.Content.ReadFromJsonAsync<AggregatedSummaryDTO>();
+        dto.Should().NotBeNull();
+        dto!.TotalBought.Should().Be(300m);
+        dto.TotalSold.Should().Be(250m);
+    }
+
+    [Fact]
+    public async Task GetPortfolioSummary_ScopeHistoric_ReturnsHistoricOnly()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/portfolio/XPI/Uncategorized?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var dto = await response.Content.ReadFromJsonAsync<AggregatedSummaryDTO>();
+        dto.Should().NotBeNull();
+        dto!.TotalBought.Should().Be(300m);
+        dto.TotalSold.Should().Be(250m);
+    }
+
+    [Fact]
+    public async Task GetPortfolioAssetsSummary_ScopeHistoric_ReturnsHistoricOnly()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/portfolio/XPI/Uncategorized/assets?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var items = await response.Content.ReadFromJsonAsync<List<PortfolioAssetSummaryItemDTO>>();
+        items.Should().NotBeNull();
+        items!.Should().ContainSingle(i => i.AssetName == "CLOSEDASSET");
+    }
+
+    [Fact]
+    public async Task GetBrokerBreakdown_ScopeHistoric_ReturnsHistoricOnly()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/broker/XPI/breakdown?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var items = await response.Content.ReadFromJsonAsync<List<PortfolioBreakdownItemDTO>>();
+        items.Should().NotBeNull();
+        items!.Should().ContainSingle(p => p.PortfolioName == "Uncategorized");
+        items!.SelectMany(p => p.Assets).Should().Contain(a => a.AssetName == "CLOSEDASSET");
+    }
 }

--- a/Tests/Financial.Api.Tests/TestData/data.test.json
+++ b/Tests/Financial.Api.Tests/TestData/data.test.json
@@ -46,5 +46,40 @@
       ]
     }
   ],
-  "HistoricBrokers": []
+  "HistoricBrokers": [
+    {
+      "Name": "XPI",
+      "Currency": "BRL",
+      "Portfolios": [
+        {
+          "Name": "Uncategorized",
+          "Assets": [
+            {
+              "Name": "CLOSEDASSET",
+              "ISIN": "TESTISIN2",
+              "Exchange": "BVMF",
+              "Ticker": "CLOSEDASSET",
+              "Transactions": [
+                {
+                  "Date": "2023-01-01T00:00:00",
+                  "Type": "Buy",
+                  "Quantity": 5,
+                  "UnitPrice": 60,
+                  "Fees": 0
+                },
+                {
+                  "Date": "2023-06-01T00:00:00",
+                  "Type": "Sell",
+                  "Quantity": 5,
+                  "UnitPrice": 50,
+                  "Fees": 0
+                }
+              ],
+              "Credits": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs
@@ -92,41 +92,32 @@ public class BrokerBreakdownServiceTests
     }
 
     [Fact]
-    public void GetBrokerBreakdown_ExcludesEncerradasPortfolio()
+    public void GetBrokerBreakdown_DoesNotFilterByPortfolioName_ScopePurityComesFromRepository()
     {
         var defaultAsset = MakeAsset("DEFAULT", "DEF");
         defaultAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        var closedAsset = MakeAsset("CLOSED", "CLO");
-        closedAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 100m, 5m, 0m));
+        var otherAsset = MakeAsset("OTHER", "OTH");
+        otherAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 100m, 5m, 0m));
 
         var broker = Broker.Create("XPI", "BRL");
         broker.AddPortfolio("Default").AddAsset(defaultAsset);
-        broker.AddPortfolio("Encerradas").AddAsset(closedAsset);
+        broker.AddPortfolio("Encerradas").AddAsset(otherAsset);
         _repository.Brokers = [broker];
 
         var result = CreateService().GetBrokerBreakdown("XPI");
 
-        result.Should().ContainSingle();
-        result.Single().PortfolioName.Should().Be("Default");
+        result.Should().HaveCount(2);
+        result.Select(p => p.PortfolioName).Should().Contain(["Default", "Encerradas"]);
     }
 
-    [Theory]
-    [InlineData("Encerradas")]
-    [InlineData("encerradas")]
-    [InlineData("ENCERRADAS")]
-    [InlineData(" Encerradas ")]
-    public void GetBrokerBreakdown_ExcludesEncerradasPortfolio_CaseInsensitive(string portfolioName)
+    [Fact]
+    public void GetBrokerBreakdown_ForwardsScopeToRepository()
     {
-        var closedAsset = MakeAsset("CLOSED", "CLO");
-        closedAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 100m, 5m, 0m));
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", MakeAsset())];
 
-        var broker = Broker.Create("XPI", "BRL");
-        broker.AddPortfolio(portfolioName).AddAsset(closedAsset);
-        _repository.Brokers = [broker];
+        CreateService().GetBrokerBreakdown("XPI", InvestmentScope.Historic);
 
-        var result = CreateService().GetBrokerBreakdown("XPI");
-
-        result.Should().BeEmpty();
+        _repository.LastRequestedScope.Should().Be(InvestmentScope.Historic);
     }
 
     [Fact]
@@ -192,11 +183,7 @@ public class BrokerBreakdownServiceTests
     [Fact]
     public void GetBrokerBreakdown_ReturnsEmptyWhenNoEligiblePortfolios()
     {
-        var closedAsset = MakeAsset("CLOSED", "CLO");
-        closedAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 100m, 5m, 0m));
-
         var broker = Broker.Create("XPI", "BRL");
-        broker.AddPortfolio("Encerradas").AddAsset(closedAsset);
         broker.AddPortfolio("EmptyPortfolio").AddAsset(MakeZeroQuantityAsset());
         _repository.Brokers = [broker];
 
@@ -245,10 +232,15 @@ public class BrokerBreakdownServiceTests
         public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
         public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
         public IEnumerable<Broker> Brokers { get; set; } = [];
+        public InvestmentScope? LastRequestedScope { get; private set; }
 
         public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
         public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
-        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => Brokers;
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastRequestedScope = scope;
+            return Brokers;
+        }
         public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
         public Task SaveChangesAsync() => Task.CompletedTask;
     }

--- a/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
+++ b/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
@@ -97,6 +97,37 @@ public class NavigationMapperTests
         details!.PositionType.Should().Be(expectedPositionType);
     }
 
+    [Theory]
+    [InlineData(10)]
+    [InlineData(0)]
+    [InlineData(-10)]
+    public void GetNavigationTree_HistoricScope_AssetNode_PositionTypeIsFlat(decimal quantity)
+    {
+        _repository.Broker = BuildBrokerWithAsset("ASSET1", GlobalAssetClass.Equity, quantity);
+
+        var tree = CreateService().GetNavigationTree(InvestmentScope.Historic);
+
+        var assetNode = GetFirstAssetNode(tree);
+        assetNode.Metadata["PositionType"].Should().Be(PositionType.Flat);
+    }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(0)]
+    [InlineData(-10)]
+    public void GetAssetDetails_HistoricScope_PositionTypeIsFlat(decimal quantity)
+    {
+        var broker = Broker.Create("Broker", "BRL");
+        var portfolio = broker.AddPortfolio("Portfolio");
+        portfolio.AddAsset(BuildAssetWithQuantity("ASSET1", quantity));
+        _repository.Broker = broker;
+
+        var details = CreateService().GetAssetDetails("Broker", "Portfolio", "ASSET1", InvestmentScope.Historic);
+
+        details.Should().NotBeNull();
+        details!.PositionType.Should().Be(PositionType.Flat);
+    }
+
     private static Asset BuildAssetWithQuantity(string name, decimal quantity)
     {
         var asset = Asset.Create(name, "ISIN", "BVMF", name, CountryCode.BR, "FII", GlobalAssetClass.Equity);

--- a/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs
@@ -586,6 +586,16 @@ public class PortfolioAssetSummaryServiceTests
         result[0].CurrentMonthCredits.Should().Be(0m);
     }
 
+    [Fact]
+    public void GetPortfolioAssetsSummary_ForwardsScopeToRepository()
+    {
+        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
+
+        CreateService().GetPortfolioAssetsSummary("XPI", "Default", InvestmentScope.Historic);
+
+        _repository.LastRequestedScope.Should().Be(InvestmentScope.Historic);
+    }
+
     private PortfolioAssetSummaryService CreateService() => new(_repository);
 
     private static Asset MakeAsset(string name, string ticker, string exchange) =>
@@ -594,9 +604,14 @@ public class PortfolioAssetSummaryServiceTests
     private sealed class StubRepository : IRepository
     {
         public IEnumerable<Asset> Assets { get; set; } = [];
+        public InvestmentScope? LastRequestedScope { get; private set; }
 
         public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => [];
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => Assets;
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastRequestedScope = scope;
+            return Assets;
+        }
         public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => [];
         public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
         public Task SaveChangesAsync() => Task.CompletedTask;

--- a/Tests/Financial.Application.Tests/Services/SummaryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/SummaryServiceTests.cs
@@ -58,36 +58,33 @@ public class SummaryServiceTests
     }
 
     [Fact]
-    public void GetBrokerSummary_ExcludesInactiveAssets()
+    public void GetBrokerSummary_IncludesEveryAssetInScope_ScopePurityComesFromRepository()
     {
-        var activeAsset = MakeAsset();
-        activeAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 5m, 0m));
-        activeAsset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 20m));
+        var asset1 = MakeAsset();
+        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 5m, 0m));
+        asset1.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 20m));
 
-        var inactiveAsset = MakeZeroQuantityAsset();
-        inactiveAsset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 100m));
+        var zeroNetAsset = MakeZeroQuantityAsset();
+        zeroNetAsset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 100m));
 
-        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", activeAsset, inactiveAsset)];
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", asset1, zeroNetAsset)];
 
         var result = CreateService().GetBrokerSummary("XPI");
 
         using var _ = new AssertionScope();
-        result.TotalBought.Should().Be(50m);
-        result.TotalCredits.Should().Be(20m);
+        result.TotalBought.Should().Be(100m);
+        result.TotalSold.Should().Be(50m);
+        result.TotalCredits.Should().Be(120m);
     }
 
     [Fact]
-    public void GetBrokerSummary_ReturnsZerosForBrokerWithNoActiveAssets()
+    public void GetBrokerSummary_ForwardsScopeToRepository()
     {
-        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", MakeZeroQuantityAsset())];
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", MakeAsset())];
 
-        var result = CreateService().GetBrokerSummary("XPI");
+        CreateService().GetBrokerSummary("XPI", InvestmentScope.Historic);
 
-        using var _ = new AssertionScope();
-        result.TotalBought.Should().Be(0m);
-        result.TotalSold.Should().Be(0m);
-        result.TotalCredits.Should().Be(0m);
-        result.TotalInvested.Should().Be(0m);
+        _repository.LastRequestedBrokerListScope.Should().Be(InvestmentScope.Historic);
     }
 
     [Fact]
@@ -105,41 +102,22 @@ public class SummaryServiceTests
     }
 
     [Fact]
-    public void GetBrokerSummary_ExcludesEncerradasPortfolio()
+    public void GetBrokerSummary_IncludesEveryPortfolioRegardlessOfName()
     {
         var defaultAsset = MakeAsset("DEFAULT", "DEF");
         defaultAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
 
-        var encerradasAsset = MakeAsset("CLOSED", "CLO");
-        encerradasAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 100m, 5m, 0m));
+        var otherAsset = MakeAsset("CLOSED", "CLO");
+        otherAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 100m, 5m, 0m));
 
         var broker = Broker.Create("XPI", "BRL");
         broker.AddPortfolio("Default").AddAsset(defaultAsset);
-        broker.AddPortfolio("Encerradas").AddAsset(encerradasAsset);
+        broker.AddPortfolio("Encerradas").AddAsset(otherAsset);
         _repository.Brokers = [broker];
 
         var result = CreateService().GetBrokerSummary("XPI");
 
-        result.TotalBought.Should().Be(100m);
-    }
-
-    [Theory]
-    [InlineData("Encerradas")]
-    [InlineData("encerradas")]
-    [InlineData("ENCERRADAS")]
-    [InlineData(" Encerradas ")]
-    public void GetBrokerSummary_ExcludesEncerradasPortfolio_CaseInsensitive(string portfolioName)
-    {
-        var encerradasAsset = MakeAsset("CLOSED", "CLO");
-        encerradasAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 100m, 5m, 0m));
-
-        var broker = Broker.Create("XPI", "BRL");
-        broker.AddPortfolio(portfolioName).AddAsset(encerradasAsset);
-        _repository.Brokers = [broker];
-
-        var result = CreateService().GetBrokerSummary("XPI");
-
-        result.TotalBought.Should().Be(0m);
+        result.TotalBought.Should().Be(600m);
     }
 
     [Fact]
@@ -222,34 +200,31 @@ public class SummaryServiceTests
     }
 
     [Fact]
-    public void GetPortfolioSummary_ExcludesInactiveAssets()
+    public void GetPortfolioSummary_IncludesEveryAssetInScope_ScopePurityComesFromRepository()
     {
-        var activeAsset = MakeAsset();
-        activeAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        var asset1 = MakeAsset();
+        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
 
-        var inactiveAsset = MakeZeroQuantityAsset();
-        inactiveAsset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 999m));
+        var zeroNetAsset = MakeZeroQuantityAsset();
+        zeroNetAsset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 999m));
 
-        _repository.AssetsByBrokerPortfolio = [activeAsset, inactiveAsset];
+        _repository.AssetsByBrokerPortfolio = [asset1, zeroNetAsset];
 
         var result = CreateService().GetPortfolioSummary("XPI", "Default");
 
         using var _ = new AssertionScope();
-        result.TotalBought.Should().Be(50m);
-        result.TotalCredits.Should().Be(0m);
+        result.TotalBought.Should().Be(100m);
+        result.TotalCredits.Should().Be(999m);
     }
 
     [Fact]
-    public void GetPortfolioSummary_ReturnsZerosForPortfolioWithNoActiveAssets()
+    public void GetPortfolioSummary_ForwardsScopeToRepository()
     {
-        _repository.AssetsByBrokerPortfolio = [MakeZeroQuantityAsset()];
+        _repository.AssetsByBrokerPortfolio = [MakeAsset()];
 
-        var result = CreateService().GetPortfolioSummary("XPI", "Default");
+        CreateService().GetPortfolioSummary("XPI", "Default", InvestmentScope.Historic);
 
-        using var _ = new AssertionScope();
-        result.TotalBought.Should().Be(0m);
-        result.TotalSold.Should().Be(0m);
-        result.TotalCredits.Should().Be(0m);
+        _repository.LastRequestedAssetsByBrokerPortfolioScope.Should().Be(InvestmentScope.Historic);
     }
 
     [Fact]
@@ -312,10 +287,20 @@ public class SummaryServiceTests
         public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
         public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
         public IEnumerable<Broker> Brokers { get; set; } = [];
+        public InvestmentScope? LastRequestedBrokerListScope { get; private set; }
+        public InvestmentScope? LastRequestedAssetsByBrokerPortfolioScope { get; private set; }
 
         public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
-        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => Brokers;
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastRequestedAssetsByBrokerPortfolioScope = scope;
+            return AssetsByBrokerPortfolio;
+        }
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastRequestedBrokerListScope = scope;
+            return Brokers;
+        }
         public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
         public Task SaveChangesAsync() => Task.CompletedTask;
     }

--- a/Tests/Financial.Application.Tests/Validation/InvestmentScopeParserTests.cs
+++ b/Tests/Financial.Application.Tests/Validation/InvestmentScopeParserTests.cs
@@ -1,0 +1,114 @@
+using Financial.Application.Interfaces;
+using Financial.Application.Validation;
+using FluentAssertions;
+
+namespace Financial.Application.Tests;
+
+public class InvestmentScopeParserTests
+{
+    public static IEnumerable<object?[]> NullValues => new[]
+    {
+        new object?[] { null }
+    };
+
+    [Theory]
+    [InlineData("Active", "Active")]
+    [InlineData("ACTIVE", "Active")]
+    [InlineData("active", "Active")]
+    [InlineData("Historic", "Historic")]
+    [InlineData("hISTORIC", "Historic")]
+    public void TryNormalize_WhenValueMatches_ReturnsCanonicalValue(string value, string expected)
+    {
+        var result = InvestmentScopeParser.TryNormalize(value, out var normalized);
+
+        result.Should().BeTrue();
+        normalized.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(NullValues))]
+    public void TryNormalize_WhenValueIsNull_ReturnsFalseAndEmpty(string? value)
+    {
+        var result = InvestmentScopeParser.TryNormalize(value, out var normalized);
+
+        result.Should().BeFalse();
+        normalized.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("garbage")]
+    public void TryNormalize_WhenValueInvalid_ReturnsFalseAndEmpty(string value)
+    {
+        var result = InvestmentScopeParser.TryNormalize(value, out var normalized);
+
+        result.Should().BeFalse();
+        normalized.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(NullValues))]
+    public void TryParse_WhenValueIsNull_ReturnsFalseAndDefault(string? value)
+    {
+        var result = InvestmentScopeParser.TryParse(value, out var parsed);
+
+        result.Should().BeFalse();
+        parsed.Should().Be(default(InvestmentScope));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void TryParse_WhenValueIsWhitespace_ReturnsFalseAndDefault(string value)
+    {
+        var result = InvestmentScopeParser.TryParse(value, out var parsed);
+
+        result.Should().BeFalse();
+        parsed.Should().Be(default(InvestmentScope));
+    }
+
+    [Theory]
+    [InlineData("Active", InvestmentScope.Active)]
+    [InlineData("HISTORIC", InvestmentScope.Historic)]
+    [InlineData(" historic ", InvestmentScope.Historic)]
+    public void TryParse_WhenValueValid_ReturnsTrueAndParsed(string value, InvestmentScope expected)
+    {
+        var result = InvestmentScopeParser.TryParse(value, out var parsed);
+
+        result.Should().BeTrue();
+        parsed.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("garbage")]
+    [InlineData("closed")]
+    public void TryParse_WhenValueInvalid_ReturnsFalseAndDefault(string value)
+    {
+        var result = InvestmentScopeParser.TryParse(value, out var parsed);
+
+        result.Should().BeFalse();
+        parsed.Should().Be(default(InvestmentScope));
+    }
+
+    [Theory]
+    [MemberData(nameof(NullValues))]
+    public void ParseOrDefault_WhenValueIsNull_ReturnsActive(string? value)
+    {
+        InvestmentScopeParser.ParseOrDefault(value).Should().Be(InvestmentScope.Active);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("garbage")]
+    public void ParseOrDefault_WhenValueInvalid_ReturnsActive(string value)
+    {
+        InvestmentScopeParser.ParseOrDefault(value).Should().Be(InvestmentScope.Active);
+    }
+
+    [Fact]
+    public void ParseOrDefault_WhenValueIsHistoric_ReturnsHistoric()
+    {
+        InvestmentScopeParser.ParseOrDefault("historic").Should().Be(InvestmentScope.Historic);
+    }
+}

--- a/Tests/Financial.Infrastructure.Tests/TestData/data.test.json
+++ b/Tests/Financial.Infrastructure.Tests/TestData/data.test.json
@@ -46,5 +46,40 @@
       ]
     }
   ],
-  "HistoricBrokers": []
+  "HistoricBrokers": [
+    {
+      "Name": "XPI",
+      "Currency": "BRL",
+      "Portfolios": [
+        {
+          "Name": "Uncategorized",
+          "Assets": [
+            {
+              "Name": "CLOSEDASSET",
+              "ISIN": "TESTISIN2",
+              "Exchange": "BVMF",
+              "Ticker": "CLOSEDASSET",
+              "Transactions": [
+                {
+                  "Date": "2023-01-01T00:00:00",
+                  "Type": "Buy",
+                  "Quantity": 5,
+                  "UnitPrice": 60,
+                  "Fees": 0
+                },
+                {
+                  "Date": "2023-06-01T00:00:00",
+                  "Type": "Sell",
+                  "Quantity": 5,
+                  "UnitPrice": 50,
+                  "Fees": 0
+                }
+              ],
+              "Credits": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetPriceFetchViewModelTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetPriceFetchViewModelTests.cs
@@ -105,9 +105,9 @@ public class AssetPriceFetchViewModelTests
     {
         public Dictionary<(string BrokerName, string PortfolioName), List<AssetNodeDTO>> AssetsByBrokerPortfolio { get; } = new();
 
-        public TreeNodeDTO GetNavigationTree() => throw new NotImplementedException();
-        public AssetDetailsDTO? GetAssetDetails(string brokerName, string portfolioName, string assetName) => throw new NotImplementedException();
-        public IEnumerable<BrokerNodeDTO> GetBrokers() => throw new NotImplementedException();
+        public TreeNodeDTO GetNavigationTree(InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
+        public AssetDetailsDTO? GetAssetDetails(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
+        public IEnumerable<BrokerNodeDTO> GetBrokers(InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
 
         public IEnumerable<AssetNodeDTO> GetAssetsByBrokerPortfolio(string brokerName, string portfolioName) =>
             AssetsByBrokerPortfolio.TryGetValue((brokerName, portfolioName), out var assets) ? assets : [];

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -379,7 +379,7 @@ public class MainNavigationViewModelBaseTests
         public string? LastBrokerName { get; private set; }
         public string? LastPortfolioName { get; private set; }
 
-        public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName)
+        public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active)
         {
             LastBrokerName = brokerName;
             LastPortfolioName = portfolioName;
@@ -395,13 +395,13 @@ public class MainNavigationViewModelBaseTests
         public string? LastBrokerNameForPortfolio { get; private set; }
         public string? LastPortfolioName { get; private set; }
 
-        public AggregatedSummaryDTO GetBrokerSummary(string brokerName)
+        public AggregatedSummaryDTO GetBrokerSummary(string brokerName, InvestmentScope scope = InvestmentScope.Active)
         {
             LastBrokerNameForBroker = brokerName;
             return BrokerSummary;
         }
 
-        public AggregatedSummaryDTO GetPortfolioSummary(string brokerName, string portfolioName)
+        public AggregatedSummaryDTO GetPortfolioSummary(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active)
         {
             LastBrokerNameForPortfolio = brokerName;
             LastPortfolioName = portfolioName;
@@ -411,9 +411,9 @@ public class MainNavigationViewModelBaseTests
 
     private sealed class StubNavigationService : INavigationService
     {
-        public TreeNodeDTO GetNavigationTree() => new() { NodeType = TreeNodeType.Broker, DisplayName = "Root", Metadata = [], Children = [] };
-        public AssetDetailsDTO? GetAssetDetails(string brokerName, string portfolioName, string assetName) => null;
-        public IEnumerable<BrokerNodeDTO> GetBrokers() => [];
+        public TreeNodeDTO GetNavigationTree(InvestmentScope scope = InvestmentScope.Active) => new() { NodeType = TreeNodeType.Broker, DisplayName = "Root", Metadata = [], Children = [] };
+        public AssetDetailsDTO? GetAssetDetails(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
+        public IEnumerable<BrokerNodeDTO> GetBrokers(InvestmentScope scope = InvestmentScope.Active) => [];
         public IEnumerable<AssetNodeDTO> GetAssetsByBrokerPortfolio(string brokerName, string portfolioName) => [];
     }
 

--- a/Tests/Financial.Presentation.Tests/ViewModels/TestStubs.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/TestStubs.cs
@@ -33,7 +33,7 @@ internal sealed class StubBrokerBreakdownService : IBrokerBreakdownService
     public Exception? ExceptionToThrow { get; set; }
     public string? LastBrokerName { get; private set; }
 
-    public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName)
+    public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName, InvestmentScope scope = InvestmentScope.Active)
     {
         LastBrokerName = brokerName;
         if (ExceptionToThrow != null) throw ExceptionToThrow;

--- a/docs/P10-F05-scoped-navigation-summary-api/plan.md
+++ b/docs/P10-F05-scoped-navigation-summary-api/plan.md
@@ -1,0 +1,27 @@
+# Implementation Plan: F05. Scoped Navigation & Summary API
+
+**Prerequisites:**
+- No new tools, libraries, or environment variables required
+- Builds on `IRepository`'s existing `InvestmentScope`-parameterized methods (F02) and `GoogleGenerator`'s Active/Historic routing (F04); consumes `PositionType` as already computed by F01
+
+### Stage 1: Scope Parsing and Application-Layer Threading
+
+**1. Investment Scope Parser** - Add a new validation helper that parses a raw scope string into `InvestmentScope`, following the same generic-parser pattern already used for transaction and credit types, including a convenience method that resolves straight to a default when parsing fails.
+
+**2. Navigation Service and Mapper Scope Threading** - Extend `INavigationService`/`NavigationService` and `NavigationMapper`'s internal mapping chain to accept and forward an investment scope, overriding position type to the closed/flat value whenever the scope is Historic.
+
+**3. Summary and Breakdown Services Scope Threading** - Extend `ISummaryService`/`SummaryService`, `IPortfolioAssetSummaryService`/`PortfolioAssetSummaryService`, and `IBrokerBreakdownService`/`BrokerBreakdownService` to accept and forward an investment scope to their repository calls, removing the now-redundant closed-portfolio/inactive-asset filters from the two services that still have them.
+
+### Stage 2: API Surface
+
+**4. Controller Query Parameter Wiring** - Add a scope query parameter to `NavigationController`'s tree/brokers endpoints, `AssetsController`'s asset-detail endpoint, and all four `SummaryController` endpoints, parsing it through the new helper and defaulting to the active scope when absent or unrecognized.
+
+### Stage 3: Test Coverage
+
+**5. Application-Layer Test Updates** - Update the existing navigation/summary/breakdown unit test suites to remove or rewrite assertions tied to the deleted filters, and add coverage proving the scope value reaches the repository and correctly overrides position type for historic assets; add unit tests for the new scope parser.
+
+**6. API-Level Test Fixture and Coverage** - Extend both `data.test.json` copies with a historic broker/portfolio/asset entry, then extend the navigation, summary, and asset-detail integration test suites to cover scoped requests (active, historic, and omitted) end-to-end through the real HTTP pipeline.
+
+### Stage 4: Presentation-Layer Compatibility
+
+**7. WPF Test Stub Signature Updates** - Update the navigation, summary, portfolio-asset-summary, and broker-breakdown stub implementations used by the existing WPF view-model tests so they compile against the extended service interfaces, without changing any production WPF call site.

--- a/docs/P10-F05-scoped-navigation-summary-api/spec.md
+++ b/docs/P10-F05-scoped-navigation-summary-api/spec.md
@@ -1,0 +1,279 @@
+# Feature Spec: F05. Scoped Navigation & Summary API
+
+## 1. Technical Overview
+
+**What:** Thread the `InvestmentScope` concept that F02 already introduced on `IRepository` up through the Application-layer navigation/summary services and out to the API surface. `NavigationController` (`GET /navigation/tree`, `GET /navigation/brokers`) and `AssetsController` (`GET /assets/{brokerName}/{portfolioName}/{assetName}`) gain a `scope` query parameter; `SummaryController`'s four endpoints (`/summary/broker/{name}`, `/summary/portfolio/{broker}/{portfolio}`, `/summary/portfolio/{broker}/{portfolio}/assets`, `/summary/broker/{name}/breakdown`) gain the same parameter. Every controller action defaults to `Active` when the parameter is omitted, so no existing caller (WPF `Financial.App`, current Web SPA) breaks. `NavigationMapper.MapAsset` starts returning `PositionType.Flat` for Historic-scoped assets, since a historic asset is closed by definition regardless of its stored `PositionType`.
+
+**Why:** F02 built the two-collection repository (`ActiveBrokers`/`HistoricBrokers` behind one `IRepository`, scoped via an optional `InvestmentScope` parameter) and F04 already routes closed positions into `HistoricBrokers` at import time. Nothing yet lets a caller ask for the Historic collection through the API — every Application service still calls `_repository.*(...)` with the implicit default (`Active`), and `BrokerBreakdownService`/`SummaryService` still carry the old `Encerradas`/`Active`-bool filters left over from before F02 physically separated the data. F05 is the piece that exposes the scope choice to callers and retires those now-redundant filters, since scope purity is now a property of which repository collection was queried, not of a runtime `.Where()`.
+
+**Scope:**
+- **Included:** `scope` query parameter (`active` default, `historic`) on all 7 controller actions listed above; a new `InvestmentScopeParser` validation helper mirroring the existing `TransactionTypeParser`/`CreditTypeParser` pattern; `InvestmentScope` threaded through `INavigationService`/`NavigationService`, `ISummaryService`/`SummaryService`, `IPortfolioAssetSummaryService`/`PortfolioAssetSummaryService`, `IBrokerBreakdownService`/`BrokerBreakdownService`, and `NavigationMapper`'s internal mapping chain (`MapBroker`→`MapPortfolios`→`MapPortfolio`→`MapAsset`); removal of `SummaryService`'s and `BrokerBreakdownService`'s `.Where(p => !NavigationMapper.IsEncerradas(...))` / `.Where(a => a.Active)` filters; Historic-scoped `PositionType` forced to `Flat` in both `NavigationMapper.MapAsset` and `NavigationService.GetAssetDetails`; test fixture updates (both `data.test.json` copies) adding historic broker data so `scope=historic` is exercisable end-to-end.
+- **Excluded:** `INavigationService.GetAssetsByBrokerPortfolio` — not exposed by any controller (confirmed via repo-wide search; its only caller is WPF's `AssetPriceFetchViewModel`, which has no historic-scope use case per the PRD's "no live price fetch for Historic" rule) — stays scope-less (YAGNI). `CreditService`/`TransactionService`'s own `.Where(asset => asset.Active)` query filters — the PRD's F05 Capabilities name only `NavigationController`/`SummaryController`; these two services are outside F05's declared surface and are left untouched. Any new endpoint, DTO field, or Historic-specific business metric (realized totals, breakdown-by-realized-value) — that is F06/F07's job; F05 only makes the *existing* tree/summary/breakdown shapes selectable by scope. `PositionType` derivation itself (already done, F01) and the two-collection storage/serialization format (already done, F02) are not touched, only consumed.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Api/Controllers/NavigationController.cs` — `GetNavigationTree`/`GetBrokers` gain `[FromQuery] string? scope`
+- `Financial.Api/Controllers/AssetsController.cs` — `GetAssetDetails` gains `[FromQuery] string? scope`
+- `Financial.Api/Controllers/SummaryController.cs` — all 4 actions gain `[FromQuery] string? scope`
+- `Financial.Application/Validation/InvestmentScopeParser.cs` — new, parses the query string into `InvestmentScope`
+- `Financial.Application/Interfaces/INavigationService.cs` — `GetNavigationTree`, `GetAssetDetails`, `GetBrokers` gain `InvestmentScope scope = InvestmentScope.Active`
+- `Financial.Application/Services/NavigationService.cs` — threads `scope` into the 3 repository calls above; `GetAssetDetails` forces `PositionType.Flat` when `scope == Historic`
+- `Financial.Application/Services/NavigationMapper.cs` — `MapBroker`, `MapPortfolios`, `MapPortfolio`, `MapAsset` gain a required `InvestmentScope scope` parameter; `MapAsset` forces `PositionType.Flat` when `scope == Historic`
+- `Financial.Application/Interfaces/ISummaryService.cs` — `GetBrokerSummary`, `GetPortfolioSummary` gain `InvestmentScope scope = InvestmentScope.Active`
+- `Financial.Application/Services/SummaryService.cs` — threads `scope` into repository calls; deletes the `IsEncerradas`/`Active`-bool filters
+- `Financial.Application/Interfaces/IPortfolioAssetSummaryService.cs` — `GetPortfolioAssetsSummary` gains `InvestmentScope scope = InvestmentScope.Active`
+- `Financial.Application/Services/PortfolioAssetSummaryService.cs` — threads `scope` into its repository call (no filter to remove — it already processes every asset unconditionally)
+- `Financial.Application/Interfaces/IBrokerBreakdownService.cs` — `GetBrokerBreakdown` gains `InvestmentScope scope = InvestmentScope.Active`
+- `Financial.Application/Services/BrokerBreakdownService.cs` — threads `scope` into its repository call; deletes the `IsEncerradas`/`Active`-bool filters
+- `Tests/Financial.Application.Tests/Services/{BrokerBreakdownServiceTests,SummaryServiceTests,PortfolioAssetSummaryServiceTests,NavigationMapperTests}.cs` — updated `StubRepository`s already accept `InvestmentScope` (no signature change needed, per F02); obsolete filter-behavior tests rewritten/removed, scope-threading tests added
+- `Tests/Financial.Api.Tests/{NavigationEndpointsTests,SummaryEndpointsTests,AssetEndpointsTests}.cs` — new `scope=historic`/`scope=active` HTTP-level test cases
+- `Tests/Financial.Api.Tests/TestData/data.test.json`, `Tests/Financial.Infrastructure.Tests/TestData/data.test.json` — both gain a `HistoricBrokers` entry (broker `"XPI"`, a closed asset) so `scope=historic` has real data to return
+- `Tests/Financial.Presentation.Tests/ViewModels/TestStubs.cs` — `StubBrokerBreakdownService.GetBrokerBreakdown` signature updated
+- `Tests/Financial.Presentation.Tests/ViewModels/AssetPriceFetchViewModelTests.cs` — its private `StubNavigationService`'s `GetNavigationTree`/`GetAssetDetails`/`GetBrokers` signatures updated
+- `Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs` — its private `StubNavigationService`, `StubPortfolioAssetSummaryService`, `StubSummaryService` signatures updated
+
+**Data flow:**
+
+```mermaid
+graph TD
+    A["GET /navigation/tree?scope=historic"] --> B["InvestmentScopeParser.ParseOrDefault"]
+    B --> C["NavigationService.GetNavigationTree(scope)"]
+    C --> D["IRepository.GetBrokerList(scope)"]
+    D --> E{"scope"}
+    E -->|"Active"| F["ActiveBrokers"]
+    E -->|"Historic"| G["HistoricBrokers"]
+    F --> H["NavigationMapper.MapBroker(broker, scope)"]
+    G --> H
+    H --> I["MapAsset: PositionType = scope==Historic ? Flat : asset.PositionType"]
+    I --> J["TreeNodeDTO / BrokerNodeDTO response"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Query-parameter parsing convention | Manual `[FromQuery] string? scope` + a new `InvestmentScopeParser` (generic `EnumParser<TEnum>` wrapper, matching `TransactionTypeParser`/`CreditTypeParser`), with a `ParseOrDefault(string?) => InvestmentScope` convenience method | Native ASP.NET Core enum model binding (`[FromQuery] InvestmentScope scope = InvestmentScope.Active`) | Direct precedent in `AssetPricesController` uses manual `Enum.TryParse` for query-string enum-likes, not native binding — following the established codebase convention over introducing a second parsing style. `ParseOrDefault` is new (not present on the two existing parser wrappers) because every one of the 7 controller actions needs exactly "parse-or-default-Active" in one line, and duplicating that ternary at 7 call sites would violate DRY |
+| Scope-purity mechanism in `SummaryService`/`BrokerBreakdownService` | Delete the `.Where(p => !NavigationMapper.IsEncerradas(...))` and `.Where(a => a.Active)` filters entirely; correctness now comes from which repository collection (`Active` vs `Historic`) was queried | Keep the filters as defense-in-depth alongside the new scope parameter | PRD explicitly mandates this for `BrokerBreakdownService` ("scope purity now comes from which repository collection was queried, not from a runtime filter"); user confirmed extending the same principle to `SummaryService` during this spec's interview. Keeping both would let a bug in repository scoping hide behind the redundant filter, defeating the purpose of F02's structural split. This is a real behavior change: an Active-scoped asset with `Quantity = 0` (not yet reflected as historic by a re-import) is now included in Active totals, matching `BrokerBreakdownService`'s already-decided behavior instead of the old asymmetric filtering |
+| `NavigationMapper` scope threading | Add a required `InvestmentScope scope` parameter to `MapBroker`/`MapPortfolios`/`MapPortfolio`/`MapAsset` (all `internal`, single-assembly surface); only `MapAsset` branches on it (`PositionType.Flat` when `Historic`) | Add scope only to `MapAsset` and have callers thread it manually without changing the intermediate methods' signatures | These are private/internal helper methods with a single call chain inside `Financial.Application`; a required parameter (no default) at every level keeps the branch decision co-located with the one place (`MapAsset`) that actually needs it, while still making it impossible to accidentally call `MapAsset` without an explicit scope |
+| `GetAssetDetails`'s inline `PositionType` assignment | `NavigationService.GetAssetDetails` builds `AssetDetailsDTO` directly (not via `NavigationMapper`), so it gets its own `scope == InvestmentScope.Historic ? PositionType.Flat : asset.PositionType` inline, mirroring `MapAsset`'s logic | Route `GetAssetDetails` through `NavigationMapper` to share the branch | `GetAssetDetails` already builds a different DTO shape (`AssetDetailsDTO`, not `AssetNodeDTO`) with additional fields beyond what `NavigationMapper.MapAsset` produces; forcing it through the mapper would require reshaping `NavigationMapper` around a DTO it doesn't otherwise touch. Duplicating one ternary line is cheaper than that reshape |
+| Scope support on `AssetsController.GetAssetDetails` | Included in F05, even though the PRD's F05 Capabilities list only names `NavigationController`/`SummaryController` | Leave `AssetsController` out of F05, defer to a later feature | The PRD's F05 User Story explicitly says "asset-detail endpoints" — `AssetsController.GetAssetDetails` is the only asset-detail endpoint in the codebase. User confirmed extending scope here during this spec's interview |
+| `CreditService`/`TransactionService` filters | Left untouched — out of scope for F05 | Extend the same filter-removal principle to these services for consistency | Neither service nor its underlying `.Where(asset => asset.Active)` filter is named anywhere in the PRD's F05 Capabilities, User Story, or Acceptance Criteria; their controllers are not among the 7 the PRD lists. Touching them would be scope creep beyond what F05 was asked to deliver — a future feature can address them explicitly if needed |
+
+## 4. Component Overview
+
+**Application — Interfaces:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|------------------------|
+| `Financial.Application/Interfaces/INavigationService.cs` | Modified | Navigation service contract | `GetNavigationTree(InvestmentScope scope = Active)`, `GetAssetDetails(string, string, string, InvestmentScope scope = Active)`, `GetBrokers(InvestmentScope scope = Active)`; `GetAssetsByBrokerPortfolio` unchanged |
+| `Financial.Application/Interfaces/ISummaryService.cs` | Modified | Summary service contract | `GetBrokerSummary(string, InvestmentScope scope = Active)`, `GetPortfolioSummary(string, string, InvestmentScope scope = Active)` |
+| `Financial.Application/Interfaces/IPortfolioAssetSummaryService.cs` | Modified | Per-asset summary contract | `GetPortfolioAssetsSummary(string, string, InvestmentScope scope = Active)` |
+| `Financial.Application/Interfaces/IBrokerBreakdownService.cs` | Modified | Breakdown chart contract | `GetBrokerBreakdown(string, InvestmentScope scope = Active)` |
+
+**Application — Services:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|------------------------|
+| `Financial.Application/Services/NavigationService.cs` | Modified | Navigation orchestration | Threads `scope` into `_repository.GetBrokerList(scope)`/`GetAsset(..., scope)`; passes `scope` to `NavigationMapper.MapBroker`; forces `PositionType.Flat` in `GetAssetDetails` when `Historic` |
+| `Financial.Application/Services/NavigationMapper.cs` | Modified | Broker→Portfolio→Asset DTO mapping | `MapBroker(Broker, InvestmentScope)`, `MapPortfolios(IEnumerable<Portfolio>, InvestmentScope)`, `MapPortfolio(Portfolio, InvestmentScope)`, `MapAsset(Asset, InvestmentScope)` — only `MapAsset` branches for `PositionType`; `BuildBrokerTreeNode`/`BuildPortfolioTreeNode`/`BuildAssetTreeNode` unchanged (operate on already-mapped DTOs) |
+| `Financial.Application/Services/SummaryService.cs` | Modified | Broker/portfolio totals | Threads `scope` into `_repository.GetBrokerList(scope)`/`GetAssetsByBrokerPortfolio(..., scope)`; deletes `.Where(p => !IsEncerradas(...))` and `.Where(a => a.Active)` |
+| `Financial.Application/Services/PortfolioAssetSummaryService.cs` | Modified | Per-asset summary computation | Threads `scope` into `_repository.GetAssetsByBrokerPortfolio(..., scope)`; no filter removal needed (none exists today) |
+| `Financial.Application/Services/BrokerBreakdownService.cs` | Modified | Portfolio breakdown for charts | Threads `scope` into `_repository.GetBrokerList(scope)`; deletes `.Where(p => !IsEncerradas(...))` and `.Where(a => a.Active)` |
+| `Financial.Application/Validation/InvestmentScopeParser.cs` | New | Query-string parsing | `TryNormalize(string?, out string)`, `TryParse(string?, out InvestmentScope)` (both delegating to `EnumParser<InvestmentScope>`), plus `ParseOrDefault(string?) => InvestmentScope` returning `Active` on any parse failure |
+
+**Presentation (API):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|------------------------|
+| `Financial.Api/Controllers/NavigationController.cs` | Modified | Navigation endpoints | `GetNavigationTree([FromQuery] string? scope)`, `GetBrokers([FromQuery] string? scope)` — both call `InvestmentScopeParser.ParseOrDefault(scope)` before delegating |
+| `Financial.Api/Controllers/AssetsController.cs` | Modified | Asset detail endpoint | `GetAssetDetails(string, string, string, [FromQuery] string? scope)` |
+| `Financial.Api/Controllers/SummaryController.cs` | Modified | Summary/breakdown endpoints | All 4 actions accept `[FromQuery] string? scope`, parsed the same way |
+
+**Tests:**
+
+| File Path | New/Modified | Purpose |
+|-----------|--------------|---------|
+| `Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs` | Modified | Remove/rewrite `GetBrokerBreakdown_ExcludesInactiveAssets`, `GetBrokerBreakdown_ExcludesEncerradasPortfolio`, `GetBrokerBreakdown_ExcludesEncerradasPortfolio_CaseInsensitive`, `GetBrokerBreakdown_OmitsPortfolioWithNoQualifyingAssets`, `GetBrokerBreakdown_ReturnsEmptyWhenNoEligiblePortfolios` (they assert the now-deleted filter behavior); add tests proving `scope` is forwarded to `GetBrokerList` |
+| `Tests/Financial.Application.Tests/Services/SummaryServiceTests.cs` | Modified | Remove/rewrite `GetBrokerSummary_ExcludesInactiveAssets`, `GetBrokerSummary_ReturnsZerosForBrokerWithNoActiveAssets`, `GetBrokerSummary_ExcludesEncerradasPortfolio`, `GetBrokerSummary_ExcludesEncerradasPortfolio_CaseInsensitive`, `GetPortfolioSummary_ExcludesInactiveAssets`, `GetPortfolioSummary_ReturnsZerosForPortfolioWithNoActiveAssets` (same reason); add scope-forwarding tests |
+| `Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs` | Modified | Add a test proving `scope` reaches `GetAssetsByBrokerPortfolio` |
+| `Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs` | Modified | Add tests: Historic-scoped asset reports `PositionType.Flat` regardless of quantity, via both `GetNavigationTree(Historic)` and `GetAssetDetails(..., Historic)` |
+| `Tests/Financial.Application.Tests/Validation/InvestmentScopeParserTests.cs` | New | Unit tests for `TryParse`/`ParseOrDefault` (valid values, case-insensitivity, null/empty/garbage input) |
+| `Tests/Financial.Api.Tests/NavigationEndpointsTests.cs` | Modified | `GET /navigation/tree?scope=historic` returns only the historic broker; omitted `scope` preserves today's active-only response |
+| `Tests/Financial.Api.Tests/SummaryEndpointsTests.cs` | Modified | Each of the 4 endpoints respects `scope=historic` vs default `active` |
+| `Tests/Financial.Api.Tests/AssetEndpointsTests.cs` | Modified | `GET /assets/{broker}/{portfolio}/{asset}?scope=historic` resolves the historic asset; `PositionType` is `Flat` |
+| `Tests/Financial.Api.Tests/TestData/data.test.json` | Modified | Add `HistoricBrokers: [{ "Name": "XPI", ... }]` with one closed asset in an `"Uncategorized"` portfolio |
+| `Tests/Financial.Infrastructure.Tests/TestData/data.test.json` | Modified | Same addition, kept in sync per the established F02 convention |
+| `Tests/Financial.Presentation.Tests/ViewModels/TestStubs.cs` | Modified | `StubBrokerBreakdownService.GetBrokerBreakdown(string brokerName, InvestmentScope scope = InvestmentScope.Active)` |
+| `Tests/Financial.Presentation.Tests/ViewModels/AssetPriceFetchViewModelTests.cs` | Modified | Its private `StubNavigationService`'s 3 affected methods gain the `scope` parameter (bodies unchanged — this file never exercises them) |
+| `Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs` | Modified | Its private `StubNavigationService`, `StubPortfolioAssetSummaryService`, `StubSummaryService` gain the `scope` parameter on their respective methods |
+
+**Not touched (explicitly out of scope):** `Financial.Application/Interfaces/IRepository.cs` and its implementation (already scope-parameterized by F02); `INavigationService.GetAssetsByBrokerPortfolio` (no controller exposes it); `CreditService.cs`/`TransactionService.cs` (not named in F05's PRD surface); any WPF production code (existing calls compile unchanged against the new optional-parameter defaults); `NavigationMapper.IsEncerradas`/`EncerradasName` (still relied on elsewhere per F02's boundary).
+
+## 5. API Contracts
+
+**Endpoint: Get Navigation Tree**
+- **Method:** GET
+- **Path:** `/navigation/tree`
+- **Authentication:** None (single-user personal app)
+
+**Request:**
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|--------------|
+| `scope` | `string` (query) | No | `active` \| `historic`, case-insensitive; any other value or omission defaults to `active` | Selects the Active or Historic investment collection |
+
+**Request Example:** `GET /navigation/tree?scope=historic`
+
+**Response (Success — 200):** Unchanged `TreeNodeDTO` shape; for `scope=historic`, every `AssetNodeDTO`-derived tree node's `Metadata["PositionType"]` is `Flat`.
+
+**Response Example (`scope=historic`):**
+```json
+{
+  "nodeType": "Broker",
+  "displayName": "XPI",
+  "metadata": {},
+  "children": [
+    {
+      "nodeType": "Portfolio",
+      "displayName": "Uncategorized",
+      "metadata": {},
+      "children": [
+        {
+          "nodeType": "Asset",
+          "displayName": "CLOSEDASSET",
+          "metadata": { "PositionType": "Flat", "GlobalAssetClass": "Equity" },
+          "children": []
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Error Codes:** None new — an unrecognized `scope` value silently falls back to `active` (no 400), consistent with the existing `AssetPricesController` convention of defaulting rather than rejecting an unparseable enum-like query value.
+
+---
+
+**Endpoint: Get Brokers**
+- **Method:** GET
+- **Path:** `/navigation/brokers`
+- Same `scope` query parameter as above. Response: `IEnumerable<BrokerNodeDTO>` filtered to the selected collection.
+
+---
+
+**Endpoint: Get Asset Details**
+- **Method:** GET
+- **Path:** `/assets/{brokerName}/{portfolioName}/{assetName}`
+- Same `scope` query parameter. Response: `AssetDetailsDTO` (404 if not found in the selected scope); `PositionType` is `Flat` when `scope=historic`.
+
+---
+
+**Endpoint: Get Broker Summary**
+- **Method:** GET
+- **Path:** `/summary/broker/{name}`
+- Same `scope` query parameter. Response: `AggregatedSummaryDTO` computed from the selected collection, no `Encerradas`/`Active` filtering applied on top.
+
+---
+
+**Endpoint: Get Portfolio Summary**
+- **Method:** GET
+- **Path:** `/summary/portfolio/{broker}/{portfolio}`
+- Same `scope` query parameter and response shape as Broker Summary, scoped to one portfolio.
+
+---
+
+**Endpoint: Get Portfolio Assets Summary**
+- **Method:** GET
+- **Path:** `/summary/portfolio/{broker}/{portfolio}/assets`
+- Same `scope` query parameter. Response: `IReadOnlyList<PortfolioAssetSummaryItemDTO>`, unchanged shape, sourced from the selected collection.
+
+---
+
+**Endpoint: Get Broker Breakdown**
+- **Method:** GET
+- **Path:** `/summary/broker/{name}/breakdown`
+- Same `scope` query parameter. Response: `IReadOnlyList<PortfolioBreakdownItemDTO>`, unchanged shape, sourced from the selected collection with no runtime filter layered on top.
+
+## 6. Data Model
+
+No schema change. `data.json`'s `ActiveBrokers`/`HistoricBrokers` shape (F02) and `Broker`/`Portfolio`/`Asset`/`Transaction`/`Credit` entities (unchanged since F01–F04) are consumed as-is. The only data-adjacent change is to the two `data.test.json` **test fixtures**, which currently have `"HistoricBrokers": []` and need a non-empty entry so `scope=historic` is exercisable through the real `WebApplicationFactory`-based API tests:
+
+```json
+{
+  "ActiveBrokers": [ /* unchanged existing "XPI" entry */ ],
+  "HistoricBrokers": [
+    {
+      "Name": "XPI",
+      "Currency": "BRL",
+      "Portfolios": [
+        {
+          "Name": "Uncategorized",
+          "Assets": [
+            {
+              "Name": "CLOSEDASSET",
+              "ISIN": "TESTISIN2",
+              "Exchange": "BVMF",
+              "Ticker": "CLOSEDASSET",
+              "Transactions": [
+                { "Date": "2023-01-01T00:00:00", "Type": "Buy", "Quantity": 5, "UnitPrice": 50, "Fees": 0 },
+                { "Date": "2023-06-01T00:00:00", "Type": "Sell", "Quantity": 5, "UnitPrice": 60, "Fees": 0 }
+              ],
+              "Credits": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Using broker name `"XPI"` in both collections (rather than a differently-named historic broker) is deliberate: it lets the new tests prove that `scope` — not broker name — determines which collection is queried.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Tests/Financial.Application.Tests/Validation/InvestmentScopeParserTests.cs` | Unit | `InvestmentScopeParser` | Valid/invalid/case-insensitive parsing |
+| `Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs` | Unit | `NavigationService` (via `NavigationMapper`) | Historic-scope `PositionType` override |
+| `Tests/Financial.Application.Tests/Services/SummaryServiceTests.cs` | Unit | `SummaryService` | Scope forwarding; filter-removal behavior change |
+| `Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs` | Unit | `BrokerBreakdownService` | Scope forwarding; filter-removal behavior change |
+| `Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs` | Unit | `PortfolioAssetSummaryService` | Scope forwarding |
+| `Tests/Financial.Api.Tests/NavigationEndpointsTests.cs` | Integration | `NavigationController` | `scope=active`/`historic`/omitted via real HTTP |
+| `Tests/Financial.Api.Tests/SummaryEndpointsTests.cs` | Integration | `SummaryController` | Same, across all 4 actions |
+| `Tests/Financial.Api.Tests/AssetEndpointsTests.cs` | Integration | `AssetsController` | Same, plus `PositionType == Flat` assertion for historic |
+
+**Test Functions:**
+
+| Test Function | Description | Assertions |
+|----------------|-------------|------------|
+| `TryParse_ValidValues_ReturnsExpectedEnum` (`Theory`: `"active"`, `"Active"`, `"HISTORIC"`, `" historic "`) | Parse recognized values case-insensitively | Returns `true` and the matching `InvestmentScope` |
+| `TryParse_InvalidOrEmpty_ReturnsFalse` (`Theory`: `null`, `""`, `"   "`, `"garbage"`) | Parse unrecognized/empty input | Returns `false` |
+| `ParseOrDefault_InvalidOrOmitted_ReturnsActive` | Convenience method on bad input | Returns `InvestmentScope.Active` |
+| `GetNavigationTree_HistoricScope_AssetNode_PositionTypeIsFlat` | Historic-scoped asset with a nonzero stored quantity | `Metadata["PositionType"]` is `Flat`, not derived from quantity |
+| `GetAssetDetails_HistoricScope_PositionTypeIsFlat` | Same, via `GetAssetDetails` | `PositionType == Flat` |
+| `GetBrokerSummary_ForwardsScopeToRepository` | Call with `scope: Historic` | `StubRepository` receives `Historic` in `GetBrokerList` |
+| `GetPortfolioSummary_ForwardsScopeToRepository` | Call with `scope: Historic` | `StubRepository` receives `Historic` in `GetAssetsByBrokerPortfolio` |
+| `GetBrokerBreakdown_ForwardsScopeToRepository` | Call with `scope: Historic` | `StubRepository` receives `Historic` in `GetBrokerList` |
+| `GetPortfolioAssetsSummary_ForwardsScopeToRepository` | Call with `scope: Historic` | `StubRepository` receives `Historic` in `GetAssetsByBrokerPortfolio` |
+| `GetNavigationTree_ScopeHistoric_ReturnsOnlyHistoricBroker` (API) | `GET /navigation/tree?scope=historic` | Response contains the `"XPI"`/`"Uncategorized"`/`"CLOSEDASSET"` historic node, not the active `"Default"`/`"BCIA11"` node — covers PRD AC "`GET /navigation/tree?scope=historic` returns only assets from `historicInvestments`" |
+| `GetNavigationTree_ScopeOmitted_PreservesActiveOnlyBehavior` (API) | `GET /navigation/tree` (no query string) | Response matches today's active-only tree exactly — covers PRD AC "Omitting the scope parameter preserves today's Active-only behavior" |
+| `GetNavigationTree_ScopeActive_AssetNode_IncludesPositionType` (API) | `GET /navigation/tree?scope=active` | Response's asset node metadata includes `PositionType` — covers PRD AC "including their `PositionType`" |
+| `GetBrokerSummary_ScopeHistoric_ReturnsRealizedFromHistoricBrokerOnly` (API) | `GET /summary/broker/XPI?scope=historic` | Totals reflect only the historic `CLOSEDASSET` transactions, not the active `BCIA11` ones — covers "Each `SummaryController` endpoint respects the same scope selector" |
+| `GetPortfolioSummary_ScopeHistoric_ReturnsHistoricOnly`, `GetPortfolioAssetsSummary_ScopeHistoric_ReturnsHistoricOnly`, `GetBrokerBreakdown_ScopeHistoric_ReturnsHistoricOnly` (API) | Same pattern across the remaining 3 summary endpoints | Same coverage goal, one per endpoint |
+| `GetAssetDetails_ScopeHistoric_ResolvesHistoricAsset` (API) | `GET /assets/XPI/Uncategorized/CLOSEDASSET?scope=historic` | 200 with `PositionType == Flat`; the same asset name/portfolio requested with `scope=active` (or omitted) returns 404, proving scope selects the collection, not just the name |
+
+**PRD acceptance criteria covered:**
+- "`GET /navigation/tree?scope=active` returns only assets from `activeInvestments`, including their `PositionType`" → `GetNavigationTree_ScopeActive_AssetNode_IncludesPositionType`
+- "`GET /navigation/tree?scope=historic` returns only assets from `historicInvestments`" → `GetNavigationTree_ScopeHistoric_ReturnsOnlyHistoricBroker`
+- "Each `SummaryController` endpoint respects the same scope selector" → the 4 `*_ScopeHistoric_Returns*Only` API tests
+- "Omitting the scope parameter preserves today's Active-only behavior" → `GetNavigationTree_ScopeOmitted_PreservesActiveOnlyBehavior` (and the equivalent default-behavior check across the summary/asset-detail endpoints)
+
+**Cross-Feature Integration (from PRD Section 9):**
+- "Data written by import (F04) into `activeInvestments`/`historicInvestments` (F02's structure) is correctly returned by the scoped navigation API (F05)" — covered structurally by the API-level tests above reading from the two-collection `data.test.json` fixture (the same shape F04 writes into); no additional test needed beyond what's listed
+- "Position type computed by F01 appears correctly on every Active-scoped asset returned by F05" — covered by `GetNavigationTree_ScopeActive_AssetNode_IncludesPositionType` and the existing `NavigationMapperTests` `PositionType` theory tests (F01, unaffected by this feature)
+
+**Obsolete tests removed/rewritten (documented, not silently dropped):** `BrokerBreakdownServiceTests.GetBrokerBreakdown_ExcludesInactiveAssets`, `.GetBrokerBreakdown_ExcludesEncerradasPortfolio`, `.GetBrokerBreakdown_ExcludesEncerradasPortfolio_CaseInsensitive`, `.GetBrokerBreakdown_OmitsPortfolioWithNoQualifyingAssets`, `.GetBrokerBreakdown_ReturnsEmptyWhenNoEligiblePortfolios`; `SummaryServiceTests.GetBrokerSummary_ExcludesInactiveAssets`, `.GetBrokerSummary_ReturnsZerosForBrokerWithNoActiveAssets`, `.GetBrokerSummary_ExcludesEncerradasPortfolio`, `.GetBrokerSummary_ExcludesEncerradasPortfolio_CaseInsensitive`, `.GetPortfolioSummary_ExcludesInactiveAssets`, `.GetPortfolioSummary_ReturnsZerosForPortfolioWithNoActiveAssets`. Each asserted behavior of the filters being deleted in this feature (Decision #2); the responsibility they tested (never returning a historic/closed asset from an Active-scoped query) is now covered structurally by F02's repository-level tests plus this feature's own scope-forwarding and API-level tests, so removing them is not a coverage regression.


### PR DESCRIPTION
## Summary
- Threads `InvestmentScope` (Active/Historic) from F02's repository through `NavigationService`, `NavigationMapper`, `SummaryService`, `PortfolioAssetSummaryService`, and `BrokerBreakdownService`, exposed via a new `scope` query parameter on `NavigationController`, `AssetsController`, and `SummaryController` — all defaulting to `active` for backward compatibility.
- Deletes the now-redundant `Encerradas`/`Active`-bool filters from `SummaryService` and `BrokerBreakdownService`; scope purity now comes from which repository collection was queried, per the PRD's decision.
- Historic-scoped assets always report `PositionType.Flat`, both in navigation tree metadata and asset-details responses.
- Adds `InvestmentScopeParser`, mirroring the existing `TransactionTypeParser`/`CreditTypeParser` pattern.

## Test plan
- [x] `dotnet test` on the full solution: `Financial.Application.Tests` 200/200, `Financial.Api.Tests` 52/52, `Financial.Presentation.Tests` 150/150, `Financial.Domain.Tests` 64/64 all green.
- [x] `Financial.Infrastructure.Tests` has 7 pre-existing failures unrelated to this change (malformed `AssetClassifications.json`, a file left mid-edit outside this branch's scope — untouched here).
- [x] Rewrote obsolete `BrokerBreakdownServiceTests`/`SummaryServiceTests` cases that asserted the deleted filters; added scope-forwarding tests across all four services.
- [x] Added end-to-end HTTP coverage (`scope=active`/`historic`/omitted) across navigation, summary, and asset-detail endpoints against an extended `data.test.json` fixture (both copies kept in sync).
- [x] Live smoke-tested the running API against the fixture data: confirmed `scope=active` vs `scope=historic` return disjoint data with correct totals, and `PositionType` correctly forces to `Flat` for historic assets.

Docs: `docs/P10-F05-scoped-navigation-summary-api/spec.md` and `plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)