### PR TITLE
fix: unify realized vs unrealized gain/loss calculation

### DIFF
--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -228,7 +228,7 @@
                                                Margin="10,5"
                                                Foreground="Red"/>
 
-                                    <!-- Row 5: Total Credits -->
+                                    <!-- Row 5: Total Credits & Realized Gain/Loss -->
                                     <TextBlock Grid.Row="5" Grid.Column="0" Text="Total Credits:" FontWeight="Bold" Margin="0,5"/>
                                     <TextBlock Grid.Row="5" Grid.Column="1"
                                                Text="{Binding AssetDetails.TotalCredits, Mode=OneWay, StringFormat=N2}"
@@ -236,6 +236,14 @@
                                                FontFamily="Consolas"
                                                Margin="10,5"
                                                Foreground="Blue"/>
+
+                                    <TextBlock Grid.Row="5" Grid.Column="2" Text="Realized Gain/Loss:" FontWeight="Bold" Margin="20,5,0,5"/>
+                                    <TextBlock Grid.Row="5" Grid.Column="3"
+                                               Text="{Binding AssetDetails.RealizedGainLoss, Mode=OneWay, StringFormat=N2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Foreground="{Binding AssetDetails.RealizedGainLoss, Converter={StaticResource SignedValueToBrushConverter}}"
+                                               Margin="10,5"/>
 
                                     <!-- Separator -->
                                     <Border Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="4"

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -48,6 +48,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private decimal _totalBought;
     private decimal _totalSold;
     private decimal _totalCredits;
+    private decimal _realizedGainLoss;
     private decimal _todayCurrentValue;
     private string _todayCurrentValueAsOf = string.Empty;
     private string _todayInfoMessage = string.Empty;
@@ -133,6 +134,12 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     {
         get => _totalCredits;
         private set { if (SetProperty(ref _totalCredits, value)) NotifyCurrentValueChanged(); }
+    }
+
+    public decimal RealizedGainLoss
+    {
+        get => _realizedGainLoss;
+        private set => SetProperty(ref _realizedGainLoss, value);
     }
 
     public PlotModel? CreditsPlotModel { get => _creditsPlotModel; private set => SetProperty(ref _creditsPlotModel, value); }
@@ -417,6 +424,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         TotalBought = details.TotalBought;
         TotalSold = details.TotalSold;
         TotalCredits = details.TotalCredits;
+        RealizedGainLoss = details.RealizedGainLoss;
         IsCreditsAggregateView = false;
         HasCreditsContext = true;
         SetCreditsContext(BuildCreditsAssetKey(details.BrokerName, details.PortfolioName, details.Name), rebuild: false);
@@ -781,6 +789,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         TotalBought = 0;
         TotalSold = 0;
         TotalCredits = 0;
+        RealizedGainLoss = 0;
         _cashFlowsWithCredits = Array.Empty<AssetCashFlowDTO>();
         _cashFlowsWithoutCredits = Array.Empty<AssetCashFlowDTO>();
         _todayInfo.Clear();

--- a/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
+++ b/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
@@ -119,12 +119,14 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
         _currentPrice = price;
         _currentValue = price * CurrentQuantity;
 
-        _profitPercent = TotalInvested != 0
-            ? (_currentValue.Value - TotalInvested) / TotalInvested * 100
+        var costBasis = CurrentQuantity * AveragePrice;
+
+        _profitPercent = costBasis != 0
+            ? (_currentValue.Value - costBasis) / costBasis * 100
             : (decimal?)null;
 
-        _profitWithCreditsPercent = TotalInvested != 0
-            ? (_currentValue.Value + TotalCredits - TotalInvested) / TotalInvested * 100
+        _profitWithCreditsPercent = costBasis != 0
+            ? (_currentValue.Value + TotalCredits - costBasis) / costBasis * 100
             : (decimal?)null;
 
         var xirrFraction = _xirrCalculationService.Calculate(CashFlows, _currentValue.Value);

--- a/Financial.Application/DTOs/AssetDetailsDTO.cs
+++ b/Financial.Application/DTOs/AssetDetailsDTO.cs
@@ -92,6 +92,12 @@ public class AssetDetailsDTO
     public decimal TotalCredits { get; set; }
 
     /// <summary>
+    /// Realized gain/loss from closed (sold) quantity plus credits, computed via
+    /// weighted-average cost-basis replay of the asset's transaction history
+    /// </summary>
+    public decimal RealizedGainLoss { get; set; }
+
+    /// <summary>
     /// List of all transactions (buy/sell)
     /// </summary>
     public List<TransactionDTO> Transactions { get; set; } = new();

--- a/Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs
+++ b/Financial.Application/DTOs/PortfolioAssetSummaryItemDTO.cs
@@ -16,7 +16,7 @@ public sealed class PortfolioAssetSummaryItemDTO
     public decimal TotalBought { get; init; }
     public decimal TotalSold { get; init; }
     public decimal TotalInvested { get; init; }
-    public decimal? RealizedGainLoss { get; init; }
+    public decimal RealizedGainLoss { get; init; }
     public decimal PortfolioWeight { get; init; }
     public decimal TotalCredits { get; init; }
     public IReadOnlyList<AssetCashFlowDTO> CashFlows { get; init; } = [];

