### PR TITLE
test(P10): close out F06/F11 acceptance criteria

### DIFF
--- a/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/SummaryEndpointsTests.cs
@@ -2,6 +2,7 @@ using Financial.Application.DTOs;
 using FluentAssertions;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 namespace Financial.Api.Tests;
 
@@ -164,6 +165,32 @@ public class SummaryEndpointsTests
         // CLOSEDASSET: bought 5 x 60 = 300, sold 5 x 50 = 250, no credits — RealizedGainLoss = 250 - 300 + 0 = -50
         items!.Single().RealizedGainLoss.Should().Be(-50m);
         items!.Single().PortfolioWeight.Should().Be(100m);
+    }
+
+    [Fact]
+    public async Task GetPortfolioAssetsSummary_ScopeHistoric_ResponseHasNoCurrentPriceOrXirrField()
+    {
+        // PRD F06: "No current price fetch or XIRR field is present in the historic summary
+        // response" - price/XIRR are computed entirely client-side (Web/WPF), never returned
+        // by this endpoint for any scope; this guards against that ever regressing.
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/summary/portfolio/XPI/Uncategorized/assets?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(json);
+        var propertyNames = document.RootElement.EnumerateArray()
+            .SelectMany(item => item.EnumerateObject())
+            .Select(prop => prop.Name)
+            .Distinct()
+            .ToList();
+
+        propertyNames.Should().NotContain(name => name.Contains("currentPrice", StringComparison.OrdinalIgnoreCase));
+        propertyNames.Should().NotContain(name => name.Contains("currentValue", StringComparison.OrdinalIgnoreCase));
+        propertyNames.Should().NotContain(name => name.Contains("xirr", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/Tests/Financial.Presentation.Tests/ViewModels/CreditActionsTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/CreditActionsTests.cs
@@ -1,0 +1,289 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+using System.Windows;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class CreditActionsTests
+{
+    private const string BrokerName = "XPI";
+    private const string PortfolioName = "Default";
+    private const string AssetName = "BBAS3";
+
+    private static (CreditActions Actions, StubCreditService Service, Spy Spy) Build(
+        bool hasContext = true,
+        ICreditService? service = null)
+    {
+        var stubService = service as StubCreditService ?? new StubCreditService();
+        var spy = new Spy();
+        var actions = new CreditActions(
+            stubService,
+            () => hasContext,
+            () => BrokerName,
+            () => PortfolioName,
+            () => AssetName,
+            spy.ApplyDetails,
+            spy.ShowMessage);
+        return (actions, stubService, spy);
+    }
+
+    private static CreditDialogData ValidDialogData(Guid? id = null) => new(
+        CreditId: id ?? Guid.NewGuid(),
+        Date: DateTime.Today,
+        Type: "Dividend",
+        Value: 12.5m);
+
+    // --- Add ---
+
+    [Fact]
+    public async Task Add_NoContext_ShowsInfoAndDoesNotCallService()
+    {
+        var (actions, service, spy) = Build(hasContext: false);
+
+        await actions.Add(() => ValidDialogData());
+
+        service.AddCallCount.Should().Be(0);
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Information);
+    }
+
+    [Fact]
+    public async Task Add_DialogCancelled_DoesNotCallService()
+    {
+        var (actions, service, spy) = Build();
+
+        await actions.Add(() => null);
+
+        service.AddCallCount.Should().Be(0);
+        spy.Messages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Add_InvalidType_ShowsWarningAndDoesNotCallService()
+    {
+        var (actions, service, spy) = Build();
+
+        await actions.Add(() => ValidDialogData() with { Type = "NotAType" });
+
+        service.AddCallCount.Should().Be(0);
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+    }
+
+    [Fact]
+    public async Task Add_ServiceReturnsNull_ShowsWarningAndDoesNotApplyDetails()
+    {
+        var service = new StubCreditService { AddResult = null };
+        var (actions, _, spy) = Build(service: service);
+
+        await actions.Add(() => ValidDialogData());
+
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+        spy.AppliedDetails.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Add_Success_PassesCorrectRequestAndAppliesReturnedDetails()
+    {
+        var expectedDetails = new AssetDetailsDTO { Name = AssetName, BrokerName = BrokerName, PortfolioName = PortfolioName, Ticker = "T" };
+        var service = new StubCreditService { AddResult = expectedDetails };
+        var (actions, _, spy) = Build(service: service);
+
+        await actions.Add(() => ValidDialogData());
+
+        service.LastAddRequest.Should().NotBeNull();
+        service.LastAddRequest!.BrokerName.Should().Be(BrokerName);
+        service.LastAddRequest.PortfolioName.Should().Be(PortfolioName);
+        service.LastAddRequest.AssetName.Should().Be(AssetName);
+        service.LastAddRequest.Type.Should().Be("Dividend");
+        service.LastAddRequest.Value.Should().Be(12.5m);
+        spy.AppliedDetails.Should().Be(expectedDetails);
+    }
+
+    // --- Update ---
+
+    [Fact]
+    public async Task Update_NullSelectedCredit_DoesNotCallService()
+    {
+        var (actions, service, _) = Build();
+
+        await actions.Update(null, () => ValidDialogData());
+
+        service.UpdateCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Update_EmptyId_ShowsWarningAndDoesNotCallService()
+    {
+        var (actions, service, spy) = Build();
+        var selected = new CreditDTO { Id = Guid.Empty, Date = DateTime.Today, Type = "Dividend", Value = 1m };
+
+        await actions.Update(selected, () => ValidDialogData());
+
+        service.UpdateCallCount.Should().Be(0);
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+    }
+
+    [Fact]
+    public async Task Update_DialogCancelled_DoesNotCallService()
+    {
+        var (actions, service, _) = Build();
+        var selected = new CreditDTO { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Dividend", Value = 1m };
+
+        await actions.Update(selected, () => null);
+
+        service.UpdateCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Update_InvalidType_ShowsWarningAndDoesNotCallService()
+    {
+        var (actions, service, spy) = Build();
+        var selected = new CreditDTO { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Dividend", Value = 1m };
+
+        await actions.Update(selected, () => ValidDialogData(selected.Id) with { Type = "NotAType" });
+
+        service.UpdateCallCount.Should().Be(0);
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+    }
+
+    [Fact]
+    public async Task Update_Success_PassesCorrectRequestAndAppliesReturnedDetails()
+    {
+        var expectedDetails = new AssetDetailsDTO { Name = AssetName, BrokerName = BrokerName, PortfolioName = PortfolioName, Ticker = "T" };
+        var service = new StubCreditService { UpdateResult = expectedDetails };
+        var (actions, _, spy) = Build(service: service);
+        var id = Guid.NewGuid();
+        var selected = new CreditDTO { Id = id, Date = DateTime.Today, Type = "Dividend", Value = 1m };
+
+        await actions.Update(selected, () => ValidDialogData(id) with { Type = "Rent", Value = 99m });
+
+        service.LastUpdateRequest.Should().NotBeNull();
+        service.LastUpdateRequest!.Id.Should().Be(id);
+        service.LastUpdateRequest.Type.Should().Be("Rent");
+        service.LastUpdateRequest.Value.Should().Be(99m);
+        spy.AppliedDetails.Should().Be(expectedDetails);
+    }
+
+    [Fact]
+    public async Task Update_ServiceReturnsNull_ShowsWarningAndDoesNotApplyDetails()
+    {
+        var service = new StubCreditService { UpdateResult = null };
+        var (actions, _, spy) = Build(service: service);
+        var id = Guid.NewGuid();
+        var selected = new CreditDTO { Id = id, Date = DateTime.Today, Type = "Dividend", Value = 1m };
+
+        await actions.Update(selected, () => ValidDialogData(id));
+
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+        spy.AppliedDetails.Should().BeNull();
+    }
+
+    // --- Delete ---
+
+    [Fact]
+    public async Task Delete_NullSelectedCredit_DoesNotCallService()
+    {
+        var (actions, service, _) = Build();
+
+        await actions.Delete(null, () => true);
+
+        service.DeleteCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Delete_EmptyId_ShowsWarningAndDoesNotCallService()
+    {
+        var (actions, service, spy) = Build();
+        var selected = new CreditDTO { Id = Guid.Empty, Date = DateTime.Today, Type = "Dividend", Value = 1m };
+
+        await actions.Delete(selected, () => true);
+
+        service.DeleteCallCount.Should().Be(0);
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+    }
+
+    [Fact]
+    public async Task Delete_NotConfirmed_DoesNotCallService()
+    {
+        var (actions, service, _) = Build();
+        var selected = new CreditDTO { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Dividend", Value = 1m };
+
+        await actions.Delete(selected, () => false);
+
+        service.DeleteCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Delete_Success_PassesCorrectIdAndAppliesReturnedDetails()
+    {
+        var expectedDetails = new AssetDetailsDTO { Name = AssetName, BrokerName = BrokerName, PortfolioName = PortfolioName, Ticker = "T" };
+        var service = new StubCreditService { DeleteResult = expectedDetails };
+        var (actions, _, spy) = Build(service: service);
+        var id = Guid.NewGuid();
+        var selected = new CreditDTO { Id = id, Date = DateTime.Today, Type = "Dividend", Value = 1m };
+
+        await actions.Delete(selected, () => true);
+
+        service.LastDeleteRequest.Should().NotBeNull();
+        service.LastDeleteRequest!.Id.Should().Be(id);
+        service.LastDeleteRequest.BrokerName.Should().Be(BrokerName);
+        spy.AppliedDetails.Should().Be(expectedDetails);
+    }
+
+    [Fact]
+    public async Task Delete_ServiceReturnsNull_ShowsWarningAndDoesNotApplyDetails()
+    {
+        var service = new StubCreditService { DeleteResult = null };
+        var (actions, _, spy) = Build(service: service);
+        var selected = new CreditDTO { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Dividend", Value = 1m };
+
+        await actions.Delete(selected, () => true);
+
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+        spy.AppliedDetails.Should().BeNull();
+    }
+
+    private sealed class Spy
+    {
+        public AssetDetailsDTO? AppliedDetails { get; private set; }
+        public List<(string Message, string Caption, MessageBoxImage Image)> Messages { get; } = [];
+
+        public void ApplyDetails(AssetDetailsDTO details) => AppliedDetails = details;
+        public void ShowMessage(string message, string caption, MessageBoxImage image) => Messages.Add((message, caption, image));
+    }
+
+    private sealed class StubCreditService : ICreditService
+    {
+        public AssetDetailsDTO? AddResult { get; set; }
+        public AssetDetailsDTO? UpdateResult { get; set; }
+        public AssetDetailsDTO? DeleteResult { get; set; }
+        public int AddCallCount { get; private set; }
+        public int UpdateCallCount { get; private set; }
+        public int DeleteCallCount { get; private set; }
+        public CreditCreateDTO? LastAddRequest { get; private set; }
+        public CreditUpdateDTO? LastUpdateRequest { get; private set; }
+        public CreditDeleteDTO? LastDeleteRequest { get; private set; }
+
+        public Task<AssetDetailsDTO?> AddCreditAsync(CreditCreateDTO request)
+        {
+            AddCallCount++;
+            LastAddRequest = request;
+            return Task.FromResult(AddResult);
+        }
+
+        public Task<AssetDetailsDTO?> UpdateCreditAsync(CreditUpdateDTO request)
+        {
+            UpdateCallCount++;
+            LastUpdateRequest = request;
+            return Task.FromResult(UpdateResult);
+        }
+
+        public Task<AssetDetailsDTO?> DeleteCreditAsync(CreditDeleteDTO request)
+        {
+            DeleteCallCount++;
+            LastDeleteRequest = request;
+            return Task.FromResult(DeleteResult);
+        }
+    }
+}

--- a/Tests/Financial.Presentation.Tests/ViewModels/TransactionActionsTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/TransactionActionsTests.cs
@@ -1,0 +1,293 @@
+using Financial.Application.DTOs;
+using Financial.Application.Interfaces;
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+using System.Windows;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class TransactionActionsTests
+{
+    private const string BrokerName = "XPI";
+    private const string PortfolioName = "Default";
+    private const string AssetName = "BBAS3";
+
+    private static (TransactionActions Actions, StubTransactionService Service, Spy Spy) Build(
+        bool hasContext = true,
+        ITransactionService? service = null)
+    {
+        var stubService = service as StubTransactionService ?? new StubTransactionService();
+        var spy = new Spy();
+        var actions = new TransactionActions(
+            stubService,
+            () => hasContext,
+            () => BrokerName,
+            () => PortfolioName,
+            () => AssetName,
+            spy.ApplyDetails,
+            spy.ShowMessage);
+        return (actions, stubService, spy);
+    }
+
+    private static TransactionDialogData ValidDialogData(Guid? id = null) => new(
+        TransactionId: id ?? Guid.NewGuid(),
+        Date: DateTime.Today,
+        Type: "Buy",
+        Quantity: 10m,
+        UnitPrice: 25m,
+        Fees: 1.5m);
+
+    // --- Add ---
+
+    [Fact]
+    public async Task Add_NoContext_ShowsInfoAndDoesNotCallService()
+    {
+        var (actions, service, spy) = Build(hasContext: false);
+
+        await actions.Add(() => ValidDialogData());
+
+        service.AddCallCount.Should().Be(0);
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Information);
+    }
+
+    [Fact]
+    public async Task Add_DialogCancelled_DoesNotCallService()
+    {
+        var (actions, service, spy) = Build();
+
+        await actions.Add(() => null);
+
+        service.AddCallCount.Should().Be(0);
+        spy.Messages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Add_InvalidType_ShowsWarningAndDoesNotCallService()
+    {
+        var (actions, service, spy) = Build();
+
+        await actions.Add(() => ValidDialogData() with { Type = "NotAType" });
+
+        service.AddCallCount.Should().Be(0);
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+    }
+
+    [Fact]
+    public async Task Add_ServiceReturnsNull_ShowsWarningAndDoesNotApplyDetails()
+    {
+        var service = new StubTransactionService { AddResult = null };
+        var (actions, _, spy) = Build(service: service);
+
+        await actions.Add(() => ValidDialogData());
+
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+        spy.AppliedDetails.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Add_Success_PassesCorrectRequestAndAppliesReturnedDetails()
+    {
+        var expectedDetails = new AssetDetailsDTO { Name = AssetName, BrokerName = BrokerName, PortfolioName = PortfolioName, Ticker = "T" };
+        var service = new StubTransactionService { AddResult = expectedDetails };
+        var (actions, _, spy) = Build(service: service);
+
+        await actions.Add(() => ValidDialogData());
+
+        service.LastAddRequest.Should().NotBeNull();
+        service.LastAddRequest!.BrokerName.Should().Be(BrokerName);
+        service.LastAddRequest.PortfolioName.Should().Be(PortfolioName);
+        service.LastAddRequest.AssetName.Should().Be(AssetName);
+        service.LastAddRequest.Type.Should().Be("Buy");
+        service.LastAddRequest.Quantity.Should().Be(10m);
+        service.LastAddRequest.UnitPrice.Should().Be(25m);
+        service.LastAddRequest.Fees.Should().Be(1.5m);
+        spy.AppliedDetails.Should().Be(expectedDetails);
+    }
+
+    // --- Update ---
+
+    [Fact]
+    public async Task Update_NullSelectedTransaction_DoesNotCallService()
+    {
+        var (actions, service, _) = Build();
+
+        await actions.Update(null, () => ValidDialogData());
+
+        service.UpdateCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Update_EmptyId_ShowsWarningAndDoesNotCallService()
+    {
+        var (actions, service, spy) = Build();
+        var selected = new TransactionDTO { Id = Guid.Empty, Date = DateTime.Today, Type = "Buy", Quantity = 1m, UnitPrice = 1m, Fees = 0m };
+
+        await actions.Update(selected, () => ValidDialogData());
+
+        service.UpdateCallCount.Should().Be(0);
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+    }
+
+    [Fact]
+    public async Task Update_DialogCancelled_DoesNotCallService()
+    {
+        var (actions, service, _) = Build();
+        var selected = new TransactionDTO { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Buy", Quantity = 1m, UnitPrice = 1m, Fees = 0m };
+
+        await actions.Update(selected, () => null);
+
+        service.UpdateCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Update_InvalidType_ShowsWarningAndDoesNotCallService()
+    {
+        var (actions, service, spy) = Build();
+        var selected = new TransactionDTO { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Buy", Quantity = 1m, UnitPrice = 1m, Fees = 0m };
+
+        await actions.Update(selected, () => ValidDialogData(selected.Id) with { Type = "NotAType" });
+
+        service.UpdateCallCount.Should().Be(0);
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+    }
+
+    [Fact]
+    public async Task Update_Success_PassesCorrectRequestAndAppliesReturnedDetails()
+    {
+        var expectedDetails = new AssetDetailsDTO { Name = AssetName, BrokerName = BrokerName, PortfolioName = PortfolioName, Ticker = "T" };
+        var service = new StubTransactionService { UpdateResult = expectedDetails };
+        var (actions, _, spy) = Build(service: service);
+        var id = Guid.NewGuid();
+        var selected = new TransactionDTO { Id = id, Date = DateTime.Today, Type = "Buy", Quantity = 1m, UnitPrice = 1m, Fees = 0m };
+
+        await actions.Update(selected, () => ValidDialogData(id) with { Type = "Sell", Quantity = 3m });
+
+        service.LastUpdateRequest.Should().NotBeNull();
+        service.LastUpdateRequest!.Id.Should().Be(id);
+        service.LastUpdateRequest.Type.Should().Be("Sell");
+        service.LastUpdateRequest.Quantity.Should().Be(3m);
+        spy.AppliedDetails.Should().Be(expectedDetails);
+    }
+
+    [Fact]
+    public async Task Update_ServiceReturnsNull_ShowsWarningAndDoesNotApplyDetails()
+    {
+        var service = new StubTransactionService { UpdateResult = null };
+        var (actions, _, spy) = Build(service: service);
+        var id = Guid.NewGuid();
+        var selected = new TransactionDTO { Id = id, Date = DateTime.Today, Type = "Buy", Quantity = 1m, UnitPrice = 1m, Fees = 0m };
+
+        await actions.Update(selected, () => ValidDialogData(id));
+
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+        spy.AppliedDetails.Should().BeNull();
+    }
+
+    // --- Delete ---
+
+    [Fact]
+    public async Task Delete_NullSelectedTransaction_DoesNotCallService()
+    {
+        var (actions, service, _) = Build();
+
+        await actions.Delete(null, () => true);
+
+        service.DeleteCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Delete_EmptyId_ShowsWarningAndDoesNotCallService()
+    {
+        var (actions, service, spy) = Build();
+        var selected = new TransactionDTO { Id = Guid.Empty, Date = DateTime.Today, Type = "Buy", Quantity = 1m, UnitPrice = 1m, Fees = 0m };
+
+        await actions.Delete(selected, () => true);
+
+        service.DeleteCallCount.Should().Be(0);
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+    }
+
+    [Fact]
+    public async Task Delete_NotConfirmed_DoesNotCallService()
+    {
+        var (actions, service, _) = Build();
+        var selected = new TransactionDTO { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Buy", Quantity = 1m, UnitPrice = 1m, Fees = 0m };
+
+        await actions.Delete(selected, () => false);
+
+        service.DeleteCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Delete_Success_PassesCorrectIdAndAppliesReturnedDetails()
+    {
+        var expectedDetails = new AssetDetailsDTO { Name = AssetName, BrokerName = BrokerName, PortfolioName = PortfolioName, Ticker = "T" };
+        var service = new StubTransactionService { DeleteResult = expectedDetails };
+        var (actions, _, spy) = Build(service: service);
+        var id = Guid.NewGuid();
+        var selected = new TransactionDTO { Id = id, Date = DateTime.Today, Type = "Buy", Quantity = 1m, UnitPrice = 1m, Fees = 0m };
+
+        await actions.Delete(selected, () => true);
+
+        service.LastDeleteRequest.Should().NotBeNull();
+        service.LastDeleteRequest!.Id.Should().Be(id);
+        service.LastDeleteRequest.BrokerName.Should().Be(BrokerName);
+        spy.AppliedDetails.Should().Be(expectedDetails);
+    }
+
+    [Fact]
+    public async Task Delete_ServiceReturnsNull_ShowsWarningAndDoesNotApplyDetails()
+    {
+        var service = new StubTransactionService { DeleteResult = null };
+        var (actions, _, spy) = Build(service: service);
+        var selected = new TransactionDTO { Id = Guid.NewGuid(), Date = DateTime.Today, Type = "Buy", Quantity = 1m, UnitPrice = 1m, Fees = 0m };
+
+        await actions.Delete(selected, () => true);
+
+        spy.Messages.Should().ContainSingle(m => m.Image == MessageBoxImage.Warning);
+        spy.AppliedDetails.Should().BeNull();
+    }
+
+    private sealed class Spy
+    {
+        public AssetDetailsDTO? AppliedDetails { get; private set; }
+        public List<(string Message, string Caption, MessageBoxImage Image)> Messages { get; } = [];
+
+        public void ApplyDetails(AssetDetailsDTO details) => AppliedDetails = details;
+        public void ShowMessage(string message, string caption, MessageBoxImage image) => Messages.Add((message, caption, image));
+    }
+
+    private sealed class StubTransactionService : ITransactionService
+    {
+        public AssetDetailsDTO? AddResult { get; set; }
+        public AssetDetailsDTO? UpdateResult { get; set; }
+        public AssetDetailsDTO? DeleteResult { get; set; }
+        public int AddCallCount { get; private set; }
+        public int UpdateCallCount { get; private set; }
+        public int DeleteCallCount { get; private set; }
+        public TransactionCreateDTO? LastAddRequest { get; private set; }
+        public TransactionUpdateDTO? LastUpdateRequest { get; private set; }
+        public TransactionDeleteDTO? LastDeleteRequest { get; private set; }
+
+        public Task<AssetDetailsDTO?> AddTransactionAsync(TransactionCreateDTO request)
+        {
+            AddCallCount++;
+            LastAddRequest = request;
+            return Task.FromResult(AddResult);
+        }
+
+        public Task<AssetDetailsDTO?> UpdateTransactionAsync(TransactionUpdateDTO request)
+        {
+            UpdateCallCount++;
+            LastUpdateRequest = request;
+            return Task.FromResult(UpdateResult);
+        }
+
+        public Task<AssetDetailsDTO?> DeleteTransactionAsync(TransactionDeleteDTO request)
+        {
+            DeleteCallCount++;
+            LastDeleteRequest = request;
+            return Task.FromResult(DeleteResult);
+        }
+    }
+}

--- a/docs/prd/P10-prd-historic-investments/prd-historic-investments.md
+++ b/docs/prd/P10-prd-historic-investments/prd-historic-investments.md
@@ -389,7 +389,7 @@ graph TD
 
 ### F06. Historic Realized Totals Service
 - [x] A historic asset's summary returns `TotalBought`, `TotalSold`, `TotalCredits`, and `RealizedGainLoss = TotalSold - TotalBought + TotalCredits`
-- [ ] No current price fetch or XIRR field is present in the historic summary response
+- [x] No current price fetch or XIRR field is present in the historic summary response
 - [x] Portfolio weight sums to 100% across a historic portfolio's assets (by `TotalBought`)
 
 ### F07. Historic Broker Breakdown Charts Service
@@ -414,7 +414,7 @@ graph TD
 ### F11. WPF — Historic Investments Tab
 - [x] A new "Historic Investments" tab shows a tree, summary, transactions, credits, and charts scoped to historic data only
 - [x] The summary view shows realized totals, not current-value/XIRR fields
-- [ ] A transaction or credit can be added, edited, and deleted for a historic asset through the same UI flow as an active asset
+- [x] A transaction or credit can be added, edited, and deleted for a historic asset through the same UI flow as an active asset
 
 ### Cross-Feature Integration
 - [x] Data written by import (F04) into `activeInvestments`/`historicInvestments` (F02's structure) is correctly returned by the scoped navigation API (F05)


### PR DESCRIPTION
## Summary

Closes the last two open acceptance-criteria boxes in the P10 (Historic Investments) PRD, both of which represented untested-but-working code, not missing functionality:

1. **F06** — "No current price fetch or XIRR field is present in the historic summary response": structurally true (no summary DTO has ever had a price/XIRR field — those are computed entirely client-side), but had no test asserting it.
2. **F11** — "A transaction or credit can be added, edited, and deleted for a historic asset through the same UI flow as an active asset": `TransactionActions`/`CreditActions` are scope-agnostic (identified purely by broker/portfolio/asset name), so the exact same code path Active already used works for Historic — but neither had ever been unit tested, for either scope.

With this PR, every acceptance criterion and Cross-Feature Integration criterion in `docs/prd/P10-prd-historic-investments/prd-historic-investments.md` is checked off — **PRD10 (Historic Investments) is fully delivered.**

## Changes

- `Tests/Financial.Api.Tests/SummaryEndpointsTests.cs`: new `GetPortfolioAssetsSummary_ScopeHistoric_ResponseHasNoCurrentPriceOrXirrField` integration test — hits the real historic-scope endpoint and asserts the JSON response contains no `currentPrice`/`currentValue`/`xirr`-shaped keys, guarding against a future regression.
- `Tests/Financial.Presentation.Tests/ViewModels/TransactionActionsTests.cs` (new, 16 tests) and `CreditActionsTests.cs` (new, 16 tests): first-ever coverage for these two classes — Add/Update/Delete success paths (correct request shape, `ApplyDetails` called with the returned DTO), and the guard paths (no context, dialog cancelled, invalid type, empty ID, unconfirmed delete, service returns null).
- PRD checkboxes for F06 and F11 marked complete.

## Test plan
- [x] `dotnet test Financial.slnx` — 713/713 passed, 5 pre-existing skips (unrelated live-network integration tests); confirmed with 3 consecutive full-suite runs, no flakiness
- [x] New tests verified to actually exercise the intended paths (e.g. `Add_ServiceReturnsNull_ShowsWarningAndDoesNotApplyDetails` targets the "service returned null" branch specifically, distinct from the "`_service` field is null" guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)