### PR TITLE
feat(P11-F13): Web — Reserva View

### DIFF
--- a/Financial.Web/src/api/apiError.ts
+++ b/Financial.Web/src/api/apiError.ts
@@ -1,0 +1,9 @@
+export class ApiError extends Error {
+  status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+  }
+}

--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it, vi } from 'vitest'
+import { ApiError } from './apiError'
 import { API_BASE_URL } from './config'
 import { createFinancialApiClient } from './financialApiClient'
-import type { AssetDetailsDto, AssetPriceDto, TreeNodeDto, XirrResultDto } from './types'
+import type {
+  AssetDetailsDto,
+  AssetPriceDto,
+  IncomeSplitRequestDto,
+  IncomeSplitResultDto,
+  ReserveBucketBalanceDto,
+  ReserveMovementDto,
+  TreeNodeDto,
+  WithdrawalRequestDto,
+  XirrResultDto,
+} from './types'
 
 const okResponse = <T,>(payload: T) =>
   ({
@@ -272,5 +283,112 @@ describe('financialApiClient', () => {
     await expect(client.getDividendSummary('ASDF', 'BVMF')).rejects.toThrow(
       "Could not find dividend data for 'ASDF'. Check the ticker and try again.",
     )
+  })
+
+  it('throws an ApiError carrying the response status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(errorResponse())
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const error = await client.getNavigationTree().catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(ApiError)
+    expect((error as ApiError).status).toBe(500)
+  })
+
+  it('throws an ApiError with status 409 on a conflict response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: 'Conflict',
+      text: async () => JSON.stringify({ detail: 'This withdrawal exceeds the balance.' }),
+    } as Response)
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const error = await client
+      .postWithdrawal({ bucket: 'Ariana', amount: 100, date: '2026-07-01', description: 'Test', confirmed: false })
+      .catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(ApiError)
+    expect((error as ApiError).status).toBe(409)
+  })
+
+  it('calls reserve balances endpoint', async () => {
+    const responseBody: ReserveBucketBalanceDto[] = [{ bucket: 'Dizimo', balance: 637 }]
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.getReserveBalances()
+
+    expect(result).toEqual(responseBody)
+    expect(fetchMock.mock.calls[0][0]).toBe(`${API_BASE_URL}/reserve/balances`)
+  })
+
+  it('calls reserve movements endpoint', async () => {
+    const responseBody: ReserveMovementDto[] = [
+      { id: 'm1', bucket: 'Dizimo', amount: 10, date: '2026-07-01', description: 'Test' },
+    ]
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.getReserveMovements()
+
+    expect(result).toEqual(responseBody)
+    expect(fetchMock.mock.calls[0][0]).toBe(`${API_BASE_URL}/reserve/movements`)
+  })
+
+  it('posts an income split request', async () => {
+    const requestBody: IncomeSplitRequestDto = {
+      date: '2026-07-01',
+      gleisonSalaryGross: 4500,
+      gleisonSalaryNet: 3600,
+      arianaSalaryGross: 3200,
+      arianaSalaryNet: 2600,
+      lottery: 50,
+      dividendoJuros: 120,
+    }
+    const responseBody: IncomeSplitResultDto = {
+      dizimo: 637,
+      investimento: 1854.33,
+      houseTreats: 1854.33,
+      ariana: 927.17,
+      gleison: 927.17,
+    }
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.postIncomeSplit(requestBody)
+
+    expect(result).toEqual(responseBody)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/reserve/income-split`)
+    expect(init?.method).toBe('POST')
+    expect(JSON.parse(init?.body as string)).toEqual(requestBody)
+  })
+
+  it('posts a withdrawal request', async () => {
+    const requestBody: WithdrawalRequestDto = {
+      bucket: 'Investimento',
+      amount: 30,
+      date: '2026-07-01',
+      description: 'Groceries top-up',
+      confirmed: false,
+    }
+    const responseBody: ReserveMovementDto = {
+      id: 'm2',
+      bucket: 'Investimento',
+      amount: -30,
+      date: '2026-07-01',
+      description: 'Groceries top-up',
+    }
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.postWithdrawal(requestBody)
+
+    expect(result).toEqual(responseBody)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/reserve/withdrawals`)
+    expect(init?.method).toBe('POST')
+    expect(JSON.parse(init?.body as string)).toEqual(requestBody)
   })
 })

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -1,3 +1,4 @@
+import { ApiError } from './apiError'
 import { API_BASE_URL } from './config'
 import type {
   AggregatedSummaryDto,
@@ -12,16 +13,21 @@ import type {
   CreditUpdateDto,
   DividendHistoryItemDto,
   DividendSummaryDto,
+  IncomeSplitRequestDto,
+  IncomeSplitResultDto,
   InvestmentScope,
   PortfolioAssetSummaryItemDto,
   PortfolioBreakdownItemDto,
   PortfolioReferenceDto,
+  ReserveBucketBalanceDto,
+  ReserveMovementDto,
   TransactionCreateDto,
   TransactionDeleteDto,
   TransactionSummaryItemDto,
   TransactionUpdateDto,
   TreeNodeDto,
   WatchlistItemDto,
+  WithdrawalRequestDto,
   XirrResultDto,
 } from './types'
 
@@ -55,6 +61,10 @@ export interface FinancialApiClient {
   getAssetPriceFetchScope: () => Promise<PortfolioReferenceDto[]>
   getPortfolioAssetsSummary: (brokerName: string, portfolioName: string, scope?: InvestmentScope) => Promise<PortfolioAssetSummaryItemDto[]>
   calculateXirr: (cashFlows: AssetCashFlowDto[], terminalValue: number) => Promise<XirrResultDto>
+  getReserveBalances: () => Promise<ReserveBucketBalanceDto[]>
+  getReserveMovements: () => Promise<ReserveMovementDto[]>
+  postIncomeSplit: (request: IncomeSplitRequestDto) => Promise<IncomeSplitResultDto>
+  postWithdrawal: (request: WithdrawalRequestDto) => Promise<ReserveMovementDto>
 }
 
 export interface FinancialApiClientOptions {
@@ -111,7 +121,7 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
 
     if (!response.ok) {
       const method = init?.method ?? 'GET'
-      throw new Error(await buildErrorMessage(response, method, url))
+      throw new ApiError(await buildErrorMessage(response, method, url), response.status)
     }
 
     return (await response.json()) as T
@@ -207,6 +217,18 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       request<XirrResultDto>('/xirr/calculate', {
         method: 'POST',
         body: JSON.stringify({ cashFlows, terminalValue } satisfies CalculateXirrRequestDto),
+      }),
+    getReserveBalances: () => request<ReserveBucketBalanceDto[]>('/reserve/balances'),
+    getReserveMovements: () => request<ReserveMovementDto[]>('/reserve/movements'),
+    postIncomeSplit: (requestBody) =>
+      request<IncomeSplitResultDto>('/reserve/income-split', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      }),
+    postWithdrawal: (requestBody) =>
+      request<ReserveMovementDto>('/reserve/withdrawals', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
       }),
   }
 }

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -260,3 +260,42 @@ export interface PortfolioAssetSummaryItemDto {
   estimatedAnnualPercent: number | null
   currentMonthCredits: number
 }
