### PR TITLE
refactor: split AssetClassification.cs/MarketData.cs, move GlobalAssetClassMapping to Rules

### DIFF
--- a/Financial.Domain/Entities/Asset.cs
+++ b/Financial.Domain/Entities/Asset.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Financial.Domain.Rules;
 
 namespace Financial.Domain.Entities;
 

--- a/Financial.Domain/Entities/CountryCode.cs
+++ b/Financial.Domain/Entities/CountryCode.cs
@@ -1,0 +1,9 @@
+namespace Financial.Domain.Entities;
+
+public enum CountryCode
+{
+    Unknown = 0,
+    BR,
+    US,
+    UK
+}

--- a/Financial.Domain/Entities/GlobalAssetClass.cs
+++ b/Financial.Domain/Entities/GlobalAssetClass.cs
@@ -1,0 +1,16 @@
+namespace Financial.Domain.Entities;
+
+public enum GlobalAssetClass
+{
+    Unknown = 0,
+    Equity,
+    RealEstate,
+    Bond,
+    Fund,
+    ETF,
+    Cash,
+    Pension,
+    Other,
+    Cryptocurrency,
+    PrivateCredit
+}

--- a/Financial.Domain/Rules/GlobalAssetClassMapping.cs
+++ b/Financial.Domain/Rules/GlobalAssetClassMapping.cs
@@ -1,30 +1,8 @@
 using System;
 using System.Collections.Generic;
+using Financial.Domain.Entities;
 
-namespace Financial.Domain.Entities;
-
-public enum CountryCode
-{
-    Unknown = 0,
-    BR,
-    US,
-    UK
-}
-
-public enum GlobalAssetClass
-{
-    Unknown = 0,
-    Equity,
-    RealEstate,
-    Bond,
-    Fund,
-    ETF,
-    Cash,
-    Pension,
-    Other,
-    Cryptocurrency,
-    PrivateCredit
-}
+namespace Financial.Domain.Rules;
 
 public static class GlobalAssetClassMapping
 {

--- a/Financial.Domain/ValueObjects/AssetValueSnapshot.cs
+++ b/Financial.Domain/ValueObjects/AssetValueSnapshot.cs
@@ -2,8 +2,4 @@ using System;
 
 namespace Financial.Domain.ValueObjects;
 
-public enum DividendType { Dividend, JCP }
-
 public record AssetValueSnapshot(string Ticker, string Name, decimal Price, DateTimeOffset AsOf);
-
-public record DividendValue(DividendType Type, DateTime Date, decimal Value);

--- a/Financial.Domain/ValueObjects/DividendType.cs
+++ b/Financial.Domain/ValueObjects/DividendType.cs
@@ -1,0 +1,3 @@
+namespace Financial.Domain.ValueObjects;
+
+public enum DividendType { Dividend, JCP }

--- a/Financial.Domain/ValueObjects/DividendValue.cs
+++ b/Financial.Domain/ValueObjects/DividendValue.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace Financial.Domain.ValueObjects;
+
+public record DividendValue(DividendType Type, DateTime Date, decimal Value);

--- a/Tests/Financial.Domain.Tests/Domain/GlobalAssetClassMappingTests.cs
+++ b/Tests/Financial.Domain.Tests/Domain/GlobalAssetClassMappingTests.cs
@@ -1,4 +1,5 @@
 using Financial.Domain.Entities;
+using Financial.Domain.Rules;
 using FluentAssertions;
 
 namespace Financial.Domain.Tests;


### PR DESCRIPTION
## Summary
- Neither `AssetClassification` nor `MarketData` exist as types — both were files named after nothing they actually defined, each bundling several unrelated top-level types together:
  - `Financial.Domain/Entities/AssetClassification.cs` → `CountryCode` (enum) + `GlobalAssetClass` (enum) + `GlobalAssetClassMapping` (static resolver class)
  - `Financial.Domain/ValueObjects/MarketData.cs` → `DividendType` (enum) + `AssetValueSnapshot` (record) + `DividendValue` (record)
- Split each along type boundaries, matching the one-top-level-type-per-file convention already used elsewhere (`PositionType.cs`).
- `GlobalAssetClassMapping` is a pure static lookup with no state/IO — structurally identical to what already lives in `Financial.Domain/Rules/` (`DividendValuationRules`, `ProfitCalculator`, `XirrCalculator`), so it moves there (namespace `Financial.Domain.Entities` → `Financial.Domain.Rules`) instead of staying bundled in `Entities/`.
- `CountryCode`/`GlobalAssetClass` stay in `Entities/`, each in its own file, namespace unchanged — 17 and 36 call sites respectively needed zero changes since they're namespace-based imports.
- `DividendType`/`AssetValueSnapshot`/`DividendValue` stay in `ValueObjects/`, namespace unchanged — 27 files reference these by namespace, zero changes needed.
- Only 2 files needed a `using Financial.Domain.Rules;` addition (the namespace-changing move): `Asset.cs` (calls `GlobalAssetClassMapping.Resolve` in its factory) and `GlobalAssetClassMappingTests.cs`.

## Test plan
- [x] `dotnet build` — solution builds clean
- [x] `dotnet test` — full suite green (844 tests), including `GlobalAssetClassMappingTests.cs` and `Asset.Create` factory tests that exercise the resolver indirectly
- [x] Grepped for stray `AssetClassification` references — only the unrelated `AssetClassificationLookup` (a separate Infrastructure/Integrations concept, confirmed distinct during investigation) remains

## Definition of Done
- [x] No layer violations — pure file/namespace reorganization within Domain, no behavior change
- [x] Clean Code — fixes misleading file names (neither matched any type they contained) and joins an established folder convention (`Rules/`) instead of leaving a pure static resolver bundled with unrelated enums
- [x] Existing tests unchanged in behavior, all still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)