### PR TITLE
feat(P10-F06): Historic Realized Totals Service

### DIFF
--- a/Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs
+++ b/Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs
@@ -16,6 +16,7 @@ public sealed class PortfolioAssetSummaryItemDTO
     public decimal TotalBought { get; init; }
     public decimal TotalSold { get; init; }
     public decimal TotalInvested { get; init; }
+    public decimal? RealizedGainLoss { get; init; }
     public decimal PortfolioWeight { get; init; }
     public decimal TotalCredits { get; init; }
     public IReadOnlyList<AssetCashFlowDTO> CashFlows { get; init; } = [];

--- a/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -19,6 +19,8 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<IActiveBrokerBreakdownService, ActiveBrokerBreakdownService>();
         services.AddSingleton<IHistoricBrokerBreakdownService, HistoricBrokerBreakdownService>();
         services.AddSingleton<IBrokerBreakdownService, BrokerBreakdownService>();
+        services.AddSingleton<IActivePortfolioAssetSummaryService, ActivePortfolioAssetSummaryService>();
+        services.AddSingleton<IHistoricPortfolioAssetSummaryService, HistoricPortfolioAssetSummaryService>();
         services.AddSingleton<IPortfolioAssetSummaryService, PortfolioAssetSummaryService>();
         services.AddSingleton<ISummaryService, SummaryService>();
         services.AddSingleton<IXirrCalculationService, XirrCalculationService>();

--- a/Financial.Application/Interfaces/IActivePortfolioAssetSummaryService.cs
+++ b/Financial.Application/Interfaces/IActivePortfolioAssetSummaryService.cs
@@ -1,0 +1,8 @@
+using Financial.Application.DTOs;
+
+namespace Financial.Application.Interfaces;
+
+public interface IActivePortfolioAssetSummaryService
+{
+    IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName);
+}

--- a/Financial.Application/Interfaces/IHistoricPortfolioAssetSummaryService.cs
+++ b/Financial.Application/Interfaces/IHistoricPortfolioAssetSummaryService.cs
@@ -1,0 +1,8 @@
+using Financial.Application.DTOs;
+
+namespace Financial.Application.Interfaces;
+
+public interface IHistoricPortfolioAssetSummaryService
+{
+    IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName);
+}

--- a/Financial.Application/Services/ActivePortfolioAssetSummaryService.cs
+++ b/Financial.Application/Services/ActivePortfolioAssetSummaryService.cs
@@ -1,0 +1,30 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+
+namespace Financial.Application.Services;
+
+public sealed class ActivePortfolioAssetSummaryService : IActivePortfolioAssetSummaryService
+{
+    private readonly IRepository _repository;
+
+    public ActivePortfolioAssetSummaryService(IRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
+            return [];
+
+        var assets = _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName, InvestmentScope.Active).ToList();
+        if (assets.Count == 0)
+            return [];
+
+        return PortfolioAssetSummaryBuilder.Build(assets, DateTime.Today, CalculateNetInvested, NoRealizedGainLoss);
+    }
+
+    private static decimal CalculateNetInvested(AssetTotals totals) => totals.TotalBought - totals.TotalSold;
+
+    private static decimal? NoRealizedGainLoss(AssetTotals totals) => null;
+}

--- a/Financial.Application/Services/HistoricPortfolioAssetSummaryService.cs
+++ b/Financial.Application/Services/HistoricPortfolioAssetSummaryService.cs
@@ -1,0 +1,31 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+
+namespace Financial.Application.Services;
+
+public sealed class HistoricPortfolioAssetSummaryService : IHistoricPortfolioAssetSummaryService
+{
+    private readonly IRepository _repository;
+
+    public HistoricPortfolioAssetSummaryService(IRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName)
+    {
+        if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
+            return [];
+
+        var assets = _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName, InvestmentScope.Historic).ToList();
+        if (assets.Count == 0)
+            return [];
+
+        return PortfolioAssetSummaryBuilder.Build(assets, DateTime.Today, CalculateGrossBought, CalculateRealizedGainLoss);
+    }
+
+    private static decimal CalculateGrossBought(AssetTotals totals) => totals.TotalBought;
+
+    private static decimal? CalculateRealizedGainLoss(AssetTotals totals) =>
+        totals.TotalSold - totals.TotalBought + totals.TotalCredits;
+}

--- a/Financial.Application/Services/PortfolioAssetSummaryBuilder.cs
+++ b/Financial.Application/Services/PortfolioAssetSummaryBuilder.cs
@@ -1,0 +1,168 @@
+using Financial.Application.DTOs;
+using Financial.Domain.Entities;
+
+namespace Financial.Application.Services;
+
+internal readonly record struct AssetTotals(decimal TotalBought, decimal TotalSold, decimal TotalCredits);
+
+internal static class PortfolioAssetSummaryBuilder
+{
+    internal static IReadOnlyList<PortfolioAssetSummaryItemDTO> Build(
+        IEnumerable<Asset> assets,
+        DateTime today,
+        Func<AssetTotals, decimal> weightBasisSelector,
+        Func<AssetTotals, decimal?> realizedGainLossSelector)
+    {
+        var computed = assets
+            .Select(a => ComputeAssetData(a, today, weightBasisSelector, realizedGainLossSelector))
+            .ToList();
+        var portfolioWeightBasis = computed.Sum(c => c.WeightBasis);
+
+        return computed
+            .OrderBy(c => c.AssetName, StringComparer.CurrentCultureIgnoreCase)
+            .Select(c => ToDTO(c, CalculateWeight(c.WeightBasis, portfolioWeightBasis)))
+            .ToList();
+    }
+
+    private static AssetComputedData ComputeAssetData(
+        Asset asset,
+        DateTime today,
+        Func<AssetTotals, decimal> weightBasisSelector,
+        Func<AssetTotals, decimal?> realizedGainLossSelector)
+    {
+        var (totalBought, totalSold, totalCredits) = NavigationMapper.CalculateTotals(asset);
+        var totals = new AssetTotals(totalBought, totalSold, totalCredits);
+        var weightBasis = weightBasisSelector(totals);
+        var realizedGainLoss = realizedGainLossSelector(totals);
+
+        var firstBuyDate = asset.Transactions
+            .Where(t => t.Type == Transaction.TransactionType.Buy)
+            .Select(t => (DateTime?)t.Date)
+            .DefaultIfEmpty(null)
+            .Min();
+
+        var cashFlows = AssetCashFlowBuilder.BuildWithCredits(asset);
+        var creditsAnalysis = ComputeCreditsAnalysis(asset, weightBasis, today);
+
+        return new AssetComputedData(
+            asset.Name, asset.Ticker, asset.Exchange, asset.Class,
+            firstBuyDate, asset.Quantity, asset.AveragePrice,
+            totalBought, totalSold, totalBought - totalSold, realizedGainLoss, weightBasis,
+            totalCredits, cashFlows,
+            creditsAnalysis.LastMonthCredits, creditsAnalysis.LastCreditMonth,
+            creditsAnalysis.LastMonthCreditsPercent, creditsAnalysis.CreditFrequencyPerYear,
+            creditsAnalysis.EstimatedAnnualCredits, creditsAnalysis.EstimatedAnnualPercent,
+            creditsAnalysis.CurrentMonthCredits);
+    }
+
+    private static CreditsAnalysis ComputeCreditsAnalysis(Asset asset, decimal weightBasis, DateTime today)
+    {
+        var pastCredits = asset.Credits.Where(c => c.Date <= today).ToList();
+
+        var lastCreditMonth = pastCredits
+            .GroupBy(c => (c.Date.Year, c.Date.Month))
+            .Select(g => g.Key)
+            .OrderByDescending(g => g.Year).ThenByDescending(g => g.Month)
+            .Cast<(int Year, int Month)?>()
+            .FirstOrDefault();
+
+        var lastMonthCreditsString = lastCreditMonth.HasValue
+            ? $"{lastCreditMonth.Value.Year:D4}-{lastCreditMonth.Value.Month:D2}"
+            : null;
+
+        var lastMonthCredits = lastCreditMonth.HasValue
+            ? pastCredits
+                .Where(c => c.Date.Year == lastCreditMonth.Value.Year && c.Date.Month == lastCreditMonth.Value.Month)
+                .Sum(c => c.Value)
+            : 0m;
+
+        decimal? lastMonthCreditsPercent = lastCreditMonth.HasValue && weightBasis != 0m
+            ? lastMonthCredits / weightBasis * 100m
+            : null;
+
+        var frequencyPerYear = DetectCreditFrequency(asset.Credits);
+
+        decimal? estimatedAnnualCredits = frequencyPerYear.HasValue
+            ? lastMonthCredits * frequencyPerYear.Value
+            : null;
+
+        decimal? estimatedAnnualPercent = estimatedAnnualCredits.HasValue && weightBasis != 0m
+            ? estimatedAnnualCredits.Value / weightBasis * 100m
+            : null;
+
+        var currentMonthCredits = asset.Credits
+            .Where(c => c.Date.Year == today.Year && c.Date.Month == today.Month)
+            .Sum(c => c.Value);
+
+        return new CreditsAnalysis(
+            lastMonthCredits, lastMonthCreditsString, lastMonthCreditsPercent,
+            frequencyPerYear, estimatedAnnualCredits, estimatedAnnualPercent,
+            currentMonthCredits);
+    }
+
+    private static int? DetectCreditFrequency(IEnumerable<Credit> credits)
+    {
+        var distinctMonths = credits
+            .Select(c => c.Date.Year * 12 + (c.Date.Month - 1))
+            .Distinct()
+            .OrderBy(m => m)
+            .ToList();
+
+        if (distinctMonths.Count < 2)
+            return null;
+
+        var totalGap = distinctMonths[^1] - distinctMonths[0];
+        var averageGap = (double)totalGap / (distinctMonths.Count - 1);
+
+        return averageGap switch
+        {
+            <= 1.5 => 12,
+            <= 3.5 => 4,
+            <= 5.0 => 3,
+            _ => null
+        };
+    }
+
+    private static PortfolioAssetSummaryItemDTO ToDTO(AssetComputedData c, decimal weight) =>
+        new()
+        {
+            AssetName = c.AssetName,
+            Ticker = c.Ticker,
+            Exchange = c.Exchange,
+            Class = c.Class,
+            FirstInvestmentDate = c.FirstInvestmentDate,
+            CurrentQuantity = c.CurrentQuantity,
+            AveragePrice = c.AveragePrice,
+            TotalBought = c.TotalBought,
+            TotalSold = c.TotalSold,
+            TotalInvested = c.TotalInvested,
+            RealizedGainLoss = c.RealizedGainLoss,
+            PortfolioWeight = weight,
+            TotalCredits = c.TotalCredits,
+            CashFlows = c.CashFlows,
+            LastMonthCredits = c.LastMonthCredits,
+            LastCreditMonth = c.LastCreditMonth,
+            LastMonthCreditsPercent = c.LastMonthCreditsPercent,
+            CreditFrequencyPerYear = c.CreditFrequencyPerYear,
+            EstimatedAnnualCredits = c.EstimatedAnnualCredits,
+            EstimatedAnnualPercent = c.EstimatedAnnualPercent,
+            CurrentMonthCredits = c.CurrentMonthCredits
+        };
+
+    private static decimal CalculateWeight(decimal weightBasis, decimal portfolioWeightBasis) =>
+        portfolioWeightBasis == 0m ? 0m : weightBasis / portfolioWeightBasis * 100m;
+
+    private sealed record AssetComputedData(
+        string AssetName, string Ticker, string Exchange, GlobalAssetClass Class,
+        DateTime? FirstInvestmentDate, decimal CurrentQuantity, decimal AveragePrice,
+        decimal TotalBought, decimal TotalSold, decimal TotalInvested, decimal? RealizedGainLoss, decimal WeightBasis,
+        decimal TotalCredits, IReadOnlyList<AssetCashFlowDTO> CashFlows,
+        decimal LastMonthCredits, string? LastCreditMonth, decimal? LastMonthCreditsPercent,
+        int? CreditFrequencyPerYear, decimal? EstimatedAnnualCredits, decimal? EstimatedAnnualPercent,
+        decimal CurrentMonthCredits);
+
+    private sealed record CreditsAnalysis(
+        decimal LastMonthCredits, string? LastCreditMonth, decimal? LastMonthCreditsPercent,
+        int? CreditFrequencyPerYear, decimal? EstimatedAnnualCredits, decimal? EstimatedAnnualPercent,
+        decimal CurrentMonthCredits);
+}

