### PR TITLE
feat(P11-F02): CashFlow Domain Model & Storage

### DIFF
--- a/Financial.Api/Financial.Api.csproj
+++ b/Financial.Api/Financial.Api.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Financial.CashFlow.Infrastructure\Financial.CashFlow.Infrastructure.csproj" />
     <ProjectReference Include="..\Financial.Investment.Application\Financial.Investment.Application.csproj" />
     <ProjectReference Include="..\Financial.Investment.Infrastructure\Financial.Investment.Infrastructure.csproj" />
     <ProjectReference Include="..\Integrations\GoogleFinancialSupport\GoogleFinancialSupport.csproj" />

--- a/Financial.Api/Program.cs
+++ b/Financial.Api/Program.cs
@@ -1,3 +1,4 @@
+using Financial.CashFlow.Infrastructure.DependencyInjection;
 using Financial.Investment.Application.Configuration;
 using Financial.Investment.Application.DependencyInjection;
 using Financial.Investment.Infrastructure.DependencyInjection;
@@ -48,6 +49,7 @@ builder.Services.Configure<AssetPriceFetchOptions>(configuration.GetSection(Asse
 builder.Services.AddFinancialApplication();
 builder.Services.AddGoogleDriveFileClient();
 builder.Services.AddFinancialInfrastructure(configuration);
+builder.Services.AddFinancialCashFlowInfrastructure(configuration);
 
 var app = builder.Build();
 

--- a/Financial.Api/appsettings.Development.json
+++ b/Financial.Api/appsettings.Development.json
@@ -20,5 +20,15 @@
   "GoogleDrive": {
     "CredentialsPath": "",
     "FilePath": "Pessoais/Gleison/Financeiros/data.json"
+  },
+  "CashFlow": {
+    "Repository": {
+      "Provider": "LocalJson"
+    },
+    "DataJsonFile": "../../../../data/data-cashflow.json",
+    "GoogleDrive": {
+      "CredentialsPath": "",
+      "FilePath": "Pessoais/Gleison/Financeiros/data-cashflow.json"
+    }
   }
 }

--- a/Financial.Api/appsettings.Production.json
+++ b/Financial.Api/appsettings.Production.json
@@ -6,6 +6,15 @@
     "CredentialsPath": "",
     "FilePath": "data.json"
   },
+  "CashFlow": {
+    "Repository": {
+      "Provider": "GoogleDriveJson"
+    },
+    "GoogleDrive": {
+      "CredentialsPath": "",
+      "FilePath": "data-cashflow.json"
+    }
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",

--- a/Financial.Api/appsettings.json
+++ b/Financial.Api/appsettings.json
@@ -14,6 +14,16 @@
     "CredentialsPath": "",
     "FilePath": ""
   },
+  "CashFlow": {
+    "Repository": {
+      "Provider": "LocalJson"
+    },
+    "DataJsonFile": "",
+    "GoogleDrive": {
+      "CredentialsPath": "",
+      "FilePath": ""
+    }
+  },
   "Dividends": {
     "DefaultExchange": "BVMF"
   },

--- a/Financial.CashFlow.Application/Configuration/CashFlowRepositorySettingsOptions.cs
+++ b/Financial.CashFlow.Application/Configuration/CashFlowRepositorySettingsOptions.cs
@@ -1,0 +1,9 @@
+namespace Financial.CashFlow.Application.Configuration;
+
+public sealed class CashFlowRepositorySettingsOptions
+{
+    public string? Provider { get; set; }
+    public string? DataJsonFile { get; set; }
+    public string? GoogleDriveCredentialsPath { get; set; }
+    public string? GoogleDriveFilePath { get; set; }
+}

--- a/Financial.CashFlow.Application/Financial.CashFlow.Application.csproj
+++ b/Financial.CashFlow.Application/Financial.CashFlow.Application.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Financial.CashFlow.Domain\Financial.CashFlow.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Financial.CashFlow.Application/Interfaces/ICashFlowRepository.cs
+++ b/Financial.CashFlow.Application/Interfaces/ICashFlowRepository.cs
@@ -1,0 +1,29 @@
+using Financial.CashFlow.Domain.Entities;
+
+namespace Financial.CashFlow.Application.Interfaces;
+
+public interface ICashFlowRepository
+{
+    IEnumerable<Expense> GetExpenses();
+    void AddExpense(Expense expense);
+
+    IEnumerable<ReserveMovement> GetReserveMovements();
+    void AddReserveMovement(ReserveMovement movement);
+
+    IEnumerable<CardStatement> GetCardStatements();
+    void AddCardStatement(CardStatement statement);
+
+    IEnumerable<RecurringBillTemplate> GetRecurringBillTemplates();
+    void AddRecurringBillTemplate(RecurringBillTemplate template);
+
+    IEnumerable<RecurringBillInstance> GetRecurringBillInstances();
+    void AddRecurringBillInstance(RecurringBillInstance instance);
+
+    IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries();
+    void AddMaeLedgerEntry(MaeLedgerEntry entry);
+
+    IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots();
+    void AddInvestmentSnapshot(InvestmentSnapshot snapshot);
+
+    Task SaveChangesAsync();
+}

--- a/Financial.CashFlow.Domain/Entities/CardStatement.cs
+++ b/Financial.CashFlow.Domain/Entities/CardStatement.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Financial.CashFlow.Domain.Entities;
+
+public class CardStatement
+{
+    public Guid Id { get; private set; }
+
+    private CardStatement() { }
+
+    public static CardStatement Create() => new() { Id = Guid.NewGuid() };
+}

--- a/Financial.CashFlow.Domain/Entities/CashFlowData.cs
+++ b/Financial.CashFlow.Domain/Entities/CashFlowData.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+
+namespace Financial.CashFlow.Domain.Entities;
+
+public class CashFlowData
+{
+    private List<Expense> _expenses = new List<Expense>();
+    public IReadOnlyCollection<Expense> Expenses { get => _expenses.AsReadOnly(); private set => SetExpenses(value); }
+    private void SetExpenses(IReadOnlyCollection<Expense> data)
+    {
+        _expenses.Clear();
+        _expenses.AddRange(data);
+    }
+
+    private List<ReserveMovement> _reserveMovements = new List<ReserveMovement>();
+    public IReadOnlyCollection<ReserveMovement> ReserveMovements { get => _reserveMovements.AsReadOnly(); private set => SetReserveMovements(value); }
+    private void SetReserveMovements(IReadOnlyCollection<ReserveMovement> data)
+    {
+        _reserveMovements.Clear();
+        _reserveMovements.AddRange(data);
+    }
+
+    private List<CardStatement> _cardStatements = new List<CardStatement>();
+    public IReadOnlyCollection<CardStatement> CardStatements { get => _cardStatements.AsReadOnly(); private set => SetCardStatements(value); }
+    private void SetCardStatements(IReadOnlyCollection<CardStatement> data)
+    {
+        _cardStatements.Clear();
+        _cardStatements.AddRange(data);
+    }
+
+    private List<RecurringBillTemplate> _recurringBillTemplates = new List<RecurringBillTemplate>();
+    public IReadOnlyCollection<RecurringBillTemplate> RecurringBillTemplates { get => _recurringBillTemplates.AsReadOnly(); private set => SetRecurringBillTemplates(value); }
+    private void SetRecurringBillTemplates(IReadOnlyCollection<RecurringBillTemplate> data)
+    {
+        _recurringBillTemplates.Clear();
+        _recurringBillTemplates.AddRange(data);
+    }
+
+    private List<RecurringBillInstance> _recurringBillInstances = new List<RecurringBillInstance>();
+    public IReadOnlyCollection<RecurringBillInstance> RecurringBillInstances { get => _recurringBillInstances.AsReadOnly(); private set => SetRecurringBillInstances(value); }
+    private void SetRecurringBillInstances(IReadOnlyCollection<RecurringBillInstance> data)
+    {
+        _recurringBillInstances.Clear();
+        _recurringBillInstances.AddRange(data);
+    }
+
+    private List<MaeLedgerEntry> _maeLedgerEntries = new List<MaeLedgerEntry>();
+    public IReadOnlyCollection<MaeLedgerEntry> MaeLedgerEntries { get => _maeLedgerEntries.AsReadOnly(); private set => SetMaeLedgerEntries(value); }
+    private void SetMaeLedgerEntries(IReadOnlyCollection<MaeLedgerEntry> data)
+    {
+        _maeLedgerEntries.Clear();
+        _maeLedgerEntries.AddRange(data);
+    }
+
+    private List<InvestmentSnapshot> _investmentSnapshots = new List<InvestmentSnapshot>();
+    public IReadOnlyCollection<InvestmentSnapshot> InvestmentSnapshots { get => _investmentSnapshots.AsReadOnly(); private set => SetInvestmentSnapshots(value); }
+    private void SetInvestmentSnapshots(IReadOnlyCollection<InvestmentSnapshot> data)
+    {
+        _investmentSnapshots.Clear();
+        _investmentSnapshots.AddRange(data);
+    }
+
+    private CashFlowData() { }
+
+    public static CashFlowData Create() => new();
+
+    public void AddExpense(Expense expense) => _expenses.Add(expense);
+
+    public void AddReserveMovement(ReserveMovement movement) => _reserveMovements.Add(movement);
+
+    public void AddCardStatement(CardStatement statement) => _cardStatements.Add(statement);
+
+    public void AddRecurringBillTemplate(RecurringBillTemplate template) => _recurringBillTemplates.Add(template);
+
+    public void AddRecurringBillInstance(RecurringBillInstance instance) => _recurringBillInstances.Add(instance);
+
+    public void AddMaeLedgerEntry(MaeLedgerEntry entry) => _maeLedgerEntries.Add(entry);
+
+    public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) => _investmentSnapshots.Add(snapshot);
+}

