### PR TITLE
feat(P10-F08): Web Active Investments Tab Update

### DIFF
--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -25,9 +25,10 @@ The skill only needs to locate two files and one reference source:
 ## OUTPUT
 
 - **Commits**: one per phase of `plan.md`, on the current branch (no branch creation, no branch switching).
+- **PRD update** (only when the run's final status is `success`): the PRD's acceptance-criteria checkboxes for this feature are checked off, in their own commit. See Step 7.
 - **Chat report** at the end: the feature's acceptance-criteria checklist marked ✓ / ✗ / — against actual test results, plus sections for Deviations, Soft-fails, Pre-existing failures, Overrides applied, Overrides ignored, and Phase status.
 
-No files are written besides code changes and commit objects. The chat report is ephemeral.
+No files are written besides code changes, commit objects, and — on a successful run only — the PRD checkbox update described in Step 7. The chat report itself remains ephemeral; the PRD checkbox update is its durable counterpart.
 
 ---
 
@@ -182,7 +183,19 @@ The run's final status is determined by this step, not by whether phases committ
 
 Never report `success` when any of the checks above has an unresolved failure, even if every phase individually committed clean.
 
-### Step 7: Final Report
+### Step 7: Update PRD Acceptance Criteria
+
+If Step 6.5 determined status `success`: edit the PRD to check off (`- [ ]` → `- [x]`) every acceptance-criterion checkbox for this feature that was confirmed ✓ in Step 6.3. Match the PRD's existing checkbox list format exactly — flip the marker only, do not add new sections, prose, dates, or reformat surrounding content.
+
+A cross-feature integration checkbox often names more than one feature (e.g. "...renders correctly in both the Web (F08) and WPF (F10)..."). Check it off only when *every* feature it names is already implemented (its own PRD boxes checked or its `docs/<feature>/` spec confirmed shipped) — not just the one this run completed. If other named features aren't done yet, leave that box unchecked even though this run's half is verified true.
+
+Stage only the PRD file and commit it separately from the phase commits, e.g. `docs(F<ID>): mark acceptance criteria complete`. This is the durable counterpart to the chat report's AC checklist — the chat report disappears with the session, but the checked boxes stay in the repo as a versioned record of what has actually shipped.
+
+If status is `completed with regressions`, `incomplete`, or `aborted at phase <N>`: do not touch the PRD. Leave every box as-is so a partial or failed run never claims false progress.
+
+Skip this step entirely if the PRD has no acceptance-criteria checkboxes for this feature (see Edge Case: "PRD has no AC content for this feature").
+
+### Step 8: Final Report
 
 Output the report to chat. Status comes from Step 6.5, never from "I think I finished":
 
@@ -250,11 +263,14 @@ If aborted, the report still lists whatever committed phases achieved and clearl
 - For phases that produce runtime surfaces (UI, HTTP route, migration, CLI), actually exercise them against a local environment before claiming done, or soft-fail the runtime check.
 - Execute Step 6 (Final Verification) in full before reporting — full-suite re-run, Component Overview walk-through, AC re-check, environment smoke check.
 - Derive the final status exclusively from Step 6.5. Report `success` only when every Step 6 check is green.
+- On a `success` status, check off this feature's satisfied acceptance-criteria and cross-feature-integration checkboxes in the PRD (Step 7), in their own commit, before the final report.
 
 **Never:**
 - Claim the run is `success` when Step 6 found regressions, missing-from-spec items, or unresolved failures — even if every phase individually committed clean.
 - Skip the AC report or its traceability (immutable core).
 - Skip Step 6 (Final Verification).
+- Check off PRD acceptance-criteria boxes when the run's status is anything other than `success`.
+- Check off a PRD box for an AC that Step 6.3 did not confirm ✓.
 - Create or switch branches.
 - Abort on name/path/type cosmetic divergences.
 - Abort on external dependency missing for a test — soft-fail the test, keep implementing.

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -71,7 +71,7 @@ internal static class NavigationMapper
                 ["Quantity"] = asset.Quantity,
                 ["AveragePrice"] = asset.AveragePrice,
                 ["IsActive"] = asset.IsActive,
-                ["PositionType"] = asset.PositionType,
+                ["PositionType"] = asset.PositionType.ToString(),
                 ["TransactionCount"] = asset.TransactionCount,
                 ["CreditCount"] = asset.CreditCount
             }