--- a/Financial.Application/Services/PortfolioAssetSummaryService.cs
+++ b/Financial.Application/Services/PortfolioAssetSummaryService.cs
@@ -1,168 +1,23 @@
 using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
-using Financial.Domain.Entities;
 
 namespace Financial.Application.Services;
 
 public sealed class PortfolioAssetSummaryService : IPortfolioAssetSummaryService
 {
-    private readonly IRepository _repository;
+    private readonly IActivePortfolioAssetSummaryService _activePortfolioAssetSummaryService;
+    private readonly IHistoricPortfolioAssetSummaryService _historicPortfolioAssetSummaryService;
 
-    public PortfolioAssetSummaryService(IRepository repository)
+    public PortfolioAssetSummaryService(
+        IActivePortfolioAssetSummaryService activePortfolioAssetSummaryService,
+        IHistoricPortfolioAssetSummaryService historicPortfolioAssetSummaryService)
     {
-        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _activePortfolioAssetSummaryService = activePortfolioAssetSummaryService ?? throw new ArgumentNullException(nameof(activePortfolioAssetSummaryService));
+        _historicPortfolioAssetSummaryService = historicPortfolioAssetSummaryService ?? throw new ArgumentNullException(nameof(historicPortfolioAssetSummaryService));
     }
 
-    public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active)
-    {
-        if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
-            return [];
-
-        var assets = _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName, scope).ToList();
-
-        if (assets.Count == 0)
-            return [];
-
-        var today = DateTime.Today;
-        var computed = assets.Select(a => ComputeAssetData(a, today)).ToList();
-        var portfolioTotalInvested = computed.Sum(c => c.TotalInvested);
-
-        return computed
-            .OrderBy(c => c.AssetName, StringComparer.CurrentCultureIgnoreCase)
-            .Select(c => ToDTO(c, CalculateWeight(c.TotalInvested, portfolioTotalInvested)))
-            .ToList();
-    }
-
-    private static AssetComputedData ComputeAssetData(Asset asset, DateTime today)
-    {
-        var (totalBought, totalSold, totalCredits) = NavigationMapper.CalculateTotals(asset);
-        var firstBuyDate = asset.Transactions
-            .Where(t => t.Type == Transaction.TransactionType.Buy)
-            .Select(t => (DateTime?)t.Date)
-            .DefaultIfEmpty(null)
-            .Min();
-
-        var cashFlows = AssetCashFlowBuilder.BuildWithCredits(asset);
-        var creditsAnalysis = ComputeCreditsAnalysis(asset, totalBought - totalSold, today);
-
-        return new AssetComputedData(
-            asset.Name, asset.Ticker, asset.Exchange, asset.Class,
-            firstBuyDate, asset.Quantity, asset.AveragePrice,
-            totalBought, totalSold, totalBought - totalSold,
-            totalCredits, cashFlows,
-            creditsAnalysis.LastMonthCredits, creditsAnalysis.LastCreditMonth,
-            creditsAnalysis.LastMonthCreditsPercent, creditsAnalysis.CreditFrequencyPerYear,
-            creditsAnalysis.EstimatedAnnualCredits, creditsAnalysis.EstimatedAnnualPercent,
-            creditsAnalysis.CurrentMonthCredits);
-    }
-
-    private static CreditsAnalysis ComputeCreditsAnalysis(Asset asset, decimal totalInvested, DateTime today)
-    {
-        var pastCredits = asset.Credits.Where(c => c.Date <= today).ToList();
-
-        var lastCreditMonth = pastCredits
-            .GroupBy(c => (c.Date.Year, c.Date.Month))
-            .Select(g => g.Key)
-            .OrderByDescending(g => g.Year).ThenByDescending(g => g.Month)
-            .Cast<(int Year, int Month)?>()
-            .FirstOrDefault();
-
-        var lastMonthCreditsString = lastCreditMonth.HasValue
-            ? $"{lastCreditMonth.Value.Year:D4}-{lastCreditMonth.Value.Month:D2}"
-            : null;
-
-        var lastMonthCredits = lastCreditMonth.HasValue
-            ? pastCredits
-                .Where(c => c.Date.Year == lastCreditMonth.Value.Year && c.Date.Month == lastCreditMonth.Value.Month)
-                .Sum(c => c.Value)
-            : 0m;
-
-        decimal? lastMonthCreditsPercent = lastCreditMonth.HasValue && totalInvested != 0m
-            ? lastMonthCredits / totalInvested * 100m
-            : null;
-
-        var frequencyPerYear = DetectCreditFrequency(asset.Credits);
-
-        decimal? estimatedAnnualCredits = frequencyPerYear.HasValue
-            ? lastMonthCredits * frequencyPerYear.Value
-            : null;
-
-        decimal? estimatedAnnualPercent = estimatedAnnualCredits.HasValue && totalInvested != 0m
-            ? estimatedAnnualCredits.Value / totalInvested * 100m
-            : null;
-
-        var currentMonthCredits = asset.Credits
-            .Where(c => c.Date.Year == today.Year && c.Date.Month == today.Month)
-            .Sum(c => c.Value);
-
-        return new CreditsAnalysis(
-            lastMonthCredits, lastMonthCreditsString, lastMonthCreditsPercent,
-            frequencyPerYear, estimatedAnnualCredits, estimatedAnnualPercent,
-            currentMonthCredits);
-    }
-
-    private static int? DetectCreditFrequency(IEnumerable<Credit> credits)
-    {
-        var distinctMonths = credits
-            .Select(c => c.Date.Year * 12 + (c.Date.Month - 1))
-            .Distinct()
-            .OrderBy(m => m)
-            .ToList();
-
-        if (distinctMonths.Count < 2)
-            return null;
-
-        var totalGap = distinctMonths[^1] - distinctMonths[0];
-        var averageGap = (double)totalGap / (distinctMonths.Count - 1);
-
-        return averageGap switch
-        {
-            <= 1.5 => 12,
-            <= 3.5 => 4,
-            <= 5.0 => 3,
-            _ => null
-        };
-    }
-
-    private static PortfolioAssetSummaryItemDTO ToDTO(AssetComputedData c, decimal weight) =>
-        new()
-        {
-            AssetName = c.AssetName,
-            Ticker = c.Ticker,
-            Exchange = c.Exchange,
-            Class = c.Class,
-            FirstInvestmentDate = c.FirstInvestmentDate,
-            CurrentQuantity = c.CurrentQuantity,
-            AveragePrice = c.AveragePrice,
-            TotalBought = c.TotalBought,
-            TotalSold = c.TotalSold,
-            TotalInvested = c.TotalInvested,
-            PortfolioWeight = weight,
-            TotalCredits = c.TotalCredits,
-            CashFlows = c.CashFlows,
-            LastMonthCredits = c.LastMonthCredits,
-            LastCreditMonth = c.LastCreditMonth,
-            LastMonthCreditsPercent = c.LastMonthCreditsPercent,
-            CreditFrequencyPerYear = c.CreditFrequencyPerYear,
-            EstimatedAnnualCredits = c.EstimatedAnnualCredits,
-            EstimatedAnnualPercent = c.EstimatedAnnualPercent,
-            CurrentMonthCredits = c.CurrentMonthCredits
-        };
-
-    private static decimal CalculateWeight(decimal totalInvested, decimal portfolioTotalInvested) =>
-        portfolioTotalInvested == 0m ? 0m : totalInvested / portfolioTotalInvested * 100m;
-
-    private sealed record AssetComputedData(
-        string AssetName, string Ticker, string Exchange, GlobalAssetClass Class,
-        DateTime? FirstInvestmentDate, decimal CurrentQuantity, decimal AveragePrice,
-        decimal TotalBought, decimal TotalSold, decimal TotalInvested,
-        decimal TotalCredits, IReadOnlyList<AssetCashFlowDTO> CashFlows,
-        decimal LastMonthCredits, string? LastCreditMonth, decimal? LastMonthCreditsPercent,
-        int? CreditFrequencyPerYear, decimal? EstimatedAnnualCredits, decimal? EstimatedAnnualPercent,
-        decimal CurrentMonthCredits);
-
-    private sealed record CreditsAnalysis(
-        decimal LastMonthCredits, string? LastCreditMonth, decimal? LastMonthCreditsPercent,
-        int? CreditFrequencyPerYear, decimal? EstimatedAnnualCredits, decimal? EstimatedAnnualPercent,
-        decimal CurrentMonthCredits);
+    public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active) =>
+        scope == InvestmentScope.Historic
+            ? _historicPortfolioAssetSummaryService.GetPortfolioAssetsSummary(brokerName, portfolioName)
+            : _activePortfolioAssetSummaryService.GetPortfolioAssetsSummary(brokerName, portfolioName);
 }

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -245,6 +245,7 @@ export interface PortfolioAssetSummaryItemDto {
   totalBought: number
   totalSold: number
   totalInvested: number
+  realizedGainLoss: number | null
   portfolioWeight: number
   totalCredits: number
   cashFlows: AssetCashFlowDto[]

--- a/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
@@ -63,6 +63,7 @@ const ITEM_1: PortfolioAssetSummaryItemDto = {
   totalBought: 2500,
   totalSold: 0,
   totalInvested: 2500,
+  realizedGainLoss: null,
   portfolioWeight: 23.4,
   totalCredits: 0,
   cashFlows: [],

--- a/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
@@ -47,6 +47,7 @@ const ITEM_1: PortfolioAssetSummaryItemDto = {
   totalBought: 2500,
   totalSold: 0,
   totalInvested: 2500,
+  realizedGainLoss: null,
   portfolioWeight: 71.4,
   totalCredits: 125,
   cashFlows: [
@@ -74,6 +75,7 @@ const ITEM_2: PortfolioAssetSummaryItemDto = {
   totalBought: 1000,
   totalSold: 0,
   totalInvested: 1000,
+  realizedGainLoss: null,
   portfolioWeight: 28.6,
   totalCredits: 0,
   cashFlows: [

--- a/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
@@ -161,6 +161,43 @@ public class SummaryEndpointsTests
         var items = await response.Content.ReadFromJsonAsync<List<PortfolioAssetSummaryItemDTO>>();
         items.Should().NotBeNull();
         items!.Should().ContainSingle(i => i.AssetName == "CLOSEDASSET");
+        // CLOSEDASSET: bought 5 x 60 = 300, sold 5 x 50 = 250, no credits — RealizedGainLoss = 250 - 300 + 0 = -50
+        items!.Single().RealizedGainLoss.Should().Be(-50m);
+        items!.Single().PortfolioWeight.Should().Be(100m);
+    }
+
+    [Fact]
+    public async Task GetPortfolioAssetsSummary_ScopeHistoric_PortfolioWeightsSumTo100()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/portfolio/XPI/Uncategorized/assets?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var items = await response.Content.ReadFromJsonAsync<List<PortfolioAssetSummaryItemDTO>>();
+        items.Should().NotBeNull();
+        items!.Sum(i => i.PortfolioWeight).Should().Be(100m);
+    }
+
+    [Fact]
+    public async Task GetPortfolioAssetsSummary_ScopeActive_PreservesNetInvestedWeightingAndNullRealizedGainLoss()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/portfolio/XPI/Default/assets?scope=active");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var items = await response.Content.ReadFromJsonAsync<List<PortfolioAssetSummaryItemDTO>>();
+        items.Should().NotBeNull();
+        // BCIA11: bought 10 x 100 = 1000, sold 2 x 110 = 220 — active weighting stays net invested (780), 100% of the portfolio
+        var bcia11 = items!.Single(i => i.AssetName == "BCIA11");
+        bcia11.TotalInvested.Should().Be(780m);
+        bcia11.PortfolioWeight.Should().Be(100m);
+        bcia11.RealizedGainLoss.Should().BeNull();
     }
 
     [Fact]

--- a/Tests/Financial.Application.Tests/Services/ActivePortfolioAssetSummaryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/ActivePortfolioAssetSummaryServiceTests.cs
@@ -1,0 +1,633 @@
+using Financial.Application.Interfaces;
+using Financial.Application.Services;
+using Financial.Domain.Entities;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace Financial.Application.Tests.Services;
+
+public class ActivePortfolioAssetSummaryServiceTests
+{
+    private readonly StubRepository _repository = new();
+
+    [Fact]
+    public void Constructor_WithNullRepository_Throws()
+    {
+        Action act = () => new ActivePortfolioAssetSummaryService(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsAssetClass_MatchingAssetClassification()
+    {
+        var asset = Asset.Create("Bitcoin", "", "", "BTC", CountryCode.UK, "", GlobalAssetClass.Cryptocurrency);
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("Coinbase", "Cryptocurrency");
+
+        result.Should().HaveCount(1);
+        result[0].Class.Should().Be(GlobalAssetClass.Cryptocurrency);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsSingleAsset_WithCorrectFields()
+    {
+        var asset = MakeAsset("ALZR11", "ALZR11", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 3, 1), Transaction.TransactionType.Buy, 10m, 100m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 5, 1), Transaction.TransactionType.Buy, 15m, 100m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2022, 1, 1), Transaction.TransactionType.Sell, 5m, 110m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        using var _ = new AssertionScope();
+        result.Should().HaveCount(1);
+        var item = result[0];
+        item.AssetName.Should().Be("ALZR11");
+        item.Ticker.Should().Be("ALZR11");
+        item.Exchange.Should().Be("BVMF");
+        item.CurrentQuantity.Should().Be(20m);
+        item.AveragePrice.Should().Be(100m);
+        item.TotalBought.Should().Be(2500m);
+        item.TotalSold.Should().Be(550m);
+        item.TotalInvested.Should().Be(1950m);
+        item.RealizedGainLoss.Should().BeNull();
+        item.PortfolioWeight.Should().Be(100m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_SortsAlphabetically()
+    {
+        _repository.Assets = [
+            MakeAsset("ZEBRA", "ZBR", "BVMF"),
+            MakeAsset("APPLE", "APL", "BVMF"),
+            MakeAsset("MANGO", "MNG", "BVMF"),
+        ];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result.Select(i => i.AssetName).Should().Equal("APPLE", "MANGO", "ZEBRA");
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ComputesPortfolioWeight()
+    {
+        var asset1 = MakeAsset("ALPHA", "ALP", "BVMF");
+        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 300m, 0m));
+
+        var asset2 = MakeAsset("BETA", "BET", "BVMF");
+        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 700m, 0m));
+
+        _repository.Assets = [asset1, asset2];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        using var _ = new AssertionScope();
+        result.First(i => i.AssetName == "ALPHA").PortfolioWeight.Should().Be(30m);
+        result.First(i => i.AssetName == "BETA").PortfolioWeight.Should().Be(70m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsZeroPortfolioWeight_WhenAllTotalInvestedAreZero()
+    {
+        var asset1 = MakeAsset("ALPHA", "ALP", "BVMF");
+        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 100m, 0m));
+
+        var asset2 = MakeAsset("BETA", "BET", "BVMF");
+        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 200m, 0m));
+        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 200m, 0m));
+
+        _repository.Assets = [asset1, asset2];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result.Should().AllSatisfy(i => i.PortfolioWeight.Should().Be(0m));
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_SetsFirstInvestmentDate_FromEarliestBuyTransaction()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 6, 1), Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 15), Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].FirstInvestmentDate.Should().Be(new DateTime(2020, 1, 15));
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_SetsFirstInvestmentDate_Null_WhenNoBuyTransactions()
+    {
+        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].FirstInvestmentDate.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_IncludesAllAssets_RegardlessOfActiveStatus()
+    {
+        var active = MakeAsset("ACTIVE", "ACT", "BVMF");
+        active.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
+
+        var inactive = MakeAsset("INACTIVE", "INA", "BVMF");
+        inactive.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        inactive.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 10m, 0m));
+
+        _repository.Assets = [active, inactive];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEmptyList_WhenPortfolioHasNoAssets()
+    {
+        _repository.Assets = [];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetPortfolioAssetsSummary_ReturnsEmptyList_OnNullOrWhitespaceBrokerName(string? brokerName)
+    {
+        var result = CreateService().GetPortfolioAssetsSummary(brokerName!, "Default");
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetPortfolioAssetsSummary_ReturnsEmptyList_OnNullOrWhitespacePortfolioName(string? portfolioName)
+    {
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", portfolioName!);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsTotalCredits_SumOfAllCreditValues()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 10m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2023, 1, 1), Credit.CreditType.Dividend, 30m));
+        asset.AddCredit(Credit.Create(new DateTime(2023, 6, 1), Credit.CreditType.Rent, 15m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].TotalCredits.Should().Be(45m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsTotalCredits_Zero_WhenNoCredits()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].TotalCredits.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsCashFlows_BuyEntriesAreNegative()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        using var _ = new AssertionScope();
+        result[0].CashFlows.Should().HaveCount(1);
+        result[0].CashFlows[0].Amount.Should().Be(-100m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsCashFlows_SellEntriesArePositive()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 10m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2022, 1, 1), Transaction.TransactionType.Sell, 5m, 10m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        var sellFlow = result[0].CashFlows.First(f => f.Amount > 0 && f.Date.Year == 2022);
+        sellFlow.Amount.Should().Be(50m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsCashFlows_CreditEntriesArePositive()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 1m, 10m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2023, 3, 1), Credit.CreditType.Dividend, 25m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        var creditFlow = result[0].CashFlows.First(f => f.Date.Year == 2023);
+        creditFlow.Amount.Should().Be(25m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsCashFlows_SortedAscendingByDate()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2022, 6, 1), Transaction.TransactionType.Buy, 1m, 10m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2021, 9, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2023, 1, 1), Transaction.TransactionType.Sell, 1m, 12m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        var dates = result[0].CashFlows.Select(f => f.Date).ToList();
+        dates.Should().BeInAscendingOrder();
+        dates[0].Should().Be(new DateTime(2021, 9, 15));
+        dates[1].Should().Be(new DateTime(2022, 6, 1));
+        dates[2].Should().Be(new DateTime(2023, 1, 1));
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsCashFlows_Empty_WhenNoTransactionsOrCredits()
+    {
+        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CashFlows.Should().NotBeNull();
+        result[0].CashFlows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsCashFlows_ContainsAllThreeEventTypes()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 5m, 10m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2022, 1, 1), Transaction.TransactionType.Sell, 2m, 12m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2021, 6, 1), Credit.CreditType.Dividend, 8m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        using var _ = new AssertionScope();
+        result[0].CashFlows.Should().HaveCount(3);
+        result[0].CashFlows.Count(f => f.Amount < 0).Should().Be(1);
+        result[0].CashFlows.Count(f => f.Amount > 0).Should().Be(2);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsCashFlows_BuyAmountMatchesTotalPrice()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 10m, 15m, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CashFlows[0].Amount.Should().Be(-155m);
+    }
+
+    // ── Phase 3: Credits-analysis unit tests ─────────────────────────────────
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastMonthCredits_SumOfMostRecentMonthCredits()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 20m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 10m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 15), Credit.CreditType.Dividend, 8m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastMonthCredits.Should().Be(18m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastMonthCredits_Zero_WhenNoCredits()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastMonthCredits.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastCreditMonth_FormattedYYYYMM()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 10), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastCreditMonth.Should().Be("2024-06");
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastCreditMonth_Null_WhenNoCredits()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastCreditMonth.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ExcludesFutureCreditDatesFromLastMonthCalculation()
+    {
+        var pastDate = DateTime.Today.AddMonths(-1);
+        var futureDate = DateTime.Today.AddDays(5);
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(pastDate, Credit.CreditType.Dividend, 10m));
+        asset.AddCredit(Credit.Create(futureDate, Credit.CreditType.Dividend, 99m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        using var _ = new AssertionScope();
+        result[0].LastCreditMonth.Should().Be($"{pastDate.Year:D4}-{pastDate.Month:D2}");
+        result[0].LastMonthCredits.Should().Be(10m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Computed()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 10m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastMonthCreditsPercent.Should().Be(1m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Null_WhenTotalInvestedIsZero()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 2, 1), Transaction.TransactionType.Sell, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastMonthCreditsPercent.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Null_WhenNoCredits()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].LastMonthCreditsPercent.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_DetectsMonthlyFrequency()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 15), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CreditFrequencyPerYear.Should().Be(12);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_DetectsQuarterlyFrequency()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 4, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 7, 15), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CreditFrequencyPerYear.Should().Be(4);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_DetectsFourMonthFrequency()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 5, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 9, 15), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CreditFrequencyPerYear.Should().Be(3);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsNullFrequency_WhenOnlyOneDistinctCreditMonth()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 15), Credit.CreditType.Dividend, 3m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CreditFrequencyPerYear.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsNullFrequency_WhenGapOutsideKnownRanges()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 9, 15), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CreditFrequencyPerYear.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualCredits_Computed()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 10000m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 50m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 50m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 50m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].EstimatedAnnualCredits.Should().Be(600m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualCredits_Null_WhenFrequencyNull()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].EstimatedAnnualCredits.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Computed()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 10000m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 50m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 50m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 50m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].EstimatedAnnualPercent.Should().Be(6m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Null_WhenEstimatedCreditsNull()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].EstimatedAnnualPercent.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Null_WhenTotalInvestedIsZero()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 2, 1), Transaction.TransactionType.Sell, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 5m));
+        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 5m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].EstimatedAnnualPercent.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsCurrentMonthCredits_SumOfCurrentMonthCredits()
+    {
+        var today = DateTime.Today;
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(today.Year, today.Month, 1), Credit.CreditType.Dividend, 12m));
+        asset.AddCredit(Credit.Create(new DateTime(today.Year, today.Month, 10), Credit.CreditType.Dividend, 8m));
+        asset.AddCredit(Credit.Create(today.AddMonths(-1), Credit.CreditType.Dividend, 99m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CurrentMonthCredits.Should().Be(20m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsCurrentMonthCredits_Zero_WhenNoneInCurrentMonth()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
+        asset.AddCredit(Credit.Create(DateTime.Today.AddMonths(-1), Credit.CreditType.Dividend, 15m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].CurrentMonthCredits.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_QueriesActiveScopeFromRepository()
+    {
+        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
+
+        CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        _repository.LastRequestedScope.Should().Be(InvestmentScope.Active);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_RealizedGainLossIsAlwaysNull()
+    {
+        var asset = MakeAsset("TEST", "TST", "BVMF");
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 60m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 50m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
+
+        result[0].RealizedGainLoss.Should().BeNull();
+    }
+
+    private ActivePortfolioAssetSummaryService CreateService() => new(_repository);
+
+    private static Asset MakeAsset(string name, string ticker, string exchange) =>
+        Asset.Create(name, "ISIN", exchange, ticker);
+
+    private sealed class StubRepository : IRepository
+    {
+        public IEnumerable<Asset> Assets { get; set; } = [];
+        public InvestmentScope? LastRequestedScope { get; private set; }
+
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => [];
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastRequestedScope = scope;
+            return Assets;
+        }
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => [];
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
+        public Task SaveChangesAsync() => Task.CompletedTask;
+    }
+}

--- a/Tests/Financial.Application.Tests/Services/HistoricPortfolioAssetSummaryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/HistoricPortfolioAssetSummaryServiceTests.cs
@@ -1,0 +1,139 @@
+using Financial.Application.Interfaces;
+using Financial.Application.Services;
+using Financial.Domain.Entities;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace Financial.Application.Tests.Services;
+
+public class HistoricPortfolioAssetSummaryServiceTests
+{
+    private readonly StubRepository _repository = new();
+
+    [Fact]
+    public void Constructor_WithNullRepository_Throws()
+    {
+        Action act = () => new HistoricPortfolioAssetSummaryService(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_WeightsByGrossTotalBought()
+    {
+        var asset = MakeAsset("CLOSEDASSET", "CLOSEDASSET", "BVMF");
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 60m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 50m, 0m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized");
+
+        using var _ = new AssertionScope();
+        result.Should().HaveCount(1);
+        result[0].TotalBought.Should().Be(300m);
+        result[0].TotalSold.Should().Be(250m);
+        result[0].PortfolioWeight.Should().Be(100m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ComputesRealizedGainLoss()
+    {
+        var asset = MakeAsset("CLOSEDASSET", "CLOSEDASSET", "BVMF");
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 60m, 0m));
+        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 50m, 0m));
+        asset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 20m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized");
+
+        // RealizedGainLoss = TotalSold - TotalBought + TotalCredits = 250 - 300 + 20 = -30
+        result[0].RealizedGainLoss.Should().Be(-30m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_PortfolioWeightsSumTo100Percent()
+    {
+        var asset1 = MakeAsset("ALPHA", "ALP", "BVMF");
+        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 300m, 0m));
+        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 290m, 0m));
+
+        var asset2 = MakeAsset("BETA", "BET", "BVMF");
+        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 700m, 0m));
+        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 690m, 0m));
+
+        _repository.Assets = [asset1, asset2];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized");
+
+        using var _ = new AssertionScope();
+        result.First(i => i.AssetName == "ALPHA").PortfolioWeight.Should().Be(30m);
+        result.First(i => i.AssetName == "BETA").PortfolioWeight.Should().Be(70m);
+        result.Sum(i => i.PortfolioWeight).Should().Be(100m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_CreditPercentFields_UseGrossTotalBoughtBasis()
+    {
+        var asset = MakeAsset("CLOSEDASSET", "CLOSEDASSET", "BVMF");
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2020, 6, 1), Transaction.TransactionType.Sell, 1m, 990m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2020, 3, 1), Credit.CreditType.Dividend, 10m));
+        _repository.Assets = [asset];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized");
+
+        // Net invested would be 1000 - 990 = 10, making 10/10*100 = 100%; gross bought basis gives 10/1000*100 = 1%
+        result[0].LastMonthCreditsPercent.Should().Be(1m);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_QueriesHistoricScopeFromRepository()
+    {
+        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
+
+        CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized");
+
+        _repository.LastRequestedScope.Should().Be(InvestmentScope.Historic);
+    }
+
+    [Fact]
+    public void GetPortfolioAssetsSummary_ReturnsEmptyList_WhenPortfolioHasNoAssets()
+    {
+        _repository.Assets = [];
+
+        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized");
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetPortfolioAssetsSummary_ReturnsEmptyList_OnNullOrWhitespaceBrokerName(string? brokerName)
+    {
+        var result = CreateService().GetPortfolioAssetsSummary(brokerName!, "Uncategorized");
+
+        result.Should().BeEmpty();
+    }
+
+    private HistoricPortfolioAssetSummaryService CreateService() => new(_repository);
+
+    private static Asset MakeAsset(string name, string ticker, string exchange) =>
+        Asset.Create(name, "ISIN", exchange, ticker);
+
+    private sealed class StubRepository : IRepository
+    {
+        public IEnumerable<Asset> Assets { get; set; } = [];
+        public InvestmentScope? LastRequestedScope { get; private set; }
+
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => [];
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastRequestedScope = scope;
+            return Assets;
+        }
+        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => [];
+        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
+        public Task SaveChangesAsync() => Task.CompletedTask;
+    }
+}

