### PR TITLE
feat(P10-F07): Historic Broker Breakdown Charts Service

### DIFF
--- a/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -16,6 +16,8 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<ITransactionService>(sp => sp.GetRequiredService<TransactionService>());
         services.AddSingleton<ITransactionQueryService>(sp => sp.GetRequiredService<TransactionService>());
         services.AddSingleton<IDividendService, DividendService>();
+        services.AddSingleton<IActiveBrokerBreakdownService, ActiveBrokerBreakdownService>();
+        services.AddSingleton<IHistoricBrokerBreakdownService, HistoricBrokerBreakdownService>();
         services.AddSingleton<IBrokerBreakdownService, BrokerBreakdownService>();
         services.AddSingleton<IPortfolioAssetSummaryService, PortfolioAssetSummaryService>();
         services.AddSingleton<ISummaryService, SummaryService>();

--- a/Financial.Application/Interfaces/IActiveBrokerBreakdownService.cs
+++ b/Financial.Application/Interfaces/IActiveBrokerBreakdownService.cs
@@ -1,0 +1,8 @@
+using Financial.Application.DTOs;
+
+namespace Financial.Application.Interfaces;
+
+public interface IActiveBrokerBreakdownService
+{
+    IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName);
+}

--- a/Financial.Application/Interfaces/IHistoricBrokerBreakdownService.cs
+++ b/Financial.Application/Interfaces/IHistoricBrokerBreakdownService.cs
@@ -1,0 +1,8 @@
+using Financial.Application.DTOs;
+
+namespace Financial.Application.Interfaces;
+
+public interface IHistoricBrokerBreakdownService
+{
+    IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName);
+}

--- a/Financial.Application/Services/ActiveBrokerBreakdownService.cs
+++ b/Financial.Application/Services/ActiveBrokerBreakdownService.cs
@@ -1,0 +1,33 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Domain.Entities;
+
+namespace Financial.Application.Services;
+
+public sealed class ActiveBrokerBreakdownService : IActiveBrokerBreakdownService
+{
+    private readonly IRepository _repository;
+
+    public ActiveBrokerBreakdownService(IRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName))
+            return [];
+
+        var broker = _repository.GetBrokerList(InvestmentScope.Active).FirstOrDefault(b => b.Name == brokerName);
+        if (broker is null)
+            return [];
+
+        return BrokerBreakdownBuilder.Build(broker, CalculateNetInvested);
+    }
+
+    private static decimal CalculateNetInvested(Asset asset)
+    {
+        var (totalBought, totalSold, _) = NavigationMapper.CalculateTotals(asset);
+        return totalBought - totalSold;
+    }
+}

--- a/Financial.Application/Services/BrokerBreakdownBuilder.cs
+++ b/Financial.Application/Services/BrokerBreakdownBuilder.cs
@@ -1,0 +1,39 @@
+using Financial.Application.DTOs;
+using Financial.Domain.Entities;
+
+namespace Financial.Application.Services;
+
+internal static class BrokerBreakdownBuilder
+{
+    internal static IReadOnlyList<PortfolioBreakdownItemDTO> Build(Broker broker, Func<Asset, decimal> investedSelector)
+    {
+        return broker.Portfolios
+            .Select(p => BuildPortfolioBreakdown(p, investedSelector))
+            .Where(p => p.Assets.Count > 0)
+            .OrderBy(p => p.PortfolioName, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+    }
+
+    private static PortfolioBreakdownItemDTO BuildPortfolioBreakdown(Portfolio portfolio, Func<Asset, decimal> investedSelector)
+    {
+        var assets = portfolio.Assets
+            .Select(a => BuildAssetBreakdown(a, investedSelector))
+            .Where(a => a.TotalInvested > 0)
+            .OrderBy(a => a.AssetName, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+
+        return new PortfolioBreakdownItemDTO
+        {
+            PortfolioName = portfolio.Name,
+            TotalInvested = assets.Sum(a => a.TotalInvested),
+            Assets = assets,
+        };
+    }
+
+    private static AssetBreakdownItemDTO BuildAssetBreakdown(Asset asset, Func<Asset, decimal> investedSelector) =>
+        new()
+        {
+            AssetName = asset.Name,
+            TotalInvested = investedSelector(asset),
+        };
+}

--- a/Financial.Application/Services/BrokerBreakdownService.cs
+++ b/Financial.Application/Services/BrokerBreakdownService.cs
@@ -1,57 +1,23 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
-using Financial.Domain.Entities;
 
 namespace Financial.Application.Services;
 
 public sealed class BrokerBreakdownService : IBrokerBreakdownService
 {
-    private readonly IRepository _repository;
+    private readonly IActiveBrokerBreakdownService _activeBrokerBreakdownService;
+    private readonly IHistoricBrokerBreakdownService _historicBrokerBreakdownService;
 
-    public BrokerBreakdownService(IRepository repository)
+    public BrokerBreakdownService(
+        IActiveBrokerBreakdownService activeBrokerBreakdownService,
+        IHistoricBrokerBreakdownService historicBrokerBreakdownService)
     {
-        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _activeBrokerBreakdownService = activeBrokerBreakdownService ?? throw new ArgumentNullException(nameof(activeBrokerBreakdownService));
+        _historicBrokerBreakdownService = historicBrokerBreakdownService ?? throw new ArgumentNullException(nameof(historicBrokerBreakdownService));
     }
 
-    public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName, InvestmentScope scope = InvestmentScope.Active)
-    {
-        if (string.IsNullOrWhiteSpace(brokerName))
-            return [];
-
-        var broker = _repository.GetBrokerList(scope).FirstOrDefault(b => b.Name == brokerName);
-        if (broker is null)
-            return [];
-
-        return broker.Portfolios
-            .Select(BuildPortfolioBreakdown)
-            .Where(p => p.Assets.Count > 0)
-            .OrderBy(p => p.PortfolioName, StringComparer.CurrentCultureIgnoreCase)
-            .ToList();
-    }
-
-    private static PortfolioBreakdownItemDTO BuildPortfolioBreakdown(Portfolio portfolio)
-    {
-        var assets = portfolio.Assets
-            .Select(BuildAssetBreakdown)
-            .Where(a => a.TotalInvested > 0)
-            .OrderBy(a => a.AssetName, StringComparer.CurrentCultureIgnoreCase)
-            .ToList();
-
-        return new PortfolioBreakdownItemDTO
-        {
-            PortfolioName = portfolio.Name,
-            TotalInvested = assets.Sum(a => a.TotalInvested),
-            Assets = assets,
-        };
-    }
-
-    private static AssetBreakdownItemDTO BuildAssetBreakdown(Asset asset)
-    {
-        var (totalBought, totalSold, _) = NavigationMapper.CalculateTotals(asset);
-        return new AssetBreakdownItemDTO
-        {
-            AssetName = asset.Name,
-            TotalInvested = totalBought - totalSold,
-        };
-    }
+    public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName, InvestmentScope scope = InvestmentScope.Active) =>
+        scope == InvestmentScope.Historic
+            ? _historicBrokerBreakdownService.GetBrokerBreakdown(brokerName)
+            : _activeBrokerBreakdownService.GetBrokerBreakdown(brokerName);
 }

