### PR TITLE
fix(P10-F11): Historic portfolio grid columns and status row

### DIFF
--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -188,6 +188,9 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
                                     <!-- Row 0: Quantity & Average Price -->
@@ -228,7 +231,7 @@
                                                Margin="10,5"
                                                Foreground="Red"/>
 
-                                    <!-- Row 5: Total Credits & Realized Gain/Loss -->
+                                    <!-- Row 5: Total Credits & Realized Gain/Loss (latter shown only for Active; Historic shows it in the Realized section below instead) -->
                                     <TextBlock Grid.Row="5" Grid.Column="0" Text="Total Credits:" FontWeight="Bold" Margin="0,5"/>
                                     <TextBlock Grid.Row="5" Grid.Column="1"
                                                Text="{Binding AssetDetails.TotalCredits, Mode=OneWay, StringFormat=N2}"
@@ -237,56 +240,101 @@
                                                Margin="10,5"
                                                Foreground="Blue"/>
 
-                                    <TextBlock Grid.Row="5" Grid.Column="2" Text="Realized Gain/Loss:" FontWeight="Bold" Margin="20,5,0,5"/>
+                                    <TextBlock Grid.Row="5" Grid.Column="2" Text="Realized Gain/Loss:" FontWeight="Bold" Margin="20,5,0,5"
+                                               Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                     <TextBlock Grid.Row="5" Grid.Column="3"
                                                Text="{Binding AssetDetails.RealizedGainLoss, Mode=OneWay, StringFormat=N2}"
                                                TextAlignment="Right"
                                                FontFamily="Consolas"
                                                Foreground="{Binding AssetDetails.RealizedGainLoss, Converter={StaticResource SignedValueToBrushConverter}}"
-                                               Margin="10,5"/>
+                                               Margin="10,5"
+                                               Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
                                     <!-- Separator -->
                                     <Border Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="4"
                                             BorderBrush="#EEEEEE" BorderThickness="0,1,0,0" Margin="0,15,0,15"/>
 
-                                    <!-- Row 7: Current Header (Active scope only - Historic never has a live price) -->
-                                    <TextBlock Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Text="Current" FontWeight="Bold" FontSize="13" Margin="0,5"
+                                    <!-- Row 7: Realized Header (Historic scope only) -->
+                                    <TextBlock Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Text="Realized" FontWeight="Bold" FontSize="13" Margin="0,5"
+                                               Visibility="{Binding AssetDetails.IsHistoricScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+                                    <!-- Row 8: Realized Gain/Loss & Portfolio Weight (Historic scope only) -->
+                                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Realized Gain/Loss:" FontWeight="Bold" Margin="0,5"
+                                               Visibility="{Binding AssetDetails.IsHistoricScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="8" Grid.Column="1"
+                                               Text="{Binding AssetDetails.RealizedGainLoss, Mode=OneWay, StringFormat=N2}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Foreground="{Binding AssetDetails.RealizedGainLoss, Converter={StaticResource SignedValueToBrushConverter}}"
+                                               Margin="10,5"
+                                               Visibility="{Binding AssetDetails.IsHistoricScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="8" Grid.Column="2" Text="Portfolio Weight:" FontWeight="Bold" Margin="20,5,0,5"
+                                               Visibility="{Binding AssetDetails.IsHistoricScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="8" Grid.Column="3"
+                                               Text="{Binding AssetDetails.DisplayRealizedPortfolioWeight, Mode=OneWay}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Margin="10,5"
+                                               Visibility="{Binding AssetDetails.IsHistoricScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+                                    <!-- Row 9: XIRR & XIRR w/ Credits, realized (Historic scope only) -->
+                                    <TextBlock Grid.Row="9" Grid.Column="0" Text="XIRR:" FontWeight="Bold" Margin="0,5"
+                                               Visibility="{Binding AssetDetails.IsHistoricScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="9" Grid.Column="1"
+                                               Text="{Binding AssetDetails.RealizedXirr, Mode=OneWay, StringFormat=P2, TargetNullValue='—'}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Foreground="{Binding AssetDetails.RealizedXirr, Converter={StaticResource SignedValueToBrushConverter}}"
+                                               Margin="10,5"
+                                               Visibility="{Binding AssetDetails.IsHistoricScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="9" Grid.Column="2" Text="XIRR w/ Credits:" FontWeight="Bold" Margin="20,5,0,5"
+                                               Visibility="{Binding AssetDetails.IsHistoricScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock Grid.Row="9" Grid.Column="3"
+                                               Text="{Binding AssetDetails.RealizedXirrWithCredits, Mode=OneWay, StringFormat=P2, TargetNullValue='—'}"
+                                               TextAlignment="Right"
+                                               FontFamily="Consolas"
+                                               Foreground="{Binding AssetDetails.RealizedXirrWithCredits, Converter={StaticResource SignedValueToBrushConverter}}"
+                                               Margin="10,5"
+                                               Visibility="{Binding AssetDetails.IsHistoricScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+                                    <!-- Row 10: Current Header (Active scope only - Historic never has a live price) -->
+                                    <TextBlock Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="2" Text="Current" FontWeight="Bold" FontSize="13" Margin="0,5"
                                                Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <Button Grid.Row="7" Grid.Column="2" Grid.ColumnSpan="2"
+                                    <Button Grid.Row="10" Grid.Column="2" Grid.ColumnSpan="2"
                                             Command="{Binding AssetDetails.RefreshTodayInfoCommand}"
                                             Content="Refresh"
                                             HorizontalAlignment="Right"
                                             Margin="0,5"
                                             Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-                                    <!-- Row 8: Current Value & As Of (Active scope only) -->
-                                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Current Value:" FontWeight="Bold" Margin="0,5"
+                                    <!-- Row 11: Current Value & As Of (Active scope only) -->
+                                    <TextBlock Grid.Row="11" Grid.Column="0" Text="Current Value:" FontWeight="Bold" Margin="0,5"
                                                Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="8" Grid.Column="1"
+                                    <TextBlock Grid.Row="11" Grid.Column="1"
                                                Text="{Binding AssetDetails.TodayCurrentValue, Mode=OneWay, StringFormat=N2}"
                                                TextAlignment="Right"
                                                FontFamily="Consolas"
                                                Margin="10,5"
                                                Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="8" Grid.Column="2" Text="As of:" FontWeight="Bold" Margin="20,5,0,5"
+                                    <TextBlock Grid.Row="11" Grid.Column="2" Text="As of:" FontWeight="Bold" Margin="20,5,0,5"
                                                Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="8" Grid.Column="3"
+                                    <TextBlock Grid.Row="11" Grid.Column="3"
                                                Text="{Binding AssetDetails.TodayCurrentValueAsOf, Mode=OneWay}"
                                                Margin="10,5"
                                                Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-                                    <!-- Row 9: Total Current Value & Result % -->
-                                    <TextBlock Grid.Row="9" Grid.Column="0" Text="Total Current Value:" FontWeight="Bold" Margin="0,5"
+                                    <!-- Row 12: Total Current Value & Result % -->
+                                    <TextBlock Grid.Row="12" Grid.Column="0" Text="Total Current Value:" FontWeight="Bold" Margin="0,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="9" Grid.Column="1"
+                                    <TextBlock Grid.Row="12" Grid.Column="1"
                                                Text="{Binding AssetDetails.TotalCurrentValue, Mode=OneWay, StringFormat=N2}"
                                                TextAlignment="Right"
                                                FontFamily="Consolas"
                                                Margin="10,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="9" Grid.Column="2" Text="Result %:" FontWeight="Bold" Margin="20,5,0,5"
+                                    <TextBlock Grid.Row="12" Grid.Column="2" Text="Result %:" FontWeight="Bold" Margin="20,5,0,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="9" Grid.Column="3"
+                                    <TextBlock Grid.Row="12" Grid.Column="3"
                                                Text="{Binding AssetDetails.ResultPercent, Mode=OneWay, StringFormat=P2}"
                                                TextAlignment="Right"
                                                FontFamily="Consolas"