--- a/Financial.CashFlow.Domain/Entities/Expense.cs
+++ b/Financial.CashFlow.Domain/Entities/Expense.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Financial.CashFlow.Domain.Entities;
+
+public class Expense
+{
+    public Guid Id { get; private set; }
+
+    private Expense() { }
+
+    public static Expense Create() => new() { Id = Guid.NewGuid() };
+}

--- a/Financial.CashFlow.Domain/Entities/InvestmentSnapshot.cs
+++ b/Financial.CashFlow.Domain/Entities/InvestmentSnapshot.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Financial.CashFlow.Domain.Entities;
+
+public class InvestmentSnapshot
+{
+    public Guid Id { get; private set; }
+
+    private InvestmentSnapshot() { }
+
+    public static InvestmentSnapshot Create() => new() { Id = Guid.NewGuid() };
+}

--- a/Financial.CashFlow.Domain/Entities/MaeLedgerEntry.cs
+++ b/Financial.CashFlow.Domain/Entities/MaeLedgerEntry.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Financial.CashFlow.Domain.Entities;
+
+public class MaeLedgerEntry
+{
+    public Guid Id { get; private set; }
+
+    private MaeLedgerEntry() { }
+
+    public static MaeLedgerEntry Create() => new() { Id = Guid.NewGuid() };
+}

--- a/Financial.CashFlow.Domain/Entities/RecurringBillInstance.cs
+++ b/Financial.CashFlow.Domain/Entities/RecurringBillInstance.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Financial.CashFlow.Domain.Entities;
+
+public class RecurringBillInstance
+{
+    public Guid Id { get; private set; }
+
+    private RecurringBillInstance() { }
+
+    public static RecurringBillInstance Create() => new() { Id = Guid.NewGuid() };
+}

--- a/Financial.CashFlow.Domain/Entities/RecurringBillTemplate.cs
+++ b/Financial.CashFlow.Domain/Entities/RecurringBillTemplate.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Financial.CashFlow.Domain.Entities;
+
+public class RecurringBillTemplate
+{
+    public Guid Id { get; private set; }
+
+    private RecurringBillTemplate() { }
+
+    public static RecurringBillTemplate Create() => new() { Id = Guid.NewGuid() };
+}

--- a/Financial.CashFlow.Domain/Entities/ReserveMovement.cs
+++ b/Financial.CashFlow.Domain/Entities/ReserveMovement.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Financial.CashFlow.Domain.Entities;
+
+public class ReserveMovement
+{
+    public Guid Id { get; private set; }
+
+    private ReserveMovement() { }
+
+    public static ReserveMovement Create() => new() { Id = Guid.NewGuid() };
+}

--- a/Financial.CashFlow.Domain/Enums/Category.cs
+++ b/Financial.CashFlow.Domain/Enums/Category.cs
@@ -1,0 +1,19 @@
+namespace Financial.CashFlow.Domain.Enums;
+
+public enum Category
+{
+    Ariana,
+    Carro,
+    Casa,
+    Estudo,
+    Extras,
+    Familia,
+    Gleison,
+    Mercado,
+    Samuel,
+    Saude,
+    Viagem,
+    Dizimo,
+    Investimento,
+    Reserva
+}

--- a/Financial.CashFlow.Domain/Enums/CreditCard.cs
+++ b/Financial.CashFlow.Domain/Enums/CreditCard.cs
@@ -1,0 +1,10 @@
+namespace Financial.CashFlow.Domain.Enums;
+
+public enum CreditCard
+{
+    BarclaysPlatinumVisa8003,
+    BarclaysPlatinumVisa6007,
+    ChaseMaster4023,
+    BaAmex,
+    PaypalCredit
+}

--- a/Financial.CashFlow.Domain/Enums/PaymentSource.cs
+++ b/Financial.CashFlow.Domain/Enums/PaymentSource.cs
@@ -1,0 +1,8 @@
+namespace Financial.CashFlow.Domain.Enums;
+
+public enum PaymentSource
+{
+    Barclays,
+    Trading212,
+    Chase
+}

--- a/Financial.CashFlow.Domain/Financial.CashFlow.Domain.csproj
+++ b/Financial.CashFlow.Domain/Financial.CashFlow.Domain.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/Financial.CashFlow.Infrastructure/Configuration/CashFlowRepositoryConfigurationKeys.cs
+++ b/Financial.CashFlow.Infrastructure/Configuration/CashFlowRepositoryConfigurationKeys.cs
@@ -1,0 +1,9 @@
+namespace Financial.CashFlow.Infrastructure.Configuration;
+
+public static class CashFlowRepositoryConfigurationKeys
+{
+    public const string Provider = "CashFlow:Repository:Provider";
+    public const string LocalJsonDataFile = "CashFlow:DataJsonFile";
+    public const string GoogleDriveCredentialsPath = "CashFlow:GoogleDrive:CredentialsPath";
+    public const string GoogleDriveFilePath = "CashFlow:GoogleDrive:FilePath";
+}

--- a/Financial.CashFlow.Infrastructure/DependencyInjection/CashFlowInfrastructureServiceCollectionExtensions.cs
+++ b/Financial.CashFlow.Infrastructure/DependencyInjection/CashFlowInfrastructureServiceCollectionExtensions.cs
@@ -1,0 +1,56 @@
+using Financial.CashFlow.Application.Configuration;
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Infrastructure.Configuration;
+using Financial.CashFlow.Infrastructure.Persistence;
+using Financial.CashFlow.Infrastructure.Repositories;
+using Financial.Shared.Infrastructure.Persistence;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Financial.CashFlow.Infrastructure.DependencyInjection;
+
+public static class CashFlowInfrastructureServiceCollectionExtensions
+{
+    public static IServiceCollection AddFinancialCashFlowInfrastructure(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<CashFlowRepositorySettingsOptions>(options =>
+        {
+            options.Provider = configuration[CashFlowRepositoryConfigurationKeys.Provider];
+            options.DataJsonFile = configuration[CashFlowRepositoryConfigurationKeys.LocalJsonDataFile];
+            options.GoogleDriveCredentialsPath = configuration[CashFlowRepositoryConfigurationKeys.GoogleDriveCredentialsPath];
+            options.GoogleDriveFilePath = configuration[CashFlowRepositoryConfigurationKeys.GoogleDriveFilePath];
+        });
+        services.AddSingleton<ICashFlowSerializer, CashFlowSerializerAdapter>();
+        services.AddSingleton<ICashFlowRepository>(sp =>
+        {
+            var settings = sp.GetRequiredService<IOptions<CashFlowRepositorySettingsOptions>>().Value;
+            var options = BuildRepositoryOptions(settings);
+            return new CashFlowRepositoryFactory(
+                sp.GetRequiredService<ICashFlowSerializer>(),
+                sp.GetService<IRemoteFileClientFactory>()).Create(options);
+        });
+
+        return services;
+    }
+
+    private static CashFlowRepositorySelectionOptions BuildRepositoryOptions(CashFlowRepositorySettingsOptions settings)
+    {
+        var providerValue = settings.Provider ?? nameof(CashFlowRepositoryProvider.LocalJson);
+
+        if (!Enum.TryParse(providerValue, ignoreCase: true, out CashFlowRepositoryProvider provider))
+        {
+            throw new InvalidOperationException(
+                $"Repository provider '{providerValue}' is not supported. " +
+                $"Valid values: {string.Join(", ", Enum.GetNames<CashFlowRepositoryProvider>())}.");
+        }
+
+        return new CashFlowRepositorySelectionOptions(
+            provider,
+            settings.DataJsonFile,
+            settings.GoogleDriveCredentialsPath,
+            settings.GoogleDriveFilePath);
+    }
+}

--- a/Financial.CashFlow.Infrastructure/Financial.CashFlow.Infrastructure.csproj
+++ b/Financial.CashFlow.Infrastructure/Financial.CashFlow.Infrastructure.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Financial.CashFlow.Application\Financial.CashFlow.Application.csproj" />
+    <ProjectReference Include="..\Financial.CashFlow.Domain\Financial.CashFlow.Domain.csproj" />
+    <ProjectReference Include="..\Financial.Shared.Infrastructure\Financial.Shared.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+  </ItemGroup>
+
+</Project>

--- a/Financial.CashFlow.Infrastructure/Persistence/CashFlowLoader.cs
+++ b/Financial.CashFlow.Infrastructure/Persistence/CashFlowLoader.cs
@@ -1,0 +1,27 @@
+using Financial.CashFlow.Domain.Entities;
+using Financial.Shared.Infrastructure.Persistence;
+
+namespace Financial.CashFlow.Infrastructure.Persistence;
+
+public static class CashFlowLoader
+{
+    // Intentionally synchronous: called from DI factory at startup before the app's async loop begins.
+    // ConfigureAwait(false) avoids SynchronizationContext deadlock in WPF startup context.
+    public static CashFlowData LoadSync(IJsonStorage storage, ICashFlowSerializer serializer)
+    {
+        string json;
+        try
+        {
+            json = storage.ReadAsync()
+                .ConfigureAwait(false)
+                .GetAwaiter()
+                .GetResult();
+        }
+        catch (FileNotFoundException)
+        {
+            return CashFlowData.Create();
+        }
+
+        return serializer.Deserialize(json);
+    }
+}