--- a/Financial.Application/Services/HistoricBrokerBreakdownService.cs
+++ b/Financial.Application/Services/HistoricBrokerBreakdownService.cs
@@ -1,0 +1,30 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Domain.Entities;
+
+namespace Financial.Application.Services;
+
+public sealed class HistoricBrokerBreakdownService : IHistoricBrokerBreakdownService
+{
+    private readonly IRepository _repository;
+
+    public HistoricBrokerBreakdownService(IRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName))
+            return [];
+
+        var broker = _repository.GetBrokerList(InvestmentScope.Historic).FirstOrDefault(b => b.Name == brokerName);
+        if (broker is null)
+            return [];
+
+        return BrokerBreakdownBuilder.Build(broker, CalculateGrossBought);
+    }
+
+    private static decimal CalculateGrossBought(Asset asset) =>
+        NavigationMapper.CalculateTotals(asset).TotalBought;
+}

--- a/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
@@ -176,6 +176,24 @@ public class SummaryEndpointsTests
         var items = await response.Content.ReadFromJsonAsync<List<PortfolioBreakdownItemDTO>>();
         items.Should().NotBeNull();
         items!.Should().ContainSingle(p => p.PortfolioName == "Uncategorized");
-        items!.SelectMany(p => p.Assets).Should().Contain(a => a.AssetName == "CLOSEDASSET");
+        // CLOSEDASSET: bought 5 x 60 = 300, sold 5 x 50 = 250 — historic sizing uses gross TotalBought (300), not net invested (50)
+        items!.Single().TotalInvested.Should().Be(300m);
+        items!.SelectMany(p => p.Assets).Should().Contain(a => a.AssetName == "CLOSEDASSET" && a.TotalInvested == 300m);
+    }
+
+    [Fact]
+    public async Task GetBrokerBreakdown_ScopeActive_PreservesNetInvestedBehavior()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/broker/XPI/breakdown?scope=active");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var items = await response.Content.ReadFromJsonAsync<List<PortfolioBreakdownItemDTO>>();
+        items.Should().NotBeNull();
+        // BCIA11: bought 10 x 100 = 1000, sold 2 x 110 = 220 — active sizing stays net invested (780)
+        items!.SelectMany(p => p.Assets).Should().Contain(a => a.AssetName == "BCIA11" && a.TotalInvested == 780m);
     }
 }

