### PR TITLE
refactor: remove per-asset active flag, InvestmentScope alone decides Active vs Historic

### DIFF
--- a/Financial.Application/DTOs/AssetDetailsDTO.cs
+++ b/Financial.Application/DTOs/AssetDetailsDTO.cs
@@ -71,11 +71,6 @@ public class AssetDetailsDTO
     public decimal? AverageSellPrice { get; set; }
 
     /// <summary>
-    /// Whether the asset is active
-    /// </summary>
-    public bool IsActive { get; set; }
-
-    /// <summary>
     /// Position type derived from quantity sign (Long/Flat/Short)
     /// </summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/Financial.Application/DTOs/AssetNodeDTO.cs
+++ b/Financial.Application/DTOs/AssetNodeDTO.cs
@@ -56,11 +56,6 @@ public class AssetNodeDTO
     public decimal AveragePrice { get; set; }
 
     /// <summary>
-    /// Whether the asset is active (quantity > 0)
-    /// </summary>
-    public bool IsActive { get; set; }
-
-    /// <summary>
     /// Position type derived from quantity sign (Long/Flat/Short)
     /// </summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/Financial.Application/DTOs/PortfolioNodeDTO.cs
+++ b/Financial.Application/DTOs/PortfolioNodeDTO.cs
@@ -16,11 +16,6 @@ public class PortfolioNodeDTO
     public int AssetCount { get; set; }
 
     /// <summary>
-    /// Number of active assets (assets with quantity > 0)
-    /// </summary>
-    public int ActiveAssetCount { get; set; }
-
-    /// <summary>
     /// Assets belonging to this portfolio
     /// </summary>
     public List<AssetNodeDTO> Assets { get; set; } = new();

--- a/Financial.Application/Services/CreditService.cs
+++ b/Financial.Application/Services/CreditService.cs
@@ -78,7 +78,6 @@ public sealed class CreditService : ICreditService, ICreditQueryService
             return Array.Empty<CreditDTO>();
 
         return _repository.GetAssetsByBroker(brokerName)
-            .Where(asset => asset.PositionType == PositionType.Long)
             .SelectMany(asset => asset.Credits)
             .Select(NavigationMapper.MapCredit)
             .OrderByDescending(credit => credit.Date)
@@ -91,7 +90,6 @@ public sealed class CreditService : ICreditService, ICreditQueryService
             return Array.Empty<CreditDTO>();
 
         return _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName)
-            .Where(asset => asset.PositionType == PositionType.Long)
             .SelectMany(asset => asset.Credits)
             .Select(NavigationMapper.MapCredit)
             .OrderByDescending(credit => credit.Date)

--- a/Financial.Application/Services/CreditService.cs
+++ b/Financial.Application/Services/CreditService.cs
@@ -78,7 +78,7 @@ public sealed class CreditService : ICreditService, ICreditQueryService
             return Array.Empty<CreditDTO>();
 
         return _repository.GetAssetsByBroker(brokerName)
-            .Where(asset => asset.Active)
+            .Where(asset => asset.PositionType == PositionType.Long)
             .SelectMany(asset => asset.Credits)
             .Select(NavigationMapper.MapCredit)
             .OrderByDescending(credit => credit.Date)
@@ -91,7 +91,7 @@ public sealed class CreditService : ICreditService, ICreditQueryService
             return Array.Empty<CreditDTO>();
 
         return _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName)
-            .Where(asset => asset.Active)
+            .Where(asset => asset.PositionType == PositionType.Long)
             .SelectMany(asset => asset.Credits)
             .Select(NavigationMapper.MapCredit)
             .OrderByDescending(credit => credit.Date)

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -194,7 +194,7 @@ internal static class NavigationMapper
         {
             Name = portfolio.Name,
             AssetCount = portfolio.Assets.Count,
-            ActiveAssetCount = portfolio.Assets.Count(a => a.Active),
+            ActiveAssetCount = portfolio.Assets.Count(a => a.PositionType == PositionType.Long),
             Assets = portfolio.Assets.OrderBy(a => a.Name, StringComparer.CurrentCultureIgnoreCase).Select(asset => MapAsset(asset, scope)).ToList()
         };
     }
@@ -212,7 +212,7 @@ internal static class NavigationMapper
             Class = asset.Class,
             Quantity = asset.Quantity,
             AveragePrice = asset.AveragePrice,