@@ -294,18 +342,18 @@
                                                Margin="10,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-                                    <!-- Row 10: Total Current + Credits & Result % -->
-                                    <TextBlock Grid.Row="10" Grid.Column="0" Text="Total Current + Credits:" FontWeight="Bold" Margin="0,5"
+                                    <!-- Row 13: Total Current + Credits & Result % -->
+                                    <TextBlock Grid.Row="13" Grid.Column="0" Text="Total Current + Credits:" FontWeight="Bold" Margin="0,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="10" Grid.Column="1"
+                                    <TextBlock Grid.Row="13" Grid.Column="1"
                                                Text="{Binding AssetDetails.TotalCurrentValueWithCredits, Mode=OneWay, StringFormat=N2}"
                                                TextAlignment="Right"
                                                FontFamily="Consolas"
                                                Margin="10,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="10" Grid.Column="2" Text="Result %:" FontWeight="Bold" Margin="20,5,0,5"
+                                    <TextBlock Grid.Row="13" Grid.Column="2" Text="Result %:" FontWeight="Bold" Margin="20,5,0,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="10" Grid.Column="3"
+                                    <TextBlock Grid.Row="13" Grid.Column="3"
                                                Text="{Binding AssetDetails.ResultPercentWithCredits, Mode=OneWay, StringFormat=P2}"
                                                TextAlignment="Right"
                                                FontFamily="Consolas"
@@ -313,19 +361,19 @@
                                                Margin="10,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-                                    <!-- Row 11: XIRR & XIRR w/ Credits -->
-                                    <TextBlock Grid.Row="11" Grid.Column="0" Text="XIRR:" FontWeight="Bold" Margin="0,5"
+                                    <!-- Row 14: XIRR & XIRR w/ Credits -->
+                                    <TextBlock Grid.Row="14" Grid.Column="0" Text="XIRR:" FontWeight="Bold" Margin="0,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="11" Grid.Column="1"
+                                    <TextBlock Grid.Row="14" Grid.Column="1"
                                                Text="{Binding AssetDetails.Xirr, Mode=OneWay, StringFormat=P2, TargetNullValue='—'}"
                                                TextAlignment="Right"
                                                FontFamily="Consolas"
                                                Foreground="{Binding AssetDetails.Xirr, Converter={StaticResource SignedValueToBrushConverter}}"
                                                Margin="10,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="11" Grid.Column="2" Text="XIRR w/ Credits:" FontWeight="Bold" Margin="20,5,0,5"
+                                    <TextBlock Grid.Row="14" Grid.Column="2" Text="XIRR w/ Credits:" FontWeight="Bold" Margin="20,5,0,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="11" Grid.Column="3"
+                                    <TextBlock Grid.Row="14" Grid.Column="3"
                                                Text="{Binding AssetDetails.XirrWithCredits, Mode=OneWay, StringFormat=P2, TargetNullValue='—'}"
                                                TextAlignment="Right"
                                                FontFamily="Consolas"
@@ -333,10 +381,10 @@
                                                Margin="10,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-                                    <!-- Row 12: Status/Error (Active scope only - reports today's price-refresh status) -->
