### PR TITLE
feat(P11-F11): Web App Shell — Investments/CashFlow Domain Switcher

### DIFF
--- a/Financial.Web/src/App.css
+++ b/Financial.Web/src/App.css
@@ -5,31 +5,33 @@
   overflow: hidden;
 }
 
-.app__nav {
+.app__domain-switcher {
   display: flex;
-  gap: 0;
-  padding: 0 16px;
+  gap: 8px;
+  padding: 8px 16px;
   border-bottom: 1px solid var(--border);
   background: var(--bg);
   flex-shrink: 0;
 }
 
-.app__nav a {
+.app__domain-switcher a {
   color: var(--text-h);
   text-decoration: none;
-  font-weight: 500;
-  padding: 12px 16px;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
 }
 
-.app__nav a.active {
-  border-bottom-color: var(--accent);
-  font-weight: 600;
+.app__domain-switcher a.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg);
 }
 
 .app__content {
   flex: 1;
+  min-height: 0;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/Financial.Web/src/App.test.tsx
+++ b/Financial.Web/src/App.test.tsx
@@ -1,90 +1,64 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter, Navigate, Route, Routes } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import App from './App'
 
-vi.mock('./api/financialApiClient', () => ({
-  createFinancialApiClient: () => ({}),
-}))
-
-const AppWithRoutes = ({ initialEntry = '/' }: { initialEntry?: string }) => (
+const AppWithRoutes = ({ initialEntry = '/investments' }: { initialEntry?: string }) => (
   <MemoryRouter initialEntries={[initialEntry]}>
     <Routes>
       <Route path="/" element={<App />}>
-        <Route index element={<Navigate to="/active-investments" replace />} />
-        <Route path="active-investments" element={<p>Active Investments placeholder</p>} />
-        <Route path="historic-investments" element={<h2>Historic Investments placeholder</h2>} />
-        <Route path="dividend-check" element={<h2>Shares Dividend Check</h2>} />
-        <Route path="current-values" element={<h2>Read Assets Current Values</h2>} />
-        <Route path="*" element={<p>Page not found.</p>} />
+        <Route path="investments" element={<p>Investments domain content</p>} />
+        <Route path="cashflow" element={<p>CashFlow domain content</p>} />
+        <Route path="*" element={<Navigate to="/investments" replace />} />
       </Route>
     </Routes>
   </MemoryRouter>
 )
 
 describe('App', () => {
-  it('renders four nav items', () => {
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('renders exactly two domain switcher options', () => {
     render(<AppWithRoutes />)
 
-    expect(screen.getByRole('link', { name: 'Active Investments' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Historic Investments' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Shares Dividend Check' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Read Assets Current Values' })).toBeInTheDocument()
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(2)
+    expect(screen.getByRole('link', { name: 'Investments' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'CashFlow' })).toBeInTheDocument()
   })
 
-  it('navigates to historic investments section', () => {
+  it('switches to the cashflow domain content', () => {
     render(<AppWithRoutes />)
 
-    fireEvent.click(screen.getByRole('link', { name: 'Historic Investments' }))
+    fireEvent.click(screen.getByRole('link', { name: 'CashFlow' }))
 
-    expect(screen.getByRole('heading', { name: 'Historic Investments placeholder' })).toBeInTheDocument()
-    expect(screen.queryByText('Active Investments placeholder')).not.toBeInTheDocument()
+    expect(screen.getByText('CashFlow domain content')).toBeInTheDocument()
+    expect(screen.queryByText('Investments domain content')).not.toBeInTheDocument()
   })
 
-  it('default route redirects to active investments', () => {
-    render(<AppWithRoutes initialEntry="/" />)
+  it('switches back to the investments domain content', () => {
+    render(<AppWithRoutes initialEntry="/cashflow" />)
 
-    expect(screen.getByText('Active Investments placeholder')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('link', { name: 'Investments' }))
+
+    expect(screen.getByText('Investments domain content')).toBeInTheDocument()
+    expect(screen.queryByText('CashFlow domain content')).not.toBeInTheDocument()
   })
 
-  it('navigates to dividend check section', async () => {
+  it('active domain link receives active class', () => {
+    render(<AppWithRoutes initialEntry="/cashflow" />)
+
+    expect(screen.getByRole('link', { name: 'CashFlow' })).toHaveClass('active')
+    expect(screen.getByRole('link', { name: 'Investments' })).not.toHaveClass('active')
+  })
+
+  it('persists the active domain to sessionStorage on navigation', () => {
     render(<AppWithRoutes />)
 
-    fireEvent.click(screen.getByRole('link', { name: 'Shares Dividend Check' }))
+    fireEvent.click(screen.getByRole('link', { name: 'CashFlow' }))
 
-    expect(screen.getByRole('heading', { name: 'Shares Dividend Check' })).toBeInTheDocument()
-    expect(screen.queryByText('Active Investments placeholder')).not.toBeInTheDocument()
-  })
-
-  it('navigates to current values section', () => {
-    render(<AppWithRoutes />)
-
-    fireEvent.click(screen.getByRole('link', { name: 'Read Assets Current Values' }))
-
-    expect(screen.getByRole('heading', { name: 'Read Assets Current Values' })).toBeInTheDocument()
-  })
-
-  it('active nav item receives active class', () => {
-    render(<AppWithRoutes initialEntry="/dividend-check" />)
-
-    const activeLink = screen.getByRole('link', { name: 'Shares Dividend Check' })
-    const activeInvestmentsLink = screen.getByRole('link', { name: 'Active Investments' })
-    const currentValuesLink = screen.getByRole('link', { name: 'Read Assets Current Values' })
-
-    expect(activeLink).toHaveClass('active')
-    expect(activeInvestmentsLink).not.toHaveClass('active')
-    expect(currentValuesLink).not.toHaveClass('active')
-  })
-
-  it('legacy broker route returns 404', () => {
-    render(<AppWithRoutes initialEntry="/brokers" />)
-
-    expect(screen.getByText('Page not found.')).toBeInTheDocument()
-  })
-
-  it('legacy navigation route returns 404', () => {
-    render(<AppWithRoutes initialEntry="/navigation" />)
-
-    expect(screen.getByText('Page not found.')).toBeInTheDocument()
+    expect(sessionStorage.getItem('financial.selectedDomain')).toBe('cashflow')
   })
 })

--- a/Financial.Web/src/App.tsx
+++ b/Financial.Web/src/App.tsx
@@ -1,14 +1,24 @@
-import { NavLink, Outlet } from 'react-router-dom'
+import { useEffect } from 'react'
+import { NavLink, Outlet, useLocation } from 'react-router-dom'
+import { setStoredDomain } from './utils/domainStorage'
 import './App.css'
 
 function App() {
+  const location = useLocation()
+
+  useEffect(() => {
+    if (location.pathname.startsWith('/investments')) {
+      setStoredDomain('investments')
+    } else if (location.pathname.startsWith('/cashflow')) {
+      setStoredDomain('cashflow')
+    }
+  }, [location.pathname])
+
   return (
     <div className="app">
-      <nav className="app__nav" aria-label="Primary">
-        <NavLink to="/active-investments">Active Investments</NavLink>
-        <NavLink to="/historic-investments">Historic Investments</NavLink>
-        <NavLink to="/dividend-check">Shares Dividend Check</NavLink>
-        <NavLink to="/current-values">Read Assets Current Values</NavLink>
+      <nav className="app__domain-switcher" aria-label="Domain">
+        <NavLink to="/investments">Investments</NavLink>
+        <NavLink to="/cashflow">CashFlow</NavLink>
       </nav>
       <main className="app__content">
         <Outlet />

--- a/Financial.Web/src/components/CashFlowLayout.css
+++ b/Financial.Web/src/components/CashFlowLayout.css
@@ -1,0 +1,38 @@
+.cashflow-layout {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.cashflow-layout__nav {
+  display: flex;
+  gap: 0;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.cashflow-layout__nav a {
+  color: var(--text-h);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 12px 16px;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+
+.cashflow-layout__nav a.active {
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+
+.cashflow-layout__content {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}

--- a/Financial.Web/src/components/CashFlowLayout.tsx
+++ b/Financial.Web/src/components/CashFlowLayout.tsx
@@ -1,0 +1,22 @@
+import { NavLink, Outlet } from 'react-router-dom'
+import './CashFlowLayout.css'
+
+function CashFlowLayout() {
+  return (
+    <div className="cashflow-layout">
+      <nav className="cashflow-layout__nav" aria-label="CashFlow">
+        <NavLink to="/cashflow/monthly">Monthly</NavLink>
+        <NavLink to="/cashflow/reserva">Reserva</NavLink>
+        <NavLink to="/cashflow/mensais">Mensais</NavLink>
+        <NavLink to="/cashflow/controle-mae">Controle Mae</NavLink>
+        <NavLink to="/cashflow/investment-snapshots">Investment Snapshots</NavLink>
+        <NavLink to="/cashflow/yearly-summary">Yearly Summary</NavLink>
+      </nav>
+      <div className="cashflow-layout__content">
+        <Outlet />
+      </div>
+    </div>
+  )
+}
+
+export default CashFlowLayout

--- a/Financial.Web/src/components/InvestmentsLayout.css
+++ b/Financial.Web/src/components/InvestmentsLayout.css
@@ -1,0 +1,37 @@
+.investments-layout {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.investments-layout__nav {
+  display: flex;
+  gap: 0;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  flex-shrink: 0;
+}
+
+.investments-layout__nav a {
+  color: var(--text-h);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 12px 16px;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+
+.investments-layout__nav a.active {
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+
+.investments-layout__content {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}

--- a/Financial.Web/src/components/InvestmentsLayout.tsx
+++ b/Financial.Web/src/components/InvestmentsLayout.tsx
@@ -1,0 +1,20 @@
+import { NavLink, Outlet } from 'react-router-dom'
+import './InvestmentsLayout.css'
+
+function InvestmentsLayout() {
+  return (
+    <div className="investments-layout">
+      <nav className="investments-layout__nav" aria-label="Investments">
+        <NavLink to="/investments/active-investments">Active Investments</NavLink>
+        <NavLink to="/investments/historic-investments">Historic Investments</NavLink>
+        <NavLink to="/investments/dividend-check">Shares Dividend Check</NavLink>
+        <NavLink to="/investments/current-values">Read Assets Current Values</NavLink>
+      </nav>
+      <div className="investments-layout__content">
+        <Outlet />
+      </div>
+    </div>
+  )
+}
+
+export default InvestmentsLayout

--- a/Financial.Web/src/components/__tests__/CashFlowLayout.test.tsx
+++ b/Financial.Web/src/components/__tests__/CashFlowLayout.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import CashFlowLayout from '../CashFlowLayout'
+
+const CashFlowLayoutWithRoutes = ({ initialEntry = '/cashflow/monthly' }: { initialEntry?: string }) => (
+  <MemoryRouter initialEntries={[initialEntry]}>
+    <Routes>
+      <Route path="/cashflow" element={<CashFlowLayout />}>
+        <Route path="monthly" element={<p>Monthly placeholder</p>} />
+        <Route path="reserva" element={<p>Reserva placeholder</p>} />
+        <Route path="mensais" element={<p>Mensais placeholder</p>} />
+        <Route path="controle-mae" element={<p>Controle Mae placeholder</p>} />
+        <Route path="investment-snapshots" element={<p>Investment Snapshots placeholder</p>} />
+        <Route path="yearly-summary" element={<p>Yearly Summary placeholder</p>} />
+      </Route>
+    </Routes>
+  </MemoryRouter>
+)
+
+describe('CashFlowLayout', () => {
+  it('renders exactly the six cashflow tab links in order', () => {
+    render(<CashFlowLayoutWithRoutes />)
+
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(6)
+    expect(links.map((link) => link.textContent)).toEqual([
+      'Monthly',
+      'Reserva',
+      'Mensais',
+      'Controle Mae',
+      'Investment Snapshots',
+      'Yearly Summary',
+    ])
+  })
+
+  it('navigates to the reserva section', () => {
+    render(<CashFlowLayoutWithRoutes />)
+
+    fireEvent.click(screen.getByRole('link', { name: 'Reserva' }))
+
+    expect(screen.getByText('Reserva placeholder')).toBeInTheDocument()
+    expect(screen.queryByText('Monthly placeholder')).not.toBeInTheDocument()
+  })
+
+  it('active nav item receives active class', () => {
+    render(<CashFlowLayoutWithRoutes initialEntry="/cashflow/mensais" />)
+
+    const activeLink = screen.getByRole('link', { name: 'Mensais' })
+    const monthlyLink = screen.getByRole('link', { name: 'Monthly' })
+
+    expect(activeLink).toHaveClass('active')
+    expect(monthlyLink).not.toHaveClass('active')
+  })
+})

--- a/Financial.Web/src/components/__tests__/InvestmentsLayout.test.tsx
+++ b/Financial.Web/src/components/__tests__/InvestmentsLayout.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import InvestmentsLayout from '../InvestmentsLayout'
+
+const InvestmentsLayoutWithRoutes = ({ initialEntry = '/investments/active-investments' }: { initialEntry?: string }) => (
+  <MemoryRouter initialEntries={[initialEntry]}>
+    <Routes>
+      <Route path="/investments" element={<InvestmentsLayout />}>
+        <Route path="active-investments" element={<p>Active Investments placeholder</p>} />
+        <Route path="historic-investments" element={<h2>Historic Investments placeholder</h2>} />
+        <Route path="dividend-check" element={<h2>Shares Dividend Check</h2>} />
+        <Route path="current-values" element={<h2>Read Assets Current Values</h2>} />
+      </Route>
+    </Routes>
+  </MemoryRouter>
+)
+
+describe('InvestmentsLayout', () => {
+  it('renders the four existing investments tab links', () => {
+    render(<InvestmentsLayoutWithRoutes />)
+
+    expect(screen.getByRole('link', { name: 'Active Investments' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Historic Investments' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Shares Dividend Check' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Read Assets Current Values' })).toBeInTheDocument()
+  })
+
+  it('navigates to historic investments section', () => {
+    render(<InvestmentsLayoutWithRoutes />)
+
+    fireEvent.click(screen.getByRole('link', { name: 'Historic Investments' }))
+
+    expect(screen.getByRole('heading', { name: 'Historic Investments placeholder' })).toBeInTheDocument()
+    expect(screen.queryByText('Active Investments placeholder')).not.toBeInTheDocument()
+  })
+
+  it('active nav item receives active class', () => {
+    render(<InvestmentsLayoutWithRoutes initialEntry="/investments/dividend-check" />)
+
+    const activeLink = screen.getByRole('link', { name: 'Shares Dividend Check' })
+    const activeInvestmentsLink = screen.getByRole('link', { name: 'Active Investments' })
+
+    expect(activeLink).toHaveClass('active')
+    expect(activeInvestmentsLink).not.toHaveClass('active')
+  })
+})

--- a/Financial.Web/src/main.tsx
+++ b/Financial.Web/src/main.tsx
@@ -4,21 +4,40 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import './index.css'
 import './styles/data-table.css'
 import App from './App'
+import InvestmentsLayout from './components/InvestmentsLayout'
+import CashFlowLayout from './components/CashFlowLayout'
 import ActiveInvestmentsPage from './pages/ActiveInvestmentsPage'
 import HistoricInvestmentsPage from './pages/HistoricInvestmentsPage'
 import DividendCheckPage from './pages/DividendCheckPage'
 import CurrentValuesPage from './pages/CurrentValuesPage'
+import CashFlowPlaceholderPage from './pages/CashFlowPlaceholderPage'
+import RootRedirect from './pages/RootRedirect'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<App />}>
-          <Route index element={<Navigate to="/active-investments" replace />} />
-          <Route path="active-investments" element={<ActiveInvestmentsPage />} />
-          <Route path="historic-investments" element={<HistoricInvestmentsPage />} />
-          <Route path="dividend-check" element={<DividendCheckPage />} />
-          <Route path="current-values" element={<CurrentValuesPage />} />
+          <Route index element={<RootRedirect />} />
+          <Route path="investments" element={<InvestmentsLayout />}>
+            <Route index element={<Navigate to="/investments/active-investments" replace />} />
+            <Route path="active-investments" element={<ActiveInvestmentsPage />} />
+            <Route path="historic-investments" element={<HistoricInvestmentsPage />} />
+            <Route path="dividend-check" element={<DividendCheckPage />} />
+            <Route path="current-values" element={<CurrentValuesPage />} />
+          </Route>
+          <Route path="cashflow" element={<CashFlowLayout />}>
+            <Route index element={<Navigate to="/cashflow/monthly" replace />} />
+            <Route path="monthly" element={<CashFlowPlaceholderPage title="Monthly" />} />
+            <Route path="reserva" element={<CashFlowPlaceholderPage title="Reserva" />} />
+            <Route path="mensais" element={<CashFlowPlaceholderPage title="Mensais" />} />
+            <Route path="controle-mae" element={<CashFlowPlaceholderPage title="Controle Mae" />} />
+            <Route
+              path="investment-snapshots"
+              element={<CashFlowPlaceholderPage title="Investment Snapshots" />}
+            />
+            <Route path="yearly-summary" element={<CashFlowPlaceholderPage title="Yearly Summary" />} />
+          </Route>
           <Route path="*" element={<div>Page not found.</div>} />
         </Route>
       </Routes>

--- a/Financial.Web/src/pages/CashFlowPlaceholderPage.css
+++ b/Financial.Web/src/pages/CashFlowPlaceholderPage.css
@@ -1,0 +1,9 @@
+.cashflow-placeholder {
+  padding: 24px;
+  text-align: center;
+  color: var(--text);
+}
+
+.cashflow-placeholder h2 {
+  color: var(--text-h);
+}

--- a/Financial.Web/src/pages/CashFlowPlaceholderPage.tsx
+++ b/Financial.Web/src/pages/CashFlowPlaceholderPage.tsx
@@ -1,0 +1,14 @@
+import './CashFlowPlaceholderPage.css'
+
+interface CashFlowPlaceholderPageProps {
+  title: string
+}
+
+export default function CashFlowPlaceholderPage({ title }: CashFlowPlaceholderPageProps) {
+  return (
+    <section className="cashflow-placeholder">
+      <h2>{title}</h2>
+      <p>{title} view is coming soon.</p>
+    </section>
+  )
+}

--- a/Financial.Web/src/pages/RootRedirect.tsx
+++ b/Financial.Web/src/pages/RootRedirect.tsx
@@ -1,0 +1,14 @@
+import { Navigate } from 'react-router-dom'
+import { getStoredDomain } from '../utils/domainStorage'
+
+function RootRedirect() {
+  const domain = getStoredDomain()
+
+  if (domain === 'cashflow') {
+    return <Navigate to="/cashflow/monthly" replace />
+  }
+
+  return <Navigate to="/investments/active-investments" replace />
+}
+
+export default RootRedirect

--- a/Financial.Web/src/pages/__tests__/CashFlowPlaceholderPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/CashFlowPlaceholderPage.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import CashFlowPlaceholderPage from '../CashFlowPlaceholderPage'
+
+describe('CashFlowPlaceholderPage', () => {
+  it('renders the given title', () => {
+    render(<CashFlowPlaceholderPage title="Reserva" />)
+
+    expect(screen.getByRole('heading', { name: 'Reserva' })).toBeInTheDocument()
+  })
+
+  it('renders a coming soon message referencing the title', () => {
+    render(<CashFlowPlaceholderPage title="Monthly" />)
+
+    expect(screen.getByText('Monthly view is coming soon.')).toBeInTheDocument()
+  })
+})

--- a/Financial.Web/src/pages/__tests__/RootRedirect.test.tsx
+++ b/Financial.Web/src/pages/__tests__/RootRedirect.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, describe, expect, it } from 'vitest'
+import RootRedirect from '../RootRedirect'
+import { setStoredDomain } from '../../utils/domainStorage'
+
+const RootRedirectWithRoutes = () => (
+  <MemoryRouter initialEntries={['/']}>
+    <Routes>
+      <Route path="/" element={<RootRedirect />} />
+      <Route path="/investments/active-investments" element={<p>Investments landing</p>} />
+      <Route path="/cashflow/monthly" element={<p>CashFlow landing</p>} />
+    </Routes>
+  </MemoryRouter>
+)
+
+describe('RootRedirect', () => {
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('redirects to investments when no domain is stored', () => {
+    render(<RootRedirectWithRoutes />)
+
+    expect(screen.getByText('Investments landing')).toBeInTheDocument()
+  })
+
+  it('redirects to cashflow when cashflow was last selected', () => {
+    setStoredDomain('cashflow')
+
+    render(<RootRedirectWithRoutes />)
+
+    expect(screen.getByText('CashFlow landing')).toBeInTheDocument()
+  })
+
+  it('redirects to investments when investments was last selected', () => {
+    setStoredDomain('investments')
+
+    render(<RootRedirectWithRoutes />)
+
+    expect(screen.getByText('Investments landing')).toBeInTheDocument()
+  })
+})

--- a/Financial.Web/src/utils/domainStorage.test.ts
+++ b/Financial.Web/src/utils/domainStorage.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { getStoredDomain, setStoredDomain } from './domainStorage'
+
+describe('domainStorage', () => {
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('returns null when nothing is stored', () => {
+    expect(getStoredDomain()).toBeNull()
+  })
+
+  it('round-trips a stored domain', () => {
+    setStoredDomain('cashflow')
+    expect(getStoredDomain()).toBe('cashflow')
+
+    setStoredDomain('investments')
+    expect(getStoredDomain()).toBe('investments')
+  })
+
+  it('returns null for an unrecognized stored value', () => {
+    sessionStorage.setItem('financial.selectedDomain', 'not-a-domain')
+    expect(getStoredDomain()).toBeNull()
+  })
+
+  it('does not throw when sessionStorage access fails', () => {
+    const original = window.sessionStorage
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get() {
+        throw new Error('sessionStorage disabled')
+      },
+    })
+
+    expect(() => setStoredDomain('cashflow')).not.toThrow()
+    expect(getStoredDomain()).toBeNull()
+
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: original,
+    })
+  })
+})

--- a/Financial.Web/src/utils/domainStorage.ts
+++ b/Financial.Web/src/utils/domainStorage.ts
@@ -1,0 +1,20 @@
+export type Domain = 'investments' | 'cashflow'
+
+const STORAGE_KEY = 'financial.selectedDomain'
+
+export function getStoredDomain(): Domain | null {
+  try {
+    const value = sessionStorage.getItem(STORAGE_KEY)
+    return value === 'investments' || value === 'cashflow' ? value : null
+  } catch {
+    return null
+  }
+}
+
+export function setStoredDomain(domain: Domain): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, domain)
+  } catch {
+    // sessionStorage unavailable (e.g. private browsing) - persistence is best-effort
+  }
+}

--- a/docs/P11-F11-web-app-shell-investments-cashflow-domain-switcher/plan.md
+++ b/docs/P11-F11-web-app-shell-investments-cashflow-domain-switcher/plan.md
@@ -1,0 +1,32 @@
+# Implementation Plan: F11. Web — App Shell: Investments/CashFlow Domain Switcher
+
+**Prerequisites:**
+- Existing Financial.Web toolchain (Vite, React Router v7, Vitest, React Testing Library) — no new dependencies
+
+### Stage 1: Domain Persistence and Redirect Helpers
+
+**1. Domain storage helper** - Add a small sessionStorage-backed utility for reading and writing the currently selected domain ("investments" or "cashflow"), defensive against environments where sessionStorage is unavailable.
+
+**2. Root redirect page** - Add a component that reads the persisted domain and redirects the root path to that domain's default tab, defaulting to Investments when nothing is stored yet.
+
+### Stage 2: Layout Components
+
+**3. Investments layout** - Add a layout component that renders the 4 existing Investments tab links exactly as they appear today, with a nested outlet for the active page.
+
+**4. CashFlow layout** - Add a layout component that renders the 6 CashFlow tab links (Monthly, Reserva, Mensais, Controle Mae, Investment Snapshots, Yearly Summary), with a nested outlet for the active page.
+
+**5. Shared CashFlow placeholder page** - Add one reusable placeholder page component, parameterized by a title, to serve as the temporary destination for all 6 CashFlow routes until F12–F17 replace them individually.
+
+### Stage 3: App Shell and Routing Restructure
+
+**6. Top-level domain switcher** - Restructure the app shell component to render only the 2-option Investments/CashFlow switcher and persist the active domain on every route change, moving the existing tab-row markup out into the new Investments layout.
+
+**7. Route tree restructure** - Nest the 4 existing Investments routes under the Investments layout at `/investments/*`, add the 6 CashFlow placeholder routes under the CashFlow layout at `/cashflow/*`, and wire the root path to the new redirect component, keeping the existing catch-all "not found" route.
+
+**8. Shell and layout styling** - Update the shell stylesheet for the new two-tier nav and add styling for the two layout components and the placeholder page, consistent with the app's existing BEM-ish naming and theme variables.
+
+### Stage 4: Verification
+
+**9. Update and extend tests** - Update the existing app-shell test to match the new two-tier nav and add coverage for both layout components, the shared placeholder page, the root redirect, and the domain storage helper.
+
+**10. Manual verification** - Run the app locally and confirm: the switcher shows exactly Investments and CashFlow, each existing Investments page still renders and behaves the same under its new URL, all 6 CashFlow tabs render the placeholder, and reloading after switching to CashFlow reopens on CashFlow.

--- a/docs/P11-F11-web-app-shell-investments-cashflow-domain-switcher/spec.md
+++ b/docs/P11-F11-web-app-shell-investments-cashflow-domain-switcher/spec.md
@@ -1,0 +1,94 @@
+# F11. Web — App Shell: Investments/CashFlow Domain Switcher
+
+## 1. Technical Overview
+
+**What:** Restructure the Financial.Web app shell to add a top-level Investments/CashFlow domain switcher above the existing tab navigation, nest the 4 existing Investments routes under `/investments/*` (unchanged behavior), and stand up 6 placeholder `/cashflow/*` routes (Monthly, Reserva, Mensais, Controle Mae, Investment Snapshots, Yearly Summary) ready for F12–F17 to fill in.
+
+**Why:** Every subsequent Web feature in this PRD (F12–F17) needs a place to render nested inside a "CashFlow" selection, and the existing Investments tabs need to keep working exactly as they do today once nested inside an "Investments" selection. This is a routing/shell restructure — no new API calls, no business logic.
+
+**Scope:**
+- Included: two-tier navigation (domain switcher + per-domain tabs), route restructuring for the 4 existing Investments pages, 6 new placeholder CashFlow routes sharing one placeholder component, sessionStorage-backed "last selected domain" persistence, root-path redirect logic.
+- Excluded: any real CashFlow tab content (Monthly/Reserva/Mensais/Controle Mae/Investment Snapshots/Yearly Summary — built by F12–F17), any change to Investments pages' internal behavior, any backend/API change, WPF app changes (CashFlow ships Web-only per PRD).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `src/App.tsx` — becomes the top-level shell: renders only the domain switcher (Investments/CashFlow) + `<Outlet/>`; the existing tab-row nav moves out
+- `src/main.tsx` — route tree restructured into nested `/investments/*` and `/cashflow/*` subtrees
+- `src/components/layout/InvestmentsLayout.tsx` — new; renders the 4 existing Investments tab links + `<Outlet/>`
+- `src/components/layout/CashFlowLayout.tsx` — new; renders the 6 CashFlow tab links + `<Outlet/>`
+- `src/pages/cashflow/CashFlowPlaceholderPage.tsx` — new; single reusable "coming soon" page, parameterized by title
+- `src/pages/RootRedirect.tsx` — new; reads the persisted domain and redirects `/` accordingly
+- `src/utils/domainStorage.ts` — new; sessionStorage read/write helpers for the selected domain
+- `src/App.css` — updated for the two-tier nav; new co-located CSS for the 2 layout components and the placeholder page
+- Existing `pages/ActiveInvestmentsPage.tsx`, `HistoricInvestmentsPage.tsx`, `DividendCheckPage.tsx`, `CurrentValuesPage.tsx` — unchanged internally, only reachable via a new URL
+
+```mermaid
+graph TD
+  A[User] --> B["App.tsx (domain switcher)"]
+  B --> C["InvestmentsLayout (tabs)"]
+  B --> D["CashFlowLayout (tabs)"]
+  C --> E["ActiveInvestmentsPage / HistoricInvestmentsPage / DividendCheckPage / CurrentValuesPage (unchanged)"]
+  D --> F["CashFlowPlaceholderPage (shared, 6 routes)"]
+  B --> G["RootRedirect (session-persisted domain)"]
+  G -.-> C
+  G -.-> D
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| URL structure | Nest existing Investments routes under `/investments/*` (e.g. `/active-investments` → `/investments/active-investments`), CashFlow under `/cashflow/*` | Keep Investments paths exactly as-is, add only `/cashflow/*` | Nesting makes the domain switcher structurally reflected in the URL for both domains symmetrically (matches "one of two symmetric bounded contexts" framing from F01); accepted cost is that the 4 existing Investments URLs change (no bookmarks/external links exist yet since this is a personal, unreleased app) |
+| Last-selected-domain persistence | `sessionStorage` key storing `"investments"` \| `"cashflow"`, written whenever the current path is under `/investments` or `/cashflow`; `/` redirects to the stored domain's first tab, defaulting to Investments when unset | No persistence — rely on nested routing alone | Nested routing alone only prevents domain-reset when switching tabs *within* a domain; it doesn't cover reloading the app or revisiting `/` after using CashFlow, which is what "remembered for the session" describes as a distinct capability. `sessionStorage` (not `localStorage`) matches "for the session" — cleared when the tab closes. |
+| CashFlow placeholder content | One shared `CashFlowPlaceholderPage` component taking a `title` prop, referenced directly as each of the 6 routes' `element` | 6 separate stub page files (one per future feature) | Six routes pointing at the same component means F12–F17 each swap out one `element` for their real page component later — no nav/routing file needs restructuring when those land. Matches the "no over-engineering" project standard. |
+| Nav layout | Two-tier: `App.tsx` renders only the 2-option domain switcher; each domain's own tab row moves into its layout component (`InvestmentsLayout`/`CashFlowLayout`) | Single nav row with domain links visually grouped alongside tab links | Matches the PRD's Experience text ("picks Investments or CashFlow... only sees that domain's own tabs") — domain-switching and tab-switching read as two distinct, separately-scoped actions, and the CSS/test precedent already separates "top nav" from "in-page tabs" (`DetailPanel`'s `.detail-tabs`). |
+| Domain-tracking mechanism | A `useEffect` in `App.tsx` (via `useLocation`) writes the current domain to `sessionStorage` on every route change under `/investments` or `/cashflow` | Only write on domain-switcher click | Writing on every navigation (not just switcher clicks) also correctly persists the domain when a user deep-links directly into a CashFlow or Investments sub-route, not only when they use the switcher. |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `src/App.tsx` | Modified | Top-level shell | Renders the 2-option domain switcher (`NavLink` to `/investments`, `/cashflow`); persists current domain to sessionStorage on route change via `useLocation`/`useEffect`; renders `<Outlet/>` |
+| `src/App.css` | Modified | Shell styling | New `.app__domain-switcher` / `.app__domain-link` classes (BEM-ish, matching existing `.app__nav` convention); existing `.app__nav` styles move to the layout components' CSS |
+| `src/main.tsx` | Modified | Route tree | Nests the 4 Investments routes under `path="investments"` + `InvestmentsLayout`, adds 6 CashFlow routes under `path="cashflow"` + `CashFlowLayout`, adds `index` route rendering `RootRedirect`, keeps the `*` "Page not found" catch-all |
+| `src/components/layout/InvestmentsLayout.tsx` | New | Investments tab nav | Renders the 4 existing tab `NavLink`s (Active Investments, Historic Investments, Shares Dividend Check, Read Assets Current Values) + `<Outlet/>`; visually/structurally identical to today's `App.tsx` nav row |
+| `src/components/layout/InvestmentsLayout.css` | New | Tab styling | Reuses the existing `.app__nav` class names/rules moved from `App.css` |
+| `src/components/layout/CashFlowLayout.tsx` | New | CashFlow tab nav | Renders the 6 CashFlow tab `NavLink`s (Monthly, Reserva, Mensais, Controle Mae, Investment Snapshots, Yearly Summary) + `<Outlet/>` |
+| `src/components/layout/CashFlowLayout.css` | New | Tab styling | Same visual pattern as `InvestmentsLayout.css` |
+| `src/pages/cashflow/CashFlowPlaceholderPage.tsx` | New | Shared CashFlow placeholder | Accepts a `title: string` prop; renders a heading with the title and a "coming soon" message |
+| `src/pages/cashflow/CashFlowPlaceholderPage.css` | New | Placeholder styling | Minimal centered placeholder styling |
+| `src/pages/RootRedirect.tsx` | New | Root path redirect | Reads the persisted domain via `domainStorage`, renders `<Navigate to="/investments/active-investments" replace/>` or `<Navigate to="/cashflow/monthly" replace/>` (default: investments) |
+| `src/utils/domainStorage.ts` | New | sessionStorage helper | `getStoredDomain(): 'investments' \| 'cashflow' \| null` and `setStoredDomain(domain)`; single sessionStorage key constant, defensive try/catch around `sessionStorage` access (private browsing can throw) |
+
+**No Backend/Database changes** — this feature is Web-frontend-only.
+
+## 5. API Contracts
+
+N/A — no new or modified HTTP endpoints; the existing Investments pages' API calls are unaffected.
+
+## 6. Data Model
+
+N/A — no persisted data changes. `sessionStorage` is browser-local UI state, not part of any data model.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `src/App.test.tsx` (existing, updated) | Unit/Integration | `App.tsx` domain switcher | Renders exactly 2 domain options; clicking each switches to that domain's default route; active domain link gets the `active` class |
+| `src/components/layout/__tests__/InvestmentsLayout.test.tsx` | Unit/Integration | `InvestmentsLayout` | Renders the 4 existing tab links; clicking a tab renders its page via `Outlet`; existing Investments behavior unchanged when reached through the new nested path |
+| `src/components/layout/__tests__/CashFlowLayout.test.tsx` | Unit/Integration | `CashFlowLayout` | Renders exactly the 6 CashFlow tab links in order (Monthly, Reserva, Mensais, Controle Mae, Investment Snapshots, Yearly Summary) |
+| `src/pages/cashflow/__tests__/CashFlowPlaceholderPage.test.tsx` | Unit | `CashFlowPlaceholderPage` | Renders the given `title` prop and a "coming soon" message |
+| `src/pages/__tests__/RootRedirect.test.tsx` | Unit | `RootRedirect` | Redirects to `/investments/active-investments` when no stored domain; redirects to `/cashflow/monthly` when `"cashflow"` is stored |
+| `src/utils/domainStorage.test.ts` | Unit | `domainStorage` | Round-trips `get`/`setStoredDomain`; returns `null` when unset; does not throw when `sessionStorage` is unavailable |
+
+**Acceptance tests (from PRD Section 9, F11):**
+- The top-level switcher shows exactly 2 options: Investments and CashFlow (`App.test.tsx`)
+- Selecting Investments shows only the existing Investments tabs, unchanged in behavior (`InvestmentsLayout.test.tsx`, existing `pages/__tests__/*` continue to pass unmodified against their page components)
+- Selecting CashFlow shows only the 6 CashFlow tabs (Monthly, Reserva, Mensais, Controle Mae, Investment Snapshots, Yearly Summary) (`CashFlowLayout.test.tsx`)
+
+**Cross-Feature Integration tests (from PRD Section 9, deferred):**
+- "F12's Web Monthly View... its Investments-domain content is correctly scoped by F11's domain switcher" — not testable until F12 exists; F11 only guarantees the `/cashflow/monthly` route and layout scoping are in place for F12 to build into.
+- "F13, F14, F15, and F16 each correctly display data from F05, F06, F07, and F08 respectively, all nested inside F11's CashFlow selection" — not testable until those features exist; F11 only guarantees the 6 CashFlow routes exist nested under `CashFlowLayout`.

--- a/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
+++ b/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
@@ -605,9 +605,9 @@ graph TD
 - [ ] Re-running the import against a freshly emptied `data-cashflow.json` produces the same result as the first run
 
 ### F11. Web — App Shell: Investments/CashFlow Domain Switcher
-- [ ] The top-level switcher shows exactly 2 options: Investments and CashFlow
-- [ ] Selecting Investments shows only the existing Investments tabs, unchanged in behavior
-- [ ] Selecting CashFlow shows only the 6 CashFlow tabs (Monthly, Reserva, Mensais, Controle Mae, Investment Snapshots, Yearly Summary)
+- [x] The top-level switcher shows exactly 2 options: Investments and CashFlow
+- [x] Selecting Investments shows only the existing Investments tabs, unchanged in behavior
+- [x] Selecting CashFlow shows only the 6 CashFlow tabs (Monthly, Reserva, Mensais, Controle Mae, Investment Snapshots, Yearly Summary)
 
 ### F12. Web — Monthly View
 - [ ] The view shows the selected month's categorized expenses and all 5 cards' outstanding totals and combined adjustment figure together


### PR DESCRIPTION
## Summary
- Adds a top-level Investments/CashFlow domain switcher above the existing tab nav in Financial.Web.
- Nests the 4 existing Investments routes under `/investments/*` via a new `InvestmentsLayout` — unchanged behavior, just a new URL.
- Adds 6 placeholder `/cashflow/*` routes (Monthly, Reserva, Mensais, Controle Mae, Investment Snapshots, Yearly Summary) via a new `CashFlowLayout`, all sharing one `CashFlowPlaceholderPage` until F12–F17 replace each one individually.
- Persists the last-selected domain via `sessionStorage`; the root path (`/`) redirects to the last-used domain's default tab, defaulting to Investments.

## Key decisions (see spec.md Section 3 for full rationale)
- Investments routes moved under `/investments/*` (not left at their old top-level paths) for structural symmetry with `/cashflow/*`.
- `sessionStorage` (not `localStorage`) for "remembered for the session," matching the PRD's wording exactly.
- One shared placeholder component for all 6 CashFlow routes rather than 6 stub files — F12–F17 each swap one route's `element`, no nav restructuring needed later.
- Two-tier nav: `App.tsx` renders only the domain switcher; each domain's own tab row lives in its own layout component.

## Deviation from spec
- Put the new layout/placeholder components in the existing flat `components/`/`pages/` folders rather than the `components/layout/`/`pages/cashflow/` subfolders originally proposed in spec.md, matching the codebase's actual flat convention (no existing subfolders under either).

## Test plan
- [x] Top-level switcher shows exactly 2 options: Investments and CashFlow
- [x] Selecting Investments shows only the existing Investments tabs, unchanged in behavior
- [x] Selecting CashFlow shows only the 6 CashFlow tabs
- Full Vitest suite: 414 passed, 0 failed
- `tsc -b --noEmit`, `eslint .`, and `npm run build` all clean
- Real-browser Playwright smoke test against the running app + API: root redirect, domain switching, tab navigation, and session-persisted domain on root revisit all verified end-to-end (console-clean aside from a pre-existing, unrelated 500 from a missing local `data.json` in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)