--- a/Tests/Financial.Application.Tests/Services/ActiveBrokerBreakdownServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/ActiveBrokerBreakdownServiceTests.cs
@@ -1,0 +1,247 @@
+using Financial.Application.Interfaces;
+using Financial.Application.Services;
+using Financial.Domain.Entities;
+using FluentAssertions;
+
+namespace Financial.Application.Tests.Services;
+
+public class ActiveBrokerBreakdownServiceTests
+{
+    private readonly StubRepository _repository = new();
+
+    [Fact]
+    public void Constructor_WithNullRepository_Throws()
+    {
+        Action act = () => new ActiveBrokerBreakdownService(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_ReturnsPortfolioWithTotalInvested()
+    {
+        var asset = MakeAsset();
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 50m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 10m, 10m, 0m));
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", asset)];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Should().ContainSingle(p => p.PortfolioName == "Default" && p.TotalInvested == 400m);
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_ReturnsAssetsWithinPortfolio()
+    {
+        var asset1 = MakeAsset("AAAA", "AAAA");
+        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        var asset2 = MakeAsset("BBBB", "BBBB");
+        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 20m, 10m, 0m));
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", asset1, asset2)];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        var portfolio = result.Single();
+        portfolio.Assets.Should().HaveCount(2);
+        portfolio.Assets.Should().Contain(a => a.AssetName == "AAAA" && a.TotalInvested == 100m);
+        portfolio.Assets.Should().Contain(a => a.AssetName == "BBBB" && a.TotalInvested == 200m);
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_PortfolioTotalInvested_EqualsSumOfIncludedAssets()
+    {
+        var includedAsset1 = MakeAsset("AAAA", "AAAA");
+        includedAsset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        var includedAsset2 = MakeAsset("BBBB", "BBBB");
+        includedAsset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 20m, 10m, 0m));
+        var excludedAsset = MakeAsset("CCCC", "CCCC");
+        excludedAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        excludedAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 100m, 0m));
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", includedAsset1, includedAsset2, excludedAsset)];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Single().TotalInvested.Should().Be(300m);
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_ExcludesAssetsWithNonPositiveTotalInvested()
+    {
+        var positiveAsset = MakeAsset("POS", "POS");
+        positiveAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        var negativeAsset = MakeAsset("NEG", "NEG");
+        negativeAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        negativeAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 100m, 0m));
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", positiveAsset, negativeAsset)];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Single().Assets.Should().ContainSingle(a => a.AssetName == "POS");
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_ExcludesInactiveAssets()
+    {
+        var activeAsset = MakeAsset("ACTIVE", "ACTIVE");
+        activeAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        var inactiveAsset = MakeZeroQuantityAsset();
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", activeAsset, inactiveAsset)];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Single().Assets.Should().ContainSingle(a => a.AssetName == "ACTIVE");
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_DoesNotFilterByPortfolioName_ScopePurityComesFromRepository()
+    {
+        var defaultAsset = MakeAsset("DEFAULT", "DEF");
+        defaultAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        var otherAsset = MakeAsset("OTHER", "OTH");
+        otherAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 100m, 5m, 0m));
+
+        var broker = Broker.Create("XPI", "BRL");
+        broker.AddPortfolio("Default").AddAsset(defaultAsset);
+        broker.AddPortfolio("Encerradas").AddAsset(otherAsset);
+        _repository.Brokers = [broker];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Should().HaveCount(2);
+        result.Select(p => p.PortfolioName).Should().Contain(["Default", "Encerradas"]);
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_QueriesActiveScopeFromRepository()
+    {
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", MakeAsset())];
+
+        CreateService().GetBrokerBreakdown("XPI");
+
+        _repository.LastRequestedScope.Should().Be(InvestmentScope.Active);
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_OmitsPortfolioWithNoQualifyingAssets()
+    {
+        var qualifyingAsset = MakeAsset("QUAL", "QUAL");
+        qualifyingAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        var inactiveAsset = MakeZeroQuantityAsset();
+
+        var broker = Broker.Create("XPI", "BRL");
+        broker.AddPortfolio("Default").AddAsset(qualifyingAsset);
+        broker.AddPortfolio("EmptyPortfolio").AddAsset(inactiveAsset);
+        _repository.Brokers = [broker];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Should().ContainSingle();
+        result.Single().PortfolioName.Should().Be("Default");
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_SortsPortfoliosAlphabetically()
+    {
+        var zetaAsset = MakeAsset("ZETA-A", "ZETA-A");
+        zetaAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        var alphaAsset = MakeAsset("ALPHA-A", "ALPHA-A");
+        alphaAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+
+        var broker = Broker.Create("XPI", "BRL");
+        broker.AddPortfolio("Zeta").AddAsset(zetaAsset);
+        broker.AddPortfolio("Alpha").AddAsset(alphaAsset);
+        _repository.Brokers = [broker];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Select(p => p.PortfolioName).Should().Equal("Alpha", "Zeta");
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_SortsAssetsAlphabeticallyWithinPortfolio()
+    {
+        var zzzz = MakeAsset("ZZZZ3", "ZZZZ3");
+        zzzz.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        var aaaa = MakeAsset("AAAA3", "AAAA3");
+        aaaa.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", zzzz, aaaa)];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Single().Assets.Select(a => a.AssetName).Should().Equal("AAAA3", "ZZZZ3");
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_ReturnsEmptyForUnknownBroker()
+    {
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", MakeAsset())];
+
+        var result = CreateService().GetBrokerBreakdown("UNKNOWN");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_ReturnsEmptyWhenNoEligiblePortfolios()
+    {
+        var broker = Broker.Create("XPI", "BRL");
+        broker.AddPortfolio("EmptyPortfolio").AddAsset(MakeZeroQuantityAsset());
+        _repository.Brokers = [broker];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetBrokerBreakdown_ReturnsEmptyOnNullOrWhitespaceBrokerName(string? brokerName)
+    {
+        var result = CreateService().GetBrokerBreakdown(brokerName!);
+
+        result.Should().BeEmpty();
+    }
+
+    private ActiveBrokerBreakdownService CreateService() => new(_repository);
+
+    private static Asset MakeAsset(string name = "TEST", string ticker = "TEST") =>
+        Asset.Create(name, "ISIN", "BVMF", ticker);
+
+    private static Asset MakeZeroQuantityAsset()
+    {
+        var asset = Asset.Create("INACTIVE", "ISIN2", "BVMF", "INACT");
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 10m, 0m));
+        return asset;
+    }
+
+    private static Broker MakeBrokerWithAssets(string brokerName, string portfolioName, params Asset[] assets)
+    {
+        var broker = Broker.Create(brokerName, "BRL");
+        var portfolio = broker.AddPortfolio(portfolioName);
+        foreach (var asset in assets)
+        {
+            portfolio.AddAsset(asset);
+        }
+        return broker;
+    }
+
+    private sealed class StubRepository : IRepository
+    {
+        public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
+        public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
+        public IEnumerable<Broker> Brokers { get; set; } = [];
+        public InvestmentScope? LastRequestedScope { get; private set; }
+
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastRequestedScope = scope;
+            return Brokers;
+        }
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
+        public Task SaveChangesAsync() => Task.CompletedTask;
+    }
+}

--- a/Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs
@@ -1,247 +1,90 @@
+using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
-using Financial.Domain.Entities;
 using FluentAssertions;
 
 namespace Financial.Application.Tests.Services;
 
 public class BrokerBreakdownServiceTests
 {
-    private readonly StubRepository _repository = new();
+    private readonly StubActiveBrokerBreakdownService _activeService = new();
+    private readonly StubHistoricBrokerBreakdownService _historicService = new();
 
     [Fact]
-    public void Constructor_WithNullRepository_Throws()
+    public void Constructor_WithNullActiveService_Throws()
     {
-        Action act = () => new BrokerBreakdownService(null!);
-        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+        Action act = () => new BrokerBreakdownService(null!, _historicService);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("activeBrokerBreakdownService");
     }
 
     [Fact]
-    public void GetBrokerBreakdown_ReturnsPortfolioWithTotalInvested()
+    public void Constructor_WithNullHistoricService_Throws()
     {
-        var asset = MakeAsset();
-        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 50m, 10m, 0m));
-        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 10m, 10m, 0m));
-        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", asset)];
-
-        var result = CreateService().GetBrokerBreakdown("XPI");
-
-        result.Should().ContainSingle(p => p.PortfolioName == "Default" && p.TotalInvested == 400m);
+        Action act = () => new BrokerBreakdownService(_activeService, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("historicBrokerBreakdownService");
     }
 
     [Fact]
-    public void GetBrokerBreakdown_ReturnsAssetsWithinPortfolio()
+    public void GetBrokerBreakdown_DefaultScope_DelegatesToActiveService()
     {
-        var asset1 = MakeAsset("AAAA", "AAAA");
-        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        var asset2 = MakeAsset("BBBB", "BBBB");
-        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 20m, 10m, 0m));
-        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", asset1, asset2)];
+        CreateService().GetBrokerBreakdown("XPI");
 
-        var result = CreateService().GetBrokerBreakdown("XPI");
-
-        var portfolio = result.Single();
-        portfolio.Assets.Should().HaveCount(2);
-        portfolio.Assets.Should().Contain(a => a.AssetName == "AAAA" && a.TotalInvested == 100m);
-        portfolio.Assets.Should().Contain(a => a.AssetName == "BBBB" && a.TotalInvested == 200m);
+        _activeService.LastRequestedBrokerName.Should().Be("XPI");
+        _historicService.LastRequestedBrokerName.Should().BeNull();
     }
 
     [Fact]
-    public void GetBrokerBreakdown_PortfolioTotalInvested_EqualsSumOfIncludedAssets()
+    public void GetBrokerBreakdown_ScopeActive_DelegatesToActiveService()
     {
-        var includedAsset1 = MakeAsset("AAAA", "AAAA");
-        includedAsset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        var includedAsset2 = MakeAsset("BBBB", "BBBB");
-        includedAsset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 20m, 10m, 0m));
-        var excludedAsset = MakeAsset("CCCC", "CCCC");
-        excludedAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
-        excludedAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 100m, 0m));
-        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", includedAsset1, includedAsset2, excludedAsset)];
+        CreateService().GetBrokerBreakdown("XPI", InvestmentScope.Active);
 
-        var result = CreateService().GetBrokerBreakdown("XPI");
-
-        result.Single().TotalInvested.Should().Be(300m);
+        _activeService.LastRequestedBrokerName.Should().Be("XPI");
+        _historicService.LastRequestedBrokerName.Should().BeNull();
     }
 
     [Fact]
