### PR TITLE
refactor: fix Infrastructure DIP gap, move AssetValueRequest to DTOs

### DIFF
--- a/Financial.Infrastructure/DTOs/AssetValueRequestDTO.cs
+++ b/Financial.Infrastructure/DTOs/AssetValueRequestDTO.cs
@@ -1,6 +1,6 @@
-namespace Financial.Infrastructure.Interfaces;
+namespace Financial.Infrastructure.DTOs;
 
-public class AssetValueRequest
+public class AssetValueRequestDTO
 {
     public string? Ticker { get; set; }
     public string? Exchange { get; set; }

--- a/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -31,7 +31,8 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<StatusInvestFinanceService>();
         services.AddSingleton<IAssetPriceFetcher, StandardAssetPriceFetcher>();
         services.AddSingleton<IAssetPriceFetcher, CryptocurrencyAssetPriceFetcher>();
-        services.AddSingleton<IAssetPriceFetcher, BondAssetPriceFetcher>();
+        services.AddSingleton<IAssetPriceFetcher>(sp =>
+            new BondAssetPriceFetcher(sp.GetRequiredService<StatusInvestFinanceService>()));
         services.AddSingleton<IRepository>(sp =>
         {
             var settings = sp.GetRequiredService<IOptions<RepositorySettingsOptions>>().Value;

--- a/Financial.Infrastructure/Interfaces/IFinanceService.cs
+++ b/Financial.Infrastructure/Interfaces/IFinanceService.cs
@@ -1,8 +1,9 @@
 using Financial.Domain.ValueObjects;
+using Financial.Infrastructure.DTOs;
 
 namespace Financial.Infrastructure.Interfaces;
 
 public interface IFinanceService
 {
-    AssetValueSnapshot GetAssetValue(AssetValueRequest request);
+    AssetValueSnapshot GetAssetValue(AssetValueRequestDTO request);
 }

--- a/Financial.Infrastructure/Services/BondAssetPriceFetcher.cs
+++ b/Financial.Infrastructure/Services/BondAssetPriceFetcher.cs
@@ -1,15 +1,16 @@
 using Financial.Application.DTOs;
 using Financial.Domain.Entities;
 using Financial.Domain.ValueObjects;
+using Financial.Infrastructure.DTOs;
 using Financial.Infrastructure.Interfaces;
 
 namespace Financial.Infrastructure.Services;
 
 public sealed class BondAssetPriceFetcher : IAssetPriceFetcher
 {
-    private readonly StatusInvestFinanceService _statusInvestFinanceService;
+    private readonly IFinanceService _statusInvestFinanceService;
 
-    public BondAssetPriceFetcher(StatusInvestFinanceService statusInvestFinanceService)
+    public BondAssetPriceFetcher(IFinanceService statusInvestFinanceService)
     {
         _statusInvestFinanceService = statusInvestFinanceService ?? throw new ArgumentNullException(nameof(statusInvestFinanceService));
     }
@@ -23,6 +24,6 @@ public sealed class BondAssetPriceFetcher : IAssetPriceFetcher
             throw new ArgumentException("Name is required for bond assets.", nameof(request));
         }
 
-        return _statusInvestFinanceService.GetAssetValue(new AssetValueRequest { Name = request.Name });
+        return _statusInvestFinanceService.GetAssetValue(new AssetValueRequestDTO { Name = request.Name });
     }
 }

--- a/Financial.Infrastructure/Services/CryptocurrencyAssetPriceFetcher.cs
+++ b/Financial.Infrastructure/Services/CryptocurrencyAssetPriceFetcher.cs
@@ -2,6 +2,7 @@ using Financial.Application.DTOs;
 using Financial.Application.Interfaces;
 using Financial.Domain.Entities;
 using Financial.Domain.ValueObjects;
+using Financial.Infrastructure.DTOs;
 using Financial.Infrastructure.Interfaces;
 
 namespace Financial.Infrastructure.Services;
@@ -27,7 +28,7 @@ public sealed class CryptocurrencyAssetPriceFetcher : IAssetPriceFetcher
         }
 
         var currency = ResolveBrokerCurrency(_repository.GetBrokerList(), request.BrokerName);
-        return _financeService.GetAssetValue(new AssetValueRequest { Currency = currency, Ticker = request.Ticker });
+        return _financeService.GetAssetValue(new AssetValueRequestDTO { Currency = currency, Ticker = request.Ticker });
     }
 
     internal static string ResolveBrokerCurrency(IEnumerable<Broker> brokers, string brokerName)

--- a/Financial.Infrastructure/Services/GoogleFinanceService.cs
+++ b/Financial.Infrastructure/Services/GoogleFinanceService.cs
@@ -1,4 +1,5 @@
 using Financial.Domain.ValueObjects;
+using Financial.Infrastructure.DTOs;
 using Financial.Infrastructure.Integrations.WebPageParser;
 using Financial.Infrastructure.Interfaces;
 