--- a/Financial.Web/src/App.test.tsx
+++ b/Financial.Web/src/App.test.tsx
@@ -11,8 +11,8 @@ const AppWithRoutes = ({ initialEntry = '/' }: { initialEntry?: string }) => (
   <MemoryRouter initialEntries={[initialEntry]}>
     <Routes>
       <Route path="/" element={<App />}>
-        <Route index element={<Navigate to="/portfolio-navigator" replace />} />
-        <Route path="portfolio-navigator" element={<p>Portfolio Navigator placeholder</p>} />
+        <Route index element={<Navigate to="/active-investments" replace />} />
+        <Route path="active-investments" element={<p>Active Investments placeholder</p>} />
         <Route path="dividend-check" element={<h2>Shares Dividend Check</h2>} />
         <Route path="current-values" element={<h2>Read Assets Current Values</h2>} />
         <Route path="*" element={<p>Page not found.</p>} />
@@ -25,15 +25,15 @@ describe('App', () => {
   it('renders three nav items', () => {
     render(<AppWithRoutes />)
 
-    expect(screen.getByRole('link', { name: 'Portfolio Navigator' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Active Investments' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Shares Dividend Check' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Read Assets Current Values' })).toBeInTheDocument()
   })
 
-  it('default route redirects to portfolio navigator', () => {
+  it('default route redirects to active investments', () => {
     render(<AppWithRoutes initialEntry="/" />)
 
-    expect(screen.getByText('Portfolio Navigator placeholder')).toBeInTheDocument()
+    expect(screen.getByText('Active Investments placeholder')).toBeInTheDocument()
   })
 
   it('navigates to dividend check section', async () => {
@@ -42,7 +42,7 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('link', { name: 'Shares Dividend Check' }))
 
     expect(screen.getByRole('heading', { name: 'Shares Dividend Check' })).toBeInTheDocument()
-    expect(screen.queryByText('Portfolio Navigator placeholder')).not.toBeInTheDocument()
+    expect(screen.queryByText('Active Investments placeholder')).not.toBeInTheDocument()
   })
 
   it('navigates to current values section', () => {
@@ -57,11 +57,11 @@ describe('App', () => {
     render(<AppWithRoutes initialEntry="/dividend-check" />)
 
     const activeLink = screen.getByRole('link', { name: 'Shares Dividend Check' })
-    const portfolioLink = screen.getByRole('link', { name: 'Portfolio Navigator' })
+    const activeInvestmentsLink = screen.getByRole('link', { name: 'Active Investments' })
     const currentValuesLink = screen.getByRole('link', { name: 'Read Assets Current Values' })
 
     expect(activeLink).toHaveClass('active')
-    expect(portfolioLink).not.toHaveClass('active')
+    expect(activeInvestmentsLink).not.toHaveClass('active')
     expect(currentValuesLink).not.toHaveClass('active')
   })
 

--- a/Financial.Web/src/App.tsx
+++ b/Financial.Web/src/App.tsx
@@ -5,7 +5,7 @@ function App() {
   return (
     <div className="app">
       <nav className="app__nav" aria-label="Primary">
-        <NavLink to="/portfolio-navigator">Portfolio Navigator</NavLink>
+        <NavLink to="/active-investments">Active Investments</NavLink>
         <NavLink to="/dividend-check">Shares Dividend Check</NavLink>
         <NavLink to="/current-values">Read Assets Current Values</NavLink>
       </nav>

--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -46,10 +46,32 @@ describe('financialApiClient', () => {
 
     expect(result).toEqual(responseBody)
     const [url, init] = fetchMock.mock.calls[0]
-    expect(url).toBe(`${API_BASE_URL}/navigation/tree`)
+    expect(url).toBe(`${API_BASE_URL}/navigation/tree?scope=active`)
     const headers = init?.headers as Headers
     expect(headers.get('Accept')).toBe('application/json')
     expect(headers.get('Content-Type')).toBeNull()
+  })
+
+  it('requests scope=active on every Active-scoped endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({}))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    await client.getNavigationTree()
+    await client.getAssetDetails('XPI', 'Default', 'BCIA11')
+    await client.getSummaryByBroker('XPI')
+    await client.getSummaryByPortfolio('XPI', 'Default')
+    await client.getBrokerBreakdown('XPI')
+    await client.getPortfolioAssetsSummary('XPI', 'Default')
+
+    const urls = fetchMock.mock.calls.map(([url]) => url as string)
+    expect(urls).toEqual([
+      `${API_BASE_URL}/navigation/tree?scope=active`,
+      `${API_BASE_URL}/assets/XPI/Default/BCIA11?scope=active`,
+      `${API_BASE_URL}/summary/broker/XPI?scope=active`,
+      `${API_BASE_URL}/summary/portfolio/XPI/Default?scope=active`,
+      `${API_BASE_URL}/summary/broker/XPI/breakdown?scope=active`,
+      `${API_BASE_URL}/summary/portfolio/XPI/Default/assets?scope=active`,
+    ])
   })
 
   it('posts a new transaction', async () => {

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -120,12 +120,14 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
     return trimmed && trimmed.length > 0 ? `?exchange=${encodeURIComponent(trimmed)}` : ''
   }
 
+  const ACTIVE_SCOPE_QUERY = '?scope=active'
+
   return {
-    getNavigationTree: () => request<TreeNodeDto>('/navigation/tree'),
+    getNavigationTree: () => request<TreeNodeDto>(`/navigation/tree${ACTIVE_SCOPE_QUERY}`),
     getBrokers: () => request<BrokerNodeDto[]>('/navigation/brokers'),
     getAssetDetails: (brokerName, portfolioName, assetName) =>
       request<AssetDetailsDto>(
-        `/assets/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}/${encodeURIComponent(assetName)}`,
+        `/assets/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}/${encodeURIComponent(assetName)}${ACTIVE_SCOPE_QUERY}`,
       ),
     getCreditsByBroker: (brokerName) =>
       request<CreditDto[]>(`/credits/broker/${encodeURIComponent(brokerName)}`),
@@ -134,13 +136,13 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
         `/credits/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}`,
       ),
     getSummaryByBroker: (brokerName) =>
-      request<AggregatedSummaryDto>(`/summary/broker/${encodeURIComponent(brokerName)}`),
+      request<AggregatedSummaryDto>(`/summary/broker/${encodeURIComponent(brokerName)}${ACTIVE_SCOPE_QUERY}`),
     getSummaryByPortfolio: (brokerName, portfolioName) =>
       request<AggregatedSummaryDto>(
-        `/summary/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}`,
+        `/summary/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}${ACTIVE_SCOPE_QUERY}`,
       ),
     getBrokerBreakdown: (brokerName) =>
-      request<PortfolioBreakdownItemDto[]>(`/summary/broker/${encodeURIComponent(brokerName)}/breakdown`),
+      request<PortfolioBreakdownItemDto[]>(`/summary/broker/${encodeURIComponent(brokerName)}/breakdown${ACTIVE_SCOPE_QUERY}`),
     getTransactionsByBroker: (brokerName) =>
       request<TransactionSummaryItemDto[]>(`/transactions/broker/${encodeURIComponent(brokerName)}`),
     getTransactionsByPortfolio: (brokerName, portfolioName) =>
@@ -197,7 +199,7 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
     getAssetPriceFetchScope: () => request<PortfolioReferenceDto[]>('/asset-price-fetch'),
     getPortfolioAssetsSummary: (brokerName, portfolioName) =>
       request<PortfolioAssetSummaryItemDto[]>(
-        `/summary/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}/assets`,
+        `/summary/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}/assets${ACTIVE_SCOPE_QUERY}`,
       ),
     calculateXirr: (cashFlows, terminalValue) =>
       request<XirrResultDto>('/xirr/calculate', {

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -1,5 +1,7 @@
 export type NodeType = 'Asset' | 'Portfolio' | 'Broker'
 
+export type PositionType = 'Long' | 'Flat' | 'Short'
+
 export interface SelectedNode {
   nodeType: NodeType
   brokerName: string
@@ -8,7 +10,7 @@ export interface SelectedNode {
   ticker?: string
   exchange?: string
   currency?: string
-  isActive?: boolean
+  positionType?: PositionType
   assetClass?: string
 }
 
@@ -50,7 +52,7 @@ export interface AssetNodeDto {
   quantity: number
   averagePrice: number
   isActive: boolean
-  positionType: string
+  positionType: PositionType
   transactionCount: number
   creditCount: number
 }
@@ -92,7 +94,7 @@ export interface AssetDetailsDto {
   quantity: number
   averagePrice: number
   isActive: boolean
-  positionType: string
+  positionType: PositionType
   totalBought: number
   totalSold: number
   totalCredits: number

--- a/Financial.Web/src/components/DetailPanel.css
+++ b/Financial.Web/src/components/DetailPanel.css
@@ -51,12 +51,16 @@
   margin-left: auto;
 }
 
-.detail-panel__status--active {
-  color: green;
+.detail-panel__status--long {
+  color: #2e7d32;
 }
 
-.detail-panel__status--inactive {
-  color: var(--text-muted, #888);
+.detail-panel__status--flat {
+  color: var(--text, #333);
+}
+
+.detail-panel__status--short {
+  color: #c62828;
 }
 
 .detail-panel__breadcrumb {

--- a/Financial.Web/src/components/DetailPanel.tsx
+++ b/Financial.Web/src/components/DetailPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
 import { useSelectedNode } from '../context/SelectedNodeContext'
+import { POSITION_TYPE_STATUS_CLASS } from '../utils/positionType'
 import AggregatedSummaryTab from './AggregatedSummaryTab'
 import AssetSummaryTab from './AssetSummaryTab'
 import PortfolioSummaryTab from './PortfolioSummaryTab'
@@ -76,11 +77,11 @@ export default function DetailPanel() {
               ⧉
             </button>
           )}
-          {isAsset && (
+          {isAsset && selectedNode.positionType && (
             <span
-              className={`detail-panel__status detail-panel__status--${selectedNode.isActive ? 'active' : 'inactive'}`}
+              className={`detail-panel__status detail-panel__status--${POSITION_TYPE_STATUS_CLASS[selectedNode.positionType]}`}
             >
-              {selectedNode.isActive ? '● Active' : '○ Inactive'}
+              ● {selectedNode.positionType}
             </span>
           )}
         </div>

--- a/Financial.Web/src/components/InvestmentTree.css
+++ b/Financial.Web/src/components/InvestmentTree.css
@@ -86,11 +86,15 @@
   padding-left: 12px;
 }
 
-.investment-tree__status-icon--active {
+.investment-tree__status-icon--long {
   color: #2e7d32;
 }
 
-.investment-tree__status-icon--inactive {
+.investment-tree__status-icon--flat {
+  color: var(--text, #333);
+}
+
+.investment-tree__status-icon--short {
   color: #c62828;
 }
 

--- a/Financial.Web/src/components/InvestmentTree.tsx
+++ b/Financial.Web/src/components/InvestmentTree.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { createFinancialApiClient } from '../api/financialApiClient'
-import type { SelectedNode, TreeNodeDto } from '../api/types'
+import type { PositionType, SelectedNode, TreeNodeDto } from '../api/types'
 import { useSelectedNode } from '../context/SelectedNodeContext'
+import { POSITION_TYPE_STATUS_CLASS } from '../utils/positionType'
 import ErrorState from './ErrorState'
 import LoadingState from './LoadingState'
 import './InvestmentTree.css'
@@ -25,8 +26,9 @@ function getMetaString(metadata: Record<string, unknown>, key: string): string {
   return typeof v === 'string' ? v : ''
 }
 
-function getMetaBool(metadata: Record<string, unknown>, key: string): boolean {
-  return metadata[key] === true
+function getMetaPositionType(metadata: Record<string, unknown>): PositionType {
+  const v = metadata['PositionType']
+  return v === 'Long' || v === 'Short' ? v : 'Flat'
 }
 
 function getMetaNumber(metadata: Record<string, unknown>, key: string): number {
@@ -60,13 +62,13 @@ function AssetNode({ node, brokerName, portfolioName, filterClass }: AssetNodePr
   const assetName = getMetaString(node.metadata, 'AssetName')
   const ticker = getMetaString(node.metadata, 'Ticker')
   const exchange = getMetaString(node.metadata, 'Exchange')
-  const isActive = getMetaBool(node.metadata, 'IsActive')
+  const positionType = getMetaPositionType(node.metadata)
   const assetClass = getMetaNumber(node.metadata, 'GlobalAssetClass')
 
   if (filterClass !== ALL_CLASSES && String(assetClass) !== filterClass) return null
 
   const isSelected = nodeMatchesSelected(selectedNode, 'Asset', { brokerName, portfolioName, assetName })
-  const prefix = isActive ? '●' : '○'
+  const statusClass = POSITION_TYPE_STATUS_CLASS[positionType]
 
   const handleClick = () => {
     setSelectedNode({
@@ -76,7 +78,7 @@ function AssetNode({ node, brokerName, portfolioName, filterClass }: AssetNodePr
       assetName,
       ticker,
       exchange,
-      isActive,
+      positionType,
       assetClass: ASSET_CLASS_OPTIONS.find((o) => o.value === assetClass)?.label,
     })
   }
@@ -88,7 +90,7 @@ function AssetNode({ node, brokerName, portfolioName, filterClass }: AssetNodePr
         onClick={handleClick}
         type="button"
       >
-        <span className={`investment-tree__status-icon investment-tree__status-icon--${isActive ? 'active' : 'inactive'}`}>{prefix}</span> {node.displayName}
+        <span className={`investment-tree__status-icon investment-tree__status-icon--${statusClass}`}>●</span> {node.displayName}
       </button>
     </li>
   )

--- a/Financial.Web/src/components/__tests__/DetailPanel.test.tsx
+++ b/Financial.Web/src/components/__tests__/DetailPanel.test.tsx
@@ -56,9 +56,10 @@ const activeAssetNode: SelectedNode = {
   assetName: 'KLBN4',
   ticker: 'KLBN4',
   exchange: 'BVMF',
-  isActive: true,
+  positionType: 'Long',
 }
-const inactiveAssetNode: SelectedNode = { ...activeAssetNode, isActive: false }
+const flatAssetNode: SelectedNode = { ...activeAssetNode, positionType: 'Flat' }
+const shortAssetNode: SelectedNode = { ...activeAssetNode, positionType: 'Short' }
 
 describe('DetailPanel', () => {
   beforeEach(() => {
@@ -88,8 +89,9 @@ describe('DetailPanel', () => {
   it('does not show status indicator for broker node', () => {
     renderPanel(brokerNode)
     act(() => screen.getByTestId('setter').click())
-    expect(screen.queryByText(/Active/)).not.toBeInTheDocument()
-    expect(screen.queryByText(/Inactive/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Long/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Flat/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Short/)).not.toBeInTheDocument()
   })
 
   it('does not show copy icon for broker node', () => {
@@ -112,16 +114,28 @@ describe('DetailPanel', () => {
     expect(screen.getByText('KLBN4 · BVMF · XPI · Acoes')).toBeInTheDocument()
   })
 
-  it('shows Active status indicator for active asset', () => {
+  it('shows Long status indicator in green for a long position', () => {
     renderPanel(activeAssetNode)
     act(() => screen.getByTestId('setter').click())
-    expect(screen.getByText('● Active')).toBeInTheDocument()
+    const status = screen.getByText('● Long')
+    expect(status).toBeInTheDocument()
+    expect(status).toHaveClass('detail-panel__status--long')
   })
 
-  it('shows Inactive status indicator for inactive asset', () => {
-    renderPanel(inactiveAssetNode)
+  it('shows Flat status indicator in the neutral color for a flat position', () => {
+    renderPanel(flatAssetNode)
     act(() => screen.getByTestId('setter').click())
-    expect(screen.getByText('○ Inactive')).toBeInTheDocument()
+    const status = screen.getByText('● Flat')
+    expect(status).toBeInTheDocument()
+    expect(status).toHaveClass('detail-panel__status--flat')
+  })
+
+  it('shows Short status indicator in red for a short position', () => {
+    renderPanel(shortAssetNode)
+    act(() => screen.getByTestId('setter').click())
+    const status = screen.getByText('● Short')
+    expect(status).toBeInTheDocument()
+    expect(status).toHaveClass('detail-panel__status--short')
   })
 
   it('copy icon calls clipboard writeText with asset name', () => {

--- a/Financial.Web/src/components/__tests__/InvestmentTree.test.tsx
+++ b/Financial.Web/src/components/__tests__/InvestmentTree.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import InvestmentTree from '../InvestmentTree'
 import { SelectedNodeProvider, useSelectedNode } from '../../context/SelectedNodeContext'
 import type { FinancialApiClient } from '../../api/financialApiClient'
-import type { TreeNodeDto } from '../../api/types'
+import type { PositionType, TreeNodeDto } from '../../api/types'
 
 const getNavigationTreeMock = vi.fn()
 
@@ -13,7 +13,12 @@ vi.mock('../../api/financialApiClient', () => ({
   }),
 }))
 
-function makeAsset(name: string, isActive: boolean, assetClass: number): TreeNodeDto {
+function makeAsset(
+  name: string,
+  isActive: boolean,
+  assetClass: number,
+  positionType: PositionType = isActive ? 'Long' : 'Flat',
+): TreeNodeDto {
   return {
     nodeType: 'Asset',
     displayName: name,
@@ -22,6 +27,7 @@ function makeAsset(name: string, isActive: boolean, assetClass: number): TreeNod
       Ticker: name,
       Exchange: 'BVMF',
       IsActive: isActive,
+      PositionType: positionType,
       GlobalAssetClass: assetClass,
     },
     children: [],
@@ -107,29 +113,48 @@ describe('InvestmentTree', () => {
     expect(screen.getByText('Acoes (2 assets)')).toBeInTheDocument()
   })
 
-  it('renders active asset with filled circle prefix', async () => {
+  it('renders a filled bullet prefix regardless of position type', async () => {
     renderTree()
     await screen.findByText('XPI (BRL)')
     const expandBtn = screen.getAllByLabelText('Expand')[0]
     fireEvent.click(expandBtn)
     expect(screen.getByRole('button', { name: '● KLBN4' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '● TRPL4' })).toBeInTheDocument()
   })
 
-  it('renders inactive asset with empty circle prefix', async () => {
-    renderTree()
+  it('renders Long/Flat/Short status icons with the matching color class', async () => {
+    const tree: TreeNodeDto = {
+      nodeType: 'Investments',
+      displayName: 'Investments',
+      metadata: {},
+      children: [
+        makeBroker('XPI', 'BRL', [
+          makePortfolio('Mix', [
+            makeAsset('LONGASSET', true, 1, 'Long'),
+            makeAsset('FLATASSET', false, 1, 'Flat'),
+            makeAsset('SHORTASSET', true, 1, 'Short'),
+          ]),
+        ]),
+      ],
+    }
+    getNavigationTreeMock.mockResolvedValue(tree)
+    render(
+      <SelectedNodeProvider>
+        <InvestmentTree />
+      </SelectedNodeProvider>,
+    )
     await screen.findByText('XPI (BRL)')
-    const expandBtn = screen.getAllByLabelText('Expand')[0]
-    fireEvent.click(expandBtn)
-    expect(screen.getByRole('button', { name: '○ TRPL4' })).toBeInTheDocument()
-  })
+    fireEvent.click(screen.getAllByLabelText('Expand')[0])
 
-  it('renders active asset status icon in green and inactive in red', async () => {
-    renderTree()
-    await screen.findByText('XPI (BRL)')
-    const expandBtn = screen.getAllByLabelText('Expand')[0]
-    fireEvent.click(expandBtn)
-    expect(screen.getByText('●')).toHaveClass('investment-tree__status-icon--active')
-    expect(screen.getByText('○')).toHaveClass('investment-tree__status-icon--inactive')
+    expect(screen.getByRole('button', { name: '● LONGASSET' }).querySelector('span')).toHaveClass(
+      'investment-tree__status-icon--long',
+    )
+    expect(screen.getByRole('button', { name: '● FLATASSET' }).querySelector('span')).toHaveClass(
+      'investment-tree__status-icon--flat',
+    )
+    expect(screen.getByRole('button', { name: '● SHORTASSET' }).querySelector('span')).toHaveClass(
+      'investment-tree__status-icon--short',
+    )
   })
 
   it('clicking asset node sets selectedNode in context', async () => {

--- a/Financial.Web/src/hooks/useAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/useAssetSummary.test.ts
@@ -24,7 +24,7 @@ const ASSET_NODE: SelectedNode = {
   assetName: 'KLBN4',
   ticker: 'KLBN4',
   exchange: 'BVMF',
-  isActive: true,
+  positionType: 'Long',
 }
 
 const OTHER_ASSET_NODE: SelectedNode = {
@@ -103,7 +103,7 @@ describe('useAssetSummary', () => {
       assetName: 'Bitcoin',
       ticker: 'BTC',
       exchange: '',
-      isActive: true,
+      positionType: 'Long',
       assetClass: 'Cryptocurrency',
     }
     getAssetDetailsMock.mockResolvedValue({ ...ASSET_DETAILS, name: 'Bitcoin', ticker: 'BTC', class: 'Cryptocurrency' })
@@ -124,7 +124,7 @@ describe('useAssetSummary', () => {
       assetName: 'TESOURO IPCA+ 2029',
       ticker: 'TESOURO IPCA+ 2029',
       exchange: '',
-      isActive: true,
+      positionType: 'Long',
       assetClass: 'Bond',
     }
     getAssetDetailsMock.mockResolvedValue({

--- a/Financial.Web/src/hooks/useCredits.test.ts
+++ b/Financial.Web/src/hooks/useCredits.test.ts
@@ -32,7 +32,7 @@ const ASSET_NODE: SelectedNode = {
   assetName: 'KLBN4',
   ticker: 'KLBN4',
   exchange: 'BVMF',
-  isActive: true,
+  positionType: 'Long',
 }
 
 const BROKER_NODE: SelectedNode = {
@@ -53,7 +53,7 @@ const ASSET_NODE_B: SelectedNode = {
   assetName: 'TASA4',
   ticker: 'TASA4',
   exchange: 'BVMF',
-  isActive: true,
+  positionType: 'Long',
 }
 
 const CREDIT_A: CreditDto = {

--- a/Financial.Web/src/hooks/useTransactions.test.ts
+++ b/Financial.Web/src/hooks/useTransactions.test.ts
@@ -32,7 +32,7 @@ const ASSET_NODE: SelectedNode = {
   assetName: 'KLBN4',
   ticker: 'KLBN4',
   exchange: 'BVMF',
-  isActive: true,
+  positionType: 'Long',
 }
 
 const PORTFOLIO_NODE: SelectedNode = {

--- a/Financial.Web/src/main.tsx
+++ b/Financial.Web/src/main.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import './index.css'
 import './styles/data-table.css'
 import App from './App'
-import PortfolioNavigatorPage from './pages/PortfolioNavigatorPage'
+import ActiveInvestmentsPage from './pages/ActiveInvestmentsPage'
 import DividendCheckPage from './pages/DividendCheckPage'
 import CurrentValuesPage from './pages/CurrentValuesPage'
 
@@ -13,8 +13,8 @@ createRoot(document.getElementById('root')!).render(
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<App />}>
-          <Route index element={<Navigate to="/portfolio-navigator" replace />} />
-          <Route path="portfolio-navigator" element={<PortfolioNavigatorPage />} />
+          <Route index element={<Navigate to="/active-investments" replace />} />
+          <Route path="active-investments" element={<ActiveInvestmentsPage />} />
           <Route path="dividend-check" element={<DividendCheckPage />} />
           <Route path="current-values" element={<CurrentValuesPage />} />
           <Route path="*" element={<div>Page not found.</div>} />

--- a/Financial.Web/src/pages/ActiveInvestmentsPage.css
+++ b/Financial.Web/src/pages/ActiveInvestmentsPage.css
@@ -1,4 +1,4 @@
-.portfolio-navigator {
+.active-investments {
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/Financial.Web/src/pages/ActiveInvestmentsPage.tsx
+++ b/Financial.Web/src/pages/ActiveInvestmentsPage.tsx
@@ -2,12 +2,12 @@ import { SelectedNodeProvider } from '../context/SelectedNodeContext'
 import SplitPanel from '../components/SplitPanel'
 import InvestmentTree from '../components/InvestmentTree'
 import DetailPanel from '../components/DetailPanel'
-import './PortfolioNavigatorPage.css'
+import './ActiveInvestmentsPage.css'
 
-export default function PortfolioNavigatorPage() {
+export default function ActiveInvestmentsPage() {
   return (
     <SelectedNodeProvider>
-      <div className="portfolio-navigator">
+      <div className="active-investments">
         <SplitPanel left={<InvestmentTree />} right={<DetailPanel />} />
       </div>
     </SelectedNodeProvider>

--- a/Financial.Web/src/pages/__tests__/ActiveInvestmentsPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/ActiveInvestmentsPage.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import PortfolioNavigatorPage from '../PortfolioNavigatorPage'
+import ActiveInvestmentsPage from '../ActiveInvestmentsPage'
 import type { FinancialApiClient } from '../../api/financialApiClient'
 import type { TreeNodeDto } from '../../api/types'
 
@@ -44,6 +44,7 @@ const stubTree: TreeNodeDto = {
                 Ticker: 'KLBN4',
                 Exchange: 'BVMF',
                 IsActive: true,
+                PositionType: 'Long',
                 GlobalAssetClass: 1,
               },
               children: [],
@@ -58,12 +59,12 @@ const stubTree: TreeNodeDto = {
 function renderPage() {
   return render(
     <MemoryRouter>
-      <PortfolioNavigatorPage />
+      <ActiveInvestmentsPage />
     </MemoryRouter>,
   )
 }
 
-describe('PortfolioNavigatorPage', () => {
+describe('ActiveInvestmentsPage', () => {
   beforeEach(() => {
     getNavigationTreeMock.mockReset()
     getAssetDetailsMock.mockReturnValue(new Promise(() => {}))

--- a/Financial.Web/src/utils/positionType.ts
+++ b/Financial.Web/src/utils/positionType.ts
@@ -1,0 +1,7 @@
+import type { PositionType } from '../api/types'
+
+export const POSITION_TYPE_STATUS_CLASS: Record<PositionType, string> = {
+  Long: 'long',
+  Flat: 'flat',
+  Short: 'short',
+}

--- a/Tests/Financial.Api.Tests/NavigationEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/NavigationEndpointsTests.cs
@@ -61,6 +61,7 @@ public class NavigationEndpointsTests
 
         var assetNode = GetAllAssetNodes(tree!).Single(a => a.DisplayName == "BCIA11");
         assetNode.Metadata.Should().ContainKey("PositionType");
+        ((System.Text.Json.JsonElement)assetNode.Metadata["PositionType"]).GetString().Should().Be("Long");
     }
 
     [Fact]

--- a/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
+++ b/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
@@ -61,7 +61,7 @@ public class NavigationMapperTests
         var tree = CreateService().GetNavigationTree();
 
         var assetNode = GetFirstAssetNode(tree);
-        assetNode.Metadata["PositionType"].Should().Be(PositionType.Long);
+        assetNode.Metadata["PositionType"].Should().Be("Long");
     }
 
     [Theory]
@@ -108,7 +108,7 @@ public class NavigationMapperTests
         var tree = CreateService().GetNavigationTree(InvestmentScope.Historic);
 
         var assetNode = GetFirstAssetNode(tree);
-        assetNode.Metadata["PositionType"].Should().Be(PositionType.Flat);
+        assetNode.Metadata["PositionType"].Should().Be("Flat");
     }
 
     [Theory]

--- a/docs/P10-F08-web-active-investments-tab-update/plan.md
+++ b/docs/P10-F08-web-active-investments-tab-update/plan.md
@@ -1,0 +1,31 @@
+# Implementation Plan: Web — Active Investments Tab Update
+
+**Prerequisites:**
+- F01 (Position Type Domain Model) and F05 (Scoped Navigation & Summary API) merged — provide `Asset.PositionType` and the `scope` query parameter this feature consumes
+- No new tools, libraries, or environment variables required
+
+### Stage 1: Backend Metadata Fix
+
+**1. Position Type Metadata Serialization** - Fix the navigation tree's asset metadata so `PositionType` serializes as a string, matching the convention every other typed enum property in the API already follows, instead of the raw integer it currently emits. Update the existing unit and integration test assertions that currently expect the raw enum value.
+
+### Stage 2: Scope-Pure Requests
+
+**2. API Client Scoping** - Update the Web API client so every scope-capable request this page's component tree reaches (navigation tree, broker/portfolio summary, broker breakdown, asset details) explicitly requests the Active scope, per the spec's Component Overview.
+
+### Stage 3: Three-Way Position Indicator and Rebrand
+
+**3. Shared Position Type Typing** - Introduce a typed `PositionType` value on the frontend and thread it through the DTOs and the selected-node context that currently only carry the boolean active/inactive flag.
+
+**4. Tree Indicator** - Replace the tree's boolean active/inactive status rendering with the three-way Long/Flat/Short color mapping, per the spec's color and glyph decisions.
+
+**5. Detail Panel Indicator** - Replace the detail panel's separate boolean-driven status indicator with the same three-way mapping, reconciling its color values with the tree's.
+
+**6. Navigation Rebrand** - Relabel the nav entry and rename the route, page component, and associated files from Portfolio Navigator to Active Investments.
+
+### Stage 4: Frontend Test Coverage
+
+**7. Frontend Component Tests** - Update the tree and detail-panel test suites for the three-way mapping, and add coverage that the selected node correctly carries position type.
+
+**8. Frontend Routing/Nav Tests** - Update the app-level tests asserting the nav label, route path, and root redirect.
+
+**9. API Client Scope Tests** - Add coverage confirming each updated client method's request includes the Active scope.

--- a/docs/P10-F08-web-active-investments-tab-update/spec.md
+++ b/docs/P10-F08-web-active-investments-tab-update/spec.md
@@ -1,0 +1,187 @@
+# Web — Active Investments Tab Update
+
+## 1. Technical Overview
+
+**What:** Relabel the Web app's "Portfolio Navigator" tab to "Active Investments", make its data fetching explicitly scope-pure (`scope=active`) now that F02/F05 have shipped the Active/Historic split, and replace the boolean active/inactive status indicator (tree + detail panel) with a three-way `Long`/`Flat`/`Short` → green/black/red mapping driven by F01's `positionType` field.
+
+**Why:** Today's page relies entirely on the backend's implicit `Active` default to stay scope-pure — no Web call site passes `scope` at all. That's a silent dependency on a default that could change. The status indicator is still driven by the old `IsActive` boolean, which cannot distinguish a closed position from an open short — exactly the ambiguity F01's `PositionType` was built to resolve, but nothing on the Web frontend consumes it yet. Discovery also surfaced a real defect blocking this: the navigation tree's `Metadata["PositionType"]` currently serializes as a raw integer (`0`/`1`/`2`), not the string every other typed enum property in this codebase uses (`AssetNodeDTO`/`AssetDetailsDTO` both apply `[JsonConverter(typeof(JsonStringEnumConverter))]` to their `PositionType` property) — confirmed by hitting the live endpoint. This is fixed as part of this feature since F08 is the first and only consumer of that metadata field.
+
+**Scope:**
+
+Included:
+- Backend: fix `Metadata["PositionType"]`'s serialization to a string, matching the codebase's established enum-as-string convention
+- Nav label rename ("Portfolio Navigator" → "Active Investments") and route rename (`/portfolio-navigator` → `/active-investments`)
+- Explicit `scope=active` on every scope-capable endpoint this page's component tree reaches: navigation tree, broker/portfolio summary, broker breakdown, and asset details (which also covers the Summary/Credits/Transactions tabs, since all three hooks feeding them call the now-scoped asset-details endpoint)
+- Three-way position-type color/status indicator in both `InvestmentTree` and `DetailPanel`, replacing the boolean `isActive` check in both places
+- Page/file rename (`PortfolioNavigatorPage` → `ActiveInvestmentsPage`) for scope-explicit naming, matching the precedent set by F07's `BrokerBreakdownService` → `ActiveBrokerBreakdownService` rename
+
+Excluded (deferred to later features, not touched here):
+- `useCredits`/`useTransactions`'s own list-fetching calls (`getCreditsByBroker`, `getTransactionsByPortfolio`, etc.) — these have no backend scope parameter at all; F05 explicitly left `CreditService`/`TransactionService` outside its scoped surface, and F08 doesn't reopen that
+- `getBrokers` (used only by the unrelated `CurrentValuesPage`) — left untouched, no historic use case there
+- Any reusable `scope` prop/parameter threading through `InvestmentTree`/`DetailPanel`/hooks for F09's future reuse — F09 is not a dependency of F08 per the PRD's dependency graph; `scope=active` is hardcoded, and F09 threads its own parameter when it's implemented
+- WPF (`Financial.App`) — that's F10, a separate feature; this spec touches only `Financial.Web` and the one backend metadata fix
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Application/Services/NavigationMapper.cs` — `Metadata["PositionType"]` serialization fix
+- `Financial.Web/src/api/types.ts` — `PositionType` union type; DTO/`SelectedNode` field updates
+- `Financial.Web/src/api/financialApiClient.ts` — `scope=active` on 5 methods
+- `Financial.Web/src/components/InvestmentTree.tsx` + `.css` — three-way status indicator
+- `Financial.Web/src/components/DetailPanel.tsx` + `.css` — three-way status indicator
+- `Financial.Web/src/pages/ActiveInvestmentsPage.tsx` + `.css` (renamed from `PortfolioNavigatorPage`)
+- `Financial.Web/src/App.tsx`, `Financial.Web/src/main.tsx` — label/route rename
+
+```mermaid
+graph TD
+  A[User] --> B["NavLink: Active Investments"]
+  B --> C["/active-investments route"]
+  C --> D[ActiveInvestmentsPage]
+  D --> E[InvestmentTree]
+  D --> F[DetailPanel]
+  E --> G["financialApiClient scope=active"]
+  F --> H[useAssetSummary / useCredits / useTransactions]
+  F --> I[useAggregatedSummary / useBrokerBreakdown]
+  H --> G
+  I --> G
+  G --> J["GET .../navigation/tree?scope=active"]
+  J --> K[NavigationMapper]
+  K --> L["Metadata PositionType as string"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| `PositionType` metadata serialization | Fix `NavigationMapper.cs` to emit `asset.PositionType.ToString()`, matching the DTO-level convention (`CountryCode`/`GlobalAssetClass`/`PositionType` all use `JsonStringEnumConverter` on `AssetNodeDTO`) | Read the raw integer ordinal on the frontend via the existing `getMetaNumber` pattern (as `GlobalAssetClass` already does) | Touches already-merged F01/F05 backend code for a defect F08 is the first feature to expose, but keeps the wire format consistent with every other typed enum in the API instead of adding a second, ordinal-based convention |
+| Route path | Rename to `/active-investments` | Keep `/portfolio-navigator`, only relabel the nav text | Slightly larger diff (`main.tsx`, `App.tsx`, 5 assertions in `App.test.tsx`) but the URL now matches the label and the upcoming `/historic-investments` (F09) sibling; confirmed safe — no external deep links or stored references exist |
+| Scope threading | Hardcode `scope=active` inside `financialApiClient.ts`'s request URLs (one named constant, no new method parameters) | Thread a reusable `scope` prop through `InvestmentTree`/`DetailPanel`/hooks so F09 can pass `'historic'` later | Simpler, smaller diff, matches an explicit YAGNI call (F09 isn't a dependency of F08) — F09 will need to add its own parameter when implemented, touching the same files again |
+| Flat-state color | `var(--text, #333)`, reusing the app's existing default-text CSS variable pattern | A new standalone literal hex (e.g. `#333333`) | Keeps a single source of truth for "default text" instead of introducing a parallel hardcoded value; also used to fix `DetailPanel.css`'s inconsistent `color: green` keyword to `#2e7d32` while touching that file |
+| Tree status glyph | Single filled `●` for all three states | Three distinct glyphs (e.g. `▲`/`●`/`▼`) for colorblind-accessible redundant signaling | Matches the PRD's capability text, which specifies only color, not iconography; avoids introducing unspecified new design surface |
+| `SelectedNode.isActive` | Retired — replaced by `positionType` | Keep both fields, `isActive` unused | Confirmed via repo-wide search it has no consumer once `DetailPanel`'s indicator switches; keeping unused fields around is dead code |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Application/Services/NavigationMapper.cs` | Modified | Fix tree metadata serialization | `BuildAssetTreeNode` sets `Metadata["PositionType"] = asset.PositionType.ToString()` instead of the raw enum |
+| `Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs` | Modified | Keep existing coverage accurate | The two existing `Metadata["PositionType"].Should().Be(PositionType.Long/Flat)` assertions updated to expect the string values `"Long"`/`"Flat"` |
+| `Tests/Financial.Api.Tests/NavigationEndpointsTests.cs` | Modified | Strengthen existing coverage | The existing key-presence-only assertion extended to assert the actual string value returned over HTTP |
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/api/types.ts` | Modified | Type-safe `PositionType` | Adds `export type PositionType = 'Long' \| 'Flat' \| 'Short'`; changes `AssetNodeDto.positionType`/`AssetDetailsDto.positionType` from `string` to `PositionType`; replaces `SelectedNode.isActive?: boolean` with `positionType?: PositionType` |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | Scope-pure requests | Adds a local `scope=active` query constant; appends it to `getNavigationTree`, `getSummaryByBroker`, `getSummaryByPortfolio`, `getBrokerBreakdown`, `getAssetDetails` request URLs |
+| `Financial.Web/src/components/InvestmentTree.tsx` | Modified | Three-way tree indicator | `AssetNode` reads `positionType` via `getMetaString(node.metadata, 'PositionType')` instead of `isActive` via `getMetaBool`; maps to a status-icon modifier class (`long`/`flat`/`short`); always renders `●`; passes `positionType` into `setSelectedNode` |
+| `Financial.Web/src/components/InvestmentTree.css` | Modified | Three-way colors | Replaces `--active`/`--inactive` status-icon color rules with `--long` (`#2e7d32`), `--flat` (`var(--text, #333)`), `--short` (`#c62828`) |
+| `Financial.Web/src/components/DetailPanel.tsx` | Modified | Three-way detail indicator | Status span switches from `selectedNode.isActive` to `selectedNode.positionType`, rendering `● Long`/`● Flat`/`● Short` with the matching modifier class |
+| `Financial.Web/src/components/DetailPanel.css` | Modified | Three-way colors + consistency fix | Adds `--long`/`--flat`/`--short` status classes with the same hex values as `InvestmentTree.css`; replaces the literal `color: green` keyword with `#2e7d32` |
+| `Financial.Web/src/pages/ActiveInvestmentsPage.tsx` (renamed from `PortfolioNavigatorPage.tsx`) | Modified (renamed) | Composition root | Unchanged internals (`SelectedNodeProvider` + `SplitPanel` wiring `InvestmentTree`/`DetailPanel`), file/class renamed for scope-explicit naming |
+| `Financial.Web/src/pages/ActiveInvestmentsPage.css` (renamed) | Modified (renamed) | Layout styling | Unchanged content, renamed alongside the component |
+| `Financial.Web/src/App.tsx` | Modified | Nav label + route target | `NavLink` text "Portfolio Navigator" → "Active Investments"; `to="/portfolio-navigator"` → `to="/active-investments"` |
+| `Financial.Web/src/main.tsx` | Modified | Route definition | Index redirect target and `Route path` both updated to `active-investments`; import updated to `ActiveInvestmentsPage` |
+
+## 5. API Contracts
+
+No new endpoint. The existing `GET /navigation/tree`, `GET /summary/broker/{name}`, `GET /summary/portfolio/{broker}/{portfolio}`, `GET /summary/broker/{name}/breakdown`, and `GET /assets/{broker}/{portfolio}/{asset}` endpoints (all shipped by F05) are reused unmodified — only the Web client's request URLs change (adding `scope=active`) and the tree's `PositionType` metadata value changes shape.
+
+**Endpoint: Get Navigation Tree (existing, F05) — response shape change**
+- **Method:** GET
+- **Path:** `/api/v1/financial/navigation/tree?scope=active`
+
+**Response (Success — 200):** `TreeNodeDTO` shape unchanged; only the `Metadata["PositionType"]` value type changes.
+
+| Field | Type (before) | Type (after) | Description |
+|-------|--------|--------|--------------|
+| `metadata.PositionType` (Asset nodes) | number (`0`/`1`/`2`, unintentional) | string (`"Long"`/`"Flat"`/`"Short"`) | Matches the string convention already used on `AssetNodeDTO`/`AssetDetailsDTO`'s typed `PositionType` property |
+
+**Response Example (after fix):**
+```json
+{
+  "nodeType": "Asset",
+  "displayName": "BCIA11",
+  "children": [],
+  "metadata": {
+    "AssetName": "BCIA11",
+    "IsActive": true,
+    "PositionType": "Long",
+    "GlobalAssetClass": 0
+  }
+}
+```
+
+**Error Codes:** unchanged from F05.
+
+## 6. Data Model
+
+No schema or `data.json` changes. This feature only changes how an already-computed value (`Asset.PositionType`, from F01) is serialized into an existing response field, and how the Web frontend requests/consumes already-shipped scope-aware endpoints (F02/F05).
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs` | Unit | `NavigationMapper` | `Metadata["PositionType"]` is a string matching the asset's position type |
+| `Tests/Financial.Api.Tests/NavigationEndpointsTests.cs` | Integration | `GET /navigation/tree` | HTTP response's `Metadata.PositionType` value is the correct string |
+| `Financial.Web/src/components/__tests__/InvestmentTree.test.tsx` | Unit | `InvestmentTree` | Three-way color-class mapping, single-glyph rendering, `positionType` propagated to `setSelectedNode` |
+| `Financial.Web/src/components/__tests__/DetailPanel.test.tsx` | Unit | `DetailPanel` | Status indicator renders the correct label/class per `positionType` |
+| `Financial.Web/src/App.test.tsx` | Unit | `App` nav + routing | Nav item reads "Active Investments"; route `/active-investments` renders the page; root redirects there |
+| `Financial.Web/src/pages/__tests__/ActiveInvestmentsPage.test.tsx` (renamed) | Unit | `ActiveInvestmentsPage` | Existing tree/detail-panel composition tests still pass under the new name |
+| `Financial.Web/src/api/__tests__/financialApiClient.test.ts` (or equivalent) | Unit | `financialApiClient` | The 5 updated methods build request URLs containing `scope=active` |
+
+**Test functions:**
+
+`NavigationMapperTests.cs`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `GetNavigationTree_AssetNode_MetadataIncludesPositionType` (updated) | Long-position asset | `Metadata["PositionType"]` equals `"Long"` |
+| `GetNavigationTree_HistoricScope_AssetNode_PositionTypeIsFlat` (updated) | Historic-scoped asset | `Metadata["PositionType"]` equals `"Flat"` |
+
+`NavigationEndpointsTests.cs`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `GetNavigationTree_AssetNode_PositionTypeMetadata_IsStringValue` (new) | Real HTTP round-trip for a long-position fixture asset | Deserialized `Metadata["PositionType"]` is the JSON string `"Long"`, not a number |
+
+`InvestmentTree.test.tsx`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `renders Long asset status icon in green` (updated) | Asset with `positionType: 'Long'` | Status icon has the `--long` modifier class |
+| `renders Flat asset status icon in the neutral text color` (updated) | Asset with `positionType: 'Flat'` | Status icon has the `--flat` modifier class |
+| `renders Short asset status icon in red` (updated) | Asset with `positionType: 'Short'` | Status icon has the `--short` modifier class |
+| `renders a filled bullet regardless of position type` (updated) | Any position type | Glyph is always `●` |
+| `selecting an asset propagates positionType to the selected node` (new) | Click an asset node | `setSelectedNode` called with `positionType` matching the node's metadata |
+
+`DetailPanel.test.tsx`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `renders Long status label and color` (updated) | `selectedNode.positionType === 'Long'` | Renders `"● Long"` with the `--long` class |
+| `renders Flat status label and color` (updated) | `selectedNode.positionType === 'Flat'` | Renders `"● Flat"` with the `--flat` class |
+| `renders Short status label and color` (updated) | `selectedNode.positionType === 'Short'` | Renders `"● Short"` with the `--short` class |
+
+`App.test.tsx`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `renders Active Investments nav label` (updated) | Default render | Nav link text is "Active Investments", not "Portfolio Navigator" |
+| `redirects root to /active-investments` (updated) | Navigate to `/` | Redirected to `/active-investments` |
+| `renders ActiveInvestmentsPage at /active-investments` (updated) | Navigate to `/active-investments` | Page content renders |
+
+`financialApiClient` client tests
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `getNavigationTree requests scope=active` (new) | Call `getNavigationTree()` | Fetch URL contains `scope=active` |
+| `getSummaryByBroker/getSummaryByPortfolio/getBrokerBreakdown/getAssetDetails request scope=active` (new, one per method) | Call each method | Fetch URL contains `scope=active` |
+
+**Acceptance tests (PRD Section 9, F08):**
+| PRD Acceptance Criterion | Covered By |
+|---|---|
+| The nav item previously labeled "Portfolio Navigator" reads "Active Investments" | `App.test.tsx: renders Active Investments nav label` |
+| The Active Investments tree never displays a historic asset | `financialApiClient.test.ts: getNavigationTree requests scope=active` (scope-purity now explicit, not implicit) |
+| Each asset's tree node shows green/black/red matching Long/Flat/Short | `InvestmentTree.test.tsx` three color-mapping tests |
+
+**Cross-Feature Integration test (PRD Section 9):**
+| Criterion | Covered By |
+|---|---|
+| Active-scoped data and position type from F01/F05 render correctly in the Web (F08) Active Investments tab | `NavigationEndpointsTests.cs: GetNavigationTree_AssetNode_PositionTypeMetadata_IsStringValue` (F05's data reaching F08 in a consumable shape) + `InvestmentTree.test.tsx`/`DetailPanel.test.tsx` (F08 rendering it correctly) |

--- a/docs/prd/P10-prd-historic-investments/prd-historic-investments.md
+++ b/docs/prd/P10-prd-historic-investments/prd-historic-investments.md
@@ -397,9 +397,9 @@ graph TD
 - [ ] A historic portfolio with no assets is excluded from the breakdown, consistent with today's Active behavior
 
 ### F08. Web — Active Investments Tab Update
-- [ ] The nav item previously labeled "Portfolio Navigator" reads "Active Investments"
-- [ ] The Active Investments tree never displays a historic asset
-- [ ] Each asset's tree node shows green/black/red matching `Long`/`Flat`/`Short`
+- [x] The nav item previously labeled "Portfolio Navigator" reads "Active Investments"
+- [x] The Active Investments tree never displays a historic asset
+- [x] Each asset's tree node shows green/black/red matching `Long`/`Flat`/`Short`
 
 ### F09. Web — Historic Investments Tab
 - [ ] A new "Historic Investments" nav item renders a tree scoped to historic data only


### PR DESCRIPTION
## Summary
- Fixes a backend defect surfaced during spec discovery: the navigation tree's `Metadata["PositionType"]` serialized as a raw integer instead of the string every other typed enum property in the API uses.
- Threads explicit `scope=active` into every scope-capable endpoint this page's component tree reaches (navigation tree, broker/portfolio summary, broker breakdown, portfolio asset summary, asset details) — the last two also cover `useAssetSummary`/`useCredits`/`useTransactions`/`PortfolioSummaryTab` for free.
- Replaces the boolean `isActive` status indicator in `InvestmentTree` and `DetailPanel` with a three-way `Long`/`Flat`/`Short` → green/neutral/red mapping, via a shared `POSITION_TYPE_STATUS_CLASS` constant.
- Relabels the nav entry and renames the route/page/CSS from Portfolio Navigator to Active Investments (`/active-investments`), matching F07's `BrokerBreakdownService` → `ActiveBrokerBreakdownService` naming precedent.

## Acceptance Criteria (PRD Section 9, F08 — re-checked fresh in this run)

✓ The nav item previously labeled "Portfolio Navigator" reads "Active Investments"
  — `App.test.tsx: renders three nav items`, confirmed live in a real browser (nav label + `/active-investments` route, no "Portfolio Navigator" text)

✓ The Active Investments tree never displays a historic asset
  — `financialApiClient.test.ts: requests scope=active on every Active-scoped endpoint`; confirmed live against the running API

✓ Each asset's tree node shows green/black/red matching Long/Flat/Short
  — `InvestmentTree.test.tsx: renders Long/Flat/Short status icons with the matching color class`; confirmed live via computed CSS color (`rgb(46, 125, 50)` for Long)

**Cross-feature integration:**

✓ Active-scoped data and position type from F01/F05 render correctly in the Web (F08) Active Investments tab
  — `NavigationEndpointsTests.cs: GetNavigationTree_ScopeActive_AssetNode_IncludesPositionType` (F05's data reaching F08 as a consumable string) + `InvestmentTree.test.tsx`/`DetailPanel.test.tsx` (F08 rendering it); confirmed end-to-end live (real API → real browser, DetailPanel showing "● Long")

## Test plan
- [x] `dotnet build --configuration Release` / `dotnet test` — full backend suite green (216 Application, 53 Api, 64 Domain, 126 Infrastructure incl. 5 pre-existing skips, 150 Presentation)
- [x] `tsc -b --noEmit`, `eslint .`, `npm run build` — all clean
- [x] `vitest run` — full frontend suite green, 366/366
- [x] Real end-to-end smoke test (Playwright, real API with test fixture data + real Vite dev server): confirmed nav label/route, `scope=active` tree rendering BCIA11 in green (Long), and DetailPanel showing "● Long" on selection — no console errors

Docs: `docs/P10-F08-web-active-investments-tab-update/spec.md` and `plan.md`.

## Deviations from spec
- `getPortfolioAssetsSummary` (feeding `PortfolioSummaryTab`, rendered by `DetailPanel` for Portfolio-node selections) was missing from the spec's file list but is reachable from this page — scoped to `scope=active` as well.
- Extracted a shared `Financial.Web/src/utils/positionType.ts` (not in the original spec) to avoid duplicating the status-color mapping between `InvestmentTree.tsx` and `DetailPanel.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)