### PR TITLE
feat: Add local deploy tooling for WPF app and web server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ dist
 terraform*
 .terraform*
 
+#local deployment output (manual, not part of CI/CD)
+/deploy
+scripts/deploy.local.json
+
 
 #specific files
 .gitignore.bak

--- a/Financial.Api/Financial.Api.csproj
+++ b/Financial.Api/Financial.Api.csproj
@@ -7,8 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Update="appsettings.Development.json">
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
+    <Content Update="appsettings.Production.json">
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Financial.Api/Program.cs
+++ b/Financial.Api/Program.cs
@@ -2,9 +2,21 @@ using Financial.Application.Configuration;
 using Financial.Application.DependencyInjection;
 using Financial.Infrastructure.DependencyInjection;
 using Financial.Infrastructure.Integrations.GoogleFinancialSupport;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 var configuration = builder.Configuration;
+
+builder.Host.UseSerilog((context, services, loggerConfiguration) =>
+{
+    loggerConfiguration
+        .ReadFrom.Configuration(context.Configuration)
+        .ReadFrom.Services(services)
+        .WriteTo.File(
+            Path.Combine(AppContext.BaseDirectory, "logs", "app-.log"),
+            rollingInterval: RollingInterval.Day,
+            retainedFileCountLimit: 14);
+});
 
 builder.Services.AddProblemDetails();
 builder.Services.AddOpenApi();

--- a/Financial.Api/appsettings.Production.json
+++ b/Financial.Api/appsettings.Production.json
@@ -1,0 +1,18 @@
+{
+  "Repository": {
+    "Provider": "GoogleDriveJson"
+  },
+  "GoogleDrive": {
+    "CredentialsPath": "",
+    "FilePath": "data.json"
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Information"
+      }
+    }
+  }
+}

--- a/Financial.App/App.xaml.cs
+++ b/Financial.App/App.xaml.cs
@@ -6,6 +6,7 @@ using Financial.Presentation.App.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using Serilog;
 using System.IO;
 using System.Windows;
 
