### PR TITLE
fix(docker): add CashFlow projects to Dockerfile, persist CashFlow data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ COPY Financial.Api/Financial.Api.csproj Financial.Api/
 COPY Financial.Investment.Application/Financial.Investment.Application.csproj Financial.Investment.Application/
 COPY Financial.Investment.Domain/Financial.Investment.Domain.csproj Financial.Investment.Domain/
 COPY Financial.Investment.Infrastructure/Financial.Investment.Infrastructure.csproj Financial.Investment.Infrastructure/
+COPY Financial.CashFlow.Application/Financial.CashFlow.Application.csproj Financial.CashFlow.Application/
+COPY Financial.CashFlow.Domain/Financial.CashFlow.Domain.csproj Financial.CashFlow.Domain/
+COPY Financial.CashFlow.Infrastructure/Financial.CashFlow.Infrastructure.csproj Financial.CashFlow.Infrastructure/
 COPY Financial.Shared.Infrastructure/Financial.Shared.Infrastructure.csproj Financial.Shared.Infrastructure/
 COPY Integrations/GoogleFinancialSupport/GoogleFinancialSupport.csproj Integrations/GoogleFinancialSupport/
 COPY Integrations/WebPageParser/WebPageParser.csproj Integrations/WebPageParser/
@@ -26,6 +29,9 @@ COPY Financial.Api/ Financial.Api/
 COPY Financial.Investment.Application/ Financial.Investment.Application/
 COPY Financial.Investment.Domain/ Financial.Investment.Domain/
 COPY Financial.Investment.Infrastructure/ Financial.Investment.Infrastructure/
+COPY Financial.CashFlow.Application/ Financial.CashFlow.Application/
+COPY Financial.CashFlow.Domain/ Financial.CashFlow.Domain/
+COPY Financial.CashFlow.Infrastructure/ Financial.CashFlow.Infrastructure/
 COPY Financial.Shared.Infrastructure/ Financial.Shared.Infrastructure/
 COPY Integrations/GoogleFinancialSupport/ Integrations/GoogleFinancialSupport/
 COPY Integrations/WebPageParser/ Integrations/WebPageParser/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,7 @@ services:
     environment:
       DataJsonFile: /app/data/data.json
       Repository__Provider: LocalJson
+      CashFlow__DataJsonFile: /app/data/data-cashflow.json
+      CashFlow__Repository__Provider: LocalJson
     volumes:
       - ./data:/app/data


### PR DESCRIPTION
## Summary
- `docker compose build` was failing during `dotnet publish` with "project not found" for `Financial.CashFlow.Application`/`.Domain`/`.Infrastructure` — the Dockerfile's explicit `COPY` list was never updated when F02 introduced those three projects (several merged PRs back). Added them alongside the existing Investment/Shared project copies, for both the csproj-only restore layer and the full source copy.
- Separately found: `docker-compose.yml` never set `CashFlow__DataJsonFile`, so `LocalJsonStorage` silently defaulted to `/app/data.json` — its own default filename, inside the container's ephemeral filesystem rather than the `./data` mounted volume. Every CashFlow write (expenses, reserve movements, etc.) would have been lost on every container restart. Added `CashFlow__DataJsonFile: /app/data/data-cashflow.json` and `CashFlow__Repository__Provider: LocalJson`, mirroring the existing Investments env vars.

## Test plan
- [x] `docker compose build` completes successfully (previously failed at the `dotnet publish` step)
- [x] `docker compose up`, confirmed `/api/v1/financial/reserve/balances` and other CashFlow endpoints respond
- [x] Created an expense via the CashFlow API, confirmed `./data/data-cashflow.json` was written on the host
- [x] `docker compose restart`, confirmed the created expense was still present — proving the data now survives a restart (the actual bug this fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)