-            IsActive = asset.Active,
+            IsActive = asset.PositionType == PositionType.Long,
             PositionType = scope == InvestmentScope.Historic ? PositionType.Flat : asset.PositionType,
             TransactionCount = asset.Transactions.Count,
             CreditCount = asset.Credits.Count

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -38,8 +38,7 @@ internal static class NavigationMapper
             Metadata = new Dictionary<string, object>
             {
                 ["PortfolioName"] = portfolio.Name,
-                ["AssetCount"] = portfolio.AssetCount,
-                ["ActiveAssetCount"] = portfolio.ActiveAssetCount
+                ["AssetCount"] = portfolio.AssetCount
             }
         };
 
@@ -68,7 +67,6 @@ internal static class NavigationMapper
                 ["GlobalAssetClass"] = asset.Class,
                 ["Quantity"] = asset.Quantity,
                 ["AveragePrice"] = asset.AveragePrice,
-                ["IsActive"] = asset.IsActive,
                 ["PositionType"] = asset.PositionType.ToString(),
                 ["TransactionCount"] = asset.TransactionCount,
                 ["CreditCount"] = asset.CreditCount
@@ -194,7 +192,6 @@ internal static class NavigationMapper
         {
             Name = portfolio.Name,
             AssetCount = portfolio.Assets.Count,
-            ActiveAssetCount = portfolio.Assets.Count(a => a.PositionType == PositionType.Long),
             Assets = portfolio.Assets.OrderBy(a => a.Name, StringComparer.CurrentCultureIgnoreCase).Select(asset => MapAsset(asset, scope)).ToList()
         };
     }
@@ -212,7 +209,6 @@ internal static class NavigationMapper
             Class = asset.Class,
             Quantity = asset.Quantity,
             AveragePrice = asset.AveragePrice,
-            IsActive = asset.PositionType == PositionType.Long,
             PositionType = scope == InvestmentScope.Historic ? PositionType.Flat : asset.PositionType,
             TransactionCount = asset.Transactions.Count,
             CreditCount = asset.Credits.Count

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -73,7 +73,6 @@ public sealed class NavigationService : INavigationService
             Quantity = asset.Quantity,
             AveragePrice = asset.AveragePrice,
             AverageSellPrice = NavigationMapper.CalculateAverageSellPrice(asset),
-            IsActive = asset.PositionType == PositionType.Long,
             PositionType = scope == InvestmentScope.Historic ? PositionType.Flat : asset.PositionType,
             TotalBought = totalBought,
             TotalSold = totalSold,

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -73,7 +73,7 @@ public sealed class NavigationService : INavigationService
             Quantity = asset.Quantity,
             AveragePrice = asset.AveragePrice,
             AverageSellPrice = NavigationMapper.CalculateAverageSellPrice(asset),
-            IsActive = asset.Active,
+            IsActive = asset.PositionType == PositionType.Long,
             PositionType = scope == InvestmentScope.Historic ? PositionType.Flat : asset.PositionType,
             TotalBought = totalBought,
             TotalSold = totalSold,

--- a/Financial.Domain/Entities/Asset.cs
+++ b/Financial.Domain/Entities/Asset.cs
@@ -23,8 +23,6 @@ public class Asset
 
     public decimal Quantity { get; private set; }
 