@@ -18,6 +19,16 @@ namespace Financial.Presentation.App
         public App()
         {
             AppHost = Host.CreateDefaultBuilder()
+                .UseSerilog((context, services, loggerConfiguration) =>
+                {
+                    loggerConfiguration
+                        .ReadFrom.Configuration(context.Configuration)
+                        .ReadFrom.Services(services)
+                        .WriteTo.File(
+                            Path.Combine(AppContext.BaseDirectory, "logs", "app-.log"),
+                            rollingInterval: RollingInterval.Day,
+                            retainedFileCountLimit: 14);
+                })
                 .ConfigureServices((context, services) =>
                 {
                     services.AddFinancialApplication();

--- a/Financial.App/Financial.App.csproj
+++ b/Financial.App/Financial.App.csproj
@@ -21,14 +21,22 @@
     </Content>
     <Content Include="appsettings.Development.json" Condition="Exists('appsettings.Development.json')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
+    <Content Include="appsettings.Production.json" Condition="Exists('appsettings.Production.json')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="DotNetProjects.WpfToolkit.DataVisualization" Version="6.1.94" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.2.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Financial.App/appsettings.Production.json
+++ b/Financial.App/appsettings.Production.json
@@ -1,0 +1,18 @@
+{
+  "Repository": {
+    "Provider": "GoogleDriveJson"
+  },
+  "GoogleDrive": {
+    "CredentialsPath": "",
+    "FilePath": "data.json"
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Information"
+      }
+    }
+  }
+}

--- a/scripts/deploy-templates/start-all.ps1
+++ b/scripts/deploy-templates/start-all.ps1
@@ -1,0 +1,5 @@
+# Starts both the web server and the desktop app from this deploy folder.
+$ErrorActionPreference = 'Stop'
+
+& (Join-Path $PSScriptRoot 'start-web.ps1')
+& (Join-Path $PSScriptRoot 'start-app.ps1')

--- a/scripts/deploy-templates/start-app.ps1
+++ b/scripts/deploy-templates/start-app.ps1
@@ -1,0 +1,13 @@
+# Launches the Financial WPF desktop app from this deploy folder.
+$ErrorActionPreference = 'Stop'
+
+$appDir = Join-Path $PSScriptRoot 'Financial.App'
+$exePath = Join-Path $appDir 'Financial.Presentation.App.exe'
+
+if (-not (Test-Path $exePath)) {
+    Write-Error "Financial.Presentation.App.exe not found at '$exePath'. Run scripts/deploy.ps1 first."
+    exit 1
+}
+
+Start-Process -FilePath $exePath -WorkingDirectory $appDir
+Write-Host "Financial desktop app started."

--- a/scripts/deploy-templates/start-web.ps1
+++ b/scripts/deploy-templates/start-web.ps1
@@ -1,0 +1,14 @@
+# Launches the Financial web server (API + SPA) from this deploy folder.
+$ErrorActionPreference = 'Stop'
+
+$webDir = Join-Path $PSScriptRoot 'Financial.Web'
+$exePath = Join-Path $webDir 'Financial.Api.exe'
+
+if (-not (Test-Path $exePath)) {
+    Write-Error "Financial.Api.exe not found at '$exePath'. Run scripts/deploy.ps1 first."
+    exit 1
+}
+
+$env:ASPNETCORE_URLS = 'http://localhost:8080'
+Start-Process -FilePath $exePath -WorkingDirectory $webDir
+Write-Host "Financial web app starting at http://localhost:8080"

--- a/scripts/deploy.local.example.json
+++ b/scripts/deploy.local.example.json
@@ -1,0 +1,3 @@
+{
+  "GoogleDriveCredentialsPath": "C:\\path\\to\\your\\google-drive-credentials.json"
+}

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -1,0 +1,127 @@
+<#
+.SYNOPSIS
+    Publishes the current local state of Financial.App (WPF) and Financial.Web (API + SPA)
+    to the local `deploy/` folder. Manual, local-only tooling - not part of CI/CD.
+
+.DESCRIPTION
+    Re-run any time to refresh the deployed copies with whatever is currently on disk.
+    Log level (Debug) and the Google Drive data source are fixed via the checked-in
+    appsettings.Production.json files, so nothing needs to be reconfigured between runs.
+    GoogleDrive:CredentialsPath is machine-specific and NOT committed to source control -
+    it's read from scripts/deploy.local.json (gitignored, created from
+    scripts/deploy.local.example.json on first run) and stamped into the deployed
+    appsettings.Production.json files after each publish.
+#>
+[CmdletBinding()]
+param(
+    [string]$Configuration = 'Release'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$deployRoot = Join-Path $repoRoot 'deploy'
+$appDeployDir = Join-Path $deployRoot 'Financial.App'
+$webDeployDir = Join-Path $deployRoot 'Financial.Web'
+$templatesDir = Join-Path $PSScriptRoot 'deploy-templates'
+$localSettingsPath = Join-Path $PSScriptRoot 'deploy.local.json'
+
+Write-Host "== Financial local deploy ==" -ForegroundColor Cyan
+Write-Host "Repo root:   $repoRoot"
+Write-Host "Deploy root: $deployRoot"
+
+# 1. Load (or seed) the machine-local settings that are never committed to source control.
+if (-not (Test-Path $localSettingsPath)) {
+    Copy-Item -Path (Join-Path $PSScriptRoot 'deploy.local.example.json') -Destination $localSettingsPath
+    Write-Warning "Created $localSettingsPath - edit GoogleDriveCredentialsPath before starting the apps."
+}
+$localSettings = Get-Content $localSettingsPath -Raw | ConvertFrom-Json
+
+# 2. Stop any running deployed instances so publish doesn't hit locked files.
+Write-Host "`n-- Stopping any running deployed instances --"
+Get-Process -Name 'Financial.Presentation.App', 'Financial.Api' -ErrorAction SilentlyContinue |
+    Where-Object { $_.Path -and $_.Path.StartsWith($deployRoot, [System.StringComparison]::OrdinalIgnoreCase) } |
+    ForEach-Object {
+        Write-Host "Stopping $($_.ProcessName) (PID $($_.Id))"
+        Stop-Process -Id $_.Id -Force
+    }
+
+# 3. Clean + recreate the two app output folders.
+foreach ($dir in @($appDeployDir, $webDeployDir)) {
+    if (Test-Path $dir) {
+        Remove-Item -Path $dir -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+}
+
+# 4. Publish the WPF desktop app (framework-dependent - build machine == run machine).
+Write-Host "`n-- Publishing Financial.App (WPF) --"
+dotnet publish (Join-Path $repoRoot 'Financial.App\Financial.App.csproj') -c $Configuration -o $appDeployDir
+if ($LASTEXITCODE -ne 0) { throw 'Publish of Financial.App failed.' }
+
+# 5. Publish the API host.
+Write-Host "`n-- Publishing Financial.Api --"
+dotnet publish (Join-Path $repoRoot 'Financial.Api\Financial.Api.csproj') -c $Configuration -o $webDeployDir
+if ($LASTEXITCODE -ne 0) { throw 'Publish of Financial.Api failed.' }
+
+# 6. Deploy appsettings.Production.json ourselves - it's excluded from `dotnet publish`
+#    output (CopyToPublishDirectory=Never, same treatment as appsettings.Development.json)
+#    so this script is the only thing that puts it in the deploy folder, then stamps in
+#    the machine-local Google Drive credentials path.
+foreach ($pair in @(
+        @{ Source = (Join-Path $repoRoot 'Financial.App\appsettings.Production.json'); Target = (Join-Path $appDeployDir 'appsettings.Production.json') },
+        @{ Source = (Join-Path $repoRoot 'Financial.Api\appsettings.Production.json'); Target = (Join-Path $webDeployDir 'appsettings.Production.json') }
+    )) {
+    $settings = Get-Content $pair.Source -Raw | ConvertFrom-Json
+    $settings.GoogleDrive.CredentialsPath = $localSettings.GoogleDriveCredentialsPath
+    $settings | ConvertTo-Json -Depth 10 | Set-Content -Path $pair.Target -Encoding utf8
+}
+
+# 7. Build the React SPA (same API_BASE_URL convention as the Docker image) and drop it into wwwroot.
+Write-Host "`n-- Building Financial.Web (SPA) --"
+$webSrcDir = Join-Path $repoRoot 'Financial.Web'
+Push-Location $webSrcDir
+try {
+    'API_BASE_URL=/api/v1/financial' | Set-Content -Path (Join-Path $webSrcDir '.env') -Encoding utf8
+    npm install
+    if ($LASTEXITCODE -ne 0) { throw 'npm install failed.' }
+    npm run build
+    if ($LASTEXITCODE -ne 0) { throw 'npm run build failed.' }
+}
+finally {
+    Pop-Location
+}
+
+$wwwrootDir = Join-Path $webDeployDir 'wwwroot'
+New-Item -ItemType Directory -Path $wwwrootDir -Force | Out-Null
+Copy-Item -Path (Join-Path $webSrcDir 'dist\*') -Destination $wwwrootDir -Recurse -Force
+
+# 8. Refresh the launcher scripts.
+Copy-Item -Path (Join-Path $templatesDir '*.ps1') -Destination $deployRoot -Force
+
+# 9. Record what was deployed.
+Push-Location $repoRoot
+try {
+    $branch = (git branch --show-current 2>$null)
+    $commit = (git rev-parse --short HEAD 2>$null)
+}
+finally {
+    Pop-Location
+}
+@"
+Deployed: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+Branch:   $branch
+Commit:   $commit
+"@ | Set-Content -Path (Join-Path $deployRoot 'deploy-info.txt') -Encoding utf8
+
+# 10. Summary.
+Write-Host "`n== Deploy complete ==" -ForegroundColor Green
+Write-Host "Financial.App -> $appDeployDir"
+Write-Host "Financial.Web -> $webDeployDir"
+
+$credentialsPath = $localSettings.GoogleDriveCredentialsPath
+if ([string]::IsNullOrWhiteSpace($credentialsPath) -or -not (Test-Path $credentialsPath)) {
+    Write-Warning "Google Drive credentials not found at '$credentialsPath'. Edit GoogleDriveCredentialsPath in $localSettingsPath, then re-run this script."
+}
+
+Write-Host "Start everything with: $deployRoot\start-all.ps1"


### PR DESCRIPTION
## Summary

- Adds `scripts/deploy.ps1`, a repeatable, local-only script (not part of CI/CD) that publishes `Financial.App` (WPF) and `Financial.Web` (API + built SPA) to `deploy/` on this machine, using whatever is currently on disk.
- Wires Serilog file logging (Debug level in Production, rolling daily, 14-day retention under a `logs/` folder in each deploy folder) into both composition roots (`App.xaml.cs`, `Program.cs`).
- Adds `appsettings.Production.json` to both projects, pointing the existing `GoogleDriveJson` repository provider at the shared Google Drive data source instead of the local dev JSON file.
- Machine-specific Google Drive credentials path is kept out of source control entirely: it lives in a gitignored `scripts/deploy.local.json` (seeded from the committed `scripts/deploy.local.example.json`), and `deploy.ps1` stamps it into the deployed config on every run.
- Both `appsettings.Development.json` and `appsettings.Production.json` are excluded from `dotnet publish` output (`CopyToPublishDirectory=Never`) — `deploy.ps1` is the sole owner of what appsettings end up in the deploy folder, so nothing needs manual edits between runs.
- Adds launcher templates (`scripts/deploy-templates/start-app.ps1`, `start-web.ps1`, `start-all.ps1`) that `deploy.ps1` copies into `deploy/` each run for easy startup.
- `deploy/` and `scripts/deploy.local.json` added to `.gitignore`.

## Architecture

- Presentation-layer composition roots only (`App.xaml.cs`, `Program.cs`) plus new `appsettings.Production.json` config files — no Domain/Application/Infrastructure changes. Reuses the existing `GoogleDriveJson` repository provider and config keys already supported by `Financial.Infrastructure`.
- No new tests: this is composition-root bootstrap glue (same testing posture as the existing untested `Program.cs`/`App.xaml.cs`) and PowerShell tooling, mirroring how the existing `Dockerfile` has no test coverage.

## Test plan

- [x] `dotnet build` — solution builds clean, 0 warnings from these changes
- [x] `dotnet test` — full suite passes (0 failures)
- [x] Ran `scripts/deploy.ps1` end-to-end multiple times, confirmed idempotent (no manual edits needed between runs)
- [x] `deploy/start-web.ps1` — started the deployed API+SPA, hit `http://localhost:8080/api/v1/financial/navigation/brokers`, got 200 OK against real Google Drive data
- [x] `deploy/start-app.ps1` — started the deployed WPF app, confirmed it loads against real Google Drive data
- [x] Confirmed `logs/app-*.log` is written in each deploy folder with Debug-level entries
- [x] Confirmed no credentials or machine-specific paths are committed to source control

🤖 Generated with [Claude Code](https://claude.com/claude-code)