-                                    <TextBlock Grid.Row="12" Grid.Column="0" Text="Status:" FontWeight="Bold" Margin="0,5"
+                                    <!-- Row 15: Status/Error (Active scope only - reports today's price-refresh status) -->
+                                    <TextBlock Grid.Row="15" Grid.Column="0" Text="Status:" FontWeight="Bold" Margin="0,5"
                                                Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="3"
+                                    <TextBlock Grid.Row="15" Grid.Column="1" Grid.ColumnSpan="3"
                                                Text="{Binding AssetDetails.TodayInfoMessage, Mode=OneWay}"
                                                Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"
                                                Margin="10,5"

--- a/Financial.App/Components/NavigationView.xaml
+++ b/Financial.App/Components/NavigationView.xaml
@@ -333,10 +333,12 @@
                                                Margin="10,5"
                                                Visibility="{Binding AssetDetails.HasAveragePrice, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-                                    <!-- Row 12: Status/Error -->
-                                    <TextBlock Grid.Row="12" Grid.Column="0" Text="Status:" FontWeight="Bold" Margin="0,5"/>
+                                    <!-- Row 12: Status/Error (Active scope only - reports today's price-refresh status) -->
+                                    <TextBlock Grid.Row="12" Grid.Column="0" Text="Status:" FontWeight="Bold" Margin="0,5"
+                                               Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                     <TextBlock Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="3"
                                                Text="{Binding AssetDetails.TodayInfoMessage, Mode=OneWay}"
+                                               Visibility="{Binding AssetDetails.IsActiveScope, Converter={StaticResource BoolToVisibilityConverter}}"
                                                Margin="10,5"
                                                Foreground="DarkRed"/>
                                 </Grid>
@@ -750,6 +752,294 @@
                                 </Border>
                             </Grid>
                         </DataTemplate>
+
+                        <!-- Historic variant of PortfolioSummaryTemplate: no live price exists for a closed
+                             position, so the current-value/price/profit/XIRR columns are replaced with their
+                             realized-cash-flow equivalents (available synchronously, no price fetch involved),
+                             with headers renamed to match. Every other column is identical. -->
+                        <DataTemplate x:Key="PortfolioSummaryTemplateHistoric">
+                            <DataTemplate.Resources>
+                                <vm:PortfolioSummaryColumnWidths x:Key="ColWidths"/>
+                            </DataTemplate.Resources>
+                            <Grid Margin="10">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <!-- Aggregated Totals -->
+                                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
+                                    <TextBlock Text="Total Bought:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                    <TextBlock Text="{Binding AssetDetails.TotalBought, Mode=OneWay, StringFormat=N2}"
+                                               FontFamily="Consolas" Foreground="Green" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Total Sold:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                    <TextBlock Text="{Binding AssetDetails.TotalSold, Mode=OneWay, StringFormat=N2}"
+                                               FontFamily="Consolas" Foreground="Red" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Total Credits:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                    <TextBlock Text="{Binding AssetDetails.TotalCredits, Mode=OneWay, StringFormat=N2}"
+                                               FontFamily="Consolas" Foreground="Blue" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Total Invested:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                    <TextBlock Text="{Binding AssetDetails.TotalInvested, Mode=OneWay, StringFormat=N2}"
+                                               FontFamily="Consolas"
+                                               Foreground="{Binding AssetDetails.TotalInvested, Converter={StaticResource SignedValueToBrushConverter}}"/>
+                                </StackPanel>
+
+                                <!-- Per-Asset DataGrid, with a group-header overlay bar above it -->
+                                <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="*"/>
+                                        </Grid.RowDefinitions>
+
+                                        <!-- Group title bar: merges related columns under one spanning header -->
+                                        <Grid Grid.Row="0">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=AssetName, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=FirstInvestment, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=Quantity, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=PortfolioWeight, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=TotalInvested, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=CurrentValue, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=TotalCredits, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=AveragePrice, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=CurrentPrice, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=Profit, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=ProfitWithCredits, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=Xirr, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=LastMonthCredits, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=LastCreditMonth, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=LastMonthPercent, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=EstAnnualCredits, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                                <ColumnDefinition Width="{Binding Source={StaticResource ColWidths}, Path=EstAnnualPercent, Converter={StaticResource DoubleToGridLengthConverter}}"/>
+                                            </Grid.ColumnDefinitions>
+
+                                            <Border Grid.Column="0" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="1" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="2" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="3" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="4" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="5" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="6" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="7" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="8" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="9" Grid.ColumnSpan="2" Style="{StaticResource GroupHeaderBarStyle}">
+                                                <TextBlock Text="Profit" Style="{StaticResource GroupHeaderTitleTextStyle}"/>
+                                            </Border>
+                                            <Border Grid.Column="11" Style="{StaticResource GroupHeaderBarStyle}"/>
+                                            <Border Grid.Column="12" Grid.ColumnSpan="3" Style="{StaticResource GroupHeaderBarStyle}" BorderThickness="3,0,1,1" BorderBrush="#007ACC">
+                                                <TextBlock Text="Last Month" Style="{StaticResource GroupHeaderTitleTextStyle}"/>
+                                            </Border>
+                                            <Border Grid.Column="15" Grid.ColumnSpan="2" Style="{StaticResource GroupHeaderBarStyle}">
+                                                <TextBlock Text="Est. Annual" Style="{StaticResource GroupHeaderTitleTextStyle}"/>
+                                            </Border>
+                                        </Grid>
+
+                                        <DataGrid Grid.Row="1"
+                                                  ItemsSource="{Binding AssetDetails.PortfolioAssetSummaryRows}"
+                                                  AutoGenerateColumns="False"
+                                                  CanUserAddRows="False"
+                                                  IsReadOnly="True"
+                                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                                            <DataGrid.Columns>
+                                                <DataGridTextColumn Header="Asset Name" Binding="{Binding AssetName}" Width="{Binding Source={StaticResource ColWidths}, Path=AssetName, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource PlainColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTextColumn Header="First Investment" Binding="{Binding DisplayFirstInvestmentDate}" Width="{Binding Source={StaticResource ColWidths}, Path=FirstInvestment, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource PlainColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTextColumn Header="Quantity" Binding="{Binding DisplayCurrentQuantity}" Width="{Binding Source={StaticResource ColWidths}, Path=Quantity, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTextColumn Header="% Portfolio" Binding="{Binding DisplayPortfolioWeight}" Width="{Binding Source={StaticResource ColWidths}, Path=PortfolioWeight, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTextColumn Header="Total Invested" Binding="{Binding DisplayTotalInvested}" Width="{Binding Source={StaticResource ColWidths}, Path=TotalInvested, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTemplateColumn Header="Realized Gain/Loss" Width="{Binding Source={StaticResource ColWidths}, Path=CurrentValue, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTemplateColumn.CellTemplate>
+                                                        <DataTemplate>
+                                                            <TextBlock Text="{Binding DisplayRealizedGainLoss}" TextAlignment="Right" Padding="8" VerticalAlignment="Center">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding RealizedGainLossIsPositive}" Value="True">
+                                                                                <Setter Property="Foreground" Value="Green"/>
+                                                                            </DataTrigger>
+                                                                            <DataTrigger Binding="{Binding RealizedGainLossIsNegative}" Value="True">
+                                                                                <Setter Property="Foreground" Value="Red"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                        </DataTemplate>
+                                                    </DataGridTemplateColumn.CellTemplate>
+                                                </DataGridTemplateColumn>
+                                                <DataGridTextColumn Header="Total Credits" Binding="{Binding DisplayTotalCredits}" Width="{Binding Source={StaticResource ColWidths}, Path=TotalCredits, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTextColumn Header="Average Price" Binding="{Binding DisplayAveragePrice}" Width="{Binding Source={StaticResource ColWidths}, Path=AveragePrice, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTextColumn Header="Sold Price" Binding="{Binding DisplaySoldPrice}" Width="{Binding Source={StaticResource ColWidths}, Path=CurrentPrice, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTemplateColumn Header="%" Width="{Binding Source={StaticResource ColWidths}, Path=Profit, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTemplateColumn.CellTemplate>
+                                                        <DataTemplate>
+                                                            <TextBlock Text="{Binding DisplayHistoricProfitPercent}" TextAlignment="Right" Padding="8" VerticalAlignment="Center">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding HistoricProfitIsPositive}" Value="True">
+                                                                                <Setter Property="Foreground" Value="Green"/>
+                                                                            </DataTrigger>
+                                                                            <DataTrigger Binding="{Binding HistoricProfitIsNegative}" Value="True">
+                                                                                <Setter Property="Foreground" Value="Red"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                        </DataTemplate>
+                                                    </DataGridTemplateColumn.CellTemplate>
+                                                </DataGridTemplateColumn>
+                                                <DataGridTemplateColumn Header="w/ Credits" Width="{Binding Source={StaticResource ColWidths}, Path=ProfitWithCredits, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTemplateColumn.CellTemplate>
+                                                        <DataTemplate>
+                                                            <TextBlock Text="{Binding DisplayHistoricProfitWithCreditsPercent}" TextAlignment="Right" Padding="8" VerticalAlignment="Center">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding HistoricProfitWithCreditsIsPositive}" Value="True">
+                                                                                <Setter Property="Foreground" Value="Green"/>
+                                                                            </DataTrigger>
+                                                                            <DataTrigger Binding="{Binding HistoricProfitWithCreditsIsNegative}" Value="True">
+                                                                                <Setter Property="Foreground" Value="Red"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                        </DataTemplate>
+                                                    </DataGridTemplateColumn.CellTemplate>
+                                                </DataGridTemplateColumn>
+                                                <DataGridTemplateColumn Header="XIRR" Width="{Binding Source={StaticResource ColWidths}, Path=Xirr, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTemplateColumn.CellTemplate>
+                                                        <DataTemplate>
+                                                            <TextBlock Text="{Binding DisplayHistoricXirr}" TextAlignment="Right" Padding="8" VerticalAlignment="Center">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding HistoricXirrIsPositive}" Value="True">
+                                                                                <Setter Property="Foreground" Value="Green"/>
+                                                                            </DataTrigger>
+                                                                            <DataTrigger Binding="{Binding HistoricXirrIsNegative}" Value="True">
+                                                                                <Setter Property="Foreground" Value="Red"/>
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
+                                                        </DataTemplate>
+                                                    </DataGridTemplateColumn.CellTemplate>
+                                                </DataGridTemplateColumn>
+                                                <DataGridTextColumn Header="Credits" Binding="{Binding DisplayLastMonthCredits}" Width="{Binding Source={StaticResource ColWidths}, Path=LastMonthCredits, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.CellStyle>
+                                                        <Style TargetType="DataGridCell">
+                                                            <Setter Property="BorderThickness" Value="3,0,0,0"/>
+                                                            <Setter Property="BorderBrush" Value="#007ACC"/>
+                                                        </Style>
+                                                    </DataGridTextColumn.CellStyle>
+                                                    <DataGridTextColumn.HeaderStyle>
+                                                        <Style TargetType="DataGridColumnHeader">
+                                                            <Setter Property="BorderThickness" Value="3,0,0,0"/>
+                                                            <Setter Property="BorderBrush" Value="#007ACC"/>
+                                                        </Style>
+                                                    </DataGridTextColumn.HeaderStyle>
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTextColumn Header="Month" Binding="{Binding LastCreditMonthDisplay}" Width="{Binding Source={StaticResource ColWidths}, Path=LastCreditMonth, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTextColumn Header="%" Binding="{Binding DisplayLastMonthCreditsPercent}" Width="{Binding Source={StaticResource ColWidths}, Path=LastMonthPercent, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTextColumn Header="Credits" Binding="{Binding DisplayEstimatedAnnualCredits}" Width="{Binding Source={StaticResource ColWidths}, Path=EstAnnualCredits, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                                <DataGridTextColumn Header="%" Binding="{Binding DisplayEstimatedAnnualPercent}" Width="{Binding Source={StaticResource ColWidths}, Path=EstAnnualPercent, Converter={StaticResource DoubleToDataGridLengthConverter}, Mode=TwoWay}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NumericColumnTextStyle}"/>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
+                                            </DataGrid.Columns>
+                                        </DataGrid>
+                                    </Grid>
+                                </ScrollViewer>
+                                <Border Grid.Row="2"
+                                        Background="{x:Static SystemColors.ControlBrush}"
+                                        Padding="8,6"
+                                        Margin="0,4,0,0">
+                                    <WrapPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                                            <TextBlock Text="Total Invested:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                            <TextBlock Text="{Binding AssetDetails.FooterTotalInvested, StringFormat=N2}"
+                                                       FontFamily="Consolas"/>
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                                            <TextBlock Text="Total Credits:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                            <TextBlock Text="{Binding AssetDetails.FooterTotalCredits, StringFormat=N2}"
+                                                       FontFamily="Consolas"/>
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                                            <TextBlock Text="Realized Gain/Loss:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                            <TextBlock Text="{Binding AssetDetails.FooterRealizedGainLoss, StringFormat=N2}"
+                                                       FontFamily="Consolas"
+                                                       Foreground="{Binding AssetDetails.FooterRealizedGainLoss, Converter={StaticResource SignedValueToBrushConverter}}"/>
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                                            <TextBlock Text="{Binding AssetDetails.FooterCurrentMonthLabel, StringFormat='{}{0}:'}"
+                                                       FontWeight="Bold" Margin="0,0,5,0"/>
+                                            <TextBlock Text="{Binding AssetDetails.FooterCurrentMonthCredits, StringFormat=N2}"
+                                                       FontFamily="Consolas"/>
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="Est. Annual Credits:" FontWeight="Bold" Margin="0,0,5,0"/>
+                                            <TextBlock Text="{Binding AssetDetails.FooterEstimatedAnnualCreditsDisplay}"
+                                                       FontFamily="Consolas"/>
+                                        </StackPanel>
+                                    </WrapPanel>
+                                </Border>
+                            </Grid>
+                        </DataTemplate>
                     </TabItem.Resources>
                     <ContentControl Content="{Binding}">
                         <ContentControl.Style>
@@ -762,6 +1052,13 @@
                                     <DataTrigger Binding="{Binding AssetDetails.IsBrokerView}" Value="True">
                                         <Setter Property="ContentTemplate" Value="{StaticResource BrokerSummaryTemplate}"/>
                                     </DataTrigger>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding AssetDetails.IsPortfolioView}" Value="True"/>
+                                            <Condition Binding="{Binding AssetDetails.IsActiveScope}" Value="False"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="ContentTemplate" Value="{StaticResource PortfolioSummaryTemplateHistoric}"/>
+                                    </MultiDataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </ContentControl.Style>

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -50,6 +50,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private decimal _totalSold;
     private decimal _totalCredits;
     private decimal _realizedGainLoss;
+    private decimal? _realizedPortfolioWeight;
     private decimal _todayCurrentValue;
     private string _todayCurrentValueAsOf = string.Empty;
     private string _todayInfoMessage = string.Empty;
@@ -184,8 +185,30 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public decimal ResultPercentWithCredits => AssetDetailsCalculations.CalculateResultPercentWithCredits(AveragePrice, Quantity, TotalCurrentValueWithCredits);
     public bool HasAveragePrice => AssetDetailsCalculations.HasAveragePrice(AveragePrice, Quantity);
     public bool IsActiveScope => _scope == InvestmentScope.Active;
+    public bool IsHistoricScope => _scope == InvestmentScope.Historic;
     public decimal? Xirr => _xirrCalculationService.Calculate(_cashFlowsWithoutCredits, TotalCurrentValue);
     public decimal? XirrWithCredits => _xirrCalculationService.Calculate(_cashFlowsWithCredits, TotalCurrentValueWithCredits);
+
+    // Historic (closed) positions have no live price to mark-to-market: XIRR is derived from
+    // already-realized cash flows alone, with a 0 terminal value (every buy/sell/credit is
+    // already a dated entry), matching the Web app's equivalent calculation.
+    public decimal? RealizedXirr => _xirrCalculationService.Calculate(_cashFlowsWithoutCredits, 0m);
+    public decimal? RealizedXirrWithCredits => _xirrCalculationService.Calculate(_cashFlowsWithCredits, 0m);
+
+    public decimal? RealizedPortfolioWeight
+    {
+        get => _realizedPortfolioWeight;
+        private set
+        {
+            if (SetProperty(ref _realizedPortfolioWeight, value))
+            {
+                OnPropertyChanged(nameof(DisplayRealizedPortfolioWeight));
+            }
+        }
+    }
+
+    public string DisplayRealizedPortfolioWeight =>
+        RealizedPortfolioWeight.HasValue ? $"{RealizedPortfolioWeight.Value:F2}%" : "—";
 
     public bool IsPortfolioView
     {
@@ -344,7 +367,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
             () => BrokerName,
             () => PortfolioName,
             () => AssetName,
-            LoadAssetDetails,
+            details => LoadAssetDetails(details),
             (message, caption, image) => MessageBox.Show(message, caption, MessageBoxButton.OK, image));
         _creditActions = new CreditActions(
             _creditService,
@@ -352,7 +375,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
             () => BrokerName,
             () => PortfolioName,
             () => AssetName,
-            LoadAssetDetails,
+            details => LoadAssetDetails(details),
             (message, caption, image) => MessageBox.Show(message, caption, MessageBoxButton.OK, image));
         _addTransactionCommand = new RelayCommand(AddTransaction, CanEditTransactions);
         _updateTransactionCommand = new RelayCommand(UpdateTransaction, CanUpdateTransaction);
@@ -412,7 +435,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         FetchRowPricesAsync(rows, token, brokerName);
     }
 
-    public void LoadAssetDetails(AssetDetailsDTO details)
+    public void LoadAssetDetails(AssetDetailsDTO details, decimal? realizedPortfolioWeight = null)
     {
         IsPortfolioView = false;
         IsBrokerView = false;
@@ -439,6 +462,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         TotalSold = details.TotalSold;
         TotalCredits = details.TotalCredits;
         RealizedGainLoss = details.RealizedGainLoss;
+        RealizedPortfolioWeight = realizedPortfolioWeight;
         IsCreditsAggregateView = false;
         HasCreditsContext = true;
         SetCreditsContext(BuildCreditsAssetKey(details.BrokerName, details.PortfolioName, details.Name), rebuild: false);
@@ -638,6 +662,8 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         OnPropertyChanged(nameof(ResultPercentWithCredits));
         OnPropertyChanged(nameof(Xirr));
         OnPropertyChanged(nameof(XirrWithCredits));
+        OnPropertyChanged(nameof(RealizedXirr));
+        OnPropertyChanged(nameof(RealizedXirrWithCredits));
     }
 
     private void LoadAggregateCredits(string contextKey, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
@@ -810,6 +836,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         TotalSold = 0;
         TotalCredits = 0;
         RealizedGainLoss = 0;
+        RealizedPortfolioWeight = null;
         _cashFlowsWithCredits = Array.Empty<AssetCashFlowDTO>();
         _cashFlowsWithoutCredits = Array.Empty<AssetCashFlowDTO>();
         _todayInfo.Clear();

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -72,6 +72,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     private CancellationTokenSource? _breakdownCts;
     private CancellationTokenSource? _rowPriceCts;
     private decimal _footerTotalInvested;
+    private decimal _footerRealizedGainLoss;
     private decimal _footerTotalCredits;
     private decimal _footerCurrentMonthCredits;
     private string _footerCurrentMonthLabel = string.Empty;
@@ -246,6 +247,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
     public ObservableCollection<PortfolioAssetSummaryRowViewModel> PortfolioAssetSummaryRows { get; } = new();
 
     public decimal FooterTotalInvested { get => _footerTotalInvested; private set => SetProperty(ref _footerTotalInvested, value); }
+    public decimal FooterRealizedGainLoss { get => _footerRealizedGainLoss; private set => SetProperty(ref _footerRealizedGainLoss, value); }
     public decimal FooterTotalCredits { get => _footerTotalCredits; private set => SetProperty(ref _footerTotalCredits, value); }
     public decimal FooterCurrentMonthCredits { get => _footerCurrentMonthCredits; private set => SetProperty(ref _footerCurrentMonthCredits, value); }
     public string FooterCurrentMonthLabel { get => _footerCurrentMonthLabel; private set => SetProperty(ref _footerCurrentMonthLabel, value); }
@@ -384,6 +386,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
             PortfolioAssetSummaryRows.Add(new PortfolioAssetSummaryRowViewModel(item, _xirrCalculationService));
 
         FooterTotalInvested = assetItems.Sum(i => i.TotalInvested);
+        FooterRealizedGainLoss = assetItems.Sum(i => i.RealizedGainLoss);
         FooterTotalCredits = assetItems.Sum(i => i.TotalCredits);
         FooterCurrentMonthCredits = assetItems.Sum(i => i.CurrentMonthCredits);
         FooterCurrentMonthLabel = "Credits " + DateTime.Today.ToString("MMM yyyy", CultureInfo.InvariantCulture);
@@ -462,6 +465,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         CancelAndResetRowPriceFetch();
         PortfolioAssetSummaryRows.Clear();
         FooterTotalInvested = 0m;
+        FooterRealizedGainLoss = 0m;
         FooterTotalCredits = 0m;
         FooterCurrentMonthCredits = 0m;
         FooterCurrentMonthLabel = string.Empty;

--- a/Financial.App/ViewModels/IAssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/IAssetDetailsViewModel.cs
@@ -6,7 +6,7 @@ public interface IAssetDetailsViewModel
 {
     bool IsPortfolioView { get; }
     bool IsBrokerView { get; }
-    void LoadAssetDetails(AssetDetailsDTO details);
+    void LoadAssetDetails(AssetDetailsDTO details, decimal? realizedPortfolioWeight = null);
     void LoadBrokerSummary(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits);
     Task LoadBrokerBreakdown(string brokerName);
     Task LoadBrokerTransactions(string brokerName);

--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -254,7 +254,17 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
 
         if (details != null)
         {
-            AssetDetails.LoadAssetDetails(details);
+            // No single-asset endpoint carries PortfolioWeight (it's inherently
+            // portfolio-relative); reuse the portfolio-list summary and match by name,
+            // matching the Web app's equivalent approach for the Historic Summary tab.
+            decimal? realizedPortfolioWeight = null;
+            if (_scope == InvestmentScope.Historic)
+            {
+                var assetItems = _portfolioAssetSummaryService.GetPortfolioAssetsSummary(brokerName, portfolioName, _scope);
+                realizedPortfolioWeight = assetItems.FirstOrDefault(item => item.AssetName == assetName)?.PortfolioWeight;
+            }
+
+            AssetDetails.LoadAssetDetails(details, realizedPortfolioWeight);
             _ = AssetDetails.EnsureTodayInfoLoadedAsync();
         }
     }

--- a/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
+++ b/Financial.App/ViewModels/PortfolioAssetSummaryRowViewModel.cs
@@ -24,7 +24,10 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
     public DateTime? FirstInvestmentDate { get; }
     public decimal CurrentQuantity { get; }
     public decimal AveragePrice { get; }
+    public decimal? AverageSellPrice { get; }
+    public decimal TotalBought { get; }
     public decimal TotalInvested { get; }
+    public decimal RealizedGainLoss { get; }
     public decimal PortfolioWeight { get; }
     public decimal TotalCredits { get; }
     public IReadOnlyList<AssetCashFlowDTO> CashFlows { get; }
@@ -92,6 +95,50 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
     public bool XirrIsPositive => _xirr > 0;
     public bool XirrIsNegative => _xirr < 0;
 
+    // Historic (closed) positions have no live price to mark-to-market: these are derived
+    // entirely from already-realized cash flows (bought/sold/credits), available synchronously
+    // — unlike the Active-scope fields above, which depend on an async price fetch.
+    public string DisplayRealizedGainLoss => RealizedGainLoss.ToString("N2");
+    public bool RealizedGainLossIsPositive => RealizedGainLoss > 0;
+    public bool RealizedGainLossIsNegative => RealizedGainLoss < 0;
+
+    public string DisplaySoldPrice => AverageSellPrice.HasValue ? AverageSellPrice.Value.ToString("N2") : "—";
+
+    // Realized capital gain alone (credits excluded), matching the active-scope semantic
+    // where credits are a separate "w/ Credits" column.
+    public decimal? HistoricProfitPercent =>
+        TotalBought != 0 ? (RealizedGainLoss - TotalCredits) / TotalBought * 100 : null;
+
+    public decimal? HistoricProfitWithCreditsPercent =>
+        TotalBought != 0 ? RealizedGainLoss / TotalBought * 100 : null;
+
+    // Historic cash flows already contain every buy/sell/credit as a dated entry, so the
+    // terminal value is 0 (no remaining position left to mark-to-market).
+    public decimal? HistoricXirr
+    {
+        get
+        {
+            var fraction = _xirrCalculationService.Calculate(CashFlows, 0m);
+            return fraction.HasValue ? fraction.Value * 100 : null;
+        }
+    }
+
+    public string DisplayHistoricProfitPercent =>
+        HistoricProfitPercent.HasValue ? $"{HistoricProfitPercent.Value:F2}%" : "—";
+
+    public string DisplayHistoricProfitWithCreditsPercent =>
+        HistoricProfitWithCreditsPercent.HasValue ? $"{HistoricProfitWithCreditsPercent.Value:F2}%" : "—";
+
+    public string DisplayHistoricXirr =>
+        HistoricXirr.HasValue ? $"{HistoricXirr.Value:F2}%" : "—";
+
+    public bool HistoricProfitIsPositive => HistoricProfitPercent > 0;
+    public bool HistoricProfitIsNegative => HistoricProfitPercent < 0;
+    public bool HistoricProfitWithCreditsIsPositive => HistoricProfitWithCreditsPercent > 0;
+    public bool HistoricProfitWithCreditsIsNegative => HistoricProfitWithCreditsPercent < 0;
+    public bool HistoricXirrIsPositive => HistoricXirr > 0;
+    public bool HistoricXirrIsNegative => HistoricXirr < 0;
+
     public PortfolioAssetSummaryRowViewModel(PortfolioAssetSummaryItemDTO dto, IXirrCalculationService xirrCalculationService)
     {
         _xirrCalculationService = xirrCalculationService ?? throw new ArgumentNullException(nameof(xirrCalculationService));
@@ -102,7 +149,10 @@ public class PortfolioAssetSummaryRowViewModel : ViewModelBase
         FirstInvestmentDate = dto.FirstInvestmentDate;
         CurrentQuantity = dto.CurrentQuantity;
         AveragePrice = dto.AveragePrice;
+        AverageSellPrice = dto.AverageSellPrice;
+        TotalBought = dto.TotalBought;
         TotalInvested = dto.TotalInvested;
+        RealizedGainLoss = dto.RealizedGainLoss;
         PortfolioWeight = dto.PortfolioWeight;
         TotalCredits = dto.TotalCredits;
         CashFlows = dto.CashFlows;

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
@@ -146,8 +146,11 @@ public class AssetDetailsViewModelBrokerSummaryTests
     [Fact]
     public void LoadBrokerBreakdown_SetsIsBreakdownLoadingTrue_Synchronously()
     {
-        var stub = new StubBrokerBreakdownService();
-        var vm = BuildViewModel(stub);
+        // Uses a blocking stub rather than StubBrokerBreakdownService: the latter returns
+        // instantly, so the background Task.Run could reach ApplyBrokerBreakdown (which sets
+        // IsBreakdownLoading = false) before this synchronous assertion runs - a real,
+        // previously-observed race, not a hypothetical one.
+        var vm = BuildViewModel(new BlockingBrokerBreakdownService());
         _ = vm.LoadBrokerBreakdown("XPI");
         vm.IsBreakdownLoading.Should().BeTrue();
     }
@@ -283,4 +286,19 @@ public class AssetDetailsViewModelBrokerSummaryTests
         vm.PortfolioBreakdownPieItems.Should().BeEmpty();
     }
 
+    private sealed class BlockingBrokerBreakdownService : IBrokerBreakdownService
+    {
+        // Bounded, not infinite: same reasoning as NeverResolvingPriceService
+        // (AssetDetailsViewModelPortfolioSummaryTests.cs) - the test only needs the block to
+        // outlast its own synchronous assertion, and an unbounded wait would accumulate
+        // permanently-blocked threads across the test run.
+        private readonly SemaphoreSlim _blocker = new(0);
+        private static readonly TimeSpan MaxBlockDuration = TimeSpan.FromSeconds(2);
+
+        public IReadOnlyList<PortfolioBreakdownItemDTO> GetBrokerBreakdown(string brokerName, InvestmentScope scope = InvestmentScope.Active)
+        {
+            _blocker.Wait(MaxBlockDuration);
+            return [];
+        }
+    }
 }

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
@@ -42,7 +42,8 @@ public class AssetDetailsViewModelPortfolioSummaryTests
         decimal totalInvested = 1000m,
         decimal totalCredits = 0m,
         decimal currentMonthCredits = 0m,
-        decimal? estimatedAnnualCredits = null)
+        decimal? estimatedAnnualCredits = null,
+        decimal realizedGainLoss = 0m)
     {
         return new PortfolioAssetSummaryItemDTO
         {
@@ -53,6 +54,7 @@ public class AssetDetailsViewModelPortfolioSummaryTests
             TotalBought = totalInvested,
             TotalSold = 0m,
             TotalInvested = totalInvested,
+            RealizedGainLoss = realizedGainLoss,
             PortfolioWeight = 50m,
             TotalCredits = totalCredits,
             CurrentMonthCredits = currentMonthCredits,
@@ -192,6 +194,15 @@ public class AssetDetailsViewModelPortfolioSummaryTests
     }
 
     [Fact]
+    public void LoadPortfolioSummary_SetsFooterRealizedGainLoss_SumOfRows()
+    {
+        var vm = BuildViewModel();
+        var items = new[] { BuildItem(realizedGainLoss: 100m), BuildItem(realizedGainLoss: -30m) };
+        vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], items);
+        vm.FooterRealizedGainLoss.Should().Be(70m);
+    }
+
+    [Fact]
     public void LoadPortfolioSummary_SetsFooterTotalCredits_SumOfRows()
     {
         var vm = BuildViewModel();
@@ -265,12 +276,13 @@ public class AssetDetailsViewModelPortfolioSummaryTests
     public void Clear_AfterLoadPortfolioSummary_ResetsFooterProperties()
     {
         var vm = BuildViewModel();
-        var items = new[] { BuildItem(totalInvested: 1000m, totalCredits: 50m, currentMonthCredits: 10m, estimatedAnnualCredits: 600m) };
+        var items = new[] { BuildItem(totalInvested: 1000m, totalCredits: 50m, currentMonthCredits: 10m, estimatedAnnualCredits: 600m, realizedGainLoss: 200m) };
         vm.LoadPortfolioSummary("Broker", "Portfolio", new AggregatedSummaryDTO(), [], items);
 
         vm.Clear();
 
         vm.FooterTotalInvested.Should().Be(0m);
+        vm.FooterRealizedGainLoss.Should().Be(0m);
         vm.FooterTotalCredits.Should().Be(0m);
         vm.FooterCurrentMonthCredits.Should().Be(0m);
         vm.FooterCurrentMonthLabel.Should().Be(string.Empty);

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelXirrTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelXirrTests.cs
@@ -140,6 +140,129 @@ public class AssetDetailsViewModelXirrTests
         vm.RealizedGainLoss.Should().Be(0m);
     }
 
+    [Fact]
+    public void RealizedXirr_BeforeAssetLoaded_IsNull()
+    {
+        var vm = BuildViewModel();
+
+        vm.RealizedXirr.Should().BeNull();
+        vm.RealizedXirrWithCredits.Should().BeNull();
+    }
+
+    [Fact]
+    public void RealizedXirr_ComputesFromCashFlowsWithZeroTerminalValue()
+    {
+        // One buy at -1000 exactly 2 years ago; the position's proceeds are already recorded
+        // as a +1210 cash flow today (fully realized) instead of a live terminal mark-to-market -
+        // matching the Web app's equivalent calculation for a closed position.
+        var buyDate = DateTime.Today.AddYears(-2);
+        var cashFlows = new List<AssetCashFlowDTO>
+        {
+            new() { Date = buyDate, Amount = -1000m },
+            new() { Date = DateTime.Today, Amount = 1210m }
+        };
+        var vm = BuildViewModel(scope: InvestmentScope.Historic);
+
+        vm.LoadAssetDetails(BuildAssetDetails(cashFlows, cashFlows));
+
+        vm.RealizedXirr.Should().NotBeNull();
+        vm.RealizedXirr!.Value.Should().BeApproximately(0.10m, 0.01m);
+    }
+
+    [Fact]
+    public void RealizedXirrWithCredits_UsesCreditsCashFlowsSeries()
+    {
+        var buyDate = DateTime.Today.AddYears(-2);
+        var withoutCredits = new List<AssetCashFlowDTO>
+        {
+            new() { Date = buyDate, Amount = -1000m },
+            new() { Date = DateTime.Today, Amount = 1210m }
+        };
+        var withCredits = new List<AssetCashFlowDTO>
+        {
+            new() { Date = buyDate, Amount = -1000m },
+            new() { Date = DateTime.Today.AddMonths(-6), Amount = 50m },
+            new() { Date = DateTime.Today, Amount = 1210m }
+        };
+        var vm = BuildViewModel(scope: InvestmentScope.Historic);
+
+        vm.LoadAssetDetails(BuildAssetDetails(withoutCredits, withCredits, totalCredits: 50m));
+
+        vm.RealizedXirr.Should().NotBeNull();
+        vm.RealizedXirrWithCredits.Should().NotBeNull();
+        vm.RealizedXirrWithCredits!.Value.Should().BeGreaterThan(vm.RealizedXirr!.Value);
+    }
+
+    [Fact]
+    public void Clear_ResetsRealizedXirrToNull()
+    {
+        var buyDate = DateTime.Today.AddYears(-2);
+        var cashFlows = new List<AssetCashFlowDTO>
+        {
+            new() { Date = buyDate, Amount = -1000m },
+            new() { Date = DateTime.Today, Amount = 1210m }
+        };
+        var vm = BuildViewModel(scope: InvestmentScope.Historic);
+        vm.LoadAssetDetails(BuildAssetDetails(cashFlows, cashFlows));
+
+        vm.Clear();
+
+        vm.RealizedXirr.Should().BeNull();
+        vm.RealizedXirrWithCredits.Should().BeNull();
+    }
+
+    [Fact]
+    public void LoadAssetDetails_SetsRealizedPortfolioWeightFromParameter()
+    {
+        var vm = BuildViewModel();
+
+        vm.LoadAssetDetails(BuildAssetDetails([], []), realizedPortfolioWeight: 5.15m);
+
+        vm.RealizedPortfolioWeight.Should().Be(5.15m);
+        vm.DisplayRealizedPortfolioWeight.Should().Be("5.15%");
+    }
+
+    [Fact]
+    public void LoadAssetDetails_DefaultsRealizedPortfolioWeightToNull_WhenNotProvided()
+    {
+        var vm = BuildViewModel();
+
+        vm.LoadAssetDetails(BuildAssetDetails([], []));
+
+        vm.RealizedPortfolioWeight.Should().BeNull();
+        vm.DisplayRealizedPortfolioWeight.Should().Be("—");
+    }
+
+    [Fact]
+    public void Clear_ResetsRealizedPortfolioWeightToNull()
+    {
+        var vm = BuildViewModel();
+        vm.LoadAssetDetails(BuildAssetDetails([], []), realizedPortfolioWeight: 5.15m);
+
+        vm.Clear();
+
+        vm.RealizedPortfolioWeight.Should().BeNull();
+        vm.DisplayRealizedPortfolioWeight.Should().Be("—");
+    }
+
+    [Fact]
+    public void IsHistoricScope_WhenScopeIsHistoric_IsTrue()
+    {
+        var vm = BuildViewModel(scope: InvestmentScope.Historic);
+
+        vm.IsHistoricScope.Should().BeTrue();
+        vm.IsActiveScope.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsHistoricScope_WhenScopeIsActive_IsFalse()
+    {
+        var vm = BuildViewModel(scope: InvestmentScope.Active);
+
+        vm.IsHistoricScope.Should().BeFalse();
+        vm.IsActiveScope.Should().BeTrue();
+    }
+
     private sealed class FixedPriceService : IAssetPriceService
     {
         private readonly decimal _price;

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -324,6 +324,54 @@ public class MainNavigationViewModelBaseTests
     }
 
     [Fact]
+    public void SelectingAssetNode_HistoricScope_PassesMatchingPortfolioWeightToAssetDetails()
+    {
+        var summaryService = new StubSummaryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var navigationService = new StubNavigationService
+        {
+            AssetDetails = new AssetDetailsDTO { Name = "BBAS3", BrokerName = "XPI", PortfolioName = "Uncategorized", Ticker = "BBAS3" }
+        };
+        var assetSummaryService = new StubPortfolioAssetSummaryService
+        {
+            Items =
+            [
+                new PortfolioAssetSummaryItemDTO { AssetName = "Other Asset", PortfolioWeight = 40m },
+                new PortfolioAssetSummaryItemDTO { AssetName = "BBAS3", PortfolioWeight = 5.15m }
+            ]
+        };
+        var vm = new TestableNavigationViewModel(summaryService, spy, assetSummaryService, navigationService, InvestmentScope.Historic);
+
+        var assetNode = BuildAssetNode("XPI", "Uncategorized", "BBAS3");
+        vm.SelectedNode = assetNode;
+
+        spy.LastAssetDetails.Should().NotBeNull();
+        spy.LastRealizedPortfolioWeight.Should().Be(5.15m);
+        assetSummaryService.LastBrokerName.Should().Be("XPI");
+        assetSummaryService.LastPortfolioName.Should().Be("Uncategorized");
+        assetSummaryService.LastScope.Should().Be(InvestmentScope.Historic);
+    }
+
+    [Fact]
+    public void SelectingAssetNode_ActiveScope_DoesNotFetchPortfolioWeight()
+    {
+        var summaryService = new StubSummaryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var navigationService = new StubNavigationService
+        {
+            AssetDetails = new AssetDetailsDTO { Name = "BBAS3", BrokerName = "XPI", PortfolioName = "Acoes", Ticker = "BBAS3" }
+        };
+        var assetSummaryService = new StubPortfolioAssetSummaryService();
+        var vm = new TestableNavigationViewModel(summaryService, spy, assetSummaryService, navigationService);
+
+        var assetNode = BuildAssetNode("XPI", "Acoes", "BBAS3");
+        vm.SelectedNode = assetNode;
+
+        assetSummaryService.LastBrokerName.Should().BeNull();
+        spy.LastRealizedPortfolioWeight.Should().BeNull();
+    }
+
+    [Fact]
     public void SelectingPortfolioNode_HistoricScope_RequestsHistoricScopeSummaryAndAssetItems()
     {
         var summaryService = new StubSummaryService();
@@ -470,8 +518,14 @@ public class MainNavigationViewModelBaseTests
         public bool WasPortfolioTransactionsLoaded { get; private set; }
         public bool IsPortfolioView => false;
         public bool IsBrokerView => false;
+        public AssetDetailsDTO? LastAssetDetails { get; private set; }
+        public decimal? LastRealizedPortfolioWeight { get; private set; }
 
-        public void LoadAssetDetails(AssetDetailsDTO details) { }
+        public void LoadAssetDetails(AssetDetailsDTO details, decimal? realizedPortfolioWeight = null)
+        {
+            LastAssetDetails = details;
+            LastRealizedPortfolioWeight = realizedPortfolioWeight;
+        }
 
         public void LoadBrokerSummary(string brokerName, AggregatedSummaryDTO summary, IReadOnlyList<CreditDTO> credits)
         {
@@ -562,6 +616,7 @@ public class MainNavigationViewModelBaseTests
     {
         public InvestmentScope? LastTreeScope { get; private set; }
         public InvestmentScope? LastAssetDetailsScope { get; private set; }
+        public AssetDetailsDTO? AssetDetails { get; set; }
 
         public TreeNodeDTO GetNavigationTree(InvestmentScope scope = InvestmentScope.Active)
         {
@@ -572,7 +627,7 @@ public class MainNavigationViewModelBaseTests
         public AssetDetailsDTO? GetAssetDetails(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active)
         {
             LastAssetDetailsScope = scope;
-            return null;
+            return AssetDetails;
         }
 
         public IEnumerable<BrokerNodeDTO> GetBrokers(InvestmentScope scope = InvestmentScope.Active) => [];

--- a/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/PortfolioAssetSummaryRowViewModelTests.cs
@@ -20,7 +20,10 @@ public class PortfolioAssetSummaryRowViewModelTests
         decimal? lastMonthCreditsPercent = null,
         decimal? estimatedAnnualCredits = null,
         decimal? estimatedAnnualPercent = null,
-        decimal currentMonthCredits = 0m)
+        decimal currentMonthCredits = 0m,
+        decimal? totalBought = null,
+        decimal realizedGainLoss = 0m,
+        decimal? averageSellPrice = null)
     {
         var dto = new PortfolioAssetSummaryItemDTO
         {
@@ -30,9 +33,11 @@ public class PortfolioAssetSummaryRowViewModelTests
             FirstInvestmentDate = firstInvestmentDate,
             CurrentQuantity = currentQuantity,
             AveragePrice = averagePrice,
-            TotalBought = totalInvested,
+            AverageSellPrice = averageSellPrice,
+            TotalBought = totalBought ?? totalInvested,
             TotalSold = 0m,
             TotalInvested = totalInvested,
+            RealizedGainLoss = realizedGainLoss,
             PortfolioWeight = portfolioWeight,
             TotalCredits = totalCredits,
             CashFlows = cashFlows ?? [],
@@ -513,5 +518,119 @@ public class PortfolioAssetSummaryRowViewModelTests
     {
         var row = BuildRow(estimatedAnnualPercent: null);
         row.DisplayEstimatedAnnualPercent.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayRealizedGainLoss_FormatsN2()
+    {
+        var row = BuildRow(realizedGainLoss: 123.456m);
+        row.DisplayRealizedGainLoss.Should().Be("123.46");
+    }
+
+    [Fact]
+    public void RealizedGainLossIsPositive_WhenGainPositive_IsTrue()
+    {
+        var row = BuildRow(realizedGainLoss: 100m);
+        row.RealizedGainLossIsPositive.Should().BeTrue();
+        row.RealizedGainLossIsNegative.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RealizedGainLossIsNegative_WhenLossNegative_IsTrue()
+    {
+        var row = BuildRow(realizedGainLoss: -50m);
+        row.RealizedGainLossIsNegative.Should().BeTrue();
+        row.RealizedGainLossIsPositive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DisplaySoldPrice_WhenAverageSellPriceIsSet_FormatsN2()
+    {
+        var row = BuildRow(averageSellPrice: 12.5m);
+        row.DisplaySoldPrice.Should().Be("12.50");
+    }
+
+    [Fact]
+    public void DisplaySoldPrice_WhenAverageSellPriceIsNull_ReturnsDash()
+    {
+        var row = BuildRow(averageSellPrice: null);
+        row.DisplaySoldPrice.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayHistoricProfitPercent_ExcludesCreditsFromRealizedGainLoss()
+    {
+        // Profit % reflects the realized capital gain alone: (200 - 50) / 1000 * 100 = 15.00
+        var row = BuildRow(totalBought: 1000m, totalCredits: 50m, realizedGainLoss: 200m);
+        row.HistoricProfitPercent.Should().Be(15.00m);
+        row.DisplayHistoricProfitPercent.Should().Be("15.00%");
+    }
+
+    [Fact]
+    public void DisplayHistoricProfitWithCreditsPercent_UsesFullRealizedGainLoss()
+    {
+        // Profit % w/ Credits uses the full realized gain/loss: 200 / 1000 * 100 = 20.00
+        var row = BuildRow(totalBought: 1000m, totalCredits: 50m, realizedGainLoss: 200m);
+        row.HistoricProfitWithCreditsPercent.Should().Be(20.00m);
+        row.DisplayHistoricProfitWithCreditsPercent.Should().Be("20.00%");
+    }
+
+    [Fact]
+    public void DisplayHistoricProfitPercent_WhenTotalBoughtIsZero_ReturnsDash()
+    {
+        var row = BuildRow(totalBought: 0m, realizedGainLoss: 100m);
+        row.HistoricProfitPercent.Should().BeNull();
+        row.DisplayHistoricProfitPercent.Should().Be("—");
+    }
+
+    [Fact]
+    public void DisplayHistoricProfitWithCreditsPercent_WhenTotalBoughtIsZero_ReturnsDash()
+    {
+        var row = BuildRow(totalBought: 0m, realizedGainLoss: 100m);
+        row.HistoricProfitWithCreditsPercent.Should().BeNull();
+        row.DisplayHistoricProfitWithCreditsPercent.Should().Be("—");
+    }
+
+    [Fact]
+    public void HistoricProfitIsPositive_WhenHistoricProfitPercentPositive_IsTrue()
+    {
+        var row = BuildRow(totalBought: 1000m, realizedGainLoss: 100m);
+        row.HistoricProfitIsPositive.Should().BeTrue();
+        row.HistoricProfitIsNegative.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HistoricProfitWithCreditsIsNegative_WhenHistoricProfitWithCreditsPercentNegative_IsTrue()
+    {
+        var row = BuildRow(totalBought: 1000m, realizedGainLoss: -100m);
+        row.HistoricProfitWithCreditsIsNegative.Should().BeTrue();
+        row.HistoricProfitWithCreditsIsPositive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DisplayHistoricXirr_ComputesFromCashFlowsWithZeroTerminalValue()
+    {
+        // One buy at -1000 exactly 2 years ago; the position's proceeds are already recorded
+        // as a +1210 cash flow today (fully realized) instead of a live terminal mark-to-market.
+        var buyDate = DateTime.Today.AddYears(-2);
+        var cashFlows = new List<AssetCashFlowDTO>
+        {
+            new() { Date = buyDate, Amount = -1000m },
+            new() { Date = DateTime.Today, Amount = 1210m }
+        };
+        var row = BuildRow(cashFlows: cashFlows);
+
+        row.HistoricXirr.Should().NotBeNull();
+        row.HistoricXirr!.Value.Should().BeApproximately(10m, 0.1m);
+        row.DisplayHistoricXirr.Should().NotBe("—");
+        row.HistoricXirrIsPositive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DisplayHistoricXirr_WhenCashFlowsEmpty_ReturnsDash()
+    {
+        var row = BuildRow(cashFlows: []);
+        row.HistoricXirr.Should().BeNull();
+        row.DisplayHistoricXirr.Should().Be("—");
     }
 }


### PR DESCRIPTION
## Summary

Follow-up fixes on merged PR #176 (F11 — WPF Historic Investments tab), reported after using the feature:

1. **Portfolio view columns didn't update for Historic** — the per-asset grid showed `—` in the current-value/price/profit/XIRR columns instead of realized figures, unlike the Web app (F09), which substitutes the realized equivalents and renames the column headers.
2. **Asset Summary "Status" row showed nothing** when selecting a historic asset — it reports today's price-refresh status, which never runs for Historic scope.
3. **Asset Summary was missing the "Realized" section** Web already shows for a Historic asset (Realized Gain/Loss, Portfolio Weight, XIRR, XIRR w/ Credits).

## Changes

- New `PortfolioSummaryTemplateHistoric` DataTemplate mirrors the existing Active portfolio grid but replaces `Current Value`/`Current Price`/`Profit`/`Profit w/ Credits`/`XIRR` with `Realized Gain/Loss`/`Sold Price` and profit/XIRR figures computed from already-realized cash flows (no live price fetch involved), matching Web's exact approach (including XIRR computed with a `0` terminal value, since historic cash flows already record every buy/sell/credit as a dated entry). Selected via a new `MultiDataTrigger` alongside the existing `IsPortfolioView` trigger.
- `PortfolioAssetSummaryRowViewModel` gains `TotalBought`/`RealizedGainLoss`/`AverageSellPrice` plus the historic-specific display/profit/XIRR properties.
- `AssetDetailsViewModel` gains `FooterRealizedGainLoss`, replacing the footer's "Current Value" for Historic (mirroring Web's footer swap).
- The Summary tab's "Status:" row is now hidden for Historic via the existing `IsActiveScope` binding, matching the "Current" section it sits under.
- New "Realized" section on the single-asset Summary tab (Historic scope only): `AssetDetailsViewModel` gains `RealizedXirr`/`RealizedXirrWithCredits` (computed with a `0` terminal value) and `RealizedPortfolioWeight`/`DisplayRealizedPortfolioWeight`. Since no single-asset endpoint carries `PortfolioWeight` (it's inherently portfolio-relative), `MainNavigationViewModelBase` reuses the portfolio-list summary and matches by asset name for Historic scope — the same approach Web uses. The pre-existing "Realized Gain/Loss" field at row 5 is now Active-only, since Historic now shows it once, in the new section, instead of twice.
- Eliminated a pre-existing flaky test (`LoadBrokerBreakdown_SetsIsBreakdownLoadingTrue_Synchronously`) — a genuine TOCTOU race where the background fetch could complete before the synchronous assertion ran. Replaced the instant stub with a bounded-blocking one, the same pattern already used elsewhere in this test project.

## Test plan
- [x] `dotnet test Financial.slnx` — 655/655 passed, 5 pre-existing skips (unrelated live-network integration tests); confirmed with 3+ consecutive full-suite runs, no flakiness
- [x] New `PortfolioAssetSummaryRowViewModelTests` covering `DisplayRealizedGainLoss`, `DisplaySoldPrice`, `DisplayHistoricProfitPercent`/`DisplayHistoricProfitWithCreditsPercent` (including the `TotalBought == 0` edge case), and `DisplayHistoricXirr`
- [x] New `AssetDetailsViewModelPortfolioSummaryTests` covering `FooterRealizedGainLoss` sum and reset-on-`Clear`
- [x] New `AssetDetailsViewModelXirrTests` covering `RealizedXirr`/`RealizedXirrWithCredits` (zero-terminal-value XIRR) and `RealizedPortfolioWeight`/`DisplayRealizedPortfolioWeight` (set, default-null, reset-on-`Clear`)
- [x] New `MainNavigationViewModelBaseTests` covering the portfolio-weight lookup-by-name for Historic asset selection, and confirming Active scope never triggers the extra fetch
- [x] Verified every new XAML binding resolves to an actual property via grep — WPF binding typos fail silently at runtime, not at compile time
- [x] Manual smoke test: launched `Financial.Presentation.App.exe` after each change, confirmed it starts without a XAML/binding error

🤖 Generated with [Claude Code](https://claude.com/claude-code)