### PR TITLE
refactor: move InvestmentScope enum out of Interfaces/ into Enums/

### DIFF
--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using Financial.Presentation.App.Helpers;

--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using System.Collections.ObjectModel;

--- a/Financial.App/ViewModels/MainNavigationViewModelHistoric.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelHistoric.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 
 namespace Financial.Presentation.App.ViewModels;

--- a/Financial.Application/Enums/InvestmentScope.cs
+++ b/Financial.Application/Enums/InvestmentScope.cs
@@ -1,3 +1,3 @@
-namespace Financial.Application.Interfaces;
+namespace Financial.Application.Enums;
 
 public enum InvestmentScope { Active, Historic }

--- a/Financial.Application/Interfaces/IBrokerBreakdownService.cs
+++ b/Financial.Application/Interfaces/IBrokerBreakdownService.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 
 namespace Financial.Application.Interfaces;
 

--- a/Financial.Application/Interfaces/INavigationService.cs
+++ b/Financial.Application/Interfaces/INavigationService.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 
 namespace Financial.Application.Interfaces;
 

--- a/Financial.Application/Interfaces/IPortfolioAssetSummaryService.cs
+++ b/Financial.Application/Interfaces/IPortfolioAssetSummaryService.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 
 namespace Financial.Application.Interfaces;
 

--- a/Financial.Application/Interfaces/IRepository.cs
+++ b/Financial.Application/Interfaces/IRepository.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Enums;
 using Financial.Domain.Entities;
 
 namespace Financial.Application.Interfaces;

--- a/Financial.Application/Interfaces/ISummaryService.cs
+++ b/Financial.Application/Interfaces/ISummaryService.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 
 namespace Financial.Application.Interfaces;
 

--- a/Financial.Application/Services/BrokerBreakdownService.cs
+++ b/Financial.Application/Services/BrokerBreakdownService.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 

--- a/Financial.Application/Services/NavigationMapper.cs
+++ b/Financial.Application/Services/NavigationMapper.cs
@@ -1,5 +1,5 @@
 using Financial.Application.DTOs;
-using Financial.Application.Interfaces;
+using Financial.Application.Enums;
 using Financial.Domain.Entities;
 
 namespace Financial.Application.Services;

--- a/Financial.Application/Services/NavigationService.cs
+++ b/Financial.Application/Services/NavigationService.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 

--- a/Financial.Application/Services/PortfolioAssetSummaryService.cs
+++ b/Financial.Application/Services/PortfolioAssetSummaryService.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 
 namespace Financial.Application.Services;

--- a/Financial.Application/Services/SummaryService.cs
+++ b/Financial.Application/Services/SummaryService.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 
 namespace Financial.Application.Services;

--- a/Financial.Application/Validation/InvestmentScopeParser.cs
+++ b/Financial.Application/Validation/InvestmentScopeParser.cs
@@ -1,4 +1,4 @@
-using Financial.Application.Interfaces;
+using Financial.Application.Enums;
 
 namespace Financial.Application.Validation;
 

--- a/Financial.Infrastructure/Repositories/JSONRepository.cs
+++ b/Financial.Infrastructure/Repositories/JSONRepository.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using Financial.Infrastructure.Persistence;

--- a/Tests/Financial.Api.Tests/Controllers/ControllerGuardClauseTests.cs
+++ b/Tests/Financial.Api.Tests/Controllers/ControllerGuardClauseTests.cs
@@ -1,6 +1,7 @@
 using Financial.Api.Controllers;
 using Financial.Application.Configuration;
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using FluentAssertions;
 using Microsoft.Extensions.Options;

--- a/Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/BrokerBreakdownServiceTests.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
 using Financial.Domain.Entities;

--- a/Tests/Financial.Application.Tests/Services/CreditServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/CreditServiceTests.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
 using Financial.Domain.Entities;

--- a/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
+++ b/Tests/Financial.Application.Tests/Services/NavigationMapperTests.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
 using Financial.Domain.Entities;

--- a/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
 using Financial.Domain.Entities;

--- a/Tests/Financial.Application.Tests/Services/SummaryServiceTests.cs
+++ b/Tests/Financial.Application.Tests/Services/SummaryServiceTests.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
 using Financial.Domain.Entities;

--- a/Tests/Financial.Application.Tests/Services/TransactionServiceMutationTests.cs
+++ b/Tests/Financial.Application.Tests/Services/TransactionServiceMutationTests.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
 using Financial.Domain.Entities;

--- a/Tests/Financial.Application.Tests/Services/TransactionServiceQueryTests.cs
+++ b/Tests/Financial.Application.Tests/Services/TransactionServiceQueryTests.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
 using Financial.Domain.Entities;