--- a/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs
@@ -1,619 +1,77 @@
+using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
-using Financial.Domain.Entities;
 using FluentAssertions;
-using FluentAssertions.Execution;
 
 namespace Financial.Application.Tests.Services;
 
 public class PortfolioAssetSummaryServiceTests
 {
-    private readonly StubRepository _repository = new();
+    private readonly StubActivePortfolioAssetSummaryService _activeService = new();
+    private readonly StubHistoricPortfolioAssetSummaryService _historicService = new();
 
     [Fact]
-    public void Constructor_WithNullRepository_Throws()
+    public void Constructor_WithNullActiveService_Throws()
     {
-        Action act = () => new PortfolioAssetSummaryService(null!);
-        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsAssetClass_MatchingAssetClassification()
-    {
-        var asset = Asset.Create("Bitcoin", "", "", "BTC", CountryCode.UK, "", GlobalAssetClass.Cryptocurrency);
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("Coinbase", "Cryptocurrency");
-
-        result.Should().HaveCount(1);
-        result[0].Class.Should().Be(GlobalAssetClass.Cryptocurrency);
+        Action act = () => new PortfolioAssetSummaryService(null!, _historicService);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("activePortfolioAssetSummaryService");
     }
 
     [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsSingleAsset_WithCorrectFields()
+    public void Constructor_WithNullHistoricService_Throws()
     {
-        var asset = MakeAsset("ALZR11", "ALZR11", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2021, 3, 1), Transaction.TransactionType.Buy, 10m, 100m, 0m));
-        asset.AddTransaction(Transaction.Create(new DateTime(2021, 5, 1), Transaction.TransactionType.Buy, 15m, 100m, 0m));
-        asset.AddTransaction(Transaction.Create(new DateTime(2022, 1, 1), Transaction.TransactionType.Sell, 5m, 110m, 0m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        using var _ = new AssertionScope();
-        result.Should().HaveCount(1);
-        var item = result[0];
-        item.AssetName.Should().Be("ALZR11");
-        item.Ticker.Should().Be("ALZR11");
-        item.Exchange.Should().Be("BVMF");
-        item.CurrentQuantity.Should().Be(20m);
-        item.AveragePrice.Should().Be(100m);
-        item.TotalBought.Should().Be(2500m);
-        item.TotalSold.Should().Be(550m);
-        item.TotalInvested.Should().Be(1950m);
-        item.PortfolioWeight.Should().Be(100m);
+        Action act = () => new PortfolioAssetSummaryService(_activeService, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("historicPortfolioAssetSummaryService");
     }
 
     [Fact]
-    public void GetPortfolioAssetsSummary_SortsAlphabetically()
+    public void GetPortfolioAssetsSummary_DefaultScope_DelegatesToActiveService()
     {
-        _repository.Assets = [
-            MakeAsset("ZEBRA", "ZBR", "BVMF"),
-            MakeAsset("APPLE", "APL", "BVMF"),
-            MakeAsset("MANGO", "MNG", "BVMF"),
-        ];
+        CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result.Select(i => i.AssetName).Should().Equal("APPLE", "MANGO", "ZEBRA");
+        _activeService.LastRequest.Should().Be(("XPI", "Default"));
+        _historicService.LastRequest.Should().BeNull();
     }
 
     [Fact]
-    public void GetPortfolioAssetsSummary_ComputesPortfolioWeight()
+    public void GetPortfolioAssetsSummary_ScopeActive_DelegatesToActiveService()
     {
-        var asset1 = MakeAsset("ALPHA", "ALP", "BVMF");
-        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 300m, 0m));
+        CreateService().GetPortfolioAssetsSummary("XPI", "Default", InvestmentScope.Active);
 
-        var asset2 = MakeAsset("BETA", "BET", "BVMF");
-        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 700m, 0m));
-
-        _repository.Assets = [asset1, asset2];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        using var _ = new AssertionScope();
-        result.First(i => i.AssetName == "ALPHA").PortfolioWeight.Should().Be(30m);
-        result.First(i => i.AssetName == "BETA").PortfolioWeight.Should().Be(70m);
+        _activeService.LastRequest.Should().Be(("XPI", "Default"));
+        _historicService.LastRequest.Should().BeNull();
     }
 
     [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsZeroPortfolioWeight_WhenAllTotalInvestedAreZero()
+    public void GetPortfolioAssetsSummary_ScopeHistoric_DelegatesToHistoricService()
     {
-        var asset1 = MakeAsset("ALPHA", "ALP", "BVMF");
-        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset1.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 100m, 0m));
+        CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized", InvestmentScope.Historic);
 