@@ -22,7 +23,7 @@ public sealed class GoogleFinanceService : IFinanceService
         _cryptoLookup = cryptoLookup ?? throw new ArgumentNullException(nameof(cryptoLookup));
     }
 
-    public AssetValueSnapshot GetAssetValue(AssetValueRequest request)
+    public AssetValueSnapshot GetAssetValue(AssetValueRequestDTO request)
     {
         if (string.IsNullOrWhiteSpace(request.Ticker))
         {

--- a/Financial.Infrastructure/Services/StandardAssetPriceFetcher.cs
+++ b/Financial.Infrastructure/Services/StandardAssetPriceFetcher.cs
@@ -1,6 +1,7 @@
 using Financial.Application.DTOs;
 using Financial.Domain.Entities;
 using Financial.Domain.ValueObjects;
+using Financial.Infrastructure.DTOs;
 using Financial.Infrastructure.Interfaces;
 
 namespace Financial.Infrastructure.Services;
@@ -23,6 +24,6 @@ public sealed class StandardAssetPriceFetcher : IAssetPriceFetcher
             throw new ArgumentException("Exchange is required.", nameof(request));
         }
 
-        return _financeService.GetAssetValue(new AssetValueRequest { Exchange = request.Exchange, Ticker = request.Ticker });
+        return _financeService.GetAssetValue(new AssetValueRequestDTO { Exchange = request.Exchange, Ticker = request.Ticker });
     }
 }

--- a/Financial.Infrastructure/Services/StatusInvestFinanceService.cs
+++ b/Financial.Infrastructure/Services/StatusInvestFinanceService.cs
@@ -1,4 +1,5 @@
 using Financial.Domain.ValueObjects;
+using Financial.Infrastructure.DTOs;
 using Financial.Infrastructure.Integrations.WebPageParser;
 using Financial.Infrastructure.Interfaces;
 
@@ -17,7 +18,7 @@ public sealed class StatusInvestFinanceService : IFinanceService
         _lookup = lookup ?? throw new ArgumentNullException(nameof(lookup));
     }
 