--- a/Financial.Application/Services/ActivePortfolioAssetSummaryService.cs
+++ b/Financial.Application/Services/ActivePortfolioAssetSummaryService.cs
@@ -21,10 +21,8 @@ public sealed class ActivePortfolioAssetSummaryService : IActivePortfolioAssetSu
         if (assets.Count == 0)
             return [];
 
-        return PortfolioAssetSummaryBuilder.Build(assets, DateTime.Today, CalculateNetInvested, NoRealizedGainLoss);
+        return PortfolioAssetSummaryBuilder.Build(assets, DateTime.Today, CalculateNetInvested);
     }
 
     private static decimal CalculateNetInvested(AssetTotals totals) => totals.TotalBought - totals.TotalSold;
-
-    private static decimal? NoRealizedGainLoss(AssetTotals totals) => null;
 }

--- a/Financial.Application/Services/HistoricPortfolioAssetSummaryService.cs
+++ b/Financial.Application/Services/HistoricPortfolioAssetSummaryService.cs
@@ -21,11 +21,8 @@ public sealed class HistoricPortfolioAssetSummaryService : IHistoricPortfolioAss
         if (assets.Count == 0)
             return [];
 
-        return PortfolioAssetSummaryBuilder.Build(assets, DateTime.Today, CalculateGrossBought, CalculateRealizedGainLoss);
+        return PortfolioAssetSummaryBuilder.Build(assets, DateTime.Today, CalculateGrossBought);
     }
 
     private static decimal CalculateGrossBought(AssetTotals totals) => totals.TotalBought;
-
-    private static decimal? CalculateRealizedGainLoss(AssetTotals totals) =>
-        totals.TotalSold - totals.TotalBought + totals.TotalCredits;
 }

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -143,6 +143,31 @@ internal static class NavigationMapper
         return (totalBought, totalSold, totalCredits);
     }
 