-        var asset2 = MakeAsset("BETA", "BET", "BVMF");
-        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 200m, 0m));
-        asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 200m, 0m));
-
-        _repository.Assets = [asset1, asset2];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result.Should().AllSatisfy(i => i.PortfolioWeight.Should().Be(0m));
+        _historicService.LastRequest.Should().Be(("XPI", "Uncategorized"));
+        _activeService.LastRequest.Should().BeNull();
     }
 
-    [Fact]
-    public void GetPortfolioAssetsSummary_SetsFirstInvestmentDate_FromEarliestBuyTransaction()
+    private PortfolioAssetSummaryService CreateService() => new(_activeService, _historicService);
+
+    private sealed class StubActivePortfolioAssetSummaryService : IActivePortfolioAssetSummaryService
     {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2021, 6, 1), Transaction.TransactionType.Buy, 5m, 10m, 0m));
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 15), Transaction.TransactionType.Buy, 5m, 10m, 0m));
-        _repository.Assets = [asset];
+        public (string BrokerName, string PortfolioName)? LastRequest { get; private set; }
 
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].FirstInvestmentDate.Should().Be(new DateTime(2020, 1, 15));
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_SetsFirstInvestmentDate_Null_WhenNoBuyTransactions()
-    {
-        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].FirstInvestmentDate.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_IncludesAllAssets_RegardlessOfActiveStatus()
-    {
-        var active = MakeAsset("ACTIVE", "ACT", "BVMF");
-        active.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 10m, 10m, 0m));
-
-        var inactive = MakeAsset("INACTIVE", "INA", "BVMF");
-        inactive.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
-        inactive.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 10m, 0m));
-
-        _repository.Assets = [active, inactive];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result.Should().HaveCount(2);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsEmptyList_WhenPortfolioHasNoAssets()
-    {
-        _repository.Assets = [];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result.Should().BeEmpty();
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public void GetPortfolioAssetsSummary_ReturnsEmptyList_OnNullOrWhitespaceBrokerName(string? brokerName)
-    {
-        var result = CreateService().GetPortfolioAssetsSummary(brokerName!, "Default");
-
-        result.Should().BeEmpty();
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public void GetPortfolioAssetsSummary_ReturnsEmptyList_OnNullOrWhitespacePortfolioName(string? portfolioName)
-    {
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", portfolioName!);
-
-        result.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsTotalCredits_SumOfAllCreditValues()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 10m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2023, 1, 1), Credit.CreditType.Dividend, 30m));
-        asset.AddCredit(Credit.Create(new DateTime(2023, 6, 1), Credit.CreditType.Rent, 15m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].TotalCredits.Should().Be(45m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsTotalCredits_Zero_WhenNoCredits()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].TotalCredits.Should().Be(0m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsCashFlows_BuyEntriesAreNegative()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        using var _ = new AssertionScope();
-        result[0].CashFlows.Should().HaveCount(1);
-        result[0].CashFlows[0].Amount.Should().Be(-100m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsCashFlows_SellEntriesArePositive()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        asset.AddTransaction(Transaction.Create(new DateTime(2022, 1, 1), Transaction.TransactionType.Sell, 5m, 10m, 0m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        var sellFlow = result[0].CashFlows.First(f => f.Amount > 0 && f.Date.Year == 2022);
-        sellFlow.Amount.Should().Be(50m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsCashFlows_CreditEntriesArePositive()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 1m, 10m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2023, 3, 1), Credit.CreditType.Dividend, 25m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        var creditFlow = result[0].CashFlows.First(f => f.Date.Year == 2023);
-        creditFlow.Amount.Should().Be(25m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsCashFlows_SortedAscendingByDate()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2022, 6, 1), Transaction.TransactionType.Buy, 1m, 10m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2021, 9, 15), Credit.CreditType.Dividend, 5m));
-        asset.AddTransaction(Transaction.Create(new DateTime(2023, 1, 1), Transaction.TransactionType.Sell, 1m, 12m, 0m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        var dates = result[0].CashFlows.Select(f => f.Date).ToList();
-        dates.Should().BeInAscendingOrder();
-        dates[0].Should().Be(new DateTime(2021, 9, 15));
-        dates[1].Should().Be(new DateTime(2022, 6, 1));
-        dates[2].Should().Be(new DateTime(2023, 1, 1));
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsCashFlows_Empty_WhenNoTransactionsOrCredits()
-    {
-        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].CashFlows.Should().NotBeNull();
-        result[0].CashFlows.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsCashFlows_ContainsAllThreeEventTypes()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 5m, 10m, 0m));
-        asset.AddTransaction(Transaction.Create(new DateTime(2022, 1, 1), Transaction.TransactionType.Sell, 2m, 12m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2021, 6, 1), Credit.CreditType.Dividend, 8m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        using var _ = new AssertionScope();
-        result[0].CashFlows.Should().HaveCount(3);
-        result[0].CashFlows.Count(f => f.Amount < 0).Should().Be(1);
-        result[0].CashFlows.Count(f => f.Amount > 0).Should().Be(2);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsCashFlows_BuyAmountMatchesTotalPrice()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 10m, 15m, 5m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].CashFlows[0].Amount.Should().Be(-155m);
-    }
-
-    // ── Phase 3: Credits-analysis unit tests ─────────────────────────────────
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsLastMonthCredits_SumOfMostRecentMonthCredits()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 20m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 10m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 15), Credit.CreditType.Dividend, 8m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].LastMonthCredits.Should().Be(18m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsLastMonthCredits_Zero_WhenNoCredits()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].LastMonthCredits.Should().Be(0m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsLastCreditMonth_FormattedYYYYMM()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 10), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].LastCreditMonth.Should().Be("2024-06");
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsLastCreditMonth_Null_WhenNoCredits()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].LastCreditMonth.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ExcludesFutureCreditDatesFromLastMonthCalculation()
-    {
-        var pastDate = DateTime.Today.AddMonths(-1);
-        var futureDate = DateTime.Today.AddDays(5);
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(pastDate, Credit.CreditType.Dividend, 10m));
-        asset.AddCredit(Credit.Create(futureDate, Credit.CreditType.Dividend, 99m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        using var _ = new AssertionScope();
-        result[0].LastCreditMonth.Should().Be($"{pastDate.Year:D4}-{pastDate.Month:D2}");
-        result[0].LastMonthCredits.Should().Be(10m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Computed()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 10m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].LastMonthCreditsPercent.Should().Be(1m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Null_WhenTotalInvestedIsZero()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 2, 1), Transaction.TransactionType.Sell, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].LastMonthCreditsPercent.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsLastMonthCreditsPercent_Null_WhenNoCredits()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].LastMonthCreditsPercent.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_DetectsMonthlyFrequency()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 15), Credit.CreditType.Dividend, 5m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 15), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].CreditFrequencyPerYear.Should().Be(12);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_DetectsQuarterlyFrequency()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 4, 15), Credit.CreditType.Dividend, 5m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 7, 15), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].CreditFrequencyPerYear.Should().Be(4);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_DetectsFourMonthFrequency()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 5, 15), Credit.CreditType.Dividend, 5m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 9, 15), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].CreditFrequencyPerYear.Should().Be(3);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsNullFrequency_WhenOnlyOneDistinctCreditMonth()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 15), Credit.CreditType.Dividend, 3m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].CreditFrequencyPerYear.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsNullFrequency_WhenGapOutsideKnownRanges()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 9, 15), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].CreditFrequencyPerYear.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualCredits_Computed()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 10000m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 50m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 50m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 50m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].EstimatedAnnualCredits.Should().Be(600m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualCredits_Null_WhenFrequencyNull()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].EstimatedAnnualCredits.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Computed()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 10000m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 50m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 50m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 50m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].EstimatedAnnualPercent.Should().Be(6m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Null_WhenEstimatedCreditsNull()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].EstimatedAnnualPercent.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsEstimatedAnnualPercent_Null_WhenTotalInvestedIsZero()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 2, 1), Transaction.TransactionType.Sell, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 5m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 5m));
-        asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].EstimatedAnnualPercent.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsCurrentMonthCredits_SumOfCurrentMonthCredits()
-    {
-        var today = DateTime.Today;
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(new DateTime(today.Year, today.Month, 1), Credit.CreditType.Dividend, 12m));
-        asset.AddCredit(Credit.Create(new DateTime(today.Year, today.Month, 10), Credit.CreditType.Dividend, 8m));
-        asset.AddCredit(Credit.Create(today.AddMonths(-1), Credit.CreditType.Dividend, 99m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].CurrentMonthCredits.Should().Be(20m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ReturnsCurrentMonthCredits_Zero_WhenNoneInCurrentMonth()
-    {
-        var asset = MakeAsset("TEST", "TST", "BVMF");
-        asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        asset.AddCredit(Credit.Create(DateTime.Today.AddMonths(-1), Credit.CreditType.Dividend, 15m));
-        _repository.Assets = [asset];
-
-        var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
-
-        result[0].CurrentMonthCredits.Should().Be(0m);
-    }
-
-    [Fact]
-    public void GetPortfolioAssetsSummary_ForwardsScopeToRepository()
-    {
-        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
-
-        CreateService().GetPortfolioAssetsSummary("XPI", "Default", InvestmentScope.Historic);
-
-        _repository.LastRequestedScope.Should().Be(InvestmentScope.Historic);
-    }
-
-    private PortfolioAssetSummaryService CreateService() => new(_repository);
-
-    private static Asset MakeAsset(string name, string ticker, string exchange) =>
-        Asset.Create(name, "ISIN", exchange, ticker);
-
-    private sealed class StubRepository : IRepository
-    {
-        public IEnumerable<Asset> Assets { get; set; } = [];
-        public InvestmentScope? LastRequestedScope { get; private set; }
-
-        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => [];
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
+        public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName)
         {
-            LastRequestedScope = scope;
-            return Assets;
+            LastRequest = (brokerName, portfolioName);
+            return [];
         }
-        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => [];
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
-        public Task SaveChangesAsync() => Task.CompletedTask;
+    }
+
+    private sealed class StubHistoricPortfolioAssetSummaryService : IHistoricPortfolioAssetSummaryService
+    {
+        public (string BrokerName, string PortfolioName)? LastRequest { get; private set; }
+
+        public IReadOnlyList<PortfolioAssetSummaryItemDTO> GetPortfolioAssetsSummary(string brokerName, string portfolioName)
+        {
+            LastRequest = (brokerName, portfolioName);
+            return [];
+        }
     }
 }