--- a/Financial.CashFlow.Infrastructure/Persistence/CashFlowSerializerAdapter.cs
+++ b/Financial.CashFlow.Infrastructure/Persistence/CashFlowSerializerAdapter.cs
@@ -1,0 +1,21 @@
+using Financial.CashFlow.Domain.Entities;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Financial.CashFlow.Infrastructure.Persistence;
+
+public sealed class CashFlowSerializerAdapter : ICashFlowSerializer
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = true,
+        TypeInfoResolver = new CashFlowTypeInfoResolver()
+    };
+
+    public string Serialize(CashFlowData data) =>
+        JsonSerializer.Serialize(data, Options);
+
+    public CashFlowData Deserialize(string json) =>
+        JsonSerializer.Deserialize<CashFlowData>(json, Options)!;
+}

--- a/Financial.CashFlow.Infrastructure/Persistence/CashFlowTypeInfoResolver.cs
+++ b/Financial.CashFlow.Infrastructure/Persistence/CashFlowTypeInfoResolver.cs
@@ -1,0 +1,65 @@
+using Financial.CashFlow.Domain.Entities;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Financial.CashFlow.Infrastructure.Persistence;
+
+public class CashFlowTypeInfoResolver : DefaultJsonTypeInfoResolver
+{
+    private static readonly HashSet<Type> ManagedTypes =
+    [
+        typeof(CashFlowData),
+        typeof(Expense),
+        typeof(ReserveMovement),
+        typeof(CardStatement),
+        typeof(RecurringBillTemplate),
+        typeof(RecurringBillInstance),
+        typeof(MaeLedgerEntry),
+        typeof(InvestmentSnapshot)
+    ];
+
+    public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
+    {
+        var typeInfo = base.GetTypeInfo(type, options);
+
+        if (!ManagedTypes.Contains(type) || typeInfo.Kind != JsonTypeInfoKind.Object)
+            return typeInfo;
+
+        EnablePrivateConstructor(type, typeInfo);
+        ConfigureProperties(type, typeInfo);
+
+        return typeInfo;
+    }
+
+    private static void EnablePrivateConstructor(Type type, JsonTypeInfo typeInfo)
+    {
+        if (typeInfo.CreateObject is not null)
+            return;
+
+        typeInfo.CreateObject = () =>
+            Activator.CreateInstance(type, nonPublic: true)
+            ?? throw new InvalidOperationException($"Failed to create instance of {type}.");
+    }
+
+    private static void ConfigureProperties(Type type, JsonTypeInfo typeInfo)
+    {
+        foreach (var jsonProp in typeInfo.Properties)
+        {
+            WirePropertySetter(type, jsonProp);
+        }
+    }
+
+    private static void WirePropertySetter(Type type, JsonPropertyInfo jsonProp)
+    {
+        var propInfo = type.GetProperty(
+            jsonProp.Name,
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+        if (propInfo?.SetMethod is null)
+            return;
+
+        var setter = propInfo.SetMethod;
+        jsonProp.Set = (obj, value) => setter.Invoke(obj, [value]);
+    }
+}

--- a/Financial.CashFlow.Infrastructure/Persistence/ICashFlowSerializer.cs
+++ b/Financial.CashFlow.Infrastructure/Persistence/ICashFlowSerializer.cs
@@ -1,0 +1,9 @@
+using Financial.CashFlow.Domain.Entities;
+
+namespace Financial.CashFlow.Infrastructure.Persistence;
+
+public interface ICashFlowSerializer
+{
+    string Serialize(CashFlowData data);
+    CashFlowData Deserialize(string json);
+}

--- a/Financial.CashFlow.Infrastructure/Repositories/CashFlowJsonRepository.cs
+++ b/Financial.CashFlow.Infrastructure/Repositories/CashFlowJsonRepository.cs
@@ -1,0 +1,47 @@
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Infrastructure.Persistence;
+using Financial.Shared.Infrastructure.Persistence;
+
+namespace Financial.CashFlow.Infrastructure.Repositories;
+
+public sealed class CashFlowJsonRepository : ICashFlowRepository
+{
+    private readonly IJsonStorage _storage;
+    private readonly ICashFlowSerializer _serializer;
+    private readonly CashFlowData _data;
+
+    public CashFlowJsonRepository(CashFlowData data, IJsonStorage storage, ICashFlowSerializer serializer)
+    {
+        _data = data ?? throw new ArgumentNullException(nameof(data));
+        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+    }
+
+    public IEnumerable<Expense> GetExpenses() => _data.Expenses;
+    public void AddExpense(Expense expense) => _data.AddExpense(expense);
+
+    public IEnumerable<ReserveMovement> GetReserveMovements() => _data.ReserveMovements;
+    public void AddReserveMovement(ReserveMovement movement) => _data.AddReserveMovement(movement);
+
+    public IEnumerable<CardStatement> GetCardStatements() => _data.CardStatements;
+    public void AddCardStatement(CardStatement statement) => _data.AddCardStatement(statement);
+
+    public IEnumerable<RecurringBillTemplate> GetRecurringBillTemplates() => _data.RecurringBillTemplates;
+    public void AddRecurringBillTemplate(RecurringBillTemplate template) => _data.AddRecurringBillTemplate(template);
+
+    public IEnumerable<RecurringBillInstance> GetRecurringBillInstances() => _data.RecurringBillInstances;
+    public void AddRecurringBillInstance(RecurringBillInstance instance) => _data.AddRecurringBillInstance(instance);
+
+    public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => _data.MaeLedgerEntries;
+    public void AddMaeLedgerEntry(MaeLedgerEntry entry) => _data.AddMaeLedgerEntry(entry);
+
+    public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => _data.InvestmentSnapshots;
+    public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) => _data.AddInvestmentSnapshot(snapshot);
+
+    public async Task SaveChangesAsync()
+    {
+        var json = _serializer.Serialize(_data);
+        await _storage.WriteAsync(json).ConfigureAwait(false);
+    }
+}

--- a/Financial.CashFlow.Infrastructure/Repositories/CashFlowRepositoryFactory.cs
+++ b/Financial.CashFlow.Infrastructure/Repositories/CashFlowRepositoryFactory.cs
@@ -1,0 +1,80 @@
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Infrastructure.Configuration;
+using Financial.CashFlow.Infrastructure.Persistence;
+using Financial.Shared.Infrastructure.Persistence;
+
+namespace Financial.CashFlow.Infrastructure.Repositories;
+
+public sealed class CashFlowRepositoryFactory
+{
+    private readonly ICashFlowSerializer _serializer;
+    private readonly IRemoteFileClientFactory? _remoteFileClientFactory;
+
+    public CashFlowRepositoryFactory(ICashFlowSerializer serializer, IRemoteFileClientFactory? remoteFileClientFactory = null)
+    {
+        _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+        _remoteFileClientFactory = remoteFileClientFactory;
+    }
+
+    public ICashFlowRepository Create(CashFlowRepositorySelectionOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        var storage = CreateStorage(options);
+        var data = CashFlowLoader.LoadSync(storage, _serializer);
+        return new CashFlowJsonRepository(data, storage, _serializer);
+    }
+
+    private IJsonStorage CreateStorage(CashFlowRepositorySelectionOptions options) =>
+        options.Provider switch
+        {
+            CashFlowRepositoryProvider.LocalJson =>
+                new LocalJsonStorage(options.LocalDataPath),
+            CashFlowRepositoryProvider.GoogleDriveJson =>
+                CreateGoogleDriveStorage(options),
+            _ => throw new ArgumentOutOfRangeException(
+                    nameof(options.Provider), options.Provider, "Unsupported repository provider.")
+        };
+
+    private IJsonStorage CreateGoogleDriveStorage(CashFlowRepositorySelectionOptions options)
+    {
+        var credentialsPath = ResolveGoogleCredentialsPath(options.GoogleDriveCredentialsPath);
+
+        if (_remoteFileClientFactory is null)
+        {
+            throw new InvalidOperationException(
+                $"Repository provider '{nameof(CashFlowRepositoryProvider.GoogleDriveJson)}' requires an {nameof(IRemoteFileClientFactory)} " +
+                "to be registered (see AddGoogleDriveFileClient).");
+        }
+
+        var client = _remoteFileClientFactory.Create(credentialsPath);
+        return new GoogleDriveJsonStorage(client, options.GoogleDriveFilePath);
+    }
+
+    private static string ResolveGoogleCredentialsPath(string? credentialsPath)
+    {
+        if (string.IsNullOrWhiteSpace(credentialsPath))
+        {
+            throw new FileNotFoundException(
+                $"Google Drive credentials file path is required. Configure '{CashFlowRepositoryConfigurationKeys.GoogleDriveCredentialsPath}'.");
+        }
+
+        var resolvedPath = credentialsPath;
+        if (!Path.IsPathRooted(resolvedPath))
+        {
+            resolvedPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, resolvedPath));
+        }
+
+        if (!File.Exists(resolvedPath))
+        {
+            throw new FileNotFoundException(
+                $"Google Drive credentials file not found at '{resolvedPath}'. Configure '{CashFlowRepositoryConfigurationKeys.GoogleDriveCredentialsPath}'.",
+                resolvedPath);
+        }
+
+        return resolvedPath;
+    }
+}

--- a/Financial.CashFlow.Infrastructure/Repositories/CashFlowRepositoryProvider.cs
+++ b/Financial.CashFlow.Infrastructure/Repositories/CashFlowRepositoryProvider.cs
@@ -1,0 +1,7 @@
+namespace Financial.CashFlow.Infrastructure.Repositories;
+
+public enum CashFlowRepositoryProvider
+{
+    LocalJson,
+    GoogleDriveJson
+}