-    public AssetValueSnapshot GetAssetValue(AssetValueRequest request)
+    public AssetValueSnapshot GetAssetValue(AssetValueRequestDTO request)
     {
         if (string.IsNullOrWhiteSpace(request.Name))
         {

--- a/Tests/Financial.Infrastructure.Tests/Services/GoogleFinanceServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/GoogleFinanceServiceTests.cs
@@ -1,5 +1,5 @@
 using Financial.Domain.ValueObjects;
-using Financial.Infrastructure.Interfaces;
+using Financial.Infrastructure.DTOs;
 using Financial.Infrastructure.Services;
 using FluentAssertions;
 
@@ -11,7 +11,7 @@ public class GoogleFinanceServiceTests
     public void GetAssetValue_BlankTicker_ThrowsArgumentException()
     {
         var service = new GoogleFinanceService();
-        var request = new AssetValueRequest { Exchange = "BVMF", Ticker = "" };
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "" };
 
         Action act = () => service.GetAssetValue(request);
 
@@ -22,7 +22,7 @@ public class GoogleFinanceServiceTests
     public void GetAssetValue_NeitherExchangeNorCurrencyProvided_ThrowsArgumentException()
     {
         var service = new GoogleFinanceService();
-        var request = new AssetValueRequest { Ticker = "BCIA11" };
+        var request = new AssetValueRequestDTO { Ticker = "BCIA11" };
 
         Action act = () => service.GetAssetValue(request);
 
@@ -52,7 +52,7 @@ public class GoogleFinanceServiceTests
         var service = new GoogleFinanceService(
             (exchange, ticker) => exchange == "BVMF" && ticker == "BCIA11" ? snapshot : throw new InvalidOperationException(),
             (_, _) => throw new InvalidOperationException("crypto lookup should not be called"));
-        var request = new AssetValueRequest { Exchange = "BVMF", Ticker = "BCIA11" };
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "BCIA11" };
 
         var result = service.GetAssetValue(request);
 
@@ -66,7 +66,7 @@ public class GoogleFinanceServiceTests
         var service = new GoogleFinanceService(
             (_, _) => throw new InvalidOperationException("exchange lookup should not be called"),
             (currency, ticker) => currency == "GBP" && ticker == "BTC" ? snapshot : throw new InvalidOperationException());
-        var request = new AssetValueRequest { Currency = "GBP", Ticker = "BTC" };
+        var request = new AssetValueRequestDTO { Currency = "GBP", Ticker = "BTC" };
 
         var result = service.GetAssetValue(request);
 

--- a/Tests/Financial.Infrastructure.Tests/Services/StatusInvestFinanceServiceTests.cs
+++ b/Tests/Financial.Infrastructure.Tests/Services/StatusInvestFinanceServiceTests.cs
@@ -1,5 +1,5 @@
 using Financial.Domain.ValueObjects;
-using Financial.Infrastructure.Interfaces;
+using Financial.Infrastructure.DTOs;
 using Financial.Infrastructure.Services;
 using FluentAssertions;
 
@@ -11,7 +11,7 @@ public class StatusInvestFinanceServiceTests
     public void GetAssetValue_BlankName_ThrowsArgumentException()
     {
         var service = new StatusInvestFinanceService();
-        var request = new AssetValueRequest { Name = "" };
+        var request = new AssetValueRequestDTO { Name = "" };
 
         Action act = () => service.GetAssetValue(request);
 
@@ -31,7 +31,7 @@ public class StatusInvestFinanceServiceTests
     {
         var snapshot = new AssetValueSnapshot("TESOURO IPCA+ 2029", "TESOURO IPCA+ 2029", 1234.56m, DateTimeOffset.UtcNow);
         var service = new StatusInvestFinanceService(name => name == "TESOURO IPCA+ 2029" ? snapshot : throw new InvalidOperationException());
-        var request = new AssetValueRequest { Name = "TESOURO IPCA+ 2029" };
+        var request = new AssetValueRequestDTO { Name = "TESOURO IPCA+ 2029" };
 
         var result = service.GetAssetValue(request);
 

--- a/Tests/Financial.Infrastructure.Tests/TestDoubles/StubFinanceService.cs
+++ b/Tests/Financial.Infrastructure.Tests/TestDoubles/StubFinanceService.cs
@@ -1,4 +1,5 @@
 using Financial.Domain.ValueObjects;
+using Financial.Infrastructure.DTOs;
 using Financial.Infrastructure.Interfaces;
 
 namespace Financial.Infrastructure.Tests;
@@ -12,5 +13,5 @@ internal sealed class StubFinanceService : IFinanceService
         _snapshot = snapshot;
     }
 
-    public AssetValueSnapshot GetAssetValue(AssetValueRequest request) => _snapshot ?? throw new NotImplementedException();
+    public AssetValueSnapshot GetAssetValue(AssetValueRequestDTO request) => _snapshot ?? throw new NotImplementedException();
 }


### PR DESCRIPTION
## Summary
Audited whether `Financial.Infrastructure`'s own interfaces are correctly placed and consumed (both its dedicated `Interfaces/` folder and the interfaces defined in `Persistence/`), and whether its Services correctly depend on abstractions rather than concrete types. Two real issues found and fixed; two more discussed and deliberately left as-is.

**Fixed:**
- `StatusInvestFinanceService` implements `IFinanceService` (same as `GoogleFinanceService`) but was wired and consumed by its **concrete type** — `BondAssetPriceFetcher`'s constructor took `StatusInvestFinanceService` directly, bypassing the abstraction that already exists and is used correctly for `GoogleFinanceService`. `BondAssetPriceFetcher` now depends on `IFinanceService`. DI still explicitly wires the specific `StatusInvestFinanceService` singleton via a factory registration (matching the existing `IRepository` factory pattern in the same file) — `IFinanceService` intentionally has two *non-interchangeable* implementations (Google for standard/crypto assets, StatusInvest for bonds specifically), not a resolve-any-one collection like `IAssetPriceFetcher`, so a second `services.AddSingleton<IFinanceService, StatusInvestFinanceService>()` registration would have silently broken `StandardAssetPriceFetcher`/`CryptocurrencyAssetPriceFetcher`'s resolution of the Google implementation.
- `AssetValueRequest.cs` was a plain DTO sitting inside `Financial.Infrastructure/Interfaces/`, not a contract. Moved to `Financial.Infrastructure/DTOs/AssetValueRequestDTO.cs`, renamed to match the `*DTO` naming convention already used throughout `Financial.Application`.

**Discussed, left as-is:**
- Infrastructure's 5 own interfaces are split between `Interfaces/` and `Persistence/` (next to implementations) — no consistent rule, but not worth the churn right now.
- `GoogleFinancialSupport` project depends on `Financial.Infrastructure` to implement Infrastructure-defined interfaces (`IRemoteFileClient`/`IRemoteFileClientFactory`), and a standalone `ImportGoogleSpreadSheets` utility bypasses the Application layer entirely — both are structural/bigger questions, discussed but not changed in this PR.

## Test plan
- [x] `dotnet build` — solution builds clean, zero errors
- [x] `dotnet test` — full suite green (844 tests), including the unmodified `BondAssetPriceFetcherTests.cs` (constructor parameter name was preserved, so its `ArgumentNullException` assertion needed no changes despite the type change)
- [x] Grepped for stray `AssetValueRequest` (without `DTO` suffix) references — none remain
- [x] Reviewed `git status` — exactly the expected files touched, one file renamed/moved

## Definition of Done
- [x] No layer violations — change confined to Infrastructure and its tests
- [x] Clean Code / SOLID — fixes a real DIP inconsistency (BondAssetPriceFetcher now depends on the abstraction, improving testability) and a misplaced type (DTO sitting in a contracts folder)
- [x] Existing tests unchanged in behavior, all still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)