### PR TITLE
chore: Invert Infrastructure -> GoogleFinancialSupport dependency; move IInvestmentsSerializer to Infrastructure

### DIFF
--- a/Financial.Api/Financial.Api.csproj
+++ b/Financial.Api/Financial.Api.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Financial.Application\Financial.Application.csproj" />
     <ProjectReference Include="..\Financial.Infrastructure\Financial.Infrastructure.csproj" />
+    <ProjectReference Include="..\Integrations\GoogleFinancialSupport\GoogleFinancialSupport.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Financial.Api/Program.cs
+++ b/Financial.Api/Program.cs
@@ -1,6 +1,7 @@
 using Financial.Application.Configuration;
 using Financial.Application.DependencyInjection;
 using Financial.Infrastructure.DependencyInjection;
+using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 
 var builder = WebApplication.CreateBuilder(args);
 var configuration = builder.Configuration;
@@ -33,6 +34,7 @@ builder.Services.Configure<DividendOptions>(configuration.GetSection(DividendOpt
 builder.Services.Configure<WatchlistOptions>(configuration.GetSection(WatchlistOptions.SectionName));
 builder.Services.Configure<AssetPriceFetchOptions>(configuration.GetSection(AssetPriceFetchOptions.SectionName));
 builder.Services.AddFinancialApplication();
+builder.Services.AddGoogleDriveFileClient();
 builder.Services.AddFinancialInfrastructure(configuration);
 
 var app = builder.Build();

--- a/Financial.App/App.xaml.cs
+++ b/Financial.App/App.xaml.cs
@@ -1,6 +1,7 @@
 using Financial.Application.Configuration;
 using Financial.Application.DependencyInjection;
 using Financial.Infrastructure.DependencyInjection;
+using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using Financial.Presentation.App.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -20,6 +21,7 @@ namespace Financial.Presentation.App
                 .ConfigureServices((context, services) =>
                 {
                     services.AddFinancialApplication();
+                    services.AddGoogleDriveFileClient();
                     services.AddFinancialInfrastructure(context.Configuration);
                     services.Configure<WatchlistOptions>(context.Configuration.GetSection(WatchlistOptions.SectionName));
                     services.Configure<AssetPriceFetchOptions>(context.Configuration.GetSection(AssetPriceFetchOptions.SectionName));

--- a/Financial.App/Financial.App.csproj
+++ b/Financial.App/Financial.App.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\Financial.Application\Financial.Application.csproj" />
     <ProjectReference Include="..\Financial.Domain\Financial.Domain.csproj" />
     <ProjectReference Include="..\Financial.Infrastructure\Financial.Infrastructure.csproj" />
+    <ProjectReference Include="..\Integrations\GoogleFinancialSupport\GoogleFinancialSupport.csproj" />
   </ItemGroup>
 </Project>
 

--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -36,7 +36,9 @@ public static class InfrastructureServiceCollectionExtensions
         {
             var settings = sp.GetRequiredService<IOptions<RepositorySettingsOptions>>().Value;
             var options = BuildRepositoryOptions(settings);
-            return new RepositoryFactory(sp.GetRequiredService<IInvestmentsSerializer>()).Create(options);
+            return new RepositoryFactory(
+                sp.GetRequiredService<IInvestmentsSerializer>(),
+                sp.GetService<IRemoteFileClientFactory>()).Create(options);
         });
         services.AddSingleton<IAssetPriceService, AssetPriceService>();
 

--- a/Financial.Infrastructure/Financial.Infrastructure.csproj
+++ b/Financial.Infrastructure/Financial.Infrastructure.csproj
@@ -8,8 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Financial.Application\Financial.Application.csproj" />
-<ProjectReference Include="..\Financial.Domain\Financial.Domain.csproj" />
-    <ProjectReference Include="..\Integrations\GoogleFinancialSupport\GoogleFinancialSupport.csproj" />
+    <ProjectReference Include="..\Financial.Domain\Financial.Domain.csproj" />
     <ProjectReference Include="..\Integrations\WebPageParser\WebPageParser.csproj" />
   </ItemGroup>
 

--- a/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
+++ b/Financial.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
@@ -1,6 +1,5 @@
 using Financial.Application.Interfaces;
 using Financial.Infrastructure.Configuration;
-using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 
 namespace Financial.Infrastructure.Persistence;
 
@@ -10,10 +9,10 @@ public sealed class GoogleDriveJsonStorage : IJsonStorage
     private readonly Action<string, string> _upload;
     private readonly string _driveFilePath;
 
-    public GoogleDriveJsonStorage(GoogleService service, string? driveFilePath)
+    public GoogleDriveJsonStorage(IRemoteFileClient client, string? driveFilePath)
         : this(
-            (service ?? throw new ArgumentNullException(nameof(service))).DownloadFileContent,
-            service.UploadFileContent,
+            (client ?? throw new ArgumentNullException(nameof(client))).DownloadFileContent,
+            client.UploadFileContent,
             driveFilePath)
     {
     }

--- a/Financial.Infrastructure/Persistence/IInvestmentsSerializer.cs
+++ b/Financial.Infrastructure/Persistence/IInvestmentsSerializer.cs
@@ -1,6 +1,6 @@
 using Financial.Domain.Entities;
 
-namespace Financial.Application.Interfaces;
+namespace Financial.Infrastructure.Persistence;
 
 public interface IInvestmentsSerializer
 {

--- a/Financial.Infrastructure/Persistence/IRemoteFileClient.cs
+++ b/Financial.Infrastructure/Persistence/IRemoteFileClient.cs
@@ -1,0 +1,8 @@
+namespace Financial.Infrastructure.Persistence;
+
+public interface IRemoteFileClient
+{
+    string DownloadFileContent(string path);
+
+    void UploadFileContent(string path, string content);
+}

--- a/Financial.Infrastructure/Persistence/IRemoteFileClientFactory.cs
+++ b/Financial.Infrastructure/Persistence/IRemoteFileClientFactory.cs
@@ -1,0 +1,6 @@
+namespace Financial.Infrastructure.Persistence;
+
+public interface IRemoteFileClientFactory
+{
+    IRemoteFileClient Create(string credentialsPath);
+}

--- a/Financial.Infrastructure/Persistence/InvestmentsSerializerAdapter.cs
+++ b/Financial.Infrastructure/Persistence/InvestmentsSerializerAdapter.cs
@@ -1,4 +1,3 @@
-using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/Financial.Infrastructure/Repositories/JSONRepository.cs
+++ b/Financial.Infrastructure/Repositories/JSONRepository.cs
@@ -1,5 +1,6 @@
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
+using Financial.Infrastructure.Persistence;
 
 namespace Financial.Infrastructure.Repositories;
 

--- a/Financial.Infrastructure/Repositories/RepositoryFactory.cs
+++ b/Financial.Infrastructure/Repositories/RepositoryFactory.cs
@@ -1,6 +1,5 @@
 using Financial.Application.Interfaces;
 using Financial.Infrastructure.Configuration;
-using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using Financial.Infrastructure.Persistence;
 
 namespace Financial.Infrastructure.Repositories;
@@ -8,10 +7,12 @@ namespace Financial.Infrastructure.Repositories;
 public sealed class RepositoryFactory
 {
     private readonly IInvestmentsSerializer _serializer;
+    private readonly IRemoteFileClientFactory? _remoteFileClientFactory;
 
-    public RepositoryFactory(IInvestmentsSerializer serializer)
+    public RepositoryFactory(IInvestmentsSerializer serializer, IRemoteFileClientFactory? remoteFileClientFactory = null)
     {
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+        _remoteFileClientFactory = remoteFileClientFactory;
     }
 
     public IRepository Create(RepositorySelectionOptions options)
@@ -26,18 +27,31 @@ public sealed class RepositoryFactory
         return new JSONRepository(investments, storage, _serializer);
     }
 
-    private static IJsonStorage CreateStorage(RepositorySelectionOptions options) =>
+    private IJsonStorage CreateStorage(RepositorySelectionOptions options) =>
         options.Provider switch
         {
             RepositoryProvider.LocalJson =>
                 new LocalJsonStorage(options.LocalDataPath),
             RepositoryProvider.GoogleDriveJson =>
-                new GoogleDriveJsonStorage(
-                    new GoogleService(ResolveGoogleCredentialsPath(options.GoogleDriveCredentialsPath)),
-                    options.GoogleDriveFilePath),
+                CreateGoogleDriveStorage(options),
             _ => throw new ArgumentOutOfRangeException(
                     nameof(options.Provider), options.Provider, "Unsupported repository provider.")
         };
+
+    private IJsonStorage CreateGoogleDriveStorage(RepositorySelectionOptions options)
+    {
+        var credentialsPath = ResolveGoogleCredentialsPath(options.GoogleDriveCredentialsPath);
+
+        if (_remoteFileClientFactory is null)
+        {
+            throw new InvalidOperationException(
+                $"Repository provider '{nameof(RepositoryProvider.GoogleDriveJson)}' requires an {nameof(IRemoteFileClientFactory)} " +
+                "to be registered (see AddGoogleDriveFileClient).");
+        }
+
+        var client = _remoteFileClientFactory.Create(credentialsPath);
+        return new GoogleDriveJsonStorage(client, options.GoogleDriveFilePath);
+    }
 
     private static string ResolveGoogleCredentialsPath(string? credentialsPath)
     {

--- a/Integrations/GoogleFinancialSupport/GoogleFileClientFactory.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleFileClientFactory.cs
@@ -1,0 +1,8 @@
+using Financial.Infrastructure.Persistence;
+
+namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+
+public sealed class GoogleFileClientFactory : IRemoteFileClientFactory
+{
+    public IRemoteFileClient Create(string credentialsPath) => new GoogleService(credentialsPath);
+}

--- a/Integrations/GoogleFinancialSupport/GoogleFinancialSupport.csproj
+++ b/Integrations/GoogleFinancialSupport/GoogleFinancialSupport.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Google.Apis.Core" Version="1.64.0" />
     <PackageReference Include="Google.Apis.Drive.v3" Version="1.64.0.3256" />
     <PackageReference Include="Google.Apis.Sheets.v4" Version="1.64.0.3148" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Financial.Application\Financial.Application.csproj" />
     <ProjectReference Include="..\..\Financial.Domain\Financial.Domain.csproj" />
+    <ProjectReference Include="..\..\Financial.Infrastructure\Financial.Infrastructure.csproj" />
     <ProjectReference Include="..\WebPageParser\WebPageParser.csproj" />
   </ItemGroup>
 

--- a/Integrations/GoogleFinancialSupport/GoogleFinancialSupportServiceCollectionExtensions.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleFinancialSupportServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using Financial.Infrastructure.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+
+public static class GoogleFinancialSupportServiceCollectionExtensions
+{
+    public static IServiceCollection AddGoogleDriveFileClient(this IServiceCollection services)
+    {
+        services.AddSingleton<IRemoteFileClientFactory, GoogleFileClientFactory>();
+        return services;
+    }
+}

--- a/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleGenerator.cs
@@ -1,5 +1,6 @@
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
+using Financial.Infrastructure.Persistence;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Integrations/GoogleFinancialSupport/GoogleService.cs
+++ b/Integrations/GoogleFinancialSupport/GoogleService.cs
@@ -1,10 +1,11 @@
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport.DTO;
+using Financial.Infrastructure.Persistence;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 
-public sealed class GoogleService
+public sealed class GoogleService : IRemoteFileClient
 {
     private readonly GoogleDriveClient _driveClient;
     private readonly GoogleSheetsClient _sheetsClient;

--- a/Integrations/ImportGoogleSpreadSheets/MainViewModel.cs
+++ b/Integrations/ImportGoogleSpreadSheets/MainViewModel.cs
@@ -1,4 +1,3 @@
-using Financial.Application.Interfaces;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using Financial.Infrastructure.Persistence;
 using System;

--- a/Tests/Financial.Infrastructure.Tests/Financial.Infrastructure.Tests.csproj
+++ b/Tests/Financial.Infrastructure.Tests/Financial.Infrastructure.Tests.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Financial.Infrastructure\Financial.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\Integrations\GoogleFinancialSupport\GoogleFinancialSupport.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Financial.Infrastructure.Tests/Integrations/GoogleFinancialSupportServiceCollectionExtensionsTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Integrations/GoogleFinancialSupportServiceCollectionExtensionsTests.cs
@@ -1,0 +1,21 @@
+using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+using Financial.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Financial.Infrastructure.Tests.Integrations;
+
+public class GoogleFinancialSupportServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddGoogleDriveFileClient_RegistersRemoteFileClientFactory()
+    {
+        var services = new ServiceCollection();
+
+        services.AddGoogleDriveFileClient();
+        var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IRemoteFileClientFactory>()
+            .Should().BeOfType<GoogleFileClientFactory>();
+    }
+}

--- a/Tests/Financial.Infrastructure.Tests/Persistence/GoogleDriveJsonStorageTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Persistence/GoogleDriveJsonStorageTests.cs
@@ -6,11 +6,11 @@ namespace Financial.Infrastructure.Tests.Persistence;
 public class GoogleDriveJsonStorageTests
 {
     [Fact]
-    public void Constructor_WithNullService_ThrowsArgumentNullException()
+    public void Constructor_WithNullClient_ThrowsArgumentNullException()
     {
         Action act = () => new GoogleDriveJsonStorage(null!, "some/path");
 
-        act.Should().Throw<ArgumentNullException>().WithParameterName("service");
+        act.Should().Throw<ArgumentNullException>().WithParameterName("client");
     }
 
     [Fact]

--- a/Tests/Financial.Infrastructure.Tests/Repositories/RepositoryFactoryTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Repositories/RepositoryFactoryTests.cs
@@ -1,3 +1,4 @@
+using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;
 using FluentAssertions;
@@ -7,7 +8,8 @@ namespace Financial.Infrastructure.Tests.Repositories;
 
 public class RepositoryFactoryTests
 {
-    private static readonly RepositoryFactory Factory = new(new InvestmentsSerializerAdapter());
+    private static readonly RepositoryFactory Factory =
+        new(new InvestmentsSerializerAdapter(), new GoogleFileClientFactory());
 
     [Fact]
     public void Constructor_WithNullSerializer_Throws()
@@ -98,6 +100,22 @@ public class RepositoryFactoryTests
 
         act.Should().Throw<ArgumentOutOfRangeException>()
             .WithParameterName("Provider");
+    }
+
+    [Fact]
+    public void Create_WithGoogleDriveProvider_NoRemoteFileClientFactoryRegistered_ThrowsInvalidOperationException()
+    {
+        var factoryWithoutRemoteFileClient = new RepositoryFactory(new InvestmentsSerializerAdapter());
+        var options = new RepositorySelectionOptions(
+            RepositoryProvider.GoogleDriveJson,
+            null,
+            TestDataPaths.DataJsonFile,
+            "Pessoais/Gleison/Financeiros");
+
+        Action act = () => factoryWithoutRemoteFileClient.Create(options);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*IRemoteFileClientFactory*");
     }
 
 }


### PR DESCRIPTION
## Summary
- `Financial.Infrastructure` depended directly on the `GoogleFinancialSupport` integration project (for `GoogleService`, used by `GoogleDriveJsonStorage` and `RepositoryFactory`). Applied Dependency Inversion: Infrastructure now defines vendor-neutral `IRemoteFileClient` / `IRemoteFileClientFactory` ports; `GoogleFinancialSupport` implements them via `GoogleService` / `GoogleFileClientFactory`. Wiring moved to the composition roots (`Financial.Api/Program.cs`, `Financial.App/App.xaml.cs`) via a new `AddGoogleDriveFileClient()` extension, instead of living inside Infrastructure's own DI registration.
- This removed the circular-reference blocker (`Infrastructure -> GoogleFinancialSupport -> Infrastructure`) that previously forced `IInvestmentsSerializer` to sit in `Financial.Application`, even though every real consumer (`JSONRepository`, `RepositoryFactory`, `InvestmentsLoader`, the Google integration tools) is Infrastructure-side. Moved `IInvestmentsSerializer` into `Financial.Infrastructure/Persistence`, next to its implementation `InvestmentsSerializerAdapter`.
- `RepositoryFactory` degrades gracefully with a clear `InvalidOperationException` if the `GoogleDriveJson` provider is selected without `IRemoteFileClientFactory` registered, so LocalJson-only consumers aren't forced to wire up anything Google-related.

## Test plan
- [x] Added `RepositoryFactoryTests.Create_WithGoogleDriveProvider_NoRemoteFileClientFactoryRegistered_ThrowsInvalidOperationException` covering the new missing-factory branch
- [x] Added `GoogleFinancialSupportServiceCollectionExtensionsTests.AddGoogleDriveFileClient_RegistersRemoteFileClientFactory`
- [x] Updated `GoogleDriveJsonStorageTests` for the renamed constructor parameter (`client` instead of `service`)
- [x] `dotnet build --configuration Release` — succeeds, no new warnings
- [x] `dotnet test --configuration Release` — 833 passed, 0 failed, 5 pre-existing skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)