--- a/docs/P10-F06-historic-realized-totals-service/plan.md
+++ b/docs/P10-F06-historic-realized-totals-service/plan.md
@@ -1,0 +1,38 @@
+# Implementation Plan: Historic Realized Totals Service
+
+**Prerequisites:**
+- F05 (Scoped Navigation & Summary API) merged — provides the `scope` query parameter, `InvestmentScope` enum, and scope-aware `IRepository`/`SummaryController` this feature builds on
+- F07 (Historic Broker Breakdown Charts Service) merged — establishes the Active/Historic facade pattern this feature mirrors
+- No new tools, libraries, or environment variables required
+
+### Stage 1: Shared Building Blocks
+
+**1. Portfolio Asset Summary Builder** - Extract the current service's per-asset computation (totals, cash flows, credits analysis) and portfolio-level aggregation (weight and credit-percentage calculation against a portfolio-wide basis) into a shared, scope-agnostic builder that accepts a weight-basis selector and a realized-gain-loss selector per asset, so both scopes reuse identical computation logic instead of duplicating it. Add the new realized-gain-loss field to the shared DTO the builder assembles.
+
+**2. Scoped Service Contracts** - Define two narrow contracts, one for the Active-scope summary and one for the Historic-scope summary, each exposing a single broker/portfolio-name lookup method with scope implicit in which contract is called, per the spec's Component Overview.
+
+### Stage 2: Scope-Specific Summary Services
+
+**3. Active Summary Service** - Rename the existing summary service to make explicit that it serves the Active scope, preserving its current net-invested weighting behavior unchanged and always returning a null realized-gain-loss, built through the shared builder from Stage 1.
+
+**4. Historic Summary Service** - Introduce a new service serving the Historic scope, weighting portfolio share and credit percentages by gross total bought rather than net invested, and computing the realized-gain-loss figure, built through the same shared builder.
+
+**5. Summary Facade** - Update the existing public summary service so it acts as a facade routing a request to the Active or Historic implementation based on the scope value it already receives, keeping `SummaryController`'s existing call site unchanged.
+
+**6. Dependency Injection** - Register the two scope-specific services and the facade in the Application layer's service collection, following the existing singleton registration pattern used elsewhere in this project.
+
+### Stage 3: Frontend Contract Parity
+
+**7. TypeScript Type Update** - Add the new realized-gain-loss field to the corresponding TypeScript API type, keeping the frontend contract in sync with the backend DTO without introducing any UI changes.
+
+### Stage 4: Test Coverage
+
+**8. Shared Builder Tests** - Cover the extracted builder's weight/percentage calculation against a caller-supplied basis selector and its application of the realized-gain-loss selector, independently of any scope.
+
+**9. Active Service Tests** - Adapt the existing summary service test suite to the renamed service and its simplified method signature, retaining coverage of net-invested weighting and confirming realized-gain-loss stays null.
+
+**10. Historic Service Tests** - Add coverage proving the Historic summary weights by gross total bought and computes realized gain/loss correctly, including the credit-percentage fields no longer collapsing toward a nonsensical value for a closed position.
+
+**11. Facade Dispatch Tests** - Verify the facade routes each scope value, including the default, to the correct underlying scoped service.
+
+**12. Integration Test Updates** - Extend the existing historic-scope summary endpoint test to assert on realized-gain-loss and portfolio-weight values summing to 100%, and add a regression test proving Active-scope endpoint behavior is unchanged.