-    public void GetBrokerBreakdown_ExcludesAssetsWithNonPositiveTotalInvested()
+    public void GetBrokerBreakdown_ScopeHistoric_DelegatesToHistoricService()
     {
-        var positiveAsset = MakeAsset("POS", "POS");
-        positiveAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        var negativeAsset = MakeAsset("NEG", "NEG");
-        negativeAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
-        negativeAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 100m, 0m));
-        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", positiveAsset, negativeAsset)];
-
-        var result = CreateService().GetBrokerBreakdown("XPI");
-
-        result.Single().Assets.Should().ContainSingle(a => a.AssetName == "POS");
-    }
-
-    [Fact]
-    public void GetBrokerBreakdown_ExcludesInactiveAssets()
-    {
-        var activeAsset = MakeAsset("ACTIVE", "ACTIVE");
-        activeAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        var inactiveAsset = MakeZeroQuantityAsset();
-        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", activeAsset, inactiveAsset)];
-
-        var result = CreateService().GetBrokerBreakdown("XPI");
-
-        result.Single().Assets.Should().ContainSingle(a => a.AssetName == "ACTIVE");
-    }
-
-    [Fact]
-    public void GetBrokerBreakdown_DoesNotFilterByPortfolioName_ScopePurityComesFromRepository()
-    {
-        var defaultAsset = MakeAsset("DEFAULT", "DEF");
-        defaultAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        var otherAsset = MakeAsset("OTHER", "OTH");
-        otherAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 100m, 5m, 0m));
-
-        var broker = Broker.Create("XPI", "BRL");
-        broker.AddPortfolio("Default").AddAsset(defaultAsset);
-        broker.AddPortfolio("Encerradas").AddAsset(otherAsset);
-        _repository.Brokers = [broker];
-
-        var result = CreateService().GetBrokerBreakdown("XPI");
-
-        result.Should().HaveCount(2);
-        result.Select(p => p.PortfolioName).Should().Contain(["Default", "Encerradas"]);
-    }
-
-    [Fact]
-    public void GetBrokerBreakdown_ForwardsScopeToRepository()
-    {
-        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", MakeAsset())];
-
         CreateService().GetBrokerBreakdown("XPI", InvestmentScope.Historic);
 
-        _repository.LastRequestedScope.Should().Be(InvestmentScope.Historic);
+        _historicService.LastRequestedBrokerName.Should().Be("XPI");
+        _activeService.LastRequestedBrokerName.Should().BeNull();
     }
 
     [Fact]
-    public void GetBrokerBreakdown_OmitsPortfolioWithNoQualifyingAssets()
+    public void GetBrokerBreakdown_ScopeHistoric_ReturnsHistoricServiceResult()
     {
-        var qualifyingAsset = MakeAsset("QUAL", "QUAL");
-        qualifyingAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        var inactiveAsset = MakeZeroQuantityAsset();
+        var expected = new List<PortfolioBreakdownItemDTO> { new() { PortfolioName = "Uncategorized" } };
+        _historicService.Result = expected;
 
-        var broker = Broker.Create("XPI", "BRL");
-        broker.AddPortfolio("Default").AddAsset(qualifyingAsset);
-        broker.AddPortfolio("EmptyPortfolio").AddAsset(inactiveAsset);
-        _repository.Brokers = [broker];
+        var result = CreateService().GetBrokerBreakdown("XPI", InvestmentScope.Historic);
 
-        var result = CreateService().GetBrokerBreakdown("XPI");
-
-        result.Should().ContainSingle();
-        result.Single().PortfolioName.Should().Be("Default");
+        result.Should().BeSameAs(expected);
     }
 
-    [Fact]
-    public void GetBrokerBreakdown_SortsPortfoliosAlphabetically()
+    private BrokerBreakdownService CreateService() => new(_activeService, _historicService);
+
+    private sealed class StubActiveBrokerBreakdownService : IActiveBrokerBreakdownService
     {
-        var zetaAsset = MakeAsset("ZETA-A", "ZETA-A");
-        zetaAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        var alphaAsset = MakeAsset("ALPHA-A", "ALPHA-A");
-        alphaAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        public string? LastRequestedBrokerName { get; private set; }
+        public IReadOnlyList<PortfolioBreakdownItemDTO> Result { get; set; } = [];
 
-        var broker = Broker.Create("XPI", "BRL");
-        broker.AddPortfolio("Zeta").AddAsset(zetaAsset);
-        broker.AddPortfolio("Alpha").AddAsset(alphaAsset);
-        _repository.Brokers = [broker];
-
-        var result = CreateService().GetBrokerBreakdown("XPI");
-
-        result.Select(p => p.PortfolioName).Should().Equal("Alpha", "Zeta");
-    }
-
-    [Fact]
-    public void GetBrokerBreakdown_SortsAssetsAlphabeticallyWithinPortfolio()
-    {
-        var zzzz = MakeAsset("ZZZZ3", "ZZZZ3");
-        zzzz.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        var aaaa = MakeAsset("AAAA3", "AAAA3");
-        aaaa.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", zzzz, aaaa)];
-
-        var result = CreateService().GetBrokerBreakdown("XPI");
-
-        result.Single().Assets.Select(a => a.AssetName).Should().Equal("AAAA3", "ZZZZ3");
-    }
-
-    [Fact]
-    public void GetBrokerBreakdown_ReturnsEmptyForUnknownBroker()
-    {
-        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Default", MakeAsset())];
-
-        var result = CreateService().GetBrokerBreakdown("UNKNOWN");
-
-        result.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void GetBrokerBreakdown_ReturnsEmptyWhenNoEligiblePortfolios()
-    {
-        var broker = Broker.Create("XPI", "BRL");
-        broker.AddPortfolio("EmptyPortfolio").AddAsset(MakeZeroQuantityAsset());
-        _repository.Brokers = [broker];
-
-        var result = CreateService().GetBrokerBreakdown("XPI");
-
-        result.Should().BeEmpty();
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public void GetBrokerBreakdown_ReturnsEmptyOnNullOrWhitespaceBrokerName(string? brokerName)
-    {
-        var result = CreateService().GetBrokerBreakdown(brokerName!);
-
-        result.Should().BeEmpty();
-    }
-
-    private BrokerBreakdownService CreateService() => new(_repository);
-
-    private static Asset MakeAsset(string name = "TEST", string ticker = "TEST") =>
-        Asset.Create(name, "ISIN", "BVMF", ticker);
-
-    private static Asset MakeZeroQuantityAsset()
-    {
-        var asset = Asset.Create("INACTIVE", "ISIN2", "BVMF", "INACT");
-        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
-        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 10m, 0m));
-        return asset;
-    }
-
-    private static Broker MakeBrokerWithAssets(string brokerName, string portfolioName, params Asset[] assets)
-    {
-        var broker = Broker.Create(brokerName, "BRL");
-        var portfolio = broker.AddPortfolio(portfolioName);
-        foreach (var asset in assets)
+        public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName)
         {
-            portfolio.AddAsset(asset);
+            LastRequestedBrokerName = brokerName;
+            return Result;
         }
-        return broker;
     }
 