--- a/Financial.CashFlow.Infrastructure/Repositories/CashFlowRepositorySelectionOptions.cs
+++ b/Financial.CashFlow.Infrastructure/Repositories/CashFlowRepositorySelectionOptions.cs
@@ -1,0 +1,7 @@
+namespace Financial.CashFlow.Infrastructure.Repositories;
+
+public sealed record CashFlowRepositorySelectionOptions(
+    CashFlowRepositoryProvider Provider,
+    string? LocalDataPath,
+    string? GoogleDriveCredentialsPath,
+    string? GoogleDriveFilePath);

--- a/Financial.slnx
+++ b/Financial.slnx
@@ -5,7 +5,11 @@
 		<Project Path="Financial.Investment.Domain/Financial.Investment.Domain.csproj" />
 		<Project Path="Financial.Investment.Infrastructure/Financial.Investment.Infrastructure.csproj" />
 	</Folder>
-	<Folder Name="/DDD/CashFlow/" />
+	<Folder Name="/DDD/CashFlow/">
+		<Project Path="Financial.CashFlow.Application/Financial.CashFlow.Application.csproj" />
+		<Project Path="Financial.CashFlow.Domain/Financial.CashFlow.Domain.csproj" />
+		<Project Path="Financial.CashFlow.Infrastructure/Financial.CashFlow.Infrastructure.csproj" />
+	</Folder>
 	<Folder Name="/DDD/Shared/">
 		<Project Path="Financial.Shared.Infrastructure/Financial.Shared.Infrastructure.csproj" />
 	</Folder>
@@ -21,6 +25,8 @@
 		<Project Path="Tests/Financial.Investment.Infrastructure.Tests/Financial.Investment.Infrastructure.Tests.csproj" />
 		<Project Path="Tests/Financial.Shared.Infrastructure.Tests/Financial.Shared.Infrastructure.Tests.csproj" />
 		<Project Path="Tests/Financial.Presentation.Tests/Financial.Presentation.Tests.csproj" />
