### PR TITLE
chore: Map Trading 212 SIPP sheets to ETF SIPP portfolio in migration tool

### DIFF
--- a/Integrations/GoogleFinancialSupport/AssetMetadataResolver.cs
+++ b/Integrations/GoogleFinancialSupport/AssetMetadataResolver.cs
@@ -55,10 +55,25 @@ internal sealed class AssetMetadataResolver
         {
             "Coinbase" => "Cryptocurrency",
             "FreeTrade" => "ETF",
-            "Trading 212" => spreadsheetName.Contains("ISA") ? "ETF ISA" : "ETF",
+            "Trading 212" => ResolveTrading212PortfolioName(spreadsheetName),
             "XPI" => "FII",
             _ => DefaultPortfolioName,
         };
+    }
+
+    private static string ResolveTrading212PortfolioName(string spreadsheetName)
+    {
+        if (spreadsheetName.Contains("ISA"))
+        {
+            return "ETF ISA";
+        }
+
+        if (spreadsheetName.Contains("SIPP"))
+        {
+            return "ETF SIPP";
+        }
+
+        return "ETF";
     }
 
     internal async Task<(string isin, string exchangeId, string ticker, CountryCode country, string localTypeCode, GlobalAssetClass assetClass)> ResolveAssetMetadataAsync(

--- a/Tests/Financial.Infrastructure.Tests/Integrations/AssetMetadataResolverTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Integrations/AssetMetadataResolverTests.cs
@@ -52,6 +52,39 @@ public class AssetMetadataResolverTests
     }
 
     [Fact]
+    public void ResolvePortfolioName_Trading212WithIsaInSheetName_ReturnsEtfIsa()
+    {
+        var resolver = CreateResolver();
+        var sheet = new SheetDTO { Id = 0, Name = "VUSA ISA", Color = "" };
+
+        var portfolioName = resolver.ResolvePortfolioName("Trading 212", sheet);
+
+        portfolioName.Should().Be("ETF ISA");
+    }
+
+    [Fact]
+    public void ResolvePortfolioName_Trading212WithSippInSheetName_ReturnsEtfSipp()
+    {
+        var resolver = CreateResolver();
+        var sheet = new SheetDTO { Id = 0, Name = "VUSA SIPP", Color = "" };
+
+        var portfolioName = resolver.ResolvePortfolioName("Trading 212", sheet);
+
+        portfolioName.Should().Be("ETF SIPP");
+    }
+
+    [Fact]
+    public void ResolvePortfolioName_Trading212WithoutIsaOrSippInSheetName_ReturnsEtf()
+    {
+        var resolver = CreateResolver();
+        var sheet = new SheetDTO { Id = 0, Name = "VUSA", Color = "" };
+
+        var portfolioName = resolver.ResolvePortfolioName("Trading 212", sheet);
+
+        portfolioName.Should().Be("ETF");
+    }
+
+    [Fact]
     public void IsClosedPortfolio_Encerradas_ReturnsTrue()
     {
         var resolver = CreateResolver();


### PR DESCRIPTION
## Summary
- Trading 212 added a new SIPP tab to the export spreadsheet, alongside the existing ISA tab.
- `AssetMetadataResolver.GetDefaultPortfolioName` now resolves Trading 212 sheet names containing "SIPP" to the `ETF SIPP` portfolio, mirroring the existing `ISA` -> `ETF ISA` rule (previously only ISA vs. plain ETF was handled).

## Test plan
- [x] Added `ResolvePortfolioName_Trading212WithSippInSheetName_ReturnsEtfSipp`, plus regression tests for the existing ISA and plain-ETF cases
- [x] `dotnet test Tests/Financial.Infrastructure.Tests --filter FullyQualifiedName~AssetMetadataResolverTests` — 9 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)