--- a/Tests/Financial.Application.Tests/Validation/InvestmentScopeParserTests.cs
+++ b/Tests/Financial.Application.Tests/Validation/InvestmentScopeParserTests.cs
@@ -1,4 +1,4 @@
-using Financial.Application.Interfaces;
+using Financial.Application.Enums;
 using Financial.Application.Validation;
 using FluentAssertions;
 

--- a/Tests/Financial.Infrastructure.Tests/Repositories/JsonRepositoryTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Repositories/JsonRepositoryTests.cs
@@ -1,4 +1,4 @@
-using Financial.Application.Interfaces;
+using Financial.Application.Enums;
 using Financial.Domain.Entities;
 using Financial.Infrastructure.Persistence;
 using Financial.Infrastructure.Repositories;

--- a/Tests/Financial.Infrastructure.Tests/TestDoubles/StubRepository.cs
+++ b/Tests/Financial.Infrastructure.Tests/TestDoubles/StubRepository.cs
@@ -1,3 +1,4 @@
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelBrokerSummaryTests.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
 using Financial.Presentation.App.ViewModels;

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelPortfolioSummaryTests.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
 using Financial.Domain.Entities;

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelXirrTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelXirrTests.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Application.Services;
 using Financial.Domain.Entities;

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetPriceFetchViewModelTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetPriceFetchViewModelTests.cs
@@ -1,5 +1,6 @@
 using Financial.Application.Configuration;
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using Financial.Presentation.App.ViewModels;

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using Financial.Presentation.App.ViewModels;

--- a/Tests/Financial.Presentation.Tests/ViewModels/TestStubs.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/TestStubs.cs
@@ -1,4 +1,5 @@
 using Financial.Application.DTOs;
+using Financial.Application.Enums;
 using Financial.Application.Interfaces;
 
 namespace Financial.Presentation.Tests.ViewModels;


### PR DESCRIPTION
## Summary
- Audited whether Financial.Application interfaces are correctly placed and consumed (all 17 files in Interfaces/, all Services, DI registration, and consumers in Financial.Api/Financial.App). Findings: interfaces are consumed correctly (DIP holding end-to-end - every Controller/ViewModel injects via interface type, never concrete), and the Service/Interface pairing is consistent everywhere.
- One real placement issue found: `InvestmentScope.cs` is a plain enum, not an interface, but was sitting in `Financial.Application/Interfaces/` since it was first added there.
- Moved to `Financial.Application/Enums/InvestmentScope.cs` (namespace `Financial.Application.Enums`).
- Mechanical follow-through across 32 consumer files (Interfaces, Services, Validation, Infrastructure's `JSONRepository`, the WPF app's ViewModels, and both Application/Presentation/Infrastructure/Api test projects): added `using Financial.Application.Enums;` alongside the existing `Financial.Application.Interfaces` import wherever a file also depends on `IRepository`/`INavigationService`/etc., or replaced it outright where `InvestmentScope` was the only reason for that import (e.g. `InvestmentScopeParser.cs`, `NavigationMapper.cs`, `JsonRepositoryTests.cs`).
- No behavior change anywhere - purely a namespace/folder move, verified file-by-file via the compiler (built after the move, fixed exactly the files it flagged, repeated until clean).

Two other flags from the audit were investigated and found to be correct as-is, not changed:
- `IJsonStorage` is never DI-registered - confirmed intentional: `RepositoryFactory` branches on a `RepositoryProvider` config value to pick Local vs. Google Drive storage, which is the standard idiom for "choose an implementation based on runtime config" in vanilla `Microsoft.Extensions.DependencyInjection` (no built-in keyed/conditional resolution).
- `CreditService`/`TransactionService` are registered both as concrete types and via two interfaces each - confirmed this is Microsoft's documented pattern for "one singleton instance, multiple interface facades" (register concrete as singleton, expose each interface via a factory delegate resolving that same singleton). No cleaner alternative exists in vanilla MS DI.

## Test plan
- [x] `dotnet build` - solution builds clean (iteratively verified: after the move, rebuilt and fixed exactly the files the compiler flagged as missing `InvestmentScope`, three passes until zero errors)
- [x] `dotnet test` - full suite green (844 tests, no behavior change)
- [x] Reviewed `git status` - exactly the expected 32 consumer files touched, one file renamed/moved, no unrelated changes

## Definition of Done
- [x] No layer violations - purely organizational within Application, no behavior change
- [x] Clean Code - fixes a misplaced type (enum living in a folder named for a different kind of thing), matches the same category of fix already applied to `AssetClassification.cs`/`MarketData.cs`
- [x] Existing tests unchanged in behavior, all still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)