+		<Project Path="Tests/Financial.CashFlow.Domain.Tests/Financial.CashFlow.Domain.Tests.csproj" />
+		<Project Path="Tests/Financial.CashFlow.Infrastructure.Tests/Financial.CashFlow.Infrastructure.Tests.csproj" />
 	</Folder>
 	<Folder Name="/Presentation/">
 		<Project Path="Financial.App/Financial.App.csproj" />

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/CashFlowDataTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/CashFlowDataTests.cs
@@ -1,0 +1,98 @@
+using Financial.CashFlow.Domain.Entities;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Domain.Tests;
+
+public class CashFlowDataTests
+{
+    [Fact]
+    public void Create_StartsWithAllSevenCollectionsEmpty()
+    {
+        var data = CashFlowData.Create();
+
+        data.Expenses.Should().BeEmpty();
+        data.ReserveMovements.Should().BeEmpty();
+        data.CardStatements.Should().BeEmpty();
+        data.RecurringBillTemplates.Should().BeEmpty();
+        data.RecurringBillInstances.Should().BeEmpty();
+        data.MaeLedgerEntries.Should().BeEmpty();
+        data.InvestmentSnapshots.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddExpense_AddsOnlyToExpensesCollection()
+    {
+        var data = CashFlowData.Create();
+
+        data.AddExpense(Expense.Create());
+
+        data.Expenses.Should().ContainSingle();
+        data.ReserveMovements.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddReserveMovement_AddsOnlyToReserveMovementsCollection()
+    {
+        var data = CashFlowData.Create();
+
+        data.AddReserveMovement(ReserveMovement.Create());
+
+        data.ReserveMovements.Should().ContainSingle();
+        data.Expenses.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddCardStatement_AddsOnlyToCardStatementsCollection()
+    {
+        var data = CashFlowData.Create();
+
+        data.AddCardStatement(CardStatement.Create());
+
+        data.CardStatements.Should().ContainSingle();
+        data.Expenses.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddRecurringBillTemplate_AddsOnlyToRecurringBillTemplatesCollection()
+    {
+        var data = CashFlowData.Create();
+
+        data.AddRecurringBillTemplate(RecurringBillTemplate.Create());
+
+        data.RecurringBillTemplates.Should().ContainSingle();
+        data.RecurringBillInstances.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddRecurringBillInstance_AddsOnlyToRecurringBillInstancesCollection()
+    {
+        var data = CashFlowData.Create();
+
+        data.AddRecurringBillInstance(RecurringBillInstance.Create());
+
+        data.RecurringBillInstances.Should().ContainSingle();
+        data.RecurringBillTemplates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddMaeLedgerEntry_AddsOnlyToMaeLedgerEntriesCollection()
+    {
+        var data = CashFlowData.Create();
+
+        data.AddMaeLedgerEntry(MaeLedgerEntry.Create());
+
+        data.MaeLedgerEntries.Should().ContainSingle();
+        data.Expenses.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddInvestmentSnapshot_AddsOnlyToInvestmentSnapshotsCollection()
+    {
+        var data = CashFlowData.Create();
+
+        data.AddInvestmentSnapshot(InvestmentSnapshot.Create());
+
+        data.InvestmentSnapshots.Should().ContainSingle();
+        data.Expenses.Should().BeEmpty();
+    }
+}

--- a/Tests/Financial.CashFlow.Domain.Tests/Financial.CashFlow.Domain.Tests.csproj
+++ b/Tests/Financial.CashFlow.Domain.Tests/Financial.CashFlow.Domain.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Financial.CashFlow.Domain\Financial.CashFlow.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/DependencyInjection/CashFlowInfrastructureServiceCollectionExtensionsTests.cs
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/DependencyInjection/CashFlowInfrastructureServiceCollectionExtensionsTests.cs
@@ -1,0 +1,51 @@
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Infrastructure.DependencyInjection;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Financial.CashFlow.Infrastructure.Tests.DependencyInjection;
+
+public class CashFlowInfrastructureServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddFinancialCashFlowInfrastructure_UnsupportedProvider_ThrowsOnRepositoryResolution()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"cashflow-di-{Guid.NewGuid()}.json");
+        var provider = BuildServiceProvider(new Dictionary<string, string?>
+        {
+            ["CashFlow:Repository:Provider"] = "NotARealProvider",
+            ["CashFlow:DataJsonFile"] = missingPath
+        });
+
+        Action act = () => provider.GetRequiredService<ICashFlowRepository>();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*NotARealProvider*is not supported*");
+    }
+
+    [Fact]
+    public void AddFinancialCashFlowInfrastructure_NoProviderConfigured_DefaultsToLocalJson()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"cashflow-di-{Guid.NewGuid()}.json");
+        var provider = BuildServiceProvider(new Dictionary<string, string?>
+        {
+            ["CashFlow:DataJsonFile"] = missingPath
+        });
+
+        var repository = provider.GetRequiredService<ICashFlowRepository>();
+
+        repository.Should().NotBeNull();
+    }
+
+    private static IServiceProvider BuildServiceProvider(Dictionary<string, string?> settings)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddFinancialCashFlowInfrastructure(configuration);
+        return services.BuildServiceProvider();
+    }
+}

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Financial.CashFlow.Infrastructure.Tests.csproj
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Financial.CashFlow.Infrastructure.Tests.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Financial.CashFlow.Infrastructure.Tests.csproj
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Financial.CashFlow.Infrastructure.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Financial.CashFlow.Infrastructure\Financial.CashFlow.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowLoaderTests.cs
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowLoaderTests.cs
@@ -1,0 +1,68 @@
+using Financial.CashFlow.Infrastructure.Persistence;
+using Financial.Shared.Infrastructure.Persistence;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Infrastructure.Tests.Persistence;
+
+public class CashFlowLoaderTests
+{
+    [Fact]
+    public void LoadSync_WhenFileDoesNotExist_ReturnsEmptyCashFlowData()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"cashflow-missing-{Guid.NewGuid()}.json");
+        var storage = new LocalJsonStorage(missingPath);
+        var serializer = new CashFlowSerializerAdapter();
+
+        var data = CashFlowLoader.LoadSync(storage, serializer);
+
+        data.Expenses.Should().BeEmpty();
+        data.ReserveMovements.Should().BeEmpty();
+        data.CardStatements.Should().BeEmpty();
+        data.RecurringBillTemplates.Should().BeEmpty();
+        data.RecurringBillInstances.Should().BeEmpty();
+        data.MaeLedgerEntries.Should().BeEmpty();
+        data.InvestmentSnapshots.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void LoadSync_WhenFileIsMalformed_PropagatesParseException()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"cashflow-malformed-{Guid.NewGuid()}.json");
+        File.WriteAllText(path, "{ not valid json");
+        var storage = new LocalJsonStorage(path);
+        var serializer = new CashFlowSerializerAdapter();
+
+        try
+        {
+            var act = () => CashFlowLoader.LoadSync(storage, serializer);
+
+            act.Should().Throw<Exception>();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadSync_WhenFileIsValid_DeserializesExistingData()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"cashflow-valid-{Guid.NewGuid()}.json");
+        var serializer = new CashFlowSerializerAdapter();
+        var original = Financial.CashFlow.Domain.Entities.CashFlowData.Create();
+        original.AddExpense(Financial.CashFlow.Domain.Entities.Expense.Create());
+        File.WriteAllText(path, serializer.Serialize(original));
+        var storage = new LocalJsonStorage(path);
+
+        try
+        {
+            var data = CashFlowLoader.LoadSync(storage, serializer);
+
+            data.Expenses.Should().ContainSingle();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs
@@ -1,0 +1,59 @@
+using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Infrastructure.Persistence;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Infrastructure.Tests.Persistence;
+
+public class CashFlowSerializerAdapterTests
+{
+    [Fact]
+    public void SerializeThenDeserialize_RoundTripsAllSevenCollections()
+    {
+        var serializer = new CashFlowSerializerAdapter();
+        var original = CashFlowData.Create();
+        var expense = Expense.Create();
+        var reserveMovement = ReserveMovement.Create();
+        var cardStatement = CardStatement.Create();
+        var recurringBillTemplate = RecurringBillTemplate.Create();
+        var recurringBillInstance = RecurringBillInstance.Create();
+        var maeLedgerEntry = MaeLedgerEntry.Create();
+        var investmentSnapshot = InvestmentSnapshot.Create();
+
+        original.AddExpense(expense);
+        original.AddReserveMovement(reserveMovement);
+        original.AddCardStatement(cardStatement);
+        original.AddRecurringBillTemplate(recurringBillTemplate);
+        original.AddRecurringBillInstance(recurringBillInstance);
+        original.AddMaeLedgerEntry(maeLedgerEntry);
+        original.AddInvestmentSnapshot(investmentSnapshot);
+
+        var json = serializer.Serialize(original);
+        var result = serializer.Deserialize(json);
+
+        result.Expenses.Should().ContainSingle().Which.Id.Should().Be(expense.Id);
+        result.ReserveMovements.Should().ContainSingle().Which.Id.Should().Be(reserveMovement.Id);
+        result.CardStatements.Should().ContainSingle().Which.Id.Should().Be(cardStatement.Id);
+        result.RecurringBillTemplates.Should().ContainSingle().Which.Id.Should().Be(recurringBillTemplate.Id);
+        result.RecurringBillInstances.Should().ContainSingle().Which.Id.Should().Be(recurringBillInstance.Id);
+        result.MaeLedgerEntries.Should().ContainSingle().Which.Id.Should().Be(maeLedgerEntry.Id);
+        result.InvestmentSnapshots.Should().ContainSingle().Which.Id.Should().Be(investmentSnapshot.Id);
+    }
+
+    [Fact]
+    public void SerializeThenDeserialize_WhenAllCollectionsEmpty_RoundTripsEmpty()
+    {
+        var serializer = new CashFlowSerializerAdapter();
+        var original = CashFlowData.Create();
+
+        var json = serializer.Serialize(original);
+        var result = serializer.Deserialize(json);
+
+        result.Expenses.Should().BeEmpty();
+        result.ReserveMovements.Should().BeEmpty();
+        result.CardStatements.Should().BeEmpty();
+        result.RecurringBillTemplates.Should().BeEmpty();
+        result.RecurringBillInstances.Should().BeEmpty();
+        result.MaeLedgerEntries.Should().BeEmpty();
+        result.InvestmentSnapshots.Should().BeEmpty();
+    }
+}

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Repositories/CashFlowJsonRepositoryTests.cs
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Repositories/CashFlowJsonRepositoryTests.cs
@@ -1,0 +1,66 @@
+using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Infrastructure.Persistence;
+using Financial.CashFlow.Infrastructure.Repositories;
+using Financial.Shared.Infrastructure.Persistence;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Infrastructure.Tests.Repositories;
+
+public class CashFlowJsonRepositoryTests
+{
+    [Fact]
+    public async Task SaveChangesAsync_WritesSerializedDataThroughStorage()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"cashflow-repo-{Guid.NewGuid()}.json");
+        var storage = new LocalJsonStorage(path);
+        var serializer = new CashFlowSerializerAdapter();
+        var data = CashFlowData.Create();
+        var repository = new CashFlowJsonRepository(data, storage, serializer);
+
+        try
+        {
+            repository.AddExpense(Expense.Create());
+
+            await repository.SaveChangesAsync();
+
+            var written = await storage.ReadAsync();
+            serializer.Deserialize(written).Expenses.Should().ContainSingle();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_WhenWriteFails_PropagatesException()
+    {
+        var invalidPath = Path.Combine(Path.GetTempPath(), $"cashflow-missing-dir-{Guid.NewGuid()}", "data.json");
+        var storage = new LocalJsonStorage(invalidPath);
+        var serializer = new CashFlowSerializerAdapter();
+        var repository = new CashFlowJsonRepository(CashFlowData.Create(), storage, serializer);
+
+        var act = async () => await repository.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DirectoryNotFoundException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullData_Throws()
+    {
+        Action act = () => new CashFlowJsonRepository(null!, new LocalJsonStorage(Path.GetTempFileName()), new CashFlowSerializerAdapter());
+        act.Should().Throw<ArgumentNullException>().WithParameterName("data");
+    }
+
+    [Fact]
+    public void GetExpenses_ReturnsAddedExpenses()
+    {
+        var data = CashFlowData.Create();
+        var repository = new CashFlowJsonRepository(data, new LocalJsonStorage(Path.GetTempFileName()), new CashFlowSerializerAdapter());
+        var expense = Expense.Create();
+
+        repository.AddExpense(expense);
+
+        repository.GetExpenses().Should().ContainSingle().Which.Id.Should().Be(expense.Id);
+    }
+}

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Repositories/CashFlowRepositoryFactoryTests.cs
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Repositories/CashFlowRepositoryFactoryTests.cs
@@ -1,0 +1,98 @@
+using Financial.CashFlow.Infrastructure.Persistence;
+using Financial.CashFlow.Infrastructure.Repositories;
+using Financial.Shared.Infrastructure.Persistence;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Infrastructure.Tests.Repositories;
+
+public class CashFlowRepositoryFactoryTests
+{
+    private static readonly CashFlowRepositoryFactory Factory =
+        new(new CashFlowSerializerAdapter(), new StubRemoteFileClientFactory());
+
+    [Fact]
+    public void Constructor_WithNullSerializer_Throws()
+    {
+        Action act = () => new CashFlowRepositoryFactory(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("serializer");
+    }
+
+    [Fact]
+    public void Create_WithNullOptions_Throws()
+    {
+        Action act = () => Factory.Create(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("options");
+    }
+
+    [Fact]
+    public void Create_WithLocalJsonProvider_ReturnsCashFlowJsonRepository()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"cashflow-factory-{Guid.NewGuid()}.json");
+        var options = new CashFlowRepositorySelectionOptions(
+            CashFlowRepositoryProvider.LocalJson,
+            missingPath,
+            null,
+            null);
+
+        var result = Factory.Create(options);
+
+        result.Should().BeOfType<CashFlowJsonRepository>();
+    }
+
+    [Fact]
+    public void Create_WithGoogleDriveProvider_WithoutCredentials_ThrowsFileNotFoundException()
+    {
+        var options = new CashFlowRepositorySelectionOptions(
+            CashFlowRepositoryProvider.GoogleDriveJson,
+            null,
+            null,
+            "Pessoais/Gleison/Financeiros");
+
+        Action act = () => Factory.Create(options);
+
+        act.Should().Throw<FileNotFoundException>()
+            .WithMessage("*Google Drive credentials file path is required*");
+    }
+
+    [Fact]
+    public void Create_WithUnsupportedProvider_ThrowsArgumentOutOfRangeException()
+    {
+        var options = new CashFlowRepositorySelectionOptions(
+            (CashFlowRepositoryProvider)999,
+            null,
+            null,
+            null);
+
+        Action act = () => Factory.Create(options);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("Provider");
+    }
+
+    [Fact]
+    public void Create_WithGoogleDriveProvider_NoRemoteFileClientFactoryRegistered_ThrowsInvalidOperationException()
+    {
+        var factoryWithoutRemoteFileClient = new CashFlowRepositoryFactory(new CashFlowSerializerAdapter());
+        var options = new CashFlowRepositorySelectionOptions(
+            CashFlowRepositoryProvider.GoogleDriveJson,
+            null,
+            Path.GetTempFileName(),
+            "Pessoais/Gleison/Financeiros");
+
+        Action act = () => factoryWithoutRemoteFileClient.Create(options);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*IRemoteFileClientFactory*");
+    }
+
+    private sealed class StubRemoteFileClientFactory : IRemoteFileClientFactory
+    {
+        public IRemoteFileClient Create(string credentialsPath) => new StubRemoteFileClient();
+    }
+
+    private sealed class StubRemoteFileClient : IRemoteFileClient
+    {
+        public string DownloadFileContent(string path) => throw new NotSupportedException();
+        public void UploadFileContent(string path, string content) => throw new NotSupportedException();
+    }
+}

--- a/docs/P11-F02-cashflow-domain-model-storage/plan.md
+++ b/docs/P11-F02-cashflow-domain-model-storage/plan.md
@@ -1,0 +1,51 @@
+# Implementation Plan: F02. CashFlow Domain Model & Storage
+
+**Prerequisites:**
+- .NET 10 SDK (existing solution target)
+- No new NuGet packages beyond what `Financial.Investment.*` already uses
+
+### Stage 1: Domain Layer
+
+**1. Create Financial.CashFlow.Domain project** - Add the new project under `DDD/CashFlow`, matching `Financial.Investment.Domain`'s target framework and package set.
+
+**2. Root aggregate and placeholder entities** - Add the `CashFlowData` root aggregate with 7 private collections and their `AddXxx` methods, and the 7 placeholder entity types (`Expense`, `ReserveMovement`, `CardStatement`, `RecurringBillTemplate`, `RecurringBillInstance`, `MaeLedgerEntry`, `InvestmentSnapshot`), each carrying only an identifier for now.
+
+**3. Enums** - Add the `Category` (14 members), `PaymentSource` (3 members), and `CreditCard` (5 members) enums.
+
+**4. Domain unit tests** - Add `Financial.CashFlow.Domain.Tests`, covering `CashFlowData`'s empty-by-default state and each `AddXxx` method's isolation from the other collections.
+
+### Stage 2: Application Layer
+
+**5. Create Financial.CashFlow.Application project** - Add the new project referencing `Financial.CashFlow.Domain`, matching `Financial.Investment.Application`'s package set.
+
+**6. Repository abstraction** - Add `ICashFlowRepository`, exposing a read accessor and an `AddXxx` method for each of the 7 collections plus one `SaveChangesAsync`.
+
+### Stage 3: Infrastructure Layer — Serialization
+
+**7. Create Financial.CashFlow.Infrastructure project** - Add the new project referencing `Financial.CashFlow.Application`, `Financial.CashFlow.Domain`, and `Financial.Shared.Infrastructure`.
+
+**8. Serializer and type resolver** - Add `ICashFlowSerializer`, `CashFlowSerializerAdapter`, and `CashFlowTypeInfoResolver`, mirroring the Investments serialization pattern for `CashFlowData` and its 7 entity types.
+
+**9. First-run-safe loader** - Add `CashFlowLoader`, which returns an empty `CashFlowData` when the underlying file doesn't exist yet, and lets any other load failure (e.g. malformed JSON) propagate unchanged.
+
+**10. Serialization tests** - Add tests covering round-tripping a populated `CashFlowData` through the serializer, and the loader's first-run/malformed-file/valid-file behavior.
+
+### Stage 4: Infrastructure Layer — Repository, Configuration, and DI
+
+**11. Repository implementation** - Add `CashFlowJsonRepository`, holding the in-memory `CashFlowData` and persisting the whole object back through `IJsonStorage` on save.
+
+**12. Repository factory and provider selection** - Add `CashFlowRepositoryProvider`, `CashFlowRepositorySelectionOptions`, and `CashFlowRepositoryFactory`, mirroring `RepositoryFactory`'s Local/GoogleDrive provider construction using `Financial.Shared.Infrastructure`'s storage engine.
+
+**13. Configuration keys and settings** - Add `CashFlowRepositoryConfigurationKeys` and `CashFlowRepositorySettingsOptions`, using a `CashFlow`-scoped configuration section distinct from Investments' existing keys.
+
+**14. Dependency injection wiring** - Add `CashFlowInfrastructureServiceCollectionExtensions.AddFinancialCashFlowInfrastructure`, registering the repository and its dependencies for consumption by later CashFlow features.
+
+**15. Repository and DI tests** - Add tests covering the repository's save behavior, the factory's provider-selection logic, and that the DI extension resolves a working `ICashFlowRepository`.
+
+### Stage 5: Presentation Wiring and Solution Structure
+
+**16. Wire into Financial.Api** - Call the new DI extension from `Program.cs` alongside the existing Investments registration, and add the corresponding `CashFlow` configuration section to `appsettings.json`.
+
+**17. Update Financial.slnx** - Add the 3 new projects to the `DDD/CashFlow` solution folder and the 3 new test projects to `/Tests/`.
+
+**18. Full-suite verification** - Build the entire solution, run every test project, and confirm `data-cashflow.json` is created empty on first run and round-trips correctly when populated, without any change to Investments' existing behavior or data file.

--- a/docs/P11-F02-cashflow-domain-model-storage/spec.md
+++ b/docs/P11-F02-cashflow-domain-model-storage/spec.md
@@ -1,0 +1,148 @@
+# F02. CashFlow Domain Model & Storage
+
+## 1. Technical Overview
+
+**What:** Scaffold `Financial.CashFlow.Domain`, `Financial.CashFlow.Application`, and `Financial.CashFlow.Infrastructure` projects inside the `DDD/CashFlow` solution folder, layered identically to Investments. Add a new `data-cashflow.json` file persisted through the same repository-abstraction pattern (LocalJson/GoogleDrive, selectable via config), a root aggregate holding 7 empty collections, and the 3 hardcoded enums (`Category`, `PaymentSource`, `CreditCard`) every later CashFlow feature depends on.
+
+**Why:** F03–F10 all consume the storage abstraction and enums this feature provides; none of them can start until CashFlow has its own project set, its own data file, and a place to persist records without touching Investments' `data.json` or `Financial.Investment.*` projects.
+
+**Scope:**
+- Included: 3 new projects + 1 new test project; root `CashFlowData` aggregate with 7 empty collections (expenses, reserve ledger, card statements, recurring bill templates, recurring bill instances, mae ledger, investment snapshots); 3 enums; a `CashFlowRepository`/`ICashFlowRepository` pair mirroring Investments' `JSONRepository`/`IRepository`; DI wiring in `Financial.Api`; `data-cashflow.json` first-run auto-creation.
+- Excluded: any real entity fields beyond a placeholder `Id` (F03–F08 each add their own entity's real fields when implemented); any HTTP endpoint or UI (PRD: "No direct UI; this is the storage/repository foundation every other CashFlow feature reads and writes through"); the historical import itself (F10).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.CashFlow.Domain/` — new project: `CashFlowData` root aggregate, 7 placeholder entities, 3 enums
+- `Financial.CashFlow.Application/` — new project: `ICashFlowRepository` interface
+- `Financial.CashFlow.Infrastructure/` — new project: `CashFlowJsonRepository`, `CashFlowRepositoryFactory`, `CashFlowSerializerAdapter`, `CashFlowTypeInfoResolver`, `CashFlowRepositoryConfigurationKeys`, `CashFlowRepositorySettingsOptions`, `CashFlowRepositorySelectionOptions`, DI extension — references `Financial.Shared.Infrastructure` for `IJsonStorage`/`LocalJsonStorage`/`GoogleDriveJsonStorage`/`IRemoteFileClientFactory`
+- `Tests/Financial.CashFlow.Domain.Tests/`, `Tests/Financial.CashFlow.Application.Tests/`, `Tests/Financial.CashFlow.Infrastructure.Tests/` — new test projects
+- `Financial.Api/Program.cs`, `Financial.Api/appsettings.json` — DI registration + config keys for the new repository
+- `Financial.slnx` — `DDD/CashFlow` solution folder gets the 3 new projects; new `/Tests/` entries
+
+```mermaid
+graph TD
+  A["Financial.CashFlow.Domain (CashFlowData + 7 entities + 3 enums)"] --> B["Financial.CashFlow.Application (ICashFlowRepository)"]
+  B --> C["Financial.CashFlow.Infrastructure (CashFlowJsonRepository, CashFlowRepositoryFactory)"]
+  C --> D["Financial.Shared.Infrastructure (IJsonStorage, LocalJsonStorage, GoogleDriveJsonStorage)"]
+  E["Financial.Api (Program.cs DI wiring)"] --> B
+  E --> C
+  D -.-> F["data-cashflow.json"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Domain entity style | Mirror Investments exactly: private constructors, `Create()`/`AddXxx` factory methods, a `CashFlowTypeInfoResolver` (reflection-based, same shape as `InvestmentsTypeInfoResolver`) to serialize private-setter properties | Simple `init`-only properties, no custom resolver | Consistency across both domains was chosen over the lower-code alternative; the `CashFlowTypeInfoResolver` only needs to manage the 8 CashFlow types (root + 7 entities), same complexity class as Investments' resolver managing 6 types |
+| Entity field scope | Every one of the 7 collection item types (`Expense`, `ReserveMovement`, `CardStatement`, `RecurringBillTemplate`, `RecurringBillInstance`, `MaeLedgerEntry`, `InvestmentSnapshot`) gets only a placeholder `Guid Id` for this feature | Define the full field set now, using F03–F08's own PRD Capabilities text | The PRD's own Consumes/Provides split assigns entity-field ownership to F03–F08, not F02; pre-building fields F02 doesn't own risks diverging from what each feature's own interview/spec later decides |
+| `Category` enum membership | Exactly the current 14 (`Ariana`, `Carro`, `Casa`, `Estudo`, `Extras`, `Familia`, `Gleison`, `Mercado`, `Samuel`, `Saude`, `Viagem`, `Dizimo`, `Investimento`, `Reserva`) — no additional historical-only members | Add historical-only categories found in `Despesas.xlsx` | Direct analysis of all 115 in-scope sheets (Fev2017–Jul2026) found exactly these 14 values plus one single-occurrence typo (`"Casas"` in `Out2017`, clearly a typo of `"Casa"`, not a distinct category). The PRD's own F10 error-handling ("a row with an unrecognized category... is imported with its raw label preserved and flagged in the error report") is the intended safety net for that one row — no 15th enum member needed. |
+| Repository interface shape | One `ICashFlowRepository` (mirroring the single `IRepository` Investments uses), exposing a read accessor + `AddXxx` method per collection, plus one shared `SaveChangesAsync()` | 6 separate repository interfaces (one per PRD "Provides" bullet) | All 7 collections live in one JSON file behind one root aggregate — saving is always a whole-file rewrite regardless of how many interfaces front it, so one cohesive interface avoids fragmenting a single persistence transaction into 6 near-empty interfaces. F03–F08 can still each depend on only the slice of `ICashFlowRepository` they need. |
+| First-run file creation | `CashFlowJsonRepository`'s load path catches `FileNotFoundException` specifically and falls back to `CashFlowData.Create()` (all 7 collections empty) rather than propagating | Reuse `InvestmentsLoader.LoadSync` unchanged (throws `FileNotFoundException` today) | The PRD explicitly requires different first-run behavior for CashFlow ("If `data-cashflow.json` is missing on first run, it is created with all six collections empty rather than the app failing to start") than Investments' current behavior, which requires the file to pre-exist. Any other exception (e.g. malformed JSON) still propagates unchanged, matching "surfaces a load failure the same way the existing Investments `data.json` load failure is surfaced today." |
+| Config keys | New `CashFlowRepositoryConfigurationKeys` (`CashFlow:Repository:Provider`, `CashFlow:DataJsonFile`, `CashFlow:GoogleDrive:CredentialsPath`, `CashFlow:GoogleDrive:FilePath`) in `Financial.CashFlow.Infrastructure`, distinct from Investments' `Repository:Provider`/`DataJsonFile` keys in `Financial.Shared.Infrastructure.Configuration.RepositoryConfigurationKeys` | Reuse the same shared config keys for both domains | Investments and CashFlow are two independently configurable data files (potentially different providers/paths); reusing the same config keys would make them mutually exclusive instead of independent, contradicting "Two separate data files, one per domain" from the CashFlow context doc |
+| Enum layer placement | `Category`, `PaymentSource`, `CreditCard` live in `Financial.CashFlow.Domain/Enums/` | Place them in `Financial.CashFlow.Application/Enums/` (matching `InvestmentScope`'s location) | These 3 enums are intrinsic properties of the `Expense`/`CardStatement` domain entities themselves (which category, which payment source, which card), the same category of enum as Investments' Domain-layer `PositionType`/`DividendType`, not an Application-level query-scoping concern like `InvestmentScope` |
+
+## 4. Component Overview
+
+**Backend — Financial.CashFlow.Domain:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Domain/Financial.CashFlow.Domain.csproj` | New | Project file | No package references beyond the SDK defaults, same as `Financial.Investment.Domain` |
+| `Financial.CashFlow.Domain/Entities/CashFlowData.cs` | New | Root aggregate | Private constructor + `Create()`; 7 private lists + `IReadOnlyCollection` getters; `AddExpense`/`AddReserveMovement`/`AddCardStatement`/`AddRecurringBillTemplate`/`AddRecurringBillInstance`/`AddMaeLedgerEntry`/`AddInvestmentSnapshot` |
+| `Financial.CashFlow.Domain/Entities/Expense.cs` | New | Placeholder expense entity | `Guid Id { get; }`; private constructor + `Create()` |
+| `Financial.CashFlow.Domain/Entities/ReserveMovement.cs` | New | Placeholder reserve ledger entry | Same shape as `Expense` |
+| `Financial.CashFlow.Domain/Entities/CardStatement.cs` | New | Placeholder card statement | Same shape |
+| `Financial.CashFlow.Domain/Entities/RecurringBillTemplate.cs` | New | Placeholder bill template | Same shape |
+| `Financial.CashFlow.Domain/Entities/RecurringBillInstance.cs` | New | Placeholder bill instance | Same shape |
+| `Financial.CashFlow.Domain/Entities/MaeLedgerEntry.cs` | New | Placeholder mae ledger entry | Same shape |
+| `Financial.CashFlow.Domain/Entities/InvestmentSnapshot.cs` | New | Placeholder investment snapshot | Same shape |
+| `Financial.CashFlow.Domain/Enums/Category.cs` | New | Expense category | 14 members: `Ariana`, `Carro`, `Casa`, `Estudo`, `Extras`, `Familia`, `Gleison`, `Mercado`, `Samuel`, `Saude`, `Viagem`, `Dizimo`, `Investimento`, `Reserva` |
+| `Financial.CashFlow.Domain/Enums/PaymentSource.cs` | New | Payment source tag | 3 members: `Barclays`, `Trading212`, `Chase` |
+| `Financial.CashFlow.Domain/Enums/CreditCard.cs` | New | Credit card tag | 5 members: `BarclaysPlatinumVisa8003`, `BarclaysPlatinumVisa6007`, `ChaseMaster4023`, `BaAmex`, `PaypalCredit` |
+
+**Backend — Financial.CashFlow.Application:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Application/Financial.CashFlow.Application.csproj` | New | Project file | References `Financial.CashFlow.Domain`, same package set as `Financial.Investment.Application` |
+| `Financial.CashFlow.Application/Interfaces/ICashFlowRepository.cs` | New | Repository abstraction | Read accessors + `AddXxx` for all 7 collections; `Task SaveChangesAsync()` |
+
+**Backend — Financial.CashFlow.Infrastructure:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Infrastructure/Financial.CashFlow.Infrastructure.csproj` | New | Project file | References `Financial.CashFlow.Application`, `Financial.CashFlow.Domain`, `Financial.Shared.Infrastructure` |
+| `Financial.CashFlow.Infrastructure/Persistence/CashFlowSerializerAdapter.cs` | New | JSON serialization | Mirrors `InvestmentsSerializerAdapter`: `JsonStringEnumConverter`, `WriteIndented`, `TypeInfoResolver = new CashFlowTypeInfoResolver()` |
+| `Financial.CashFlow.Infrastructure/Persistence/CashFlowTypeInfoResolver.cs` | New | Private-setter JSON support | Mirrors `InvestmentsTypeInfoResolver`: enables private constructors + wires property setters for `CashFlowData` and the 7 entities |
+| `Financial.CashFlow.Infrastructure/Persistence/ICashFlowSerializer.cs` | New | Serializer abstraction | `string Serialize(CashFlowData data)`, `CashFlowData Deserialize(string json)` |
+| `Financial.CashFlow.Infrastructure/Persistence/CashFlowLoader.cs` | New | First-run-safe loader | `LoadSync(IJsonStorage, ICashFlowSerializer)`; catches `FileNotFoundException` → returns `CashFlowData.Create()`; any other exception propagates |
+| `Financial.CashFlow.Infrastructure/Repositories/CashFlowJsonRepository.cs` | New | `ICashFlowRepository` implementation | Holds one in-memory `CashFlowData`; `SaveChangesAsync` re-serializes the whole object via `IJsonStorage.WriteAsync` |
+| `Financial.CashFlow.Infrastructure/Repositories/CashFlowRepositoryFactory.cs` | New | Repository construction | Mirrors `RepositoryFactory`: builds `IJsonStorage` from `CashFlowRepositorySelectionOptions.Provider` (Local/GoogleDrive), then `CashFlowLoader.LoadSync` + `new CashFlowJsonRepository(...)` |
+| `Financial.CashFlow.Infrastructure/Repositories/CashFlowRepositoryProvider.cs` | New | Provider enum | Mirrors `RepositoryProvider`: `LocalJson`, `GoogleDriveJson` |
+| `Financial.CashFlow.Infrastructure/Repositories/CashFlowRepositorySelectionOptions.cs` | New | Factory input | Mirrors `RepositorySelectionOptions`: `Provider`, `LocalDataPath`, `GoogleDriveCredentialsPath`, `GoogleDriveFilePath` |
+| `Financial.CashFlow.Infrastructure/Configuration/CashFlowRepositoryConfigurationKeys.cs` | New | Config key constants | `CashFlow:Repository:Provider`, `CashFlow:DataJsonFile`, `CashFlow:GoogleDrive:CredentialsPath`, `CashFlow:GoogleDrive:FilePath` |
+| `Financial.CashFlow.Infrastructure/Configuration/CashFlowRepositorySettingsOptions.cs` | New | Bound options class | Mirrors `RepositorySettingsOptions`: `Provider`, `DataJsonFile`, `GoogleDriveCredentialsPath`, `GoogleDriveFilePath` |
+| `Financial.CashFlow.Infrastructure/DependencyInjection/CashFlowInfrastructureServiceCollectionExtensions.cs` | New | DI wiring | `AddFinancialCashFlowInfrastructure(IServiceCollection, IConfiguration)`, mirrors `InfrastructureServiceCollectionExtensions.AddFinancialInfrastructure` |
+
+**Backend — Presentation wiring:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Api/Program.cs` | Modified | DI composition root | Calls `services.AddFinancialCashFlowInfrastructure(builder.Configuration)` alongside the existing Investments call |
+| `Financial.Api/appsettings.json` | Modified | Config defaults | Adds a `CashFlow` config section (`Repository:Provider = "LocalJson"`, empty `DataJsonFile`/`GoogleDrive` keys, matching the existing top-level `Repository`/`GoogleDrive` shape) |
+| `Financial.slnx` | Modified | Solution structure | `DDD/CashFlow` gains the 3 new projects; `/Tests/` gains the 3 new test projects |
+
+**Backend — test projects:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Tests/Financial.CashFlow.Domain.Tests/` | New | Domain unit tests | `CashFlowData` add/read behavior per collection |
+| `Tests/Financial.CashFlow.Application.Tests/` | New | Application unit tests | Placeholder — no logic to test yet beyond the interface shape compiling; may stay empty until F03+ add real methods |
+| `Tests/Financial.CashFlow.Infrastructure.Tests/` | New | Infrastructure unit/integration tests | `CashFlowSerializerAdapter` round-trip; `CashFlowLoader` first-run/malformed-file behavior; `CashFlowJsonRepository` save/reload; `CashFlowRepositoryFactory` provider selection |
+
+## 5. API Contracts
+
+N/A — per the PRD's own Experience note, F02 has no direct UI or HTTP endpoint; it is the storage foundation every later CashFlow feature (F03–F08) builds its own endpoints on top of.
+
+## 6. Data Model
+
+**`data-cashflow.json` root shape:**
+
+```json
+{
+  "expenses": [],
+  "reserveMovements": [],
+  "cardStatements": [],
+  "recurringBillTemplates": [],
+  "recurringBillInstances": [],
+  "maeLedgerEntries": [],
+  "investmentSnapshots": []
+}
+```
+
+Each array item for this feature is only `{ "id": "<guid>" }` — F03 (`Expense`), F04 (`CardStatement`), F05 (`ReserveMovement`), F06 (`RecurringBillTemplate`/`RecurringBillInstance`), F07 (`MaeLedgerEntry`), and F08 (`InvestmentSnapshot`) each add their own real fields to their entity when implemented, without changing the collection names or root shape established here.
+
+**Cross-feature notes:**
+- No SQL/relational schema — this project persists via a single JSON file, matching Investments' `data.json` pattern (`Financial.Shared.Infrastructure`'s `IJsonStorage`/`LocalJsonStorage`/`GoogleDriveJsonStorage`).
+- `Category`/`PaymentSource`/`CreditCard` serialize as strings (`JsonStringEnumConverter`, matching `InvestmentsSerializerAdapter`'s convention) once F03/F04 add them to `Expense`/`CardStatement` — no enum values are written to `data-cashflow.json` by this feature itself, since no entity has these fields yet.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Tests/Financial.CashFlow.Domain.Tests/Entities/CashFlowDataTests.cs` | Unit | `CashFlowData` | `Create()` starts with all 7 collections empty; each `AddXxx` method adds exactly one item to its own collection without affecting the others |
+| `Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs` | Unit | `CashFlowSerializerAdapter` | Serializing then deserializing a `CashFlowData` with one item in each of the 7 collections round-trips every item's `Id` |
+| `Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowLoaderTests.cs` | Unit | `CashFlowLoader` | Missing file → returns an empty `CashFlowData` (no exception); malformed JSON → propagates the parse exception; valid file → deserializes correctly |
+| `Tests/Financial.CashFlow.Infrastructure.Tests/Repositories/CashFlowJsonRepositoryTests.cs` | Unit | `CashFlowJsonRepository` | `SaveChangesAsync` writes the current in-memory state via `IJsonStorage`; a write failure propagates rather than being swallowed |
+| `Tests/Financial.CashFlow.Infrastructure.Tests/Repositories/CashFlowRepositoryFactoryTests.cs` | Unit | `CashFlowRepositoryFactory` | `LocalJson` provider builds a `LocalJsonStorage` from `CashFlowRepositorySelectionOptions.LocalDataPath`; `GoogleDriveJson` without a registered `IRemoteFileClientFactory` throws, matching `RepositoryFactory`'s existing behavior |
+| `Tests/Financial.CashFlow.Infrastructure.Tests/DependencyInjection/CashFlowInfrastructureServiceCollectionExtensionsTests.cs` | Unit | DI wiring | `AddFinancialCashFlowInfrastructure` resolves an `ICashFlowRepository` from a built `IServiceProvider` |
+
+**Acceptance tests (from PRD Section 9, F02):**
+- `data-cashflow.json` round-trips with all six top-level collections — `CashFlowSerializerAdapterTests` (7 physical collections cover the 6 named groups, since "recurring bill templates/instances" is one named group holding 2 physical lists)
+- A missing `data-cashflow.json` on first run is created with all six collections empty rather than failing to start — `CashFlowLoaderTests`
+- `Financial.CashFlow.Infrastructure` references `Financial.Shared.Infrastructure` for its storage engine rather than duplicating it — verified via `Financial.CashFlow.Infrastructure.csproj`'s `ProjectReference` and by `CashFlowRepositoryFactory` constructing `LocalJsonStorage`/`GoogleDriveJsonStorage` directly from `Financial.Shared.Infrastructure.Persistence`
+- A category retired from current use still displays correctly on a historical record but is not offered when creating a new entry — not testable until F03 (expense creation) and F10 (historical import) exist; F02 only guarantees the `Category` enum itself is defined and serializes as a string
+
+**Cross-Feature Integration tests (from PRD Section 9, deferred):**
+- "The `Financial.Investment.Infrastructure` project created by F01 builds and runs correctly referencing `Financial.Shared.Infrastructure`, and F02's `Financial.CashFlow.Infrastructure` references the same shared project without duplication" — F02's half is covered by `CashFlowRepositoryFactoryTests` proving `Financial.CashFlow.Infrastructure` builds `LocalJsonStorage`/`GoogleDriveJsonStorage` from `Financial.Shared.Infrastructure` directly; F01's half was already verified when F01 shipped

--- a/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
+++ b/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
@@ -557,9 +557,9 @@ graph TD
 - [x] `Financial.Api`, `Financial.Web`, and `Financial.App` build and run with no behavior change
 
 ### F02. CashFlow Domain Model & Storage
-- [ ] `data-cashflow.json` round-trips with all six top-level collections (expenses, reserve ledger, card statements, recurring bill templates/instances, mae ledger, investment snapshots)
-- [ ] A missing `data-cashflow.json` on first run is created with all six collections empty rather than failing to start
-- [ ] `Financial.CashFlow.Infrastructure` references `Financial.Shared.Infrastructure` for its storage engine rather than duplicating it
+- [x] `data-cashflow.json` round-trips with all six top-level collections (expenses, reserve ledger, card statements, recurring bill templates/instances, mae ledger, investment snapshots)
+- [x] A missing `data-cashflow.json` on first run is created with all six collections empty rather than failing to start
+- [x] `Financial.CashFlow.Infrastructure` references `Financial.Shared.Infrastructure` for its storage engine rather than duplicating it
 - [ ] A category retired from current use still displays correctly on a historical record but is not offered when creating a new entry
 
 ### F03. Monthly Expense Tracking
@@ -635,7 +635,7 @@ graph TD
 - [ ] The same view shows a month-over-month diff table per investment account, plus the combined net position, for the selected year
 
 ### Cross-Feature Integration
-- [ ] The `Financial.Investment.Infrastructure` project created by F01 builds and runs correctly referencing `Financial.Shared.Infrastructure`, and F02's `Financial.CashFlow.Infrastructure` references the same shared project without duplication
+- [x] The `Financial.Investment.Infrastructure` project created by F01 builds and runs correctly referencing `Financial.Shared.Infrastructure`, and F02's `Financial.CashFlow.Infrastructure` references the same shared project without duplication
 - [ ] Expense data written through F02's storage abstraction (F01/F02) is correctly read back by F03 as categorized expense records
 - [ ] A card tag on an F03 expense correctly feeds F04's per-card outstanding total and combined adjustment figure
 - [ ] Reserve bucket movements posted by F05 persist and reload correctly through F02's storage abstraction


### PR DESCRIPTION
## Summary
- Scaffolds `Financial.CashFlow.Domain`/`.Application`/`.Infrastructure` under `DDD/CashFlow`, mirroring the Investments layering.
- Adds a `CashFlowData` root aggregate holding 7 empty collections (expenses, reserve movements, card statements, recurring bill templates, recurring bill instances, mae ledger entries, investment snapshots), each item a placeholder with only an `Id` — F03–F08 add their own real fields when implemented.
- Adds the `Category` (14 members), `PaymentSource` (3), and `CreditCard` (5) enums.
- Adds `data-cashflow.json` persistence reusing `Financial.Shared.Infrastructure`'s storage engine (Local/GoogleDrive), with its own `CashFlow:`-scoped config section, independent of Investments' `data.json`.
- Wires `ICashFlowRepository` into `Financial.Api`'s DI container.

## Key research: Category enum completeness
The PRD called for the enum to be "the superset of every category label observed across all 115 historical sheets plus the current 14" but didn't enumerate the historical ones. I opened the real `Despesas.xlsx` and analyzed all 115 in-scope sheets (Feb2017–Jul2026) directly — after correcting for a legacy quirk where the "Quem"/"Motivo" column headers **swap meaning** between eras, the actual category vocabulary is exactly the current 14, plus one single-occurrence typo (`"Casas"` in `Out2017`). No 15th enum member was needed; that one row will be caught by F10's existing "unrecognized category → preserve raw label + flag in error report" fallback.

## Key decisions (see spec.md Section 3 for full rationale)
- CashFlow entities mirror Investments' rich-model style exactly (private constructors + a custom `JsonTypeInfoResolver`), per your preference for consistency across both domains.
- One `ICashFlowRepository` interface (not 6 fragmented ones) — all 7 collections share one JSON file and one save boundary.
- `CashFlow`-scoped config keys, distinct from Investments', since the two data files are independently configurable.

## Deviations from spec
- `CashFlowRepositorySettingsOptions` lives in `Financial.CashFlow.Application/Configuration` (not Infrastructure as spec.md listed) — matches where Investments' own `RepositorySettingsOptions` actually lives.
- No `Financial.CashFlow.Application.Tests` project yet — an interface declaration has no behavior to unit test; it'll be added when F03+ add real Application-layer services.

## Test plan
- [x] `data-cashflow.json` round-trips with all six top-level collections
- [x] A missing `data-cashflow.json` on first run is created with all six collections empty rather than failing to start
- [x] `Financial.CashFlow.Infrastructure` references `Financial.Shared.Infrastructure` rather than duplicating it
- [ ] Category-retirement display behavior (needs F03 + F10 to exist — correctly left unchecked)
- Full solution build + full test suite: 864 passed, 0 failed, 5 pre-existing skips
- Verified `Financial.Api` starts successfully with `data-cashflow.json` completely absent (no crash) — real end-to-end proof of the first-run requirement, not just a unit test

🤖 Generated with [Claude Code](https://claude.com/claude-code)