--- a/docs/P10-F06-historic-realized-totals-service/spec.md
+++ b/docs/P10-F06-historic-realized-totals-service/spec.md
@@ -1,0 +1,180 @@
+# Historic Realized Totals Service
+
+## 1. Technical Overview
+
+**What:** Make the per-asset portfolio summary returned under `scope=historic` give closed positions metrics that actually mean something: a new `RealizedGainLoss` field, and `PortfolioWeight`/credit-percentage figures weighted by gross `TotalBought` instead of the net-invested formula (`TotalBought - TotalSold`) `PortfolioAssetSummaryService` currently applies to every scope.
+
+**Why:** F05 already made `GET /summary/portfolio/{broker}/{portfolio}/assets` fully scope-aware end to end (repository, controller, DTO plumbing), but the one class doing the metric math, `PortfolioAssetSummaryService`, still weights every percentage-style field by net invested regardless of scope. For a closed historic position, `TotalBought` and `TotalSold` are close in magnitude, so `PortfolioWeight` collapses toward zero (or negative on a loss) — the exact defect F07 already fixed once for the breakdown chart's sizing metric, now showing up in the per-asset summary. Discovery also found the credit-analysis percentage fields (`LastMonthCreditsPercent`, `EstimatedAnnualPercent`) share the same near-zero denominator, though the PRD's F06 acceptance criteria don't name them.
+
+**Scope:**
+
+Included:
+- Splitting the existing single-scope metric logic into an Active-scope implementation (net-invested weighting, unchanged behavior) and a Historic-scope implementation (gross-`TotalBought` weighting, adds `RealizedGainLoss`)
+- Extracting the shared per-asset computation and portfolio-level aggregation logic so both implementations reuse it instead of duplicating it
+- A facade that preserves the existing public `IPortfolioAssetSummaryService` contract so `SummaryController` and its `scope=historic` endpoint (already shipped in F05) require no changes
+- Renaming the current `PortfolioAssetSummaryService` class to `ActivePortfolioAssetSummaryService`, matching the scope-explicit-naming precedent F07 set for `BrokerBreakdownService` → `ActiveBrokerBreakdownService`
+- New `RealizedGainLoss` field on `PortfolioAssetSummaryItemDTO` (`decimal?`, `TotalSold - TotalBought + TotalCredits` for Historic, always `null` for Active) and its TS type
+- Fixing `LastMonthCreditsPercent`/`EstimatedAnnualPercent` for Historic scope to use the same gross-`TotalBought` denominator as `PortfolioWeight`, instead of the net-invested figure that collapses toward zero
+- Unit and integration test coverage for the new metric behavior, the shared builder, and the facade's dispatch logic
+
+Excluded (already delivered by earlier features, or explicitly out of scope per the PRD, not touched here):
+- The `scope` query parameter, `InvestmentScopeParser`, and `SummaryController` routing (F05)
+- Repository-level scope resolution (`IRepository`, `JSONRepository`) (F02/F05)
+- Current price fetch and XIRR calculation — the PRD explicitly excludes these for Historic scope, and discovery confirmed `PortfolioAssetSummaryService`/`PortfolioAssetSummaryItemDTO` never fetched a price or computed XIRR to begin with (that happens entirely client-side, downstream, per consumer) — nothing to strip out here
+- `CashFlows` field — stays populated for Historic assets too (scope-agnostic, harmless historical data); no scope-specific handling needed
+- Any Web/WPF UI consuming these fields (`usePortfolioAssetSummary.ts`, `PortfolioSummaryTab.tsx`, `PortfolioAssetSummaryRowViewModel.cs`) — that's F09 (Web) and F11 (WPF), both listed as depending on F06 in the PRD; this feature is backend-only, matching its PRD Experience note ("No direct UI")
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Application/Services/PortfolioAssetSummaryBuilder.cs` (new) — shared, scope-agnostic per-asset computation and portfolio-level aggregation
+- `Financial.Application/Services/ActivePortfolioAssetSummaryService.cs` (new file, renamed from `PortfolioAssetSummaryService.cs`)
+- `Financial.Application/Services/HistoricPortfolioAssetSummaryService.cs` (new)
+- `Financial.Application/Services/PortfolioAssetSummaryService.cs` (modified — becomes the scope-dispatch facade)
+- `Financial.Application/Interfaces/IActivePortfolioAssetSummaryService.cs` (new)
+- `Financial.Application/Interfaces/IHistoricPortfolioAssetSummaryService.cs` (new)
+- `Financial.Application/Interfaces/IPortfolioAssetSummaryService.cs` (unchanged — facade keeps implementing this exact contract)
+- `Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs` (modified — new `RealizedGainLoss` field)
+- `Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs` (modified — DI registration)
+- `Financial.Web/src/api/types.ts` (modified — TS type parity for the new field; no UI consumption)
+- `Financial.Api/Controllers/SummaryController.cs` (unchanged — the facade absorbs scope dispatch, matching F07's outcome)
+
+```mermaid
+graph TD
+  A[SummaryController] --> B[PortfolioAssetSummaryService facade]
+  B --> C[ActivePortfolioAssetSummaryService]
+  B --> D[HistoricPortfolioAssetSummaryService]
+  C --> E[PortfolioAssetSummaryBuilder]
+  D --> E
+  C --> F[IRepository Active scope]
+  D --> G[IRepository Historic scope]
+  E --> H[NavigationMapper.CalculateTotals]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Service topology | Two scope-specific classes (`ActivePortfolioAssetSummaryService`, `HistoricPortfolioAssetSummaryService`) behind a facade that keeps implementing `IPortfolioAssetSummaryService` | Extend the existing single `PortfolioAssetSummaryService` in place with an internal scope branch on the weighting formula | Mirrors F07's `BrokerBreakdownService` split exactly — same problem shape (a formula wrong for one scope), same fix. Deviating now would leave two different patterns solving the same class of problem in the same codebase |
+| Scope dispatch location | A facade (`PortfolioAssetSummaryService`) in the Application layer holds both scoped implementations and picks one based on the `scope` value it already receives; `SummaryController` is unmodified | `SummaryController` injects both scoped services directly and branches on the parsed scope itself | Keeps the Presentation layer free of a scope-routing decision, consistent with CLAUDE.md's Clean Architecture rule and every other endpoint in this codebase (none branch on scope in the controller) |
+| Shared per-asset/aggregation logic | Extracted into `PortfolioAssetSummaryBuilder`, an internal static class taking a weight-basis selector (`Func<AssetTotals, decimal>`) and a realized-gain-loss selector (`Func<AssetTotals, decimal?>`) supplied by the caller | Duplicate the per-asset computation, credits-analysis, and portfolio-weight aggregation block in both scoped services | One extra file, but eliminates duplicating the ~50-line computation/aggregation block that would otherwise diverge over time between the two scopes |
+| Historic weighting basis | Gross `TotalBought` per asset, used for both `PortfolioWeight` and the credit-analysis percentage fields (`LastMonthCreditsPercent`, `EstimatedAnnualPercent`) | Net invested (`TotalBought - TotalSold`, today's formula) for all three fields | PRD-mandated for `PortfolioWeight`; extended to the two credit-percentage fields since they share the identical root cause (net-invested denominator collapsing toward zero for a closed position) — leaving them unfixed would ship a feature explicitly built to give Historic assets sane numbers next to two fields still nonsensical for that exact scope |
+| `RealizedGainLoss` for Active scope | Always `null` | Compute `TotalSold - TotalBought + TotalCredits` for Active too | The PRD frames this as a closed-position concept ("how did my closed strategy perform"); a nonzero value for an open Active position doesn't represent a realized gain, so `null` signals "not applicable" rather than a real-but-misleading number |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Application/Services/PortfolioAssetSummaryBuilder.cs` | New | Shared, scope-agnostic per-asset computation and aggregation | Computes `TotalBought`/`TotalSold`/`TotalCredits`/`CashFlows`/credits-analysis per asset via `NavigationMapper.CalculateTotals`; sums a caller-supplied weight-basis selector across the portfolio and calculates each asset's `PortfolioWeight` and credit percentages against that sum; assembles `PortfolioAssetSummaryItemDTO`, applying a caller-supplied `RealizedGainLoss` selector |
+| `Financial.Application/Services/ActivePortfolioAssetSummaryService.cs` | New (renamed from `PortfolioAssetSummaryService.cs`) | Active-scope summary | Looks up assets from the repository's Active scope; supplies net invested (`TotalBought - TotalSold`) as the weight-basis selector; supplies a selector that always returns `null` for `RealizedGainLoss`; guards null/blank broker/portfolio names |
+| `Financial.Application/Services/HistoricPortfolioAssetSummaryService.cs` | New | Historic-scope summary | Looks up assets from the repository's Historic scope; supplies gross `TotalBought` as the weight-basis selector; supplies `TotalSold - TotalBought + TotalCredits` as the `RealizedGainLoss` selector; same guard behavior as the Active service |
+| `Financial.Application/Services/PortfolioAssetSummaryService.cs` | Modified | Scope-dispatch facade | Implements the existing `IPortfolioAssetSummaryService` contract unchanged; routes to `IActivePortfolioAssetSummaryService` or `IHistoricPortfolioAssetSummaryService` based on the `InvestmentScope` argument |
+| `Financial.Application/Interfaces/IActivePortfolioAssetSummaryService.cs` | New | Active-scope contract | Single method: `GetPortfolioAssetsSummary(string brokerName, string portfolioName)` — no scope parameter, scope is implicit in the interface |
+| `Financial.Application/Interfaces/IHistoricPortfolioAssetSummaryService.cs` | New | Historic-scope contract | Single method, same shape as the Active contract |
+| `Financial.Application/Interfaces/IPortfolioAssetSummaryService.cs` | Unchanged | Facade contract consumed by `SummaryController` | `GetPortfolioAssetsSummary(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active)` — identical to today |
+| `Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs` | Modified | Add realized-gain-loss field | New `decimal? RealizedGainLoss { get; init; }` property |
+| `Financial.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs` | Modified | DI registration | Replaces the single `IPortfolioAssetSummaryService` registration with `ActivePortfolioAssetSummaryService`, `HistoricPortfolioAssetSummaryService`, and the facade, matching F07's registration ordering (scoped implementations first, facade last) |
+| `Financial.Web/src/api/types.ts` | Modified | TS contract parity | Adds `realizedGainLoss: number \| null` to `PortfolioAssetSummaryItemDto` — type only, no consuming UI code changes |
+
+## 5. API Contracts
+
+No new endpoint and no request/response shape change beyond one added field — the existing endpoint from F05 is reused unmodified; only the returned values (and the new field) for `scope=historic` change.
+
+**Endpoint: Get Portfolio Assets Summary (existing, unchanged surface)**
+- **Method:** GET
+- **Path:** `/api/v1/financial/summary/portfolio/{brokerName}/{portfolioName}/assets`
+- **Authentication:** None (single-user local application)
+
+**Request:**
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|--------------|
+| `brokerName` | `string` (route) | Yes | non-empty | Broker to build the summary for |
+| `portfolioName` | `string` (route) | Yes | non-empty | Portfolio to build the summary for |
+| `scope` | `string` (query) | No | `active`\|`historic`, case-insensitive; unparseable/absent defaults to `active` | Selects which collection to build the summary from |
+
+**Response (Success - 200):** DTO shape unchanged except for one added field.
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `[].totalBought` / `totalSold` / `totalCredits` | `decimal` | Unchanged from today, per-asset historical cash flows |
+| `[].realizedGainLoss` | `decimal?` (new) | `TotalSold - TotalBought + TotalCredits` for `scope=historic`; always `null` for `scope=active` |
+| `[].portfolioWeight` | `decimal` | For `scope=active`: unchanged, weighted by net invested. For `scope=historic`: weighted by gross `TotalBought` — this is the value this feature changes |
+| `[].lastMonthCreditsPercent` / `[].estimatedAnnualPercent` | `decimal?` | Same per-scope weighting-basis change as `portfolioWeight` |
+
+**Response Example (`scope=historic`):**
+```json
+[
+  {
+    "assetName": "CLOSEDASSET",
+    "totalBought": 300.00,
+    "totalSold": 250.00,
+    "totalCredits": 0.00,
+    "realizedGainLoss": -50.00,
+    "portfolioWeight": 100.00,
+    "lastMonthCreditsPercent": null
+  }
+]
+```
+
+**Error Codes:** unchanged from F05 — `400 Bad Request` for a null/blank `brokerName`/`portfolioName`.
+
+## 6. Data Model
+
+No schema or `data.json` changes. This feature reads the same `Broker → Portfolio → Asset` structures already established by F02, through the same `IRepository`/`InvestmentScope` abstraction already scope-aware since F05. `Asset.Transactions`/`Asset.Credits` — the source of every figure via `NavigationMapper.CalculateTotals` — are unchanged.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryBuilderTests.cs` | Unit | `PortfolioAssetSummaryBuilder` | Weight/percentage calculation against a caller-supplied basis selector, `RealizedGainLoss` selector application, independent of scope |
+| `Tests/Financial.Application.Tests/Services/ActivePortfolioAssetSummaryServiceTests.cs` | Unit | `ActivePortfolioAssetSummaryService` | Net-invested weighting (unchanged behavior), `RealizedGainLoss` always `null`, Active-scope repository lookup, guard clauses |
+| `Tests/Financial.Application.Tests/Services/HistoricPortfolioAssetSummaryServiceTests.cs` | Unit | `HistoricPortfolioAssetSummaryService` | Gross-`TotalBought` weighting, `RealizedGainLoss` computed correctly, Historic-scope repository lookup, guard clauses |
+| `Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs` | Unit | `PortfolioAssetSummaryService` (facade) | Scope-based dispatch to the correct underlying service |
+| `Tests/Financial.Api.Tests/SummaryEndpointsTests.cs` | Integration | `GET /summary/portfolio/{broker}/{portfolio}/assets` | Historic-scope response values (`realizedGainLoss`, `portfolioWeight`), Active-scope regression, weights summing to 100% |
+
+**Test functions:**
+
+`PortfolioAssetSummaryBuilderTests.cs`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `Build_UsesProvidedSelectorForPortfolioWeight` | Selector returning a fixed basis value | `PortfolioWeight` reflects the selector's output relative to the portfolio sum, not a hardcoded formula |
+| `Build_PortfolioWeightsSumTo100Percent` | Multiple assets with distinct weight-basis values | Sum of `PortfolioWeight` across all assets equals 100% |
+| `Build_ReturnsZeroWeight_WhenPortfolioBasisSumIsZero` | All assets' selector output is zero | Every asset's `PortfolioWeight` is `0`, no division-by-zero |
+| `Build_AppliesRealizedGainLossSelector` | Selector returning a fixed value / `null` | `RealizedGainLoss` on the DTO equals the selector's output exactly |
+| `Build_SortsAssetsAlphabetically` | Multiple assets, out-of-order input | Result ordered case-insensitively by `AssetName` |
+
+`ActivePortfolioAssetSummaryServiceTests.cs`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `Constructor_WithNullRepository_Throws` | Null `IRepository` | Throws `ArgumentNullException` |
+| `GetPortfolioAssetsSummary_WeightsByNetInvested` | Asset with distinct `TotalBought`/`TotalSold` | `PortfolioWeight` reflects `TotalBought - TotalSold`, matching today's behavior |
+| `GetPortfolioAssetsSummary_RealizedGainLossIsAlwaysNull` | Any asset, including one with `TotalSold > TotalBought` | `RealizedGainLoss` is `null` |
+| `GetPortfolioAssetsSummary_QueriesActiveScopeFromRepository` | Any broker/portfolio | Repository is queried with `InvestmentScope.Active` |
+| `GetPortfolioAssetsSummary_ReturnsEmptyOnNullOrWhitespaceBrokerName` | `[Theory]` over `null`/`""`/`"   "` | Empty result, no repository call |
+
+`HistoricPortfolioAssetSummaryServiceTests.cs`
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `Constructor_WithNullRepository_Throws` | Null `IRepository` | Throws `ArgumentNullException` |
+| `GetPortfolioAssetsSummary_WeightsByGrossTotalBought` | Asset with `TotalBought` and non-zero `TotalSold` | `PortfolioWeight` reflects gross `TotalBought`, not `TotalBought - TotalSold` |
+| `GetPortfolioAssetsSummary_ComputesRealizedGainLoss` | Asset with known `TotalBought`/`TotalSold`/`TotalCredits` | `RealizedGainLoss` equals `TotalSold - TotalBought + TotalCredits` |
+| `GetPortfolioAssetsSummary_CreditPercentFields_UseGrossTotalBoughtBasis` | Asset with credits and a fully-closed position (`TotalSold` ≈ `TotalBought`) | `LastMonthCreditsPercent`/`EstimatedAnnualPercent` are finite, sane values instead of collapsing toward a huge or negative percentage |
+| `GetPortfolioAssetsSummary_QueriesHistoricScopeFromRepository` | Any broker/portfolio | Repository is queried with `InvestmentScope.Historic` |
+| `GetPortfolioAssetsSummary_ReturnsEmptyOnNullOrWhitespaceBrokerName` | `[Theory]` over `null`/`""`/`"   "` | Empty result, no repository call |
+
+`PortfolioAssetSummaryServiceTests.cs` (facade)
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `Constructor_WithNullDependencies_Throws` | Null Active or Historic service dependency | Throws `ArgumentNullException` |
+| `GetPortfolioAssetsSummary_DefaultScope_DelegatesToActiveService` | No scope argument supplied | `IActivePortfolioAssetSummaryService.GetPortfolioAssetsSummary` invoked |
+| `GetPortfolioAssetsSummary_ScopeHistoric_DelegatesToHistoricService` | `InvestmentScope.Historic` | `IHistoricPortfolioAssetSummaryService.GetPortfolioAssetsSummary` invoked |
+
+`SummaryEndpointsTests.cs` (acceptance/integration — maps to PRD Section 9 F06 criteria and the Cross-Feature Integration criteria tying F05 to F06)
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `GetPortfolioAssetsSummary_ScopeHistoric_ReturnsRealizedGainLoss` (extend existing historic-scope test) | `scope=historic` for a portfolio with a closed asset | `200 OK`; `realizedGainLoss` equals `TotalSold - TotalBought + TotalCredits` from the fixture |
+| `GetPortfolioAssetsSummary_ScopeHistoric_PortfolioWeightsSumTo100` (new) | `scope=historic`, multiple historic assets | Sum of `portfolioWeight` across the response equals 100% |
+| `GetPortfolioAssetsSummary_ScopeActive_PreservesNetInvestedWeightingAndNullRealizedGainLoss` (new) | `scope=active`/omitted, unchanged fixture | `portfolioWeight` still net-invested; `realizedGainLoss` is `null` — regression guard proving the facade split didn't alter Active behavior |

--- a/docs/prd/P10-prd-historic-investments/prd-historic-investments.md
+++ b/docs/prd/P10-prd-historic-investments/prd-historic-investments.md
@@ -388,9 +388,9 @@ graph TD
 - [x] Omitting the scope parameter preserves today's Active-only behavior (no breaking change for any existing caller)
 
 ### F06. Historic Realized Totals Service
-- [ ] A historic asset's summary returns `TotalBought`, `TotalSold`, `TotalCredits`, and `RealizedGainLoss = TotalSold - TotalBought + TotalCredits`
+- [x] A historic asset's summary returns `TotalBought`, `TotalSold`, `TotalCredits`, and `RealizedGainLoss = TotalSold - TotalBought + TotalCredits`
 - [ ] No current price fetch or XIRR field is present in the historic summary response
-- [ ] Portfolio weight sums to 100% across a historic portfolio's assets (by `TotalBought`)
+- [x] Portfolio weight sums to 100% across a historic portfolio's assets (by `TotalBought`)
 
 ### F07. Historic Broker Breakdown Charts Service
 - [x] A historic broker's breakdown returns one entry per historic portfolio with assets, sized by `TotalBought`
@@ -419,7 +419,7 @@ graph TD
 ### Cross-Feature Integration
 - [x] Data written by import (F04) into `activeInvestments`/`historicInvestments` (F02's structure) is correctly returned by the scoped navigation API (F05)
 - [x] Position type computed by F01 appears correctly on every Active-scoped asset returned by F05
-- [ ] Historic tree/asset data served by F05 is correctly consumed by both the realized totals service (F06) and the breakdown charts service (F07)
+- [x] Historic tree/asset data served by F05 is correctly consumed by both the realized totals service (F06) and the breakdown charts service (F07)
 - [ ] Realized totals from F06 render correctly in both the Web (F09) and WPF (F11) Historic Investments summary views
 - [ ] Breakdown data from F07 renders correctly in both the Web (F09) and WPF (F11) Historic Investments charts views
 - [ ] Active-scoped data and position type from F01/F05 render correctly in both the Web (F08) and WPF (F10) Active Investments tabs


### PR DESCRIPTION
## Summary
- Fills the gap left in the P10 wave: F06 (Historic Realized Totals Service) was never implemented, even though F07 (which depends on the same class of fix) shipped already. The PRD backfill PR (#171) explicitly flagged this and left F06's boxes unchecked.
- Adds `RealizedGainLoss = TotalSold - TotalBought + TotalCredits` to the per-asset portfolio summary (`null` for Active scope — it's a closed-position concept).
- Fixes `PortfolioWeight` for Historic scope to weight by gross `TotalBought` instead of net invested (`TotalBought - TotalSold`), which collapses toward zero for closed positions — the same defect F07 already fixed once for the breakdown chart, here for the per-asset summary.
- Also fixes `LastMonthCreditsPercent`/`EstimatedAnnualPercent` for Historic scope, which share the identical near-zero-denominator problem but weren't named in the PRD's acceptance criteria — found during spec discovery.
- Mirrors F07's exact facade pattern: renames `PortfolioAssetSummaryService` to `ActivePortfolioAssetSummaryService`, adds `HistoricPortfolioAssetSummaryService`, extracts a shared `PortfolioAssetSummaryBuilder`, and turns `PortfolioAssetSummaryService` into a scope-dispatch facade — `SummaryController` needed zero changes.

## Acceptance Criteria (PRD Section 9, F06 — re-checked fresh in this run)

✓ A historic asset's summary returns `TotalBought`, `TotalSold`, `TotalCredits`, and `RealizedGainLoss = TotalSold - TotalBought + TotalCredits`
  — `HistoricPortfolioAssetSummaryServiceTests.GetPortfolioAssetsSummary_ComputesRealizedGainLoss` + `SummaryEndpointsTests.GetPortfolioAssetsSummary_ScopeHistoric_ReturnsHistoricOnly` (asserts `RealizedGainLoss == -50` against the `CLOSEDASSET` fixture); confirmed live against the running API

— No current price fetch or XIRR field is present in the historic summary response
  — True by the DTO's shape (`PortfolioAssetSummaryItemDTO` has never had a current-price or XIRR field — that computation happens entirely client-side, downstream, per consumer), but no test explicitly asserts the field's absence, so left unchecked rather than claiming false coverage

✓ Portfolio weight sums to 100% across a historic portfolio's assets (by `TotalBought`)
  — `HistoricPortfolioAssetSummaryServiceTests.GetPortfolioAssetsSummary_PortfolioWeightsSumTo100Percent` + `SummaryEndpointsTests.GetPortfolioAssetsSummary_ScopeHistoric_PortfolioWeightsSumTo100`

**Cross-feature integration:**

✓ Historic tree/asset data served by F05 is correctly consumed by both the realized totals service (F06) and the breakdown charts service (F07)
  — Now satisfiable since both F06 (this PR) and F07 (#169) are implemented; covered by this PR's tests plus F07's existing coverage

## Test plan
- [x] `dotnet build --configuration Release` / `dotnet test` — full backend suite green (232 Application, 55 Api, 64 Domain, 126 Infrastructure incl. 5 pre-existing skips, 150 Presentation)
- [x] `tsc -b --noEmit`, `eslint .`, `vitest run` — full frontend suite green, 366/366 (TS type parity only, no UI changes)
- [x] Real end-to-end smoke test against a locally running API with test fixture data: `scope=historic` → `CLOSEDASSET` shows `realizedGainLoss: -50`, `portfolioWeight: 100`; `scope=active` → `BCIA11` shows `realizedGainLoss: null`, unchanged net-invested weighting

Docs: `docs/P10-F06-historic-realized-totals-service/spec.md` and `plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)