+    internal static decimal CalculateRealizedGainLoss(Asset asset)
+    {
+        // Mirrors Asset.AddTransaction's weighted-average recurrence exactly, replaying
+        // asset.Transactions in stored order (not sorted by Date, since that's the same
+        // order the domain itself used to produce the asset's current AveragePrice) so the
+        // running cost basis at each Sell matches what the domain actually used.
+        decimal runningAveragePrice = 0, runningQuantity = 0, realizedCapitalGain = 0;
+        foreach (var t in asset.Transactions)
+        {
+            if (t.Type == Transaction.TransactionType.Buy)
+            {
+                runningAveragePrice = (runningAveragePrice * runningQuantity + t.TotalPrice) / (runningQuantity + t.Quantity);
+                runningQuantity += t.Quantity;
+            }
+            else
+            {
+                realizedCapitalGain += t.TotalPrice - (t.Quantity * runningAveragePrice);
+                runningQuantity -= t.Quantity;
+            }
+        }
+
+        var totalCredits = asset.Credits.Sum(c => c.Value);
+        return realizedCapitalGain + totalCredits;
+    }
+
     private static IEnumerable<PortfolioNodeDTO> MapPortfolios(IEnumerable<Portfolio> portfolios, InvestmentScope scope)
     {
         return portfolios.OrderBy(p => p.Name, StringComparer.CurrentCultureIgnoreCase).Select(portfolio => MapPortfolio(portfolio, scope));

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -77,6 +77,7 @@ public sealed class NavigationService : INavigationService
             TotalBought = totalBought,
             TotalSold = totalSold,
             TotalCredits = totalCredits,
+            RealizedGainLoss = NavigationMapper.CalculateRealizedGainLoss(asset),
             Transactions = transactions,
             Credits = credits,
             CashFlowsWithCredits = AssetCashFlowBuilder.BuildWithCredits(asset),

--- a/Financial.Application/Services/PortfolioAssetSummaryBuilder.cs
+++ b/Financial.Application/Services/PortfolioAssetSummaryBuilder.cs
@@ -10,11 +10,10 @@ internal static class PortfolioAssetSummaryBuilder
     internal static IReadOnlyList<PortfolioAssetSummaryItemDTO> Build(
         IEnumerable<Asset> assets,
         DateTime today,
-        Func<AssetTotals, decimal> weightBasisSelector,
-        Func<AssetTotals, decimal?> realizedGainLossSelector)
+        Func<AssetTotals, decimal> weightBasisSelector)
     {
         var computed = assets
-            .Select(a => ComputeAssetData(a, today, weightBasisSelector, realizedGainLossSelector))
+            .Select(a => ComputeAssetData(a, today, weightBasisSelector))
             .ToList();
         var portfolioWeightBasis = computed.Sum(c => c.WeightBasis);
 
@@ -27,13 +26,12 @@ internal static class PortfolioAssetSummaryBuilder
     private static AssetComputedData ComputeAssetData(
         Asset asset,
         DateTime today,
-        Func<AssetTotals, decimal> weightBasisSelector,
-        Func<AssetTotals, decimal?> realizedGainLossSelector)
+        Func<AssetTotals, decimal> weightBasisSelector)
     {
         var (totalBought, totalSold, totalCredits) = NavigationMapper.CalculateTotals(asset);
         var totals = new AssetTotals(totalBought, totalSold, totalCredits);
         var weightBasis = weightBasisSelector(totals);
-        var realizedGainLoss = realizedGainLossSelector(totals);
+        var realizedGainLoss = NavigationMapper.CalculateRealizedGainLoss(asset);
 
         var firstBuyDate = asset.Transactions
             .Where(t => t.Type == Transaction.TransactionType.Buy)
@@ -155,7 +153,7 @@ internal static class PortfolioAssetSummaryBuilder
     private sealed record AssetComputedData(
         string AssetName, string Ticker, string Exchange, GlobalAssetClass Class,
         DateTime? FirstInvestmentDate, decimal CurrentQuantity, decimal AveragePrice,
-        decimal TotalBought, decimal TotalSold, decimal TotalInvested, decimal? RealizedGainLoss, decimal WeightBasis,
+        decimal TotalBought, decimal TotalSold, decimal TotalInvested, decimal RealizedGainLoss, decimal WeightBasis,
         decimal TotalCredits, IReadOnlyList<AssetCashFlowDTO> CashFlows,
         decimal LastMonthCredits, string? LastCreditMonth, decimal? LastMonthCreditsPercent,
         int? CreditFrequencyPerYear, decimal? EstimatedAnnualCredits, decimal? EstimatedAnnualPercent,

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -98,6 +98,7 @@ export interface AssetDetailsDto {
   totalBought: number
   totalSold: number
   totalCredits: number
+  realizedGainLoss: number
   transactions: TransactionDto[]
   credits: CreditDto[]
   cashFlowsWithCredits: AssetCashFlowDto[]
@@ -245,7 +246,7 @@ export interface PortfolioAssetSummaryItemDto {
   totalBought: number
   totalSold: number
   totalInvested: number
-  realizedGainLoss: number | null
+  realizedGainLoss: number
   portfolioWeight: number
   totalCredits: number
   cashFlows: AssetCashFlowDto[]

--- a/Financial.Web/src/components/AssetSummaryTab.tsx
+++ b/Financial.Web/src/components/AssetSummaryTab.tsx
@@ -51,6 +51,8 @@ export default function AssetSummaryTab() {
     return null
   }
 
+  const realizedGainLossClass =
+    asset.realizedGainLoss >= 0 ? 'asset-summary__value--green' : 'asset-summary__value--red'
   const resultClass =
     resultPercent >= 0 ? 'asset-summary__value--green' : 'asset-summary__value--red'
   const resultWithCreditsClass =
@@ -104,10 +106,16 @@ export default function AssetSummaryTab() {
           </span>
         </div>
 
-        <div className="asset-summary__field asset-summary__field--full">
+        <div className="asset-summary__field">
           <span className="asset-summary__label">Total Credits</span>
           <span className="asset-summary__value asset-summary__value--blue">
             {formatN2(asset.totalCredits)}
+          </span>
+        </div>
+        <div className="asset-summary__field">
+          <span className="asset-summary__label">Realized Gain/Loss</span>
+          <span className={`asset-summary__value ${realizedGainLossClass}`}>
+            {formatN2(asset.realizedGainLoss)}
           </span>
         </div>
 

--- a/Financial.Web/src/components/PortfolioSummaryTab.tsx
+++ b/Financial.Web/src/components/PortfolioSummaryTab.tsx
@@ -34,14 +34,16 @@ function AssetRow({ item, rowPrice }: AssetRowProps) {
   const currentValue =
     rowPrice.currentPrice !== null ? rowPrice.currentPrice * item.currentQuantity : null
 
+  const costBasis = item.currentQuantity * item.averagePrice
+
   const profitPercent =
-    currentValue !== null && item.totalInvested !== 0
-      ? ((currentValue - item.totalInvested) / item.totalInvested) * 100
+    currentValue !== null && costBasis !== 0
+      ? ((currentValue - costBasis) / costBasis) * 100
       : null
 
   const profitWithCreditsPercent =
-    currentValue !== null && item.totalInvested !== 0
-      ? ((currentValue + item.totalCredits - item.totalInvested) / item.totalInvested) * 100
+    currentValue !== null && costBasis !== 0
+      ? ((currentValue + item.totalCredits - costBasis) / costBasis) * 100
       : null
 
   const xirrValue = (() => {

--- a/Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx
@@ -47,6 +47,7 @@ const ASSET: AssetDetailsDto = {
   totalBought: 2000,
   totalSold: 500,
   totalCredits: 50,
+  realizedGainLoss: 75,
   transactions: [],
   credits: [],
   cashFlowsWithCredits: [],
@@ -135,6 +136,27 @@ describe('AssetSummaryTab', () => {
     const totalCreditsLabel = screen.getByText('Total Credits')
     const valueEl = totalCreditsLabel.nextElementSibling
     expect(valueEl).toHaveClass('asset-summary__value--blue')
+  })
+
+  it('renders_realized_gain_loss_field_regardless_of_current_section', () => {
+    setMock({ asset: ASSET, showCurrentSection: false })
+    render(<AssetSummaryTab />)
+    const label = screen.getByText('Realized Gain/Loss')
+    expect(label.nextElementSibling?.textContent).toBe('75.00')
+  })
+
+  it('renders_positive_realized_gain_loss_in_green', () => {
+    setMock({ asset: { ...ASSET, realizedGainLoss: 75 } })
+    render(<AssetSummaryTab />)
+    const label = screen.getByText('Realized Gain/Loss')
+    expect(label.nextElementSibling).toHaveClass('asset-summary__value--green')
+  })
+
+  it('renders_negative_realized_gain_loss_in_red', () => {
+    setMock({ asset: { ...ASSET, realizedGainLoss: -30 } })
+    render(<AssetSummaryTab />)
+    const label = screen.getByText('Realized Gain/Loss')
+    expect(label.nextElementSibling).toHaveClass('asset-summary__value--red')
   })
 
   it('renders_current_section_when_quantity_and_price_nonzero', () => {

--- a/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/PortfolioSummaryTab.test.tsx
@@ -63,7 +63,7 @@ const ITEM_1: PortfolioAssetSummaryItemDto = {
   totalBought: 2500,
   totalSold: 0,
   totalInvested: 2500,
-  realizedGainLoss: null,
+  realizedGainLoss: 0,
   portfolioWeight: 23.4,
   totalCredits: 0,
   cashFlows: [],
@@ -223,7 +223,8 @@ describe('PortfolioSummaryTab', () => {
   })
 
   it('renders_correct_profit_percent', () => {
-    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentQuantity: 25, totalInvested: 250 }
+    // costBasis = quantity x averagePrice = 25 x 10 = 250
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentQuantity: 25, averagePrice: 10, totalInvested: 250 }
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
@@ -235,11 +236,12 @@ describe('PortfolioSummaryTab', () => {
   })
 
   it('renders_correct_profit_with_credits_percent', () => {
-    // currentValue = 10.5 * 25 = 262.50
+    // currentValue = 10.5 * 25 = 262.50; costBasis = 25 x 10 = 250
     // profitWithCreditsPercent = (262.50 + 12.50 - 250) / 250 * 100 = 10.00%
     const item: PortfolioAssetSummaryItemDto = {
       ...ITEM_1,
       currentQuantity: 25,
+      averagePrice: 10,
       totalInvested: 250,
       totalCredits: 12.5,
     }
@@ -271,7 +273,7 @@ describe('PortfolioSummaryTab', () => {
   })
 
   it('renders_dash_in_profit_when_total_invested_is_zero', () => {
-    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, totalInvested: 0 }
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, averagePrice: 0, totalInvested: 0 }
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
@@ -293,7 +295,8 @@ describe('PortfolioSummaryTab', () => {
   })
 
   it('applies_green_class_to_positive_profit', () => {
-    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentQuantity: 25, totalInvested: 200 }
+    // costBasis = 25 x 8 = 200
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentQuantity: 25, averagePrice: 8, totalInvested: 200 }
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
@@ -303,7 +306,8 @@ describe('PortfolioSummaryTab', () => {
   })
 
   it('applies_red_class_to_negative_profit', () => {
-    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentQuantity: 25, totalInvested: 300 }
+    // costBasis = 25 x 12 = 300
+    const item: PortfolioAssetSummaryItemDto = { ...ITEM_1, currentQuantity: 25, averagePrice: 12, totalInvested: 300 }
     const rowPrice: RowPriceState = { isLoading: false, currentPrice: 10.5, fetchFailed: false }
     setAggregatedMock({ summary: SUMMARY })
     setPortfolioMock({ items: [item], rowPrices: [rowPrice] })
@@ -313,11 +317,12 @@ describe('PortfolioSummaryTab', () => {
   })
 
   it('applies_green_class_to_positive_profit_with_credits', () => {
-    // currentValue = 10.5 * 25 = 262.50; totalInvested = 300; totalCredits = 50
+    // currentValue = 10.5 * 25 = 262.50; costBasis = 25 x 12 = 300; totalCredits = 50
     // profitWithCreditsPercent = (262.50 + 50 - 300) / 300 * 100 = 4.17% (positive)
     const item: PortfolioAssetSummaryItemDto = {
       ...ITEM_1,
       currentQuantity: 25,
+      averagePrice: 12,
       totalInvested: 300,
       totalCredits: 50,
     }

--- a/Financial.Web/src/hooks/useAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/useAssetSummary.test.ts
@@ -50,6 +50,7 @@ const ASSET_DETAILS: AssetDetailsDto = {
   totalBought: 2000,
   totalSold: 0,
   totalCredits: 50,
+  realizedGainLoss: 0,
   transactions: [],
   credits: [],
   cashFlowsWithCredits: [{ date: '2024-01-01T00:00:00', amount: -2000 }],
@@ -176,7 +177,8 @@ describe('useAssetSummary', () => {
     setNode(ASSET_NODE)
     await waitFor(() => expect(result.current.price).not.toBeNull())
     const tcv = PRICE.price * ASSET_DETAILS.quantity
-    const expected = (tcv - ASSET_DETAILS.totalBought) / ASSET_DETAILS.totalBought
+    const costBasis = ASSET_DETAILS.quantity * ASSET_DETAILS.averagePrice
+    const expected = (tcv - costBasis) / costBasis
     expect(result.current.resultPercent).toBeCloseTo(expected, 5)
   })
 
@@ -200,8 +202,26 @@ describe('useAssetSummary', () => {
     await waitFor(() => expect(result.current.price).not.toBeNull())
     const tcv = PRICE.price * ASSET_DETAILS.quantity
     const tcc = tcv + ASSET_DETAILS.totalCredits
-    const expected = (tcc - ASSET_DETAILS.totalBought) / ASSET_DETAILS.totalBought
+    const costBasis = ASSET_DETAILS.quantity * ASSET_DETAILS.averagePrice
+    const expected = (tcc - costBasis) / costBasis
     expect(result.current.resultWithCreditsPercent).toBeCloseTo(expected, 5)
+  })
+
+  it('computes_result_percent_using_current_cost_basis_not_gross_total_bought', async () => {
+    // Partial sell scenario: totalBought (2000) no longer reflects the current position's
+    // cost basis once some quantity has been sold — quantity x averagePrice (60 x 20 = 1200) does.
+    const partiallySold: AssetDetailsDto = { ...ASSET_DETAILS, quantity: 60, totalBought: 2000, totalSold: 800 }
+    getAssetDetailsMock.mockResolvedValue(partiallySold)
+    getCurrentPriceMock.mockResolvedValue(PRICE)
+    const { wrapper, setNode } = createSelectedNodeWrapper()
+    const { result } = renderHook(() => useAssetSummary(), { wrapper })
+    setNode(ASSET_NODE)
+    await waitFor(() => expect(result.current.price).not.toBeNull())
+    const tcv = PRICE.price * partiallySold.quantity
+    const costBasis = partiallySold.quantity * partiallySold.averagePrice
+    const expected = (tcv - costBasis) / costBasis
+    expect(result.current.resultPercent).toBeCloseTo(expected, 5)
+    expect(result.current.resultPercent).not.toBeCloseTo((tcv - partiallySold.totalBought) / partiallySold.totalBought, 5)
   })
 
   it('fetches_xirr_for_both_totals_once_asset_and_price_are_loaded', async () => {

--- a/Financial.Web/src/hooks/useAssetSummary.ts
+++ b/Financial.Web/src/hooks/useAssetSummary.ts
@@ -191,17 +191,15 @@ export function useAssetSummary(): AssetSummaryData {
   const totalCurrentValue =
     state.price && state.asset ? state.price.price * state.asset.quantity : 0
 
+  const costBasis = state.asset ? state.asset.quantity * state.asset.averagePrice : 0
+
   const resultPercent =
-    state.asset && state.asset.totalBought !== 0
-      ? (totalCurrentValue - state.asset.totalBought) / state.asset.totalBought
-      : 0
+    costBasis !== 0 ? (totalCurrentValue - costBasis) / costBasis : 0
 
   const totalCurrentPlusCredits = state.asset ? totalCurrentValue + state.asset.totalCredits : 0
 
   const resultWithCreditsPercent =
-    state.asset && state.asset.totalBought !== 0
-      ? (totalCurrentPlusCredits - state.asset.totalBought) / state.asset.totalBought
-      : 0
+    costBasis !== 0 ? (totalCurrentPlusCredits - costBasis) / costBasis : 0
 
   return {
     asset: state.asset,

--- a/Financial.Web/src/hooks/useCredits.test.ts
+++ b/Financial.Web/src/hooks/useCredits.test.ts
@@ -87,6 +87,7 @@ const ASSET_DETAILS: AssetDetailsDto = {
   totalBought: 2000,
   totalSold: 0,
   totalCredits: 470.5,
+  realizedGainLoss: 0,
   transactions: [],
   credits: [CREDIT_A, CREDIT_B],
   cashFlowsWithCredits: [],

--- a/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/usePortfolioAssetSummary.test.ts
@@ -47,7 +47,7 @@ const ITEM_1: PortfolioAssetSummaryItemDto = {
   totalBought: 2500,
   totalSold: 0,
   totalInvested: 2500,
-  realizedGainLoss: null,
+  realizedGainLoss: 0,
   portfolioWeight: 71.4,
   totalCredits: 125,
   cashFlows: [
@@ -75,7 +75,7 @@ const ITEM_2: PortfolioAssetSummaryItemDto = {
   totalBought: 1000,
   totalSold: 0,
   totalInvested: 1000,
-  realizedGainLoss: null,
+  realizedGainLoss: 0,
   portfolioWeight: 28.6,
   totalCredits: 0,
   cashFlows: [

--- a/Financial.Web/src/hooks/useTransactions.test.ts
+++ b/Financial.Web/src/hooks/useTransactions.test.ts
@@ -97,6 +97,7 @@ const ASSET_DETAILS: AssetDetailsDto = {
   totalBought: 2000,
   totalSold: 0,
   totalCredits: 50,
+  realizedGainLoss: 0,
   transactions: [TRANSACTION_A, TRANSACTION_B],
   credits: [],
   cashFlowsWithCredits: [],

--- a/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
@@ -182,7 +182,7 @@ public class SummaryEndpointsTests
     }
 
     [Fact]
-    public async Task GetPortfolioAssetsSummary_ScopeActive_PreservesNetInvestedWeightingAndNullRealizedGainLoss()
+    public async Task GetPortfolioAssetsSummary_ScopeActive_PreservesNetInvestedWeightingAndComputesRealizedGainLoss()
     {
         await using var factory = new ApiTestFactory();
         using var client = factory.CreateClient();
@@ -194,10 +194,11 @@ public class SummaryEndpointsTests
         var items = await response.Content.ReadFromJsonAsync<List<PortfolioAssetSummaryItemDTO>>();
         items.Should().NotBeNull();
         // BCIA11: bought 10 x 100 = 1000, sold 2 x 110 = 220 — active weighting stays net invested (780), 100% of the portfolio
+        // RealizedGainLoss = capital gain (220 - 2 x 100 average cost = 20) + credits (5 + 6 = 11) = 31
         var bcia11 = items!.Single(i => i.AssetName == "BCIA11");
         bcia11.TotalInvested.Should().Be(780m);
         bcia11.PortfolioWeight.Should().Be(100m);
-        bcia11.RealizedGainLoss.Should().BeNull();
+        bcia11.RealizedGainLoss.Should().Be(31m);
     }
 
     [Fact]

--- a/Tests/Financial.Application.Tests/Services/ActivePortfolioAssetSummaryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/ActivePortfolioAssetSummaryServiceTests.cs
@@ -51,7 +51,7 @@ public class ActivePortfolioAssetSummaryServiceTests
         item.TotalBought.Should().Be(2500m);
         item.TotalSold.Should().Be(550m);
         item.TotalInvested.Should().Be(1950m);
-        item.RealizedGainLoss.Should().BeNull();
+        item.RealizedGainLoss.Should().Be(50m);
         item.PortfolioWeight.Should().Be(100m);
     }
 
@@ -598,7 +598,7 @@ public class ActivePortfolioAssetSummaryServiceTests
     }
 
     [Fact]
-    public void GetPortfolioAssetsSummary_RealizedGainLossIsAlwaysNull()
+    public void GetPortfolioAssetsSummary_ComputesRealizedGainLossFromTransactionReplay()
     {
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 60m, 0m));
@@ -607,7 +607,7 @@ public class ActivePortfolioAssetSummaryServiceTests
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
-        result[0].RealizedGainLoss.Should().BeNull();
+        result[0].RealizedGainLoss.Should().Be(-50m);
     }
 
     private ActivePortfolioAssetSummaryService CreateService() => new(_repository);

--- a/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
+++ b/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
@@ -128,6 +128,43 @@ public class NavigationMapperTests
         details!.PositionType.Should().Be(PositionType.Flat);
     }
 
+    [Fact]
+    public void GetAssetDetails_ComputesRealizedGainLossFromWeightedAverageCostBasisReplay()
+    {
+        var broker = Broker.Create("Broker", "BRL");
+        var portfolio = broker.AddPortfolio("Portfolio");
+        var asset = Asset.Create("ASSET1", "ISIN", "BVMF", "ASSET1", CountryCode.BR, "FII", GlobalAssetClass.Equity);
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 3, 1), Transaction.TransactionType.Buy, 10m, 100m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 5, 1), Transaction.TransactionType.Buy, 15m, 100m, 0m));
+        asset.AddTransaction(Transaction.Create(new DateTime(2022, 1, 1), Transaction.TransactionType.Sell, 5m, 110m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2021, 6, 1), Credit.CreditType.Dividend, 12m));
+        portfolio.AddAsset(asset);
+        _repository.Broker = broker;
+
+        var details = CreateService().GetAssetDetails("Broker", "Portfolio", "ASSET1");
+
+        // Weighted-average cost after both buys is 100; capital gain = 550 - (5 x 100) = 50; plus 12 credits = 62
+        details.Should().NotBeNull();
+        details!.RealizedGainLoss.Should().Be(62m);
+    }
+
+    [Fact]
+    public void GetAssetDetails_WithNoSales_RealizedGainLossEqualsCreditsOnly()
+    {
+        var broker = Broker.Create("Broker", "BRL");
+        var portfolio = broker.AddPortfolio("Portfolio");
+        var asset = Asset.Create("ASSET1", "ISIN", "BVMF", "ASSET1", CountryCode.BR, "FII", GlobalAssetClass.Equity);
+        asset.AddTransaction(Transaction.Create(new DateTime(2021, 3, 1), Transaction.TransactionType.Buy, 10m, 100m, 0m));
+        asset.AddCredit(Credit.Create(new DateTime(2021, 6, 1), Credit.CreditType.Dividend, 8m));
+        portfolio.AddAsset(asset);
+        _repository.Broker = broker;
+
+        var details = CreateService().GetAssetDetails("Broker", "Portfolio", "ASSET1");
+
+        details.Should().NotBeNull();
+        details!.RealizedGainLoss.Should().Be(8m);
+    }
+
     private static Asset BuildAssetWithQuantity(string name, decimal quantity)
     {
         var asset = Asset.Create(name, "ISIN", "BVMF", name, CountryCode.BR, "FII", GlobalAssetClass.Equity);

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelXirrTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelXirrTests.cs
@@ -23,7 +23,8 @@ public class AssetDetailsViewModelXirrTests
     private static AssetDetailsDTO BuildAssetDetails(
         IReadOnlyList<AssetCashFlowDTO> cashFlowsWithoutCredits,
         IReadOnlyList<AssetCashFlowDTO> cashFlowsWithCredits,
-        decimal totalCredits = 0m) => new()
+        decimal totalCredits = 0m,
+        decimal realizedGainLoss = 0m) => new()
     {
         Name = "TEST",
         BrokerName = "XPI",
@@ -33,6 +34,7 @@ public class AssetDetailsViewModelXirrTests
         Quantity = 1m,
         AveragePrice = 1000m,
         TotalCredits = totalCredits,
+        RealizedGainLoss = realizedGainLoss,
         CashFlowsWithoutCredits = cashFlowsWithoutCredits,
         CashFlowsWithCredits = cashFlowsWithCredits
     };
@@ -93,6 +95,31 @@ public class AssetDetailsViewModelXirrTests
 
         vm.Xirr.Should().BeNull();
         vm.XirrWithCredits.Should().BeNull();
+    }
+
+    [Fact]
+    public void LoadAssetDetails_SetsRealizedGainLossFromDto()
+    {
+        var buyDate = DateTime.Today.AddYears(-1);
+        var cashFlows = new List<AssetCashFlowDTO> { new() { Date = buyDate, Amount = -1000m } };
+        var vm = BuildViewModel();
+
+        vm.LoadAssetDetails(BuildAssetDetails(cashFlows, cashFlows, realizedGainLoss: 62m));
+
+        vm.RealizedGainLoss.Should().Be(62m);
+    }
+
+    [Fact]
+    public void Clear_ResetsRealizedGainLossToZero()
+    {
+        var buyDate = DateTime.Today.AddYears(-1);
+        var cashFlows = new List<AssetCashFlowDTO> { new() { Date = buyDate, Amount = -1000m } };
+        var vm = BuildViewModel();
+        vm.LoadAssetDetails(BuildAssetDetails(cashFlows, cashFlows, realizedGainLoss: 62m));
+
+        vm.Clear();
+
+        vm.RealizedGainLoss.Should().Be(0m);
     }
 
     private sealed class FixedPriceService : IAssetPriceService

--- a/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
@@ -176,9 +176,9 @@ public class PortfolioAssetSummaryRowViewModelTests
     [Fact]
     public void DisplayProfitPercent_AfterApplyPrice_ReturnsFormattedPercent()
     {
-        var row = BuildRow(currentQuantity: 25m, totalInvested: 250m);
+        var row = BuildRow(currentQuantity: 25m, averagePrice: 10m, totalInvested: 250m);
         row.ApplyPrice(10.50m);
-        // CurrentValue = 262.50, Profit = (262.50 - 250) / 250 * 100 = 5.00
+        // CurrentValue = 262.50, costBasis = 25 x 10 = 250, Profit = (262.50 - 250) / 250 * 100 = 5.00
         row.DisplayProfitPercent.Should().Be("5.00%");
     }
 
@@ -209,10 +209,20 @@ public class PortfolioAssetSummaryRowViewModelTests
     [Fact]
     public void DisplayProfitWithCreditsPercent_AfterApplyPrice_ReturnsFormattedPercent()
     {
-        var row = BuildRow(currentQuantity: 25m, totalInvested: 250m, totalCredits: 12.5m);
+        var row = BuildRow(currentQuantity: 25m, averagePrice: 10m, totalInvested: 250m, totalCredits: 12.5m);
         row.ApplyPrice(10.50m);
-        // CurrentValue = 262.50, ProfitWithCredits = (262.50 + 12.5 - 250) / 250 * 100 = 10.00
+        // CurrentValue = 262.50, costBasis = 25 x 10 = 250, ProfitWithCredits = (262.50 + 12.5 - 250) / 250 * 100 = 10.00
         row.DisplayProfitWithCreditsPercent.Should().Be("10.00%");
+    }
+
+    [Fact]
+    public void DisplayProfitPercent_UsesCurrentCostBasisNotGrossTotalInvested()
+    {
+        // Partial sell scenario: totalInvested (2000, gross bought) no longer reflects the current
+        // position's cost basis once some quantity has been sold — quantity x averagePrice (60 x 20 = 1200) does.
+        var row = BuildRow(currentQuantity: 60m, averagePrice: 20m, totalInvested: 2000m);
+        row.ApplyPrice(25m); // CurrentValue = 1500, costBasis = 1200, Profit = (1500 - 1200) / 1200 * 100 = 25.00
+        row.DisplayProfitPercent.Should().Be("25.00%");
     }
 
     [Fact]
@@ -261,8 +271,8 @@ public class PortfolioAssetSummaryRowViewModelTests
     [Fact]
     public void ProfitIsPositive_WhenCurrentValueExceedsTotalInvested_IsTrue()
     {
-        var row = BuildRow(currentQuantity: 25m, totalInvested: 250m);
-        row.ApplyPrice(10.50m); // CurrentValue = 262.50 > 250
+        var row = BuildRow(currentQuantity: 25m, averagePrice: 10m, totalInvested: 250m);
+        row.ApplyPrice(10.50m); // CurrentValue = 262.50 > costBasis (250)
         row.ProfitIsPositive.Should().BeTrue();
         row.ProfitIsNegative.Should().BeFalse();
     }
@@ -270,8 +280,8 @@ public class PortfolioAssetSummaryRowViewModelTests
     [Fact]
     public void ProfitIsNegative_WhenCurrentValueBelowTotalInvested_IsTrue()
     {
-        var row = BuildRow(currentQuantity: 25m, totalInvested: 300m);
-        row.ApplyPrice(10.00m); // CurrentValue = 250 < 300
+        var row = BuildRow(currentQuantity: 25m, averagePrice: 12m, totalInvested: 300m);
+        row.ApplyPrice(10.00m); // CurrentValue = 250 < costBasis (300)
         row.ProfitIsNegative.Should().BeTrue();
         row.ProfitIsPositive.Should().BeFalse();
     }
@@ -288,9 +298,9 @@ public class PortfolioAssetSummaryRowViewModelTests
     [Fact]
     public void ProfitWithCreditsIsPositive_WhenProfitWithCreditsExceedsZero_IsTrue()
     {
-        // CurrentValue < TotalInvested but CurrentValue + TotalCredits > TotalInvested
-        var row = BuildRow(currentQuantity: 25m, totalInvested: 300m, totalCredits: 100m);
-        row.ApplyPrice(10.00m); // CurrentValue = 250, 250 + 100 = 350 > 300
+        // CurrentValue < costBasis but CurrentValue + TotalCredits > costBasis
+        var row = BuildRow(currentQuantity: 25m, averagePrice: 12m, totalInvested: 300m, totalCredits: 100m);
+        row.ApplyPrice(10.00m); // CurrentValue = 250, 250 + 100 = 350 > costBasis (300)
         row.ProfitWithCreditsIsPositive.Should().BeTrue();
         row.ProfitWithCreditsIsNegative.Should().BeFalse();
     }
@@ -298,8 +308,8 @@ public class PortfolioAssetSummaryRowViewModelTests
     [Fact]
     public void ProfitWithCreditsIsNegative_WhenProfitWithCreditsBelowZero_IsTrue()
     {
-        var row = BuildRow(currentQuantity: 25m, totalInvested: 300m, totalCredits: 0m);
-        row.ApplyPrice(10.00m); // CurrentValue = 250 < 300, no credits
+        var row = BuildRow(currentQuantity: 25m, averagePrice: 12m, totalInvested: 300m, totalCredits: 0m);
+        row.ApplyPrice(10.00m); // CurrentValue = 250 < costBasis (300), no credits
         row.ProfitWithCreditsIsNegative.Should().BeTrue();
         row.ProfitWithCreditsIsPositive.Should().BeFalse();
     }


### PR DESCRIPTION
## Summary
- Fixes an inconsistency reported when viewing BRCO11 (XPI/FII): the single-asset "Result %" (Web) and the portfolio table's "Profit %" (Web + WPF) used three different, disagreeing cost-basis formulas — gross `TotalBought`, net `TotalInvested` (bought - sold), and (on WPF's portfolio table) `TotalInvested` as well — so the same asset showed wildly different percentages depending on which screen you looked at.
- All three now compute unrealized % using the position's actual cost basis: `quantity x averagePrice`.
- Added a new backend-computed `RealizedGainLoss` field (`NavigationMapper.CalculateRealizedGainLoss`), which replays each asset's transaction history using the same weighted-average cost-basis recurrence the domain itself uses (`Asset.AddTransaction`), so realized capital gains/losses (from historical sells) plus credits are surfaced as their own value instead of being blended into — and corrupting — the unrealized percentage.
- `RealizedGainLoss` is now exposed on `AssetDetailsDTO` (both Active and Historic scope) and simplifies `PortfolioAssetSummaryBuilder`, which previously had two different, only-sometimes-correct ad-hoc formulas (one of which literally always returned `null` for Active scope).
- Web: `AssetSummaryTab` now always shows "Realized Gain/Loss" (previously nothing showed it for Active-scope assets at all).
- WPF: `AssetDetailsViewModel` now surfaces `RealizedGainLoss` next to Total Credits in the asset details panel.

## Test plan
- [x] `Financial.Domain.Tests` — 64 passed
- [x] `Financial.Application.Tests` — 234 passed (incl. new `NavigationMapper.CalculateRealizedGainLoss` coverage via `NavigationService.GetAssetDetails`)
- [x] `Financial.Infrastructure.Tests` — 121 passed, 5 pre-existing skips
- [x] `Financial.Api.Tests` — 55 passed
- [x] `Financial.Presentation.Tests` (WPF) — 153 passed (incl. new regression test proving the cost-basis fix)
- [x] `Financial.Web` vitest — 370 passed
- [x] `tsc -b --noEmit` — clean
- [x] Live smoke test against real `data.json`: confirmed BRCO11's `RealizedGainLoss` (1246.32) and cost basis (`quantity x averagePrice` ≈ 2307.35) now agree identically between the single-asset endpoint and the portfolio-list endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)