-    private sealed class StubRepository : IRepository
+    private sealed class StubHistoricBrokerBreakdownService : IHistoricBrokerBreakdownService
     {
-        public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
-        public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
-        public IEnumerable<Broker> Brokers { get; set; } = [];
-        public InvestmentScope? LastRequestedScope { get; private set; }
+        public string? LastRequestedBrokerName { get; private set; }
+        public IReadOnlyList<PortfolioBreakdownItemDTO> Result { get; set; } = [];
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
-        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active)
+        public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName)
         {
-            LastRequestedScope = scope;
-            return Brokers;
+            LastRequestedBrokerName = brokerName;
+            return Result;
         }
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
-        public Task SaveChangesAsync() => Task.CompletedTask;
     }
 }

--- a/Tests/Financial.Application.Tests/Services/HistoricBrokerBreakdownServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/HistoricBrokerBreakdownServiceTests.cs
@@ -1,0 +1,140 @@
+using Financial.Application.Interfaces;
+using Financial.Application.Services;
+using Financial.Domain.Entities;
+using FluentAssertions;
+
+namespace Financial.Application.Tests.Services;
+
+public class HistoricBrokerBreakdownServiceTests
+{
+    private readonly StubRepository _repository = new();
+
+    [Fact]
+    public void Constructor_WithNullRepository_Throws()
+    {
+        Action act = () => new HistoricBrokerBreakdownService(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_UsesGrossTotalBoughtAsSelectedAmount()
+    {
+        var asset = MakeAsset();
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 50m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 10m, 10m, 0m));
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Uncategorized", asset)];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Should().ContainSingle(p => p.PortfolioName == "Uncategorized" && p.TotalInvested == 500m);
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_IncludesFullyClosedPositionWithNonZeroTotalBought()
+    {
+        var closedAsset = MakeAsset("CLOSEDASSET", "CLOSEDASSET");
+        closedAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 60m, 0m));
+        closedAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 50m, 0m));
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Uncategorized", closedAsset)];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Single().Assets.Should().ContainSingle(a => a.AssetName == "CLOSEDASSET" && a.TotalInvested == 300m);
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_ExcludesAssetsWithNonPositiveTotalInvested()
+    {
+        var neverBoughtAsset = MakeAsset("NOBUY", "NOBUY");
+        var boughtAsset = MakeAsset("BOUGHT", "BOUGHT");
+        boughtAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Uncategorized", neverBoughtAsset, boughtAsset)];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Single().Assets.Should().ContainSingle(a => a.AssetName == "BOUGHT");
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_SortsPortfoliosAlphabetically()
+    {
+        var zetaAsset = MakeAsset("ZETA-A", "ZETA-A");
+        zetaAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        var alphaAsset = MakeAsset("ALPHA-A", "ALPHA-A");
+        alphaAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+
+        var broker = Broker.Create("XPI", "BRL");
+        broker.AddPortfolio("Zeta").AddAsset(zetaAsset);
+        broker.AddPortfolio("Alpha").AddAsset(alphaAsset);
+        _repository.Brokers = [broker];
+
+        var result = CreateService().GetBrokerBreakdown("XPI");
+
+        result.Select(p => p.PortfolioName).Should().Equal("Alpha", "Zeta");
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_QueriesHistoricScopeFromRepository()
+    {
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Uncategorized", MakeAsset())];
+
+        CreateService().GetBrokerBreakdown("XPI");
+
+        _repository.LastRequestedScope.Should().Be(InvestmentScope.Historic);
+    }
+
+    [Fact]
+    public void GetBrokerBreakdown_ReturnsEmptyForUnknownBroker()
+    {
+        _repository.Brokers = [MakeBrokerWithAssets("XPI", "Uncategorized", MakeAsset())];
+
+        var result = CreateService().GetBrokerBreakdown("UNKNOWN");
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetBrokerBreakdown_ReturnsEmptyOnNullOrWhitespaceBrokerName(string? brokerName)
+    {
+        var result = CreateService().GetBrokerBreakdown(brokerName!);
+
+        result.Should().BeEmpty();
+    }
+
+    private HistoricBrokerBreakdownService CreateService() => new(_repository);
+
+    private static Asset MakeAsset(string name = "TEST", string ticker = "TEST") =>
+        Asset.Create(name, "ISIN", "BVMF", ticker);
+
+    private static Broker MakeBrokerWithAssets(string brokerName, string portfolioName, params Asset[] assets)
+    {
+        var broker = Broker.Create(brokerName, "BRL");
+        var portfolio = broker.AddPortfolio(portfolioName);
+        foreach (var asset in assets)
+        {
+            portfolio.AddAsset(asset);
+        }
+        return broker;
+    }
+
+    private sealed class StubRepository : IRepository
+    {
+        public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
+        public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
+        public IEnumerable<Broker> Brokers { get; set; } = [];
+        public InvestmentScope? LastRequestedScope { get; private set; }
+
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastRequestedScope = scope;
+            return Brokers;
+        }
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
+        public Task SaveChangesAsync() => Task.CompletedTask;
+    }
+}

--- a/docs/P10-F07-historic-broker-breakdown-charts-service/plan.md
+++ b/docs/P10-F07-historic-broker-breakdown-charts-service/plan.md
@@ -1,0 +1,37 @@
+# Implementation Plan: Historic Broker Breakdown Charts Service
+
+**Prerequisites:**
+- F05 (Scoped Navigation & Summary API) merged — provides the `scope` query parameter, `InvestmentScope` enum, and scope-aware `IRepository`/`SummaryController` this feature builds on
+- No new tools, libraries, or environment variables required
+
+### Stage 1: Shared Breakdown Building Blocks
+
+**1. Breakdown Builder** - Extract the current breakdown service's portfolio/asset filtering, alphabetical sorting, and DTO-assembly logic into a shared, scope-agnostic builder that accepts an invested-amount selector per asset, so both scopes reuse identical construction logic instead of duplicating it.
+
+**2. Scoped Service Contracts** - Define two narrow contracts, one for the Active-scope breakdown and one for the Historic-scope breakdown, each exposing a single broker-name lookup method with scope implicit in which contract is called, per the spec's Component Overview.
+
+### Stage 2: Scope-Specific Breakdown Services
+
+**3. Active Breakdown Service** - Rename the existing breakdown service to make explicit that it serves the Active scope, preserving its current net-invested sizing behavior unchanged, and have it build its result through the shared builder from Stage 1.
+
+**4. Historic Breakdown Service** - Introduce a new service serving the Historic scope, sizing each asset by gross total bought rather than net invested, built through the same shared builder.
+
+**5. Breakdown Facade** - Update the existing public breakdown service so it acts as a facade routing a request to the Active or Historic implementation based on the scope value it already receives, keeping `SummaryController`'s existing call site unchanged.
+
+**6. Dependency Injection** - Register the two scope-specific services and the facade in the Application layer's service collection, following the existing singleton registration pattern used by every other Application service.
+
+### Stage 3: Test Coverage
+
+**7. Shared Builder Tests** - Cover the extracted builder's filtering, sorting, and selector-driven amount assignment independently of any scope.
+
+**8. Active Service Tests** - Adapt the existing breakdown service test suite to the renamed service and its simplified method signature, retaining coverage of net-invested sizing and broker-lookup guard behavior.
+
+**9. Historic Service Tests** - Add coverage proving the Historic breakdown sizes by gross total bought, including a fully-closed position case where net-invested would misleadingly collapse toward zero.
+
+**10. Facade Dispatch Tests** - Verify the facade routes each scope value, including the default, to the correct underlying scoped service.
+
+**11. Integration Test Updates** - Extend the existing historic-scope breakdown endpoint test to assert on the actual sized values, add a regression test proving Active-scope endpoint behavior is unchanged, and add a test proving a historic portfolio with no qualifying assets is excluded.
+
+### Stage 4: Documentation Alignment
+
+**12. PRD Capability Wording** - Update the F07 capability description in the historic-investments PRD to name the Active/Historic breakdown services and the shared builder introduced by this feature, replacing the now-superseded reference to a single, undifferentiated breakdown service.

--- a/docs/P10-F07-historic-broker-breakdown-charts-service/spec.md
+++ b/docs/P10-F07-historic-broker-breakdown-charts-service/spec.md
@@ -1,0 +1,171 @@
+# Historic Broker Breakdown Charts Service
+
+## 1. Technical Overview
+
+**What:** Make the broker breakdown chart data returned under `scope=historic` size each historic asset/portfolio by gross `TotalBought` (capital historically committed) instead of the net-invested formula (`TotalBought - TotalSold`) the existing `BrokerBreakdownService` currently applies to every scope. Active-scope behavior stays exactly as it is today.
+
+**Why:** F05 already made the breakdown endpoint fully scope-aware end to end (repository, controller, DTOs), but the one class doing the sizing math, `BrokerBreakdownService`, still applies the same net-invested formula regardless of scope. For a closed historic position, `TotalBought` and `TotalSold` are close in magnitude, so the net figure collapses toward zero (or negative on a loss) — exactly the defect the PRD calls out when it says a closed position's current value is always zero and asks for gross committed capital instead.
+
+**Scope:**
+
+Included:
+- Splitting the existing single-scope sizing logic into an Active-scope implementation (net invested, unchanged behavior) and a Historic-scope implementation (gross `TotalBought`)
+- Extracting the shared portfolio/asset filtering, sorting, and DTO-building logic so both implementations reuse it instead of duplicating it
+- A facade that preserves the existing public `IBrokerBreakdownService` contract so `SummaryController` and its `scope=historic` endpoint (already shipped in F05) require no changes
+- Renaming the current `BrokerBreakdownService` class to `ActiveBrokerBreakdownService` to make its scope explicit, since it is no longer the only breakdown service in the codebase
+- Unit and integration test coverage for the new sizing behavior, the shared builder, and the facade's dispatch logic
+- Updating the F07 capability wording in the PRD to reflect the class names introduced here
+
+Excluded (already delivered by earlier features, not touched here):
+- The `scope` query parameter, `InvestmentScopeParser`, and `NavigationController`/`SummaryController` routing (F05)
+- Repository-level scope resolution (`IRepository`, `JSONRepository`) (F02/F05)
+- `PortfolioBreakdownItemDTO`/`AssetBreakdownItemDTO` shape and the frontend `BrokerBreakdownCharts.tsx` consumer — both are reused unmodified, per the PRD's explicit requirement that Historic returns "the same DTO shape the Active breakdown already returns"
+- Historic Realized Totals (F06) — not a dependency of F07 and not implemented yet; F07 does not consume it
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Application/Services/BrokerBreakdownBuilder.cs` (new) — shared, scope-agnostic breakdown construction
+- `Financial.Application/Services/ActiveBrokerBreakdownService.cs` (new file, renamed from `BrokerBreakdownService.cs`)
+- `Financial.Application/Services/HistoricBrokerBreakdownService.cs` (new)
+- `Financial.Application/Services/BrokerBreakdownService.cs` (modified — becomes the scope-dispatch facade)
+- `Financial.Application/Interfaces/IActiveBrokerBreakdownService.cs` (new)
+- `Financial.Application/Interfaces/IHistoricBrokerBreakdownService.cs` (new)
+- `Financial.Application/Interfaces/IBrokerBreakdownService.cs` (unchanged — facade keeps implementing this exact contract)
+- `Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs` (modified — DI registration)
+- `Financial.Api/Controllers/SummaryController.cs` (unchanged — the facade absorbs the scope dispatch so the controller's existing call site is untouched)
+
+```mermaid
+graph TD
+  A[SummaryController] --> B[BrokerBreakdownService facade]
+  B --> C[ActiveBrokerBreakdownService]
+  B --> D[HistoricBrokerBreakdownService]
+  C --> E[BrokerBreakdownBuilder]
+  D --> E
+  C --> F[IRepository Active scope]
+  D --> G[IRepository Historic scope]
+  E --> H[NavigationMapper.CalculateTotals]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Service topology | Two scope-specific classes (`ActiveBrokerBreakdownService`, `HistoricBrokerBreakdownService`) behind a facade that keeps implementing `IBrokerBreakdownService` | Extend the existing single `BrokerBreakdownService` in place with an internal scope branch on the sizing formula | More files/interfaces for one narrow behavioral difference, but each class now has a single, explicit responsibility and scope is no longer a silent runtime branch buried inside metric math — matches user direction to make the Active/Historic split explicit in naming |
+| Scope dispatch location | A facade (`BrokerBreakdownService`) in the Application layer holds both scoped implementations and picks one based on the `scope` value it already receives; `SummaryController` is unmodified | `SummaryController` injects both scoped services directly and branches on the parsed scope itself | Keeping the branch in the facade means the Presentation layer never makes a routing decision between two service instances, consistent with CLAUDE.md's Clean Architecture rule that Presentation must not contain business logic, and consistent with every other endpoint in this codebase, none of which branch on scope in the controller |
+| Shared sort/filter/DTO logic | Extracted into `BrokerBreakdownBuilder`, an internal static class parameterized by an `investedSelector` delegate (`Func<Asset, decimal>`) supplied by the caller | Duplicate the filtering/sorting/DTO-building block in both `ActiveBrokerBreakdownService` and `HistoricBrokerBreakdownService` | One extra file, but eliminates duplicating the ~25-line filter/sort/DTO-assembly block that would otherwise diverge over time between the two scopes |
+| Historic sizing metric | Gross `TotalBought` per asset (from `NavigationMapper.CalculateTotals`) | Net invested (`TotalBought - TotalSold`, today's formula) or current value | PRD-mandated: a closed position's current value is always zero, and net invested collapses toward zero for a fully-closed position, which is the defect this feature exists to fix |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Application/Services/BrokerBreakdownBuilder.cs` | New | Shared, scope-agnostic breakdown construction | Filters assets/portfolios to those with a positive selected amount; sorts portfolios and assets alphabetically; assembles `PortfolioBreakdownItemDTO`/`AssetBreakdownItemDTO` from a caller-supplied invested-amount selector |
+| `Financial.Application/Services/ActiveBrokerBreakdownService.cs` | New (renamed from `BrokerBreakdownService.cs`) | Active-scope breakdown | Looks up the broker from the repository's Active scope; supplies `TotalBought - TotalSold` as the builder's selector; guards null/blank broker names and unknown brokers |
+| `Financial.Application/Services/HistoricBrokerBreakdownService.cs` | New | Historic-scope breakdown | Looks up the broker from the repository's Historic scope; supplies gross `TotalBought` as the builder's selector; same guard behavior as the Active service |
+| `Financial.Application/Services/BrokerBreakdownService.cs` | Modified | Scope-dispatch facade | Implements the existing `IBrokerBreakdownService` contract unchanged; routes to `IActiveBrokerBreakdownService` or `IHistoricBrokerBreakdownService` based on the `InvestmentScope` argument |
+| `Financial.Application/Interfaces/IActiveBrokerBreakdownService.cs` | New | Active-scope contract | Single method: `GetBrokerBreakdown(string brokerName)` — no scope parameter, scope is implicit in the interface |
+| `Financial.Application/Interfaces/IHistoricBrokerBreakdownService.cs` | New | Historic-scope contract | Single method: `GetBrokerBreakdown(string brokerName)` — same shape as the Active contract |
+| `Financial.Application/Interfaces/IBrokerBreakdownService.cs` | Unchanged | Facade contract consumed by `SummaryController` | `GetBrokerBreakdown(string brokerName, InvestmentScope scope = InvestmentScope.Active)` — identical to today, no changes needed |
+| `Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs` | Modified | DI registration | Registers `ActiveBrokerBreakdownService`, `HistoricBrokerBreakdownService`, and the `BrokerBreakdownService` facade as singletons, matching the existing registration style for every other Application service |
+
+## 5. API Contracts
+
+No new endpoint and no request/response shape change — the existing endpoint from F05 is reused unmodified; only the returned values for `scope=historic` change.
+
+**Endpoint: Get Broker Breakdown (existing, unchanged surface)**
+- **Method:** GET
+- **Path:** `/api/v1/financial/summary/broker/{brokerName}/breakdown`
+- **Authentication:** None (single-user local application)
+
+**Request:**
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|--------------|
+| `brokerName` | `string` (route) | Yes | non-empty | Broker to build the breakdown for |
+| `scope` | `string` (query) | No | `active`\|`historic`, case-insensitive; unparseable/absent defaults to `active` | Selects which collection (`activeInvestments`/`historicInvestments`) to build the breakdown from |
+
+**Response (Success - 200):** DTO shape unchanged from today.
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `[].portfolioName` | `string` | Historic portfolio name, resolved by F03/F04 (classification-based or per-broker `Uncategorized` fallback) |
+| `[].totalInvested` | `decimal` | For `scope=active`: net invested (`TotalBought - TotalSold`), unchanged. For `scope=historic`: gross `TotalBought` — this is the value this feature changes |
+| `[].assets[].assetName` | `string` | Asset name |
+| `[].assets[].totalInvested` | `decimal` | Same per-scope semantics as the portfolio-level field, at asset granularity |
+
+**Response Example (`scope=historic`):**
+```json
+[
+  {
+    "portfolioName": "Uncategorized",
+    "totalInvested": 5000.00,
+    "assets": [
+      { "assetName": "CLOSEDASSET", "totalInvested": 5000.00 }
+    ]
+  }
+]
+```
+
+**Error Codes:** unchanged from F05 — `400 Bad Request` for a null/blank `brokerName`; an unknown broker or a historic portfolio with no qualifying assets is omitted from the array rather than erroring.
+
+## 6. Data Model
+
+No schema or `data.json` changes. This feature reads the same `Broker → Portfolio → Asset` structures already established by F02, through the same `IRepository`/`InvestmentScope` abstraction already scope-aware since F05. `Asset.Transactions`/`Asset.Credits` — the source of the `TotalBought`/`TotalSold`/`TotalCredits` figures via `NavigationMapper.CalculateTotals` — are unchanged.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Tests/Financial.Application.Tests/Services/BrokerBreakdownBuilderTests.cs` | Unit | `BrokerBreakdownBuilder` | Filtering/sorting/DTO-assembly behavior, independent of scope |
+| `Tests/Financial.Application.Tests/Services/ActiveBrokerBreakdownServiceTests.cs` | Unit | `ActiveBrokerBreakdownService` | Net-invested sizing, Active-scope repository lookup, guard clauses |
+| `Tests/Financial.Application.Tests/Services/HistoricBrokerBreakdownServiceTests.cs` | Unit | `HistoricBrokerBreakdownService` | Gross-`TotalBought` sizing, Historic-scope repository lookup, guard clauses |
+| `Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs` | Unit | `BrokerBreakdownService` (facade) | Scope-based dispatch to the correct underlying service |
+| `Tests/Financial.Api.Tests/SummaryEndpointsTests.cs` | Integration | `GET /summary/broker/{name}/breakdown` | Historic-scope response values, Active-scope regression, empty-portfolio exclusion |
+
+**Test functions:**
+
+`BrokerBreakdownBuilderTests.cs`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `Build_ExcludesAssetsWithNonPositiveSelectedAmount` | Asset whose selector result is `<= 0` | Asset absent from the built portfolio's `Assets` |
+| `Build_ExcludesPortfoliosWithNoQualifyingAssets` | Portfolio where every asset is filtered out | Portfolio absent from the result |
+| `Build_SortsPortfoliosAlphabetically` | Multiple portfolios, out-of-order input | Result ordered case-insensitively by `PortfolioName` |
+| `Build_SortsAssetsAlphabeticallyWithinPortfolio` | Multiple assets, out-of-order input | `Assets` ordered case-insensitively by `AssetName` |
+| `Build_UsesProvidedSelectorForAssetAmount` | Selector returning a fixed value | `AssetBreakdownItemDTO.TotalInvested`/`PortfolioBreakdownItemDTO.TotalInvested` equal the selector's output, not a hardcoded formula |
+
+`ActiveBrokerBreakdownServiceTests.cs`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `Constructor_WithNullRepository_Throws` | Null `IRepository` | Throws `ArgumentNullException` |
+| `GetBrokerBreakdown_UsesNetInvestedAsSelectedAmount` | Asset with distinct `TotalBought`/`TotalSold` | Returned amount equals `TotalBought - TotalSold` |
+| `GetBrokerBreakdown_QueriesActiveScopeFromRepository` | Any broker | Repository is queried with `InvestmentScope.Active` |
+| `GetBrokerBreakdown_ReturnsEmptyForUnknownBroker` | Broker name not present in Active collection | Empty result |
+| `GetBrokerBreakdown_ReturnsEmptyOnNullOrWhitespaceBrokerName` | `[Theory]` over `null`/`""`/`"   "` | Empty result, no repository call |
+
+`HistoricBrokerBreakdownServiceTests.cs`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `Constructor_WithNullRepository_Throws` | Null `IRepository` | Throws `ArgumentNullException` |
+| `GetBrokerBreakdown_UsesGrossTotalBoughtAsSelectedAmount` | Asset with `TotalBought` and non-zero `TotalSold` | Returned amount equals `TotalBought`, not `TotalBought - TotalSold` |
+| `GetBrokerBreakdown_IncludesFullyClosedPositionWithNonZeroTotalBought` | Fully closed position where `TotalSold` ≈ `TotalBought` | Asset is present in the result sized by gross `TotalBought` (the defect this feature fixes) |
+| `GetBrokerBreakdown_QueriesHistoricScopeFromRepository` | Any broker | Repository is queried with `InvestmentScope.Historic` |
+| `GetBrokerBreakdown_ReturnsEmptyForUnknownBroker` | Broker name not present in Historic collection | Empty result |
+| `GetBrokerBreakdown_ReturnsEmptyOnNullOrWhitespaceBrokerName` | `[Theory]` over `null`/`""`/`"   "` | Empty result, no repository call |
+
+`BrokerBreakdownServiceTests.cs`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `Constructor_WithNullDependencies_Throws` | Null Active or Historic service dependency | Throws `ArgumentNullException` |
+| `GetBrokerBreakdown_DefaultScope_DelegatesToActiveService` | No scope argument supplied | `IActiveBrokerBreakdownService.GetBrokerBreakdown` invoked |
+| `GetBrokerBreakdown_ScopeActive_DelegatesToActiveService` | `InvestmentScope.Active` | `IActiveBrokerBreakdownService.GetBrokerBreakdown` invoked |
+| `GetBrokerBreakdown_ScopeHistoric_DelegatesToHistoricService` | `InvestmentScope.Historic` | `IHistoricBrokerBreakdownService.GetBrokerBreakdown` invoked |
+
+`SummaryEndpointsTests.cs` (acceptance/integration — maps to PRD Section 9 F07 criteria and the Cross-Feature Integration criterion tying F05 to F07)
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `GetBrokerBreakdown_ScopeHistoric_ReturnsHistoricOnly` (extend existing) | `scope=historic` for a broker with a closed asset | `200 OK`; portfolio/asset `totalInvested` equal gross `TotalBought` from the fixture, not net invested |
+| `GetBrokerBreakdown_ScopeHistoric_ExcludesPortfolioWithNoAssets` | Historic broker with an empty portfolio | Portfolio absent from the response — F07 acceptance criterion |
+| `GetBrokerBreakdown_ScopeActive_PreservesNetInvestedBehavior` | `scope=active`/omitted, unchanged fixture | `totalInvested` still equals `TotalBought - TotalSold` — regression guard proving the facade split didn't alter Active behavior |

--- a/docs/prd/P10-prd-historic-investments/prd-historic-investments.md
+++ b/docs/prd/P10-prd-historic-investments/prd-historic-investments.md
@@ -211,8 +211,8 @@ At the import layer, the spreadsheet importer keeps its existing tab-colour-base
 - F05: broker/portfolio/asset tree data scoped to Historic
 
 **Capabilities:**
-- Parallel to `BrokerBreakdownService`, building `PortfolioBreakdownItemDTO`/`AssetBreakdownItemDTO` for the Historic scope, sizing each slice by `TotalBought` (gross capital historically committed) rather than a current-value figure, since a closed position's current value is always zero
-- Exposed via the existing breakdown endpoint under `scope=historic` (F05), returning the same DTO shape the Active breakdown already returns so `BrokerBreakdownCharts.tsx`/`BrokerBreakdownChartBuilder.cs` can render it unmodified
+- The existing `BrokerBreakdownService` is renamed `ActiveBrokerBreakdownService` and a new sibling `HistoricBrokerBreakdownService` is introduced, both sharing a common breakdown-building helper; `HistoricBrokerBreakdownService` builds `PortfolioBreakdownItemDTO`/`AssetBreakdownItemDTO` for the Historic scope, sizing each slice by `TotalBought` (gross capital historically committed) rather than a current-value figure, since a closed position's current value is always zero
+- Exposed via the existing breakdown endpoint under `scope=historic` (F05) through the existing `IBrokerBreakdownService` facade, returning the same DTO shape the Active breakdown already returns so `BrokerBreakdownCharts.tsx`/`BrokerBreakdownChartBuilder.cs` can render it unmodified
 
 **Experience:**
 - No direct UI; consumed by F09/F11's charts tab for Historic Investments


### PR DESCRIPTION
## Summary
- Sizes the Historic-scope broker breakdown by gross `TotalBought` instead of net invested, since a closed position's `TotalBought`/`TotalSold` are close in magnitude and the old net formula collapsed toward zero — defeating the purpose of a "how was capital historically distributed" chart.
- Renames `BrokerBreakdownService` to `ActiveBrokerBreakdownService` (unchanged net-invested behavior) and adds a sibling `HistoricBrokerBreakdownService`, both built through a new shared `BrokerBreakdownBuilder` to avoid duplicating the filter/sort/DTO-assembly logic.
- `BrokerBreakdownService` becomes a scope-dispatch facade that still implements the existing `IBrokerBreakdownService` contract, so `SummaryController` and the `scope=historic` breakdown endpoint (already shipped in F05) require zero changes.

## Test plan
- [x] `dotnet build --configuration Release` — 0 errors
- [x] `dotnet test --configuration Release` — full suite green (216 Application, 53 Api, 64 Domain, 126 Infrastructure incl. 5 pre-existing skips, 150 Presentation)
- [x] New unit coverage: `ActiveBrokerBreakdownServiceTests`, `HistoricBrokerBreakdownServiceTests`, `BrokerBreakdownServiceTests` (facade dispatch)
- [x] Extended integration coverage: `SummaryEndpointsTests.GetBrokerBreakdown_ScopeHistoric_ReturnsHistoricOnly` now asserts gross-`TotalBought` values; added `GetBrokerBreakdown_ScopeActive_PreservesNetInvestedBehavior` regression test
- [x] Manual smoke test against a locally running API: `scope=historic` → `CLOSEDASSET` sized at 300 (gross bought); `scope=active` → `BCIA11` sized at 780 (unchanged net invested)

Docs: `docs/P10-F07-historic-broker-breakdown-charts-service/spec.md` and `plan.md`; PRD's F07 capability text updated to name the new services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)