+
+export interface ReserveBucketBalanceDto {
+  bucket: string
+  balance: number
+}
+
+export interface ReserveMovementDto {
+  id: string
+  bucket: string
+  amount: number
+  date: string
+  description: string
+}
+
+export interface IncomeSplitRequestDto {
+  date: string
+  gleisonSalaryGross: number
+  gleisonSalaryNet: number
+  arianaSalaryGross: number
+  arianaSalaryNet: number
+  lottery: number
+  dividendoJuros: number
+}
+
+export interface IncomeSplitResultDto {
+  dizimo: number
+  investimento: number
+  houseTreats: number
+  ariana: number
+  gleison: number
+}
+
+export interface WithdrawalRequestDto {
+  bucket: string
+  amount: number
+  date: string
+  description: string
+  confirmed: boolean
+}

--- a/Financial.Web/src/hooks/useReserva.test.ts
+++ b/Financial.Web/src/hooks/useReserva.test.ts
@@ -1,0 +1,157 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError } from '../api/apiError'
+import type { FinancialApiClient } from '../api/financialApiClient'
+import type { ReserveBucketBalanceDto, ReserveMovementDto } from '../api/types'
+import { useReserva } from './useReserva'
+
+const getReserveBalancesMock = vi.fn<FinancialApiClient['getReserveBalances']>()
+const getReserveMovementsMock = vi.fn<FinancialApiClient['getReserveMovements']>()
+const postIncomeSplitMock = vi.fn<FinancialApiClient['postIncomeSplit']>()
+const postWithdrawalMock = vi.fn<FinancialApiClient['postWithdrawal']>()
+
+vi.mock('../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getReserveBalances: getReserveBalancesMock,
+    getReserveMovements: getReserveMovementsMock,
+    postIncomeSplit: postIncomeSplitMock,
+    postWithdrawal: postWithdrawalMock,
+  }),
+}))
+
+const BALANCES: ReserveBucketBalanceDto[] = [
+  { bucket: 'Dizimo', balance: 637 },
+  { bucket: 'Investimento', balance: 1854.33 },
+  { bucket: 'HouseTreats', balance: 1854.33 },
+  { bucket: 'Ariana', balance: 927.17 },
+  { bucket: 'Gleison', balance: 927.17 },
+]
+
+const MOVEMENTS: ReserveMovementDto[] = [
+  { id: 'm1', bucket: 'Dizimo', amount: 637, date: '2026-07-01', description: 'Monthly income split' },
+]
+
+describe('useReserva', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getReserveBalancesMock.mockResolvedValue(BALANCES)
+    getReserveMovementsMock.mockResolvedValue(MOVEMENTS)
+  })
+
+  it('loads balances and movements on mount', async () => {
+    const { result } = renderHook(() => useReserva())
+
+    expect(result.current.isLoading).toBe(true)
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.balances).toEqual(BALANCES)
+    expect(result.current.movements).toEqual(MOVEMENTS)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('surfaces a fetch error', async () => {
+    getReserveBalancesMock.mockRejectedValue(new Error('Network down'))
+    const { result } = renderHook(() => useReserva())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.error).toBe('Network down')
+  })
+
+  it('submits an income split and re-fetches balances/movements on success', async () => {
+    postIncomeSplitMock.mockResolvedValue({
+      dizimo: 637,
+      investimento: 1854.33,
+      houseTreats: 1854.33,
+      ariana: 927.17,
+      gleison: 927.17,
+    })
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setSplitField('splitDate', '2026-07-01'))
+    act(() => result.current.setSplitField('gleisonSalaryNet', '3600'))
+    act(() => result.current.submitIncomeSplit())
+
+    await waitFor(() => expect(postIncomeSplitMock).toHaveBeenCalledTimes(1))
+    expect(postIncomeSplitMock).toHaveBeenCalledWith(
+      expect.objectContaining({ date: '2026-07-01', gleisonSalaryNet: 3600 }),
+    )
+    await waitFor(() => expect(getReserveBalancesMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('surfaces a validation error from the backend on income split failure', async () => {
+    postIncomeSplitMock.mockRejectedValue(new Error('GleisonSalaryNet must not be negative.'))
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setSplitField('splitDate', '2026-07-01'))
+    act(() => result.current.submitIncomeSplit())
+
+    await waitFor(() => expect(result.current.splitError).toBe('GleisonSalaryNet must not be negative.'))
+  })
+
+  it('submits a withdrawal and re-fetches on success', async () => {
+    postWithdrawalMock.mockResolvedValue({
+      id: 'm2',
+      bucket: 'Investimento',
+      amount: -30,
+      date: '2026-07-01',
+      description: 'Groceries top-up',
+    })
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setWithdrawalField('withdrawalAmount', '30'))
+    act(() => result.current.setWithdrawalField('withdrawalDate', '2026-07-01'))
+    act(() => result.current.setWithdrawalField('withdrawalDescription', 'Groceries top-up'))
+    act(() => result.current.submitWithdrawal())
+
+    await waitFor(() => expect(postWithdrawalMock).toHaveBeenCalledTimes(1))
+    expect(postWithdrawalMock).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 30, confirmed: false }),
+    )
+    await waitFor(() => expect(getReserveBalancesMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('prompts for confirmation on a 409 and resubmits confirmed when accepted', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => true))
+    postWithdrawalMock
+      .mockRejectedValueOnce(new ApiError('This withdrawal exceeds the balance.', 409))
+      .mockResolvedValueOnce({
+        id: 'm3',
+        bucket: 'Ariana',
+        amount: -100,
+        date: '2026-07-01',
+        description: 'Big purchase',
+      })
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setWithdrawalField('withdrawalBucket', 'Ariana'))
+    act(() => result.current.setWithdrawalField('withdrawalAmount', '100'))
+    act(() => result.current.setWithdrawalField('withdrawalDate', '2026-07-01'))
+    act(() => result.current.setWithdrawalField('withdrawalDescription', 'Big purchase'))
+    act(() => result.current.submitWithdrawal())
+
+    await waitFor(() => expect(postWithdrawalMock).toHaveBeenCalledTimes(2))
+    expect(postWithdrawalMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ confirmed: false }))
+    expect(postWithdrawalMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ confirmed: true }))
+  })
+
+  it('does not resubmit a 409 withdrawal when the user declines the confirmation', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => false))
+    postWithdrawalMock.mockRejectedValue(new ApiError('This withdrawal exceeds the balance.', 409))
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setWithdrawalField('withdrawalAmount', '100'))
+    act(() => result.current.setWithdrawalField('withdrawalDate', '2026-07-01'))
+    act(() => result.current.setWithdrawalField('withdrawalDescription', 'Big purchase'))
+    act(() => result.current.submitWithdrawal())
+
+    await waitFor(() => expect(result.current.withdrawalError).toBe('This withdrawal exceeds the balance.'))
+    expect(postWithdrawalMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/Financial.Web/src/hooks/useReserva.ts
+++ b/Financial.Web/src/hooks/useReserva.ts
@@ -1,0 +1,295 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react'
+import { ApiError } from '../api/apiError'
+import { createFinancialApiClient } from '../api/financialApiClient'
+import type { ReserveBucketBalanceDto, ReserveMovementDto } from '../api/types'
+
+export const RESERVE_BUCKETS = ['Dizimo', 'Investimento', 'HouseTreats', 'Ariana', 'Gleison'] as const
+
+export type SplitFormField =
+  | 'splitDate'
+  | 'gleisonSalaryGross'
+  | 'gleisonSalaryNet'
+  | 'arianaSalaryGross'
+  | 'arianaSalaryNet'
+  | 'lottery'
+  | 'dividendoJuros'
+
+export type WithdrawalFormField = 'withdrawalBucket' | 'withdrawalAmount' | 'withdrawalDate' | 'withdrawalDescription'
+
+interface ReservaState {
+  balances: ReserveBucketBalanceDto[]
+  movements: ReserveMovementDto[]
+  isLoading: boolean
+  error: string | null
+  retryCount: number
+  splitDate: string
+  gleisonSalaryGross: string
+  gleisonSalaryNet: string
+  arianaSalaryGross: string
+  arianaSalaryNet: string
+  lottery: string
+  dividendoJuros: string
+  isSubmittingSplit: boolean
+  splitError: string | null
+  withdrawalBucket: string
+  withdrawalAmount: string
+  withdrawalDate: string
+  withdrawalDescription: string
+  isSubmittingWithdrawal: boolean
+  withdrawalError: string | null
+}
+
+type ReservaAction =
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; payload: { balances: ReserveBucketBalanceDto[]; movements: ReserveMovementDto[] } }
+  | { type: 'FETCH_ERROR'; payload: string }
+  | { type: 'RETRY' }
+  | { type: 'SET_SPLIT_FIELD'; payload: { field: SplitFormField; value: string } }
+  | { type: 'SPLIT_START' }
+  | { type: 'SPLIT_SUCCESS' }
+  | { type: 'SPLIT_ERROR'; payload: string }
+  | { type: 'SET_WITHDRAWAL_FIELD'; payload: { field: WithdrawalFormField; value: string } }
+  | { type: 'WITHDRAWAL_START' }
+  | { type: 'WITHDRAWAL_SUCCESS' }
+  | { type: 'WITHDRAWAL_ERROR'; payload: string }
+
+const BLANK_SPLIT_FORM = {
+  splitDate: '',
+  gleisonSalaryGross: '',
+  gleisonSalaryNet: '',
+  arianaSalaryGross: '',
+  arianaSalaryNet: '',
+  lottery: '',
+  dividendoJuros: '',
+} as const
+
+const BLANK_WITHDRAWAL_FORM = {
+  withdrawalBucket: RESERVE_BUCKETS[0],
+  withdrawalAmount: '',
+  withdrawalDate: '',
+  withdrawalDescription: '',
+} as const
+
+const INITIAL_STATE: ReservaState = {
+  balances: [],
+  movements: [],
+  isLoading: true,
+  error: null,
+  retryCount: 0,
+  ...BLANK_SPLIT_FORM,
+  isSubmittingSplit: false,
+  splitError: null,
+  ...BLANK_WITHDRAWAL_FORM,
+  isSubmittingWithdrawal: false,
+  withdrawalError: null,
+}
+
+function reducer(state: ReservaState, action: ReservaAction): ReservaState {
+  switch (action.type) {
+    case 'FETCH_START':
+      return { ...state, isLoading: true, error: null }
+    case 'FETCH_SUCCESS':
+      return { ...state, isLoading: false, balances: action.payload.balances, movements: action.payload.movements }
+    case 'FETCH_ERROR':
+      return { ...state, isLoading: false, error: action.payload }
+    case 'RETRY':
+      return { ...state, retryCount: state.retryCount + 1 }
+    case 'SET_SPLIT_FIELD':
+      return { ...state, [action.payload.field]: action.payload.value }
+    case 'SPLIT_START':
+      return { ...state, isSubmittingSplit: true, splitError: null }
+    case 'SPLIT_SUCCESS':
+      return { ...state, ...BLANK_SPLIT_FORM, isSubmittingSplit: false }
+    case 'SPLIT_ERROR':
+      return { ...state, isSubmittingSplit: false, splitError: action.payload }
+    case 'SET_WITHDRAWAL_FIELD':
+      return { ...state, [action.payload.field]: action.payload.value }
+    case 'WITHDRAWAL_START':
+      return { ...state, isSubmittingWithdrawal: true, withdrawalError: null }
+    case 'WITHDRAWAL_SUCCESS':
+      return { ...state, ...BLANK_WITHDRAWAL_FORM, isSubmittingWithdrawal: false }
+    case 'WITHDRAWAL_ERROR':
+      return { ...state, isSubmittingWithdrawal: false, withdrawalError: action.payload }
+    default:
+      return state
+  }
+}
+
+export interface ReservaData {
+  balances: ReserveBucketBalanceDto[]
+  movements: ReserveMovementDto[]
+  isLoading: boolean
+  error: string | null
+  retry: () => void
+  splitDate: string
+  gleisonSalaryGross: string
+  gleisonSalaryNet: string
+  arianaSalaryGross: string
+  arianaSalaryNet: string
+  lottery: string
+  dividendoJuros: string
+  isSubmittingSplit: boolean
+  splitError: string | null
+  setSplitField: (field: SplitFormField, value: string) => void
+  submitIncomeSplit: () => void
+  withdrawalBucket: string
+  withdrawalAmount: string
+  withdrawalDate: string
+  withdrawalDescription: string
+  isSubmittingWithdrawal: boolean
+  withdrawalError: string | null
+  setWithdrawalField: (field: WithdrawalFormField, value: string) => void
+  submitWithdrawal: () => void
+}
+
+export function useReserva(): ReservaData {
+  const apiClient = useMemo(() => createFinancialApiClient(), [])
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  const fetchReservaData = useCallback(() => {
+    dispatch({ type: 'FETCH_START' })
+    void Promise.all([apiClient.getReserveBalances(), apiClient.getReserveMovements()])
+      .then(([balances, movements]) => dispatch({ type: 'FETCH_SUCCESS', payload: { balances, movements } }))
+      .catch((err: unknown) => {
+        dispatch({ type: 'FETCH_ERROR', payload: err instanceof Error ? err.message : 'Unable to load Reserva data' })
+      })
+  }, [apiClient])
+
+  useEffect(() => {
+    fetchReservaData()
+  }, [fetchReservaData, state.retryCount])
+
+  const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
+
+  const setSplitField = useCallback(
+    (field: SplitFormField, value: string) => dispatch({ type: 'SET_SPLIT_FIELD', payload: { field, value } }),
+    [],
+  )
+
+  const setWithdrawalField = useCallback(
+    (field: WithdrawalFormField, value: string) => dispatch({ type: 'SET_WITHDRAWAL_FIELD', payload: { field, value } }),
+    [],
+  )
+
+  function submitIncomeSplit() {
+    const {
+      splitDate,
+      gleisonSalaryGross,
+      gleisonSalaryNet,
+      arianaSalaryGross,
+      arianaSalaryNet,
+      lottery,
+      dividendoJuros,
+    } = state
+
+    if (!splitDate.trim()) {
+      dispatch({ type: 'SPLIT_ERROR', payload: 'Date is required' })
+      return
+    }
+
+    dispatch({ type: 'SPLIT_START' })
+
+    void apiClient
+      .postIncomeSplit({
+        date: splitDate,
+        gleisonSalaryGross: Number(gleisonSalaryGross) || 0,
+        gleisonSalaryNet: Number(gleisonSalaryNet) || 0,
+        arianaSalaryGross: Number(arianaSalaryGross) || 0,
+        arianaSalaryNet: Number(arianaSalaryNet) || 0,
+        lottery: Number(lottery) || 0,
+        dividendoJuros: Number(dividendoJuros) || 0,
+      })
+      .then(() => {
+        dispatch({ type: 'SPLIT_SUCCESS' })
+        fetchReservaData()
+      })
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'SPLIT_ERROR',
+          payload: err instanceof Error ? err.message : 'Failed to post income split',
+        })
+      })
+  }
+
+  function performWithdrawal(confirmed: boolean) {
+    const { withdrawalBucket, withdrawalAmount, withdrawalDate, withdrawalDescription } = state
+
+    void apiClient
+      .postWithdrawal({
+        bucket: withdrawalBucket,
+        amount: Number(withdrawalAmount) || 0,
+        date: withdrawalDate,
+        description: withdrawalDescription,
+        confirmed,
+      })
+      .then(() => {
+        dispatch({ type: 'WITHDRAWAL_SUCCESS' })
+        fetchReservaData()
+      })
+      .catch((err: unknown) => {
+        if (err instanceof ApiError && err.status === 409 && !confirmed) {
+          if (window.confirm(`${err.message}\n\nProceed anyway?`)) {
+            performWithdrawal(true)
+            return
+          }
+          dispatch({ type: 'WITHDRAWAL_ERROR', payload: err.message })
+          return
+        }
+
+        dispatch({
+          type: 'WITHDRAWAL_ERROR',
+          payload: err instanceof Error ? err.message : 'Failed to post withdrawal',
+        })
+      })
+  }
+
+  function submitWithdrawal() {
+    const { withdrawalAmount, withdrawalDate, withdrawalDescription } = state
+
+    const amount = Number(withdrawalAmount)
+    if (!withdrawalAmount.trim() || !isFinite(amount) || amount <= 0) {
+      dispatch({ type: 'WITHDRAWAL_ERROR', payload: 'Amount must be a positive number' })
+      return
+    }
+
+    if (!withdrawalDate.trim()) {
+      dispatch({ type: 'WITHDRAWAL_ERROR', payload: 'Date is required' })
+      return
+    }
+
+    if (!withdrawalDescription.trim()) {
+      dispatch({ type: 'WITHDRAWAL_ERROR', payload: 'Description is required' })
+      return
+    }
+
+    dispatch({ type: 'WITHDRAWAL_START' })
+    performWithdrawal(false)
+  }
+
+  return {
+    balances: state.balances,
+    movements: state.movements,
+    isLoading: state.isLoading,
+    error: state.error,
+    retry,
+    splitDate: state.splitDate,
+    gleisonSalaryGross: state.gleisonSalaryGross,
+    gleisonSalaryNet: state.gleisonSalaryNet,
+    arianaSalaryGross: state.arianaSalaryGross,
+    arianaSalaryNet: state.arianaSalaryNet,
+    lottery: state.lottery,
+    dividendoJuros: state.dividendoJuros,
+    isSubmittingSplit: state.isSubmittingSplit,
+    splitError: state.splitError,
+    setSplitField,
+    submitIncomeSplit,
+    withdrawalBucket: state.withdrawalBucket,
+    withdrawalAmount: state.withdrawalAmount,
+    withdrawalDate: state.withdrawalDate,
+    withdrawalDescription: state.withdrawalDescription,
+    isSubmittingWithdrawal: state.isSubmittingWithdrawal,
+    withdrawalError: state.withdrawalError,
+    setWithdrawalField,
+    submitWithdrawal,
+  }
+}