-    public bool Active => Quantity > 0;
-
     public PositionType PositionType => Quantity switch
     {
         > 0 => PositionType.Long,

--- a/Financial.Infrastructure/Persistence/InvestmentsTypeInfoResolver.cs
+++ b/Financial.Infrastructure/Persistence/InvestmentsTypeInfoResolver.cs
@@ -21,7 +21,6 @@ public class InvestmentsTypeInfoResolver : DefaultJsonTypeInfoResolver
     [
         (typeof(Asset), nameof(Asset.AveragePrice)),
         (typeof(Asset), nameof(Asset.Quantity)),
-        (typeof(Asset), nameof(Asset.Active)),
         (typeof(Transaction), nameof(Transaction.TotalPrice))
     ];
 

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -40,7 +40,6 @@ export interface BrokerNodeDto {
 export interface PortfolioNodeDto {
   name: string
   assetCount: number
-  activeAssetCount: number
   assets: AssetNodeDto[]
 }
 
@@ -54,7 +53,6 @@ export interface AssetNodeDto {
   isin: string
   quantity: number
   averagePrice: number
-  isActive: boolean
   positionType: PositionType
   transactionCount: number
   creditCount: number
@@ -97,7 +95,6 @@ export interface AssetDetailsDto {
   quantity: number
   averagePrice: number
   averageSellPrice: number | null
-  isActive: boolean
   positionType: PositionType
   totalBought: number
   totalSold: number

--- a/Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx
+++ b/Financial.Web/src/components/__tests__/AssetSummaryTab.test.tsx
@@ -53,7 +53,6 @@ const ASSET: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   averageSellPrice: null,
-  isActive: true,
   positionType: 'Long',
   totalBought: 2000,
   totalSold: 500,

--- a/Financial.Web/src/components/__tests__/InvestmentTree.test.tsx
+++ b/Financial.Web/src/components/__tests__/InvestmentTree.test.tsx
@@ -26,7 +26,6 @@ function makeAsset(
       AssetName: name,
       Ticker: name,
       Exchange: 'BVMF',
-      IsActive: isActive,
       PositionType: positionType,
       GlobalAssetClass: assetClass,
     },

--- a/Financial.Web/src/hooks/useAssetSummary.test.ts
+++ b/Financial.Web/src/hooks/useAssetSummary.test.ts
@@ -48,7 +48,6 @@ const ASSET_DETAILS: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   averageSellPrice: null,
-  isActive: true,
   positionType: 'Long',
   totalBought: 2000,
   totalSold: 0,

--- a/Financial.Web/src/hooks/useCredits.test.ts
+++ b/Financial.Web/src/hooks/useCredits.test.ts
@@ -83,7 +83,6 @@ const ASSET_DETAILS: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   averageSellPrice: null,
-  isActive: true,
   positionType: 'Long',
   totalBought: 2000,
   totalSold: 0,

--- a/Financial.Web/src/hooks/useTransactions.test.ts
+++ b/Financial.Web/src/hooks/useTransactions.test.ts
@@ -93,7 +93,6 @@ const ASSET_DETAILS: AssetDetailsDto = {
   quantity: 100,
   averagePrice: 20,
   averageSellPrice: null,
-  isActive: true,
   positionType: 'Long',
   totalBought: 2000,
   totalSold: 0,

--- a/Financial.Web/src/pages/CurrentValuesPage.tsx
+++ b/Financial.Web/src/pages/CurrentValuesPage.tsx
@@ -65,13 +65,12 @@ export default function CurrentValuesPage() {
         ticker: asset.ticker,
         exchange: asset.exchange,
         assetName: asset.name,
-        isActive: asset.isActive,
         assetClass: asset.class,
         brokerName: broker.name,
       }))
     })
     return assets.filter(
-      (asset) => asset.isActive && asset.ticker && (asset.exchange || asset.assetClass === 'Cryptocurrency'),
+      (asset) => asset.ticker && (asset.exchange || asset.assetClass === 'Cryptocurrency'),
     )
   }, [brokers, scope])
 

--- a/Financial.Web/src/pages/__tests__/ActiveInvestmentsPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/ActiveInvestmentsPage.test.tsx
@@ -43,7 +43,6 @@ const stubTree: TreeNodeDto = {
                 AssetName: 'KLBN4',
                 Ticker: 'KLBN4',
                 Exchange: 'BVMF',
-                IsActive: true,
                 PositionType: 'Long',
                 GlobalAssetClass: 1,
               },

--- a/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/CurrentValuesPage.test.tsx
@@ -28,7 +28,6 @@ const makeBroker = (
   portfolios: portfolios.map((p) => ({
     name: p.name,
     assetCount: p.assets.length,
-    activeAssetCount: p.assets.filter((a) => a.isActive !== false).length,
     assets: p.assets.map((a) => ({
       name: a.name ?? 'ASSET',
       ticker: a.ticker ?? 'TICK',
@@ -39,8 +38,7 @@ const makeBroker = (
       isin: 'BR000',
       quantity: 10,
       averagePrice: 100,
-      isActive: a.isActive ?? true,
-      positionType: a.positionType ?? ((a.isActive ?? true) ? 'Long' : 'Flat'),
+      positionType: a.positionType ?? 'Long',
       transactionCount: 0,
       creditCount: 0,
     })),
@@ -233,14 +231,15 @@ describe('CurrentValuesPage', () => {
     expect(await screen.findByRole('button', { name: 'Check Prices' })).toBeInTheDocument()
   })
 
-  it('excludes inactive assets from fetch scope', async () => {
+  it('does not exclude flat or short assets from fetch scope', async () => {
     getBrokersMock.mockResolvedValue([
       makeBroker([
         {
           name: 'Default',
           assets: [
-            { name: 'BCIA11', ticker: 'BCIA11', isActive: true },
-            { name: 'INAC11', ticker: 'INAC11', isActive: false },
+            { name: 'BCIA11', ticker: 'BCIA11', positionType: 'Long' },
+            { name: 'FLAT11', ticker: 'FLAT11', positionType: 'Flat' },
+            { name: 'SHRT11', ticker: 'SHRT11', positionType: 'Short' },
           ],
         },
       ]),
@@ -252,9 +251,10 @@ describe('CurrentValuesPage', () => {
 
     await waitFor(() => expect(screen.queryByText(/Completed!/)).toBeInTheDocument())
 
-    expect(getCurrentPriceMock).toHaveBeenCalledTimes(1)
+    expect(getCurrentPriceMock).toHaveBeenCalledTimes(3)
     expect(getCurrentPriceMock).toHaveBeenCalledWith('BVMF', 'BCIA11', 'RealEstateFund', 'XPI')
-    expect(getCurrentPriceMock).not.toHaveBeenCalledWith('BVMF', 'INAC11', 'RealEstateFund', 'XPI')
+    expect(getCurrentPriceMock).toHaveBeenCalledWith('BVMF', 'FLAT11', 'RealEstateFund', 'XPI')
+    expect(getCurrentPriceMock).toHaveBeenCalledWith('BVMF', 'SHRT11', 'RealEstateFund', 'XPI')
   })
 
   it('excludes assets with empty ticker or exchange', async () => {

--- a/Financial.Web/src/pages/__tests__/HistoricInvestmentsPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/HistoricInvestmentsPage.test.tsx
@@ -43,7 +43,6 @@ const stubTree: TreeNodeDto = {
                 AssetName: 'CLOSEDASSET',
                 Ticker: 'CLOSEDASSET',
                 Exchange: 'BVMF',
-                IsActive: true,
                 PositionType: 'Flat',
                 GlobalAssetClass: 1,
               },

--- a/Tests/Financial.Application.Tests/Services/CreditServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/CreditServiceTests.cs
@@ -210,7 +210,7 @@ public class CreditServiceTests
     }
 
     [Fact]
-    public void GetCreditsByBroker_ReturnsCreditsFromActiveAssets()
+    public void GetCreditsByBroker_ReturnsCreditsFromAsset()
     {
         var asset = MakeAsset();
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 10m, 0m));
@@ -220,6 +220,26 @@ public class CreditServiceTests
         var result = CreateService().GetCreditsByBroker("XPI");
 
         result.Should().ContainSingle(c => c.Value == 5m);
+    }
+
+    [Fact]
+    public void GetCreditsByBroker_IncludesCreditsFromFlatAndShortAssets()
+    {
+        var flatAsset = MakeAsset("FLAT");
+        flatAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 10m, 0m));
+        flatAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 10m, 0m));
+        flatAsset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 3m));
+
+        var shortAsset = MakeAsset("SHORT");
+        shortAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 10m, 0m));
+        shortAsset.AddCredit(Credit.Create(new DateTime(2024, 1, 2), Credit.CreditType.Rent, 7m));
+
+        _repository.AssetsByBroker = [flatAsset, shortAsset];
+
+        var result = CreateService().GetCreditsByBroker("XPI");
+
+        result.Should().Contain(c => c.Value == 3m);
+        result.Should().Contain(c => c.Value == 7m);
     }
 
     [Theory]
@@ -234,7 +254,7 @@ public class CreditServiceTests
     }
 
     [Fact]
-    public void GetCreditsByPortfolio_ReturnsCreditsFromActiveAssets()
+    public void GetCreditsByPortfolio_ReturnsCreditsFromAsset()
     {
         var asset = MakeAsset();
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 10m, 0m));
@@ -244,6 +264,26 @@ public class CreditServiceTests
         var result = CreateService().GetCreditsByPortfolio("XPI", "Default");
 
         result.Should().ContainSingle(c => c.Value == 5m);
+    }
+
+    [Fact]
+    public void GetCreditsByPortfolio_IncludesCreditsFromFlatAndShortAssets()
+    {
+        var flatAsset = MakeAsset("FLAT");
+        flatAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 10m, 0m));
+        flatAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 10m, 0m));
+        flatAsset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 3m));
+
+        var shortAsset = MakeAsset("SHORT");
+        shortAsset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 10m, 0m));
+        shortAsset.AddCredit(Credit.Create(new DateTime(2024, 1, 2), Credit.CreditType.Rent, 7m));
+
+        _repository.AssetsByBrokerPortfolio = [flatAsset, shortAsset];
+
+        var result = CreateService().GetCreditsByPortfolio("XPI", "Default");
+
+        result.Should().Contain(c => c.Value == 3m);
+        result.Should().Contain(c => c.Value == 7m);
     }
 
     [Theory]

--- a/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/AssetTests.cs
@@ -88,7 +88,7 @@ public class AssetTests
 
         asset.Quantity.Should().Be(20m);
         asset.AveragePrice.Should().Be(6m);
-        asset.Active.Should().BeTrue();
+        asset.PositionType.Should().Be(PositionType.Long);
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class AssetTests
 
         asset.Quantity.Should().Be(0m);
         asset.AveragePrice.Should().Be(10m);
-        asset.Active.Should().BeFalse();
+        asset.PositionType.Should().Be(PositionType.Flat);
     }
 
     [Fact]

--- a/Tests/Financial.Infrastructure.Tests/Persistence/InvestmentsTypeInfoResolverTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Persistence/InvestmentsTypeInfoResolverTests.cs
@@ -32,7 +32,6 @@ public class InvestmentsTypeInfoResolverTests
 
         typeInfo!.Properties.Should().NotContain(p => p.Name == nameof(Asset.AveragePrice));
         typeInfo.Properties.Should().NotContain(p => p.Name == nameof(Asset.Quantity));
-        typeInfo.Properties.Should().NotContain(p => p.Name == nameof(Asset.Active));
     }
 
     [Fact]

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
@@ -74,7 +74,7 @@ public class AssetDetailsViewModelBrokerSummaryTests
             Ticker = "T", ISIN = "US1234567890", Exchange = "LSE",
             Country = Financial.Domain.Entities.CountryCode.Unknown,
             LocalTypeCode = "", Class = Financial.Domain.Entities.GlobalAssetClass.Unknown,
-            Quantity = 10m, AveragePrice = 50m, IsActive = true,
+            Quantity = 10m, AveragePrice = 50m,
             TotalBought = 500m, TotalSold = 0m, TotalCredits = 0m,
             Transactions = [], Credits = []
         });
@@ -117,7 +117,7 @@ public class AssetDetailsViewModelBrokerSummaryTests
             Ticker = "T", ISIN = "", Exchange = "LSE",
             Country = Financial.Domain.Entities.CountryCode.Unknown,
             LocalTypeCode = "", Class = Financial.Domain.Entities.GlobalAssetClass.Unknown,
-            Quantity = 0m, AveragePrice = 0m, IsActive = true,
+            Quantity = 0m, AveragePrice = 0m,
             TotalBought = 0m, TotalSold = 0m, TotalCredits = 0m,
             Transactions = [], Credits = []
         });
@@ -278,7 +278,7 @@ public class AssetDetailsViewModelBrokerSummaryTests
             Ticker = "T", ISIN = "", Exchange = "LSE",
             Country = Financial.Domain.Entities.CountryCode.Unknown,
             LocalTypeCode = "", Class = Financial.Domain.Entities.GlobalAssetClass.Unknown,
-            Quantity = 0m, AveragePrice = 0m, IsActive = true,
+            Quantity = 0m, AveragePrice = 0m,
             TotalBought = 0m, TotalSold = 0m, TotalCredits = 0m,
             Transactions = [], Credits = []
         });

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
@@ -178,7 +178,7 @@ public class AssetDetailsViewModelPortfolioSummaryTests
             Ticker = "T", ISIN = "", Exchange = "LSE",
             Country = Financial.Domain.Entities.CountryCode.Unknown,
             LocalTypeCode = "", Class = Financial.Domain.Entities.GlobalAssetClass.Unknown,
-            Quantity = 0m, AveragePrice = 0m, IsActive = true,
+            Quantity = 0m, AveragePrice = 0m,
             TotalBought = 0m, TotalSold = 0m, TotalCredits = 0m,
             Transactions = [], Credits = []
         });

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelTransactionsChartTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelTransactionsChartTests.cs
@@ -36,7 +36,6 @@ public class AssetDetailsViewModelTransactionsChartTests
         Class = Financial.Domain.Entities.GlobalAssetClass.Unknown,
         Quantity = 100m,
         AveragePrice = 20m,
-        IsActive = true,
         TotalBought = 2000m,
         TotalSold = 0m,
         TotalCredits = 0m,

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetPriceFetchViewModelTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetPriceFetchViewModelTests.cs
@@ -22,7 +22,6 @@ public class AssetPriceFetchViewModelTests
                 Ticker = "BTC",
                 Exchange = "",
                 Class = GlobalAssetClass.Cryptocurrency,
-                IsActive = true,
             }
         ];
         var priceService = new StubAssetPriceService();
@@ -53,7 +52,6 @@ public class AssetPriceFetchViewModelTests
                 Ticker = "KLBN4",
                 Exchange = "BVMF",
                 Class = GlobalAssetClass.Equity,
-                IsActive = true,
             }
         ];
         var priceService = new StubAssetPriceService();
@@ -84,7 +82,6 @@ public class AssetPriceFetchViewModelTests
                 Ticker = "TESOURO IPCA+ 2029",
                 Exchange = "BVMF",
                 Class = GlobalAssetClass.Bond,
-                IsActive = true,
             }
         ];
         var priceService = new StubAssetPriceService();


### PR DESCRIPTION
## Summary
- `Asset.Active` (`Quantity > 0`) predated `PositionType` (Long/Flat/Short) and was an exact duplicate computation over the same field. First commit consolidated `Active` into `PositionType`.
- Further investigation (prompted by review) found that filtering by position status on top of `InvestmentScope` was itself redundant: `InvestmentScope` (Active/Historic) is a manual, per-tab decision made once at spreadsheet import time (`AssetMetadataResolver.IsClosedPortfolio`), completely independent of live `Quantity`. Once a query is already scoped to Active or Historic, filtering further by `PositionType == Long` just double-applies a second, unrelated "is this active" test — e.g. it silently excluded dividends from assets that were sold down to zero but whose portfolio hadn't been manually recoloured to Historic in the spreadsheet.
- Removed the `PositionType`-based filters from `CreditService.GetCreditsByBroker`/`GetCreditsByPortfolio` — credits from Flat/Short assets within the queried scope now count the same as Long ones.
- Removed `IsActive` (`AssetNodeDTO`/`AssetDetailsDTO`) and `ActiveAssetCount` (`PortfolioNodeDTO`) entirely, DTO fields and their Web TS mirrors — verified neither had any remaining real consumer (WPF's `AssetPriceFetchViewModel` never filtered by it; the tree-metadata `IsActive` key was never read by any WPF binding; Web components only referenced it in test fixtures) once the CreditService and `CurrentValuesPage.tsx` filters were removed.
- `CurrentValuesPage.tsx` (Web) price-fetch eligibility filter dropped the same `isActive` check — eligibility is already governed by which scope `getBrokers()` queries (Active, since it calls `/navigation/brokers` with no scope param and the API defaults to Active) plus the configured portfolio list, matching what the WPF `AssetPriceFetchViewModel` already did.
- `PositionType` remains untouched and is now the sole per-asset position signal (used for display colouring); `InvestmentScope` remains the sole active/historic determinant.

## Test plan
- [x] `dotnet build` — solution builds clean
- [x] `dotnet test` — full .NET suite green (839 tests: +2 new `CreditServiceTests` covering that Flat/Short assets' credits are now included)
- [x] `npx tsc -b --noEmit` — Web frontend type-checks clean
- [x] `npx vitest run` — full Web suite green (402 tests), including a rewritten `CurrentValuesPage` test asserting Flat/Short assets are no longer excluded from price-fetch scope
- [x] Grepped for stray `IsActive`/`isActive`/`ActiveAssetCount` references — none remain outside the unrelated `InvestmentScope.Active` enum and WPF's `IsActiveScope` (a different, intentionally-kept scope indicator)

## Definition of Done
- [x] No layer violations — change confined to Domain/Application/Infrastructure and both frontends' consumption of DTOs; no business logic in Presentation
- [x] Clean Code / SOLID — removes a redundant, conflicting filter and dead DTO fields (SRP: `InvestmentScope` is now the single source of truth for active-vs-historic, `PositionType` the single source for position direction)
- [x] Existing tests updated; new tests added for the corrected `CreditService` behavior and the corrected Web fetch-eligibility behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)