--- a/Financial.Web/src/main.tsx
+++ b/Financial.Web/src/main.tsx
@@ -11,6 +11,7 @@ import HistoricInvestmentsPage from './pages/HistoricInvestmentsPage'
 import DividendCheckPage from './pages/DividendCheckPage'
 import CurrentValuesPage from './pages/CurrentValuesPage'
 import CashFlowPlaceholderPage from './pages/CashFlowPlaceholderPage'
+import ReservaPage from './pages/ReservaPage'
 import RootRedirect from './pages/RootRedirect'
 
 createRoot(document.getElementById('root')!).render(
@@ -29,7 +30,7 @@ createRoot(document.getElementById('root')!).render(
           <Route path="cashflow" element={<CashFlowLayout />}>
             <Route index element={<Navigate to="/cashflow/monthly" replace />} />
             <Route path="monthly" element={<CashFlowPlaceholderPage title="Monthly" />} />
-            <Route path="reserva" element={<CashFlowPlaceholderPage title="Reserva" />} />
+            <Route path="reserva" element={<ReservaPage />} />
             <Route path="mensais" element={<CashFlowPlaceholderPage title="Mensais" />} />
             <Route path="controle-mae" element={<CashFlowPlaceholderPage title="Controle Mae" />} />
             <Route

--- a/Financial.Web/src/pages/ReservaPage.css
+++ b/Financial.Web/src/pages/ReservaPage.css
@@ -1,0 +1,36 @@
+.reserva-page {
+  padding: 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.reserva-page__section h2 {
+  color: var(--text-h);
+  margin-bottom: 12px;
+}
+
+.reserva-page__table {
+  width: 100%;
+  max-width: 640px;
+}
+
+.reserva-page__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  max-width: 720px;
+}
+
+.reserva-page__form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.reserva-page__error {
+  color: var(--error, #c0392b);
+  width: 100%;
+}

--- a/Financial.Web/src/pages/ReservaPage.tsx
+++ b/Financial.Web/src/pages/ReservaPage.tsx
@@ -1,0 +1,202 @@
+import ErrorState from '../components/ErrorState'
+import LoadingState from '../components/LoadingState'
+import { RESERVE_BUCKETS, useReserva } from '../hooks/useReserva'
+import type { SplitFormField, WithdrawalFormField } from '../hooks/useReserva'
+import { formatN2, formatShortDate } from '../utils/formatters'
+import './ReservaPage.css'
+
+const SPLIT_FIELDS: { field: SplitFormField; label: string }[] = [
+  { field: 'gleisonSalaryGross', label: 'Salario Gleison (gross)' },
+  { field: 'gleisonSalaryNet', label: 'Salario Gleison (net)' },
+  { field: 'arianaSalaryGross', label: 'Salario Ariana (gross)' },
+  { field: 'arianaSalaryNet', label: 'Salario Ariana (net)' },
+  { field: 'lottery', label: 'Lottery' },
+  { field: 'dividendoJuros', label: 'Dividendo/Juros' },
+]
+
+export default function ReservaPage() {
+  const {
+    balances,
+    movements,
+    isLoading,
+    error,
+    retry,
+    splitDate,
+    gleisonSalaryGross,
+    gleisonSalaryNet,
+    arianaSalaryGross,
+    arianaSalaryNet,
+    lottery,
+    dividendoJuros,
+    isSubmittingSplit,
+    splitError,
+    setSplitField,
+    submitIncomeSplit,
+    withdrawalBucket,
+    withdrawalAmount,
+    withdrawalDate,
+    withdrawalDescription,
+    isSubmittingWithdrawal,
+    withdrawalError,
+    setWithdrawalField,
+    submitWithdrawal,
+  } = useReserva()
+
+  if (isLoading) {
+    return <LoadingState />
+  }
+
+  if (error) {
+    return <ErrorState message={error} onRetry={retry} />
+  }
+
+  const splitValues: Record<SplitFormField, string> = {
+    splitDate,
+    gleisonSalaryGross,
+    gleisonSalaryNet,
+    arianaSalaryGross,
+    arianaSalaryNet,
+    lottery,
+    dividendoJuros,
+  }
+
+  const withdrawalValues: Record<WithdrawalFormField, string> = {
+    withdrawalBucket,
+    withdrawalAmount,
+    withdrawalDate,
+    withdrawalDescription,
+  }
+
+  return (
+    <div className="reserva-page">
+      <section className="reserva-page__section">
+        <h2>Bucket Balances</h2>
+        <table className="reserva-page__table data-table">
+          <thead>
+            <tr>
+              <th>Bucket</th>
+              <th className="data-table__col--numeric">Balance</th>
+            </tr>
+          </thead>
+          <tbody>
+            {balances.map((b) => (
+              <tr key={b.bucket}>
+                <td>{b.bucket}</td>
+                <td className="data-table__col--numeric">{formatN2(b.balance)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="reserva-page__section">
+        <h2>Post Monthly Income Split</h2>
+        <div className="reserva-page__form">
+          <div className="reserva-page__form-field">
+            <label htmlFor="split-date">Date</label>
+            <input
+              id="split-date"
+              type="date"
+              value={splitDate}
+              required
+              onChange={(e) => setSplitField('splitDate', e.target.value)}
+            />
+          </div>
+          {SPLIT_FIELDS.map(({ field, label }) => (
+            <div className="reserva-page__form-field" key={field}>
+              <label htmlFor={`split-${field}`}>{label}</label>
+              <input
+                id={`split-${field}`}
+                type="number"
+                step="0.01"
+                value={splitValues[field]}
+                onChange={(e) => setSplitField(field, e.target.value)}
+              />
+            </div>
+          ))}
+          <button type="button" disabled={isSubmittingSplit} onClick={submitIncomeSplit}>
+            {isSubmittingSplit ? 'Posting...' : 'Post Income Split'}
+          </button>
+          {splitError && <p className="reserva-page__error">{splitError}</p>}
+        </div>
+      </section>
+
+      <section className="reserva-page__section">
+        <h2>Record a Withdrawal</h2>
+        <div className="reserva-page__form">
+          <div className="reserva-page__form-field">
+            <label htmlFor="withdrawal-bucket">Bucket</label>
+            <select
+              id="withdrawal-bucket"
+              value={withdrawalValues.withdrawalBucket}
+              onChange={(e) => setWithdrawalField('withdrawalBucket', e.target.value)}
+            >
+              {RESERVE_BUCKETS.map((bucket) => (
+                <option key={bucket} value={bucket}>
+                  {bucket}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="reserva-page__form-field">
+            <label htmlFor="withdrawal-amount">Amount</label>
+            <input
+              id="withdrawal-amount"
+              type="number"
+              step="0.01"
+              min="0"
+              value={withdrawalValues.withdrawalAmount}
+              onChange={(e) => setWithdrawalField('withdrawalAmount', e.target.value)}
+            />
+          </div>
+          <div className="reserva-page__form-field">
+            <label htmlFor="withdrawal-date">Date</label>
+            <input
+              id="withdrawal-date"
+              type="date"
+              value={withdrawalValues.withdrawalDate}
+              onChange={(e) => setWithdrawalField('withdrawalDate', e.target.value)}
+            />
+          </div>
+          <div className="reserva-page__form-field">
+            <label htmlFor="withdrawal-description">Description</label>
+            <input
+              id="withdrawal-description"
+              type="text"
+              value={withdrawalValues.withdrawalDescription}
+              onChange={(e) => setWithdrawalField('withdrawalDescription', e.target.value)}
+            />
+          </div>
+          <button type="button" disabled={isSubmittingWithdrawal} onClick={submitWithdrawal}>
+            {isSubmittingWithdrawal ? 'Saving...' : 'Record Withdrawal'}
+          </button>
+          {withdrawalError && <p className="reserva-page__error">{withdrawalError}</p>}
+        </div>
+      </section>
+
+      <section className="reserva-page__section">
+        <h2>Movement History</h2>
+        <table className="reserva-page__table data-table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Bucket</th>
+              <th>Description</th>
+              <th className="data-table__col--numeric">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {movements.map((m) => (
+              <tr key={m.id}>
+                <td>{formatShortDate(m.date)}</td>
+                <td>{m.bucket}</td>
+                <td>{m.description}</td>
+                <td className="data-table__col--numeric">{formatN2(m.amount)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  )
+}

--- a/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ReservaPage from '../ReservaPage'
+import type { FinancialApiClient } from '../../api/financialApiClient'
+import type { ReserveBucketBalanceDto, ReserveMovementDto } from '../../api/types'
+
+const getReserveBalancesMock = vi.fn<FinancialApiClient['getReserveBalances']>()
+const getReserveMovementsMock = vi.fn<FinancialApiClient['getReserveMovements']>()
+const postIncomeSplitMock = vi.fn<FinancialApiClient['postIncomeSplit']>()
+const postWithdrawalMock = vi.fn<FinancialApiClient['postWithdrawal']>()
+
+vi.mock('../../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getReserveBalances: getReserveBalancesMock,
+    getReserveMovements: getReserveMovementsMock,
+    postIncomeSplit: postIncomeSplitMock,
+    postWithdrawal: postWithdrawalMock,
+  }),
+}))
+
+const BALANCES: ReserveBucketBalanceDto[] = [
+  { bucket: 'Dizimo', balance: 637 },
+  { bucket: 'Investimento', balance: 1854.33 },
+  { bucket: 'HouseTreats', balance: 1854.33 },
+  { bucket: 'Ariana', balance: 927.17 },
+  { bucket: 'Gleison', balance: 927.17 },
+]
+
+const MOVEMENTS: ReserveMovementDto[] = [
+  { id: 'm1', bucket: 'Dizimo', amount: 637, date: '2026-07-01', description: 'Monthly income split' },
+]
+
+describe('ReservaPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getReserveBalancesMock.mockResolvedValue(BALANCES)
+    getReserveMovementsMock.mockResolvedValue(MOVEMENTS)
+  })
+
+  it('shows a loading state before data arrives', () => {
+    render(<ReservaPage />)
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('shows an error state with retry when the fetch fails', async () => {
+    getReserveBalancesMock.mockRejectedValue(new Error('Network down'))
+
+    render(<ReservaPage />)
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByText('Network down')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('renders all 5 bucket balances and the movement history once loaded', async () => {
+    render(<ReservaPage />)
+
+    await waitFor(() => expect(screen.getByText('Bucket Balances')).toBeInTheDocument())
+    for (const b of BALANCES) {
+      expect(screen.getAllByText(b.bucket).length).toBeGreaterThan(0)
+    }
+    expect(screen.getByText('Monthly income split')).toBeInTheDocument()
+  })
+
+  it('renders both the income-split and withdrawal forms', async () => {
+    render(<ReservaPage />)
+
+    await waitFor(() => expect(screen.getByText('Post Monthly Income Split')).toBeInTheDocument())
+    expect(screen.getByLabelText('Salario Gleison (gross)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Salario Ariana (net)')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Post Income Split' })).toBeInTheDocument()
+
+    expect(screen.getByText('Record a Withdrawal')).toBeInTheDocument()
+    expect(screen.getByLabelText('Bucket')).toBeInTheDocument()
+    expect(screen.getByLabelText('Amount')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Record Withdrawal' })).toBeInTheDocument()
+  })
+})

--- a/docs/P11-F13-web-reserva-view/plan.md
+++ b/docs/P11-F13-web-reserva-view/plan.md
@@ -1,0 +1,30 @@
+# Implementation Plan: F13. Web — Reserva View
+
+**Prerequisites:**
+- F05's `/reserve/*` endpoints already exist and are unchanged by this feature
+- F11's Web app shell, routing, and `CashFlowLayout` nav already exist
+- No new npm packages
+
+### Stage 1: API Client Layer
+
+**1. Typed API error** - Add an `ApiError` class carrying the HTTP status alongside the message, and switch the shared `request()` helper in `financialApiClient` to throw it instead of a plain `Error`.
+
+**2. Reserva DTOs and client methods** - Add the bucket-balance, movement, income-split request/result, and withdrawal-request types, plus the four new `financialApiClient` methods that call F05's existing endpoints.
+
+**3. API client tests** - Add tests for the new methods' request shape and for `ApiError`'s `status` field on a non-2xx response, alongside a regression check that existing error-throwing tests still pass with the new error type.
+
+### Stage 2: Page Logic and UI
+
+**4. useReserva hook** - Add the hook that loads balances and movement history on mount, manages both forms' state, submits the income split and withdrawal actions, re-fetches on success, and implements the 409-triggered confirm-and-resubmit round trip for withdrawals.
+
+**5. ReservaPage component** - Add the presentational page rendering the loading/error states, the balances table, the movement history table, and both forms, wired to `useReserva`.
+
+**6. Wire up routing** - Replace the `/cashflow/reserva` placeholder route in `main.tsx` with `ReservaPage`.
+
+**7. Hook and component tests** - Add tests for `useReserva`'s fetch-on-mount, submit/re-fetch, and overdraft-confirmation behavior, and for `ReservaPage`'s rendering of all states and forms.
+
+### Stage 3: Verification
+
+**8. Full-suite validation** - Run the Web project's full test suite (`npm test`) and typecheck (`tsc -b --noEmit`), confirming no regression to any existing Investments-domain test.
+
+**9. Manual verification** - Run the Web dev server against a locally running `Financial.Api`, navigate to `/cashflow/reserva`, and exercise the view directly (confirm all 5 buckets and movement history render, post an income split and confirm the balances update immediately, attempt a withdrawal that exceeds a bucket's balance and confirm the overdraft prompt appears and a confirmed resubmit succeeds) to confirm the behavior matches the acceptance criteria end-to-end.

--- a/docs/P11-F13-web-reserva-view/spec.md
+++ b/docs/P11-F13-web-reserva-view/spec.md
@@ -1,0 +1,78 @@
+# F13. Web — Reserva View
+
+## 1. Technical Overview
+
+**What:** Replace F11's `/cashflow/reserva` placeholder with a real page that shows F05's 5 reserve bucket balances and full movement history, lets the user post a month's income to trigger the automated split, and lets the user record a manual bucket withdrawal (including the overdraft-confirmation flow).
+
+**Why:** This is the first real CashFlow screen — it turns F05's backend-only Reserva pool into something the user actually interacts with, replacing the spreadsheet's manual Reserva bucket bookkeeping.
+
+**Scope:**
+- Included: bucket balances table (5 rows); movement history table; an income-split form (date + 6 numeric fields: Gleison/Ariana salary gross+net, Lottery, Dividendo/Juros); a withdrawal form (bucket, amount, date, description) with the overdraft-confirmation round trip; a reusable typed `ApiError` (carries HTTP status) so the client can distinguish "needs confirmation" (409) from a real validation error (400).
+- Excluded: any other CashFlow view (F14/F15/F16); charts/visualizations (the PRD's Experience text describes tables, not charts, for this view — unlike the Investments-domain Credits/Transactions tabs).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/api/apiError.ts` — new: `ApiError` class carrying `status` alongside the message
+- `Financial.Web/src/api/financialApiClient.ts` — modified: `request()` throws `ApiError` instead of a plain `Error`; new methods `getReserveBalances`, `getReserveMovements`, `postIncomeSplit`, `postWithdrawal`
+- `Financial.Web/src/api/types.ts` — new: `ReserveBucketBalanceDto`, `ReserveMovementDto`, `IncomeSplitRequestDto`, `IncomeSplitResultDto`, `WithdrawalRequestDto`
+- `Financial.Web/src/hooks/useReserva.ts` — new: page business logic
+- `Financial.Web/src/pages/ReservaPage.tsx` — new: replaces `CashFlowPlaceholderPage` on the `/cashflow/reserva` route
+- `Financial.Web/src/main.tsx` — modified: route swap
+
+```mermaid
+graph TD
+  A[ReservaPage] --> B[useReserva hook]
+  B --> C["financialApiClient (getReserveBalances/getReserveMovements/postIncomeSplit/postWithdrawal)"]
+  C --> D["/api/v1/financial/reserve/*"]
+  B -.->|ApiError.status === 409| E["window.confirm, resubmit withdrawal with confirmed:true"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| 409 (overdraft) handling | Introduce a typed `ApiError` (message + HTTP `status`) thrown by the shared `request()` helper; `useReserva` checks `err.status === 409` to trigger a `window.confirm`-then-resubmit flow | Give `postWithdrawal` its own one-off fetch call outside the shared helper | The shared `request()` currently discards the status code entirely, so there's no way to special-case a single endpoint without it. A typed error is a small, reusable change any future endpoint can rely on for the same pattern, rather than duplicating fetch/parsing logic. User confirmed via interview. |
+| Confirmation UX | Reuse the existing `window.confirm(...)` pattern already used by `useCredits`' delete action | A custom confirmation modal component | No confirmation-modal component exists yet in this codebase; introducing one for a single feature would be over-engineering for a personal app, and `window.confirm` is already the established pattern for "are you sure" actions here. |
+| Refresh strategy after a successful action | Re-fetch both balances and movement history after a successful income split or withdrawal | Optimistically merge the returned result into local state | The PRD's Experience text ("immediately see the resulting split reflected in each bucket") is satisfied either way, but re-fetching guarantees the displayed balances always match the server's authoritative state (e.g. if a rollback happened server-side that the client wouldn't otherwise know about) — simpler and safer than hand-rolling a local merge for 5 buckets across 2 tables. |
+| Component granularity | A single `ReservaPage` component (balances table + movement history table + both forms), backed by one `useReserva` hook | Split into separate `Tab`-style subcomponents like the Investments domain | The Investments domain's `Tab` components exist because multiple tabs render inside one shared `DetailPanel` for a selected tree node; CashFlow views are each a standalone routed page with no such shared container, so one page component per view matches F11's routing structure directly. |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/api/apiError.ts` | New | Typed API error | `ApiError extends Error` with a `status: number` field |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | HTTP client | `request()` throws `ApiError`; add `getReserveBalances()`, `getReserveMovements()`, `postIncomeSplit(request)`, `postWithdrawal(request)` |
+| `Financial.Web/src/api/types.ts` | Modified | DTO types | `ReserveBucketBalanceDto { bucket, balance }`, `ReserveMovementDto { id, bucket, amount, date, description }`, `IncomeSplitRequestDto { date, gleisonSalaryGross, gleisonSalaryNet, arianaSalaryGross, arianaSalaryNet, lottery, dividendoJuros }`, `IncomeSplitResultDto { dizimo, investimento, houseTreats, ariana, gleison }`, `WithdrawalRequestDto { bucket, amount, date, description, confirmed }` |
+| `Financial.Web/src/hooks/useReserva.ts` | New | Page business logic | Fetches balances + movements on mount; income-split form state/submit; withdrawal form state/submit with the 409-confirm-resubmit round trip; loading/error state matching `useCredits`' reducer pattern |
+| `Financial.Web/src/pages/ReservaPage.tsx`, `ReservaPage.css` | New | Presentational page | Renders `LoadingState`/`ErrorState`, the 5-row balances table, the movement history table, and both forms, wired to `useReserva` |
+| `Financial.Web/src/main.tsx` | Modified | Routing | `/cashflow/reserva` renders `ReservaPage` instead of `CashFlowPlaceholderPage` |
+
+## 5. API Contracts
+
+Consumes F05's existing endpoints unchanged (see F05's own spec for full request/response detail):
+
+- `GET /api/v1/financial/reserve/balances` → `ReserveBucketBalanceDto[]` (always 5 rows)
+- `GET /api/v1/financial/reserve/movements` → `ReserveMovementDto[]`
+- `POST /api/v1/financial/reserve/income-split` (body: `IncomeSplitRequestDto`) → `IncomeSplitResultDto`; `400` on any negative income field
+- `POST /api/v1/financial/reserve/withdrawals` (body: `WithdrawalRequestDto`) → `ReserveMovementDto`; `400` on a non-positive amount or unrecognized bucket; `409` when the withdrawal exceeds the bucket's balance and `confirmed` is `false`
+
+No new backend endpoints — this feature is Web-only.
+
+## 6. Data Model
+
+No backend/persisted data model changes — this is a Web-only feature consuming F05's existing `data-cashflow.json`-backed endpoints.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Financial.Web/src/api/financialApiClient.test.ts` | Unit | `financialApiClient` | New Reserva methods call the correct paths/methods/bodies; a non-2xx response throws `ApiError` with the correct `status` and message |
+| `Financial.Web/src/hooks/useReserva.test.ts` | Unit | `useReserva` | Loads balances + movements on mount; income-split submit calls the endpoint and re-fetches on success, surfaces the backend's message on `400`; withdrawal submit re-fetches on success; a `409` response triggers the confirm-and-resubmit flow (mocking `window.confirm`), and declining the confirm does not resubmit |
+| `Financial.Web/src/pages/ReservaPage.test.tsx` | Component | `ReservaPage` | Renders `LoadingState` while loading, `ErrorState` with retry on failure, the 5 balance rows and movement rows once loaded, and both forms are present and submittable |
+
+**Acceptance tests (from PRD Section 9, F13):**
+- The view shows all 5 bucket balances and their movement history — `ReservaPage.test.tsx`
+- Entering a month's income fields immediately reflects the resulting split in each bucket's displayed balance — `useReserva.test.ts` (re-fetch-after-submit assertion), `ReservaPage.test.tsx`

--- a/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
+++ b/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
@@ -615,8 +615,8 @@ graph TD
 - [ ] A card statement can be marked paid from this view
 
 ### F13. Web — Reserva View
-- [ ] The view shows all 5 bucket balances and their movement history
-- [ ] Entering a month's income fields immediately reflects the resulting split in each bucket's displayed balance
+- [x] The view shows all 5 bucket balances and their movement history
+- [x] Entering a month's income fields immediately reflects the resulting split in each bucket's displayed balance
 
 ### F14. Web — Mensais View
 - [ ] The view shows Brasil and UK bills as two separate grouped sections for the selected month


### PR DESCRIPTION
## Summary
- Replaces F11's `/cashflow/reserva` placeholder with a real page showing F05's 5 reserve bucket balances and full movement history.
- Adds an income-split form (date + 6 numeric fields: Gleison/Ariana salary gross+net, Lottery, Dividendo/Juros) that posts to F05's `/reserve/income-split` and immediately re-fetches balances/movements.
- Adds a withdrawal form (bucket, amount, date, description) that posts to F05's `/reserve/withdrawals`, including the overdraft-confirmation round trip: a 409 response shows the backend's message via `window.confirm`, and accepting resubmits with `confirmed: true`.
- Introduces a typed `ApiError` (message + HTTP status) in the shared API client so any endpoint can distinguish specific status codes going forward, not just this one.

## Technical decisions (see docs/P11-F13-web-reserva-view/spec.md)
- `ApiError` carries the HTTP status — confirmed with you via interview, since the existing `financialApiClient.request()` discarded status codes entirely and the withdrawal flow needs to distinguish 409 (needs confirmation) from 400 (real validation error).
- Reuses the existing `window.confirm` pattern from `useCredits`' delete action rather than building a new confirmation-modal component.
- Re-fetches balances/movements after every successful action rather than optimistically merging — guarantees the displayed state always matches the server's authoritative data.
- One `ReservaPage` + one `useReserva` hook (no `Tab` subcomponents) since CashFlow views are standalone routed pages, unlike the Investments domain's shared-`DetailPanel` tabs.

## Test plan
- [x] `financialApiClient.test.ts` — new Reserva methods call the correct paths/bodies; `ApiError` carries the correct status on both a generic failure and a 409
- [x] `useReserva.test.ts` — fetch-on-mount, income-split submit + re-fetch, backend validation error surfaced, withdrawal submit + re-fetch, 409-confirm-and-resubmit flow (both accepting and declining the confirmation)
- [x] `ReservaPage.test.tsx` — loading/error states, all 5 balances + movement history rendered, both forms present
- [x] Full Web test suite green (431 tests, no regressions), typecheck and lint clean
- [x] Manual smoke test with a real running `Financial.Api` + Vite dev server via a scripted Playwright session: loaded `/cashflow/reserva`, confirmed 5 bucket rows, posted a real income split and confirmed Dizimo computed to exactly 637.00 (10% math), attempted an over-balance withdrawal and confirmed the overdraft dialog showed the backend's exact message, accepted it and confirmed the withdrawal posted successfully

## PRD
Acceptance criteria for F13 checked off in `docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md`. The cross-feature checkbox covering F13/F14/F15/F16 together stays unchecked until all four Web views land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)