### PR TITLE
feat(P11-F14): Web — Mensais View

### DIFF
--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -7,9 +7,11 @@ import type {
   AssetPriceDto,
   IncomeSplitRequestDto,
   IncomeSplitResultDto,
+  RecurringBillInstanceDto,
   ReserveBucketBalanceDto,
   ReserveMovementDto,
   TreeNodeDto,
+  UpdateRecurringBillInstanceDto,
   WithdrawalRequestDto,
   XirrResultDto,
 } from './types'
@@ -389,6 +391,60 @@ describe('financialApiClient', () => {
     const [url, init] = fetchMock.mock.calls[0]
     expect(url).toBe(`${API_BASE_URL}/reserve/withdrawals`)
     expect(init?.method).toBe('POST')
+    expect(JSON.parse(init?.body as string)).toEqual(requestBody)
+  })
+
+  it('calls the mensais instances endpoint for a given year/month', async () => {
+    const responseBody: RecurringBillInstanceDto[] = [
+      {
+        id: 'i1',
+        templateId: 't1',
+        year: 2026,
+        month: 7,
+        dueDay: 10,
+        description: 'INSS',
+        area: 'Brasil',
+        note: '',
+        nitNumber: null,
+        minimumWageValue: null,
+        value: 850,
+        status: 'Unset',
+      },
+    ]
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.getMensaisInstances(2026, 7)
+
+    expect(result).toEqual(responseBody)
+    expect(fetchMock.mock.calls[0][0]).toBe(`${API_BASE_URL}/mensais/2026/7`)
+  })
+
+  it('puts a mensais instance update', async () => {
+    const requestBody: UpdateRecurringBillInstanceDto = { status: 'Paid', value: 900 }
+    const responseBody: RecurringBillInstanceDto = {
+      id: 'i1',
+      templateId: 't1',
+      year: 2026,
+      month: 7,
+      dueDay: 10,
+      description: 'INSS',
+      area: 'Brasil',
+      note: '',
+      nitNumber: null,
+      minimumWageValue: null,
+      value: 900,
+      status: 'Paid',
+    }
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.updateMensaisInstance('i1', requestBody)
+
+    expect(result).toEqual(responseBody)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/mensais/instances/i1`)
+    expect(init?.method).toBe('PUT')
     expect(JSON.parse(init?.body as string)).toEqual(requestBody)
   })
 })

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -19,6 +19,7 @@ import type {
   PortfolioAssetSummaryItemDto,
   PortfolioBreakdownItemDto,
   PortfolioReferenceDto,
+  RecurringBillInstanceDto,
   ReserveBucketBalanceDto,
   ReserveMovementDto,
   TransactionCreateDto,
@@ -26,6 +27,7 @@ import type {
   TransactionSummaryItemDto,
   TransactionUpdateDto,
   TreeNodeDto,
+  UpdateRecurringBillInstanceDto,
   WatchlistItemDto,
   WithdrawalRequestDto,
   XirrResultDto,
@@ -65,6 +67,8 @@ export interface FinancialApiClient {
   getReserveMovements: () => Promise<ReserveMovementDto[]>
   postIncomeSplit: (request: IncomeSplitRequestDto) => Promise<IncomeSplitResultDto>
   postWithdrawal: (request: WithdrawalRequestDto) => Promise<ReserveMovementDto>
+  getMensaisInstances: (year: number, month: number) => Promise<RecurringBillInstanceDto[]>
+  updateMensaisInstance: (id: string, request: UpdateRecurringBillInstanceDto) => Promise<RecurringBillInstanceDto>
 }
 
 export interface FinancialApiClientOptions {
@@ -228,6 +232,13 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
     postWithdrawal: (requestBody) =>
       request<ReserveMovementDto>('/reserve/withdrawals', {
         method: 'POST',
+        body: JSON.stringify(requestBody),
+      }),
+    getMensaisInstances: (year, month) =>
+      request<RecurringBillInstanceDto[]>(`/mensais/${year}/${month}`),
+    updateMensaisInstance: (id, requestBody) =>
+      request<RecurringBillInstanceDto>(`/mensais/instances/${encodeURIComponent(id)}`, {
+        method: 'PUT',
         body: JSON.stringify(requestBody),
       }),
   }

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -299,3 +299,23 @@ export interface WithdrawalRequestDto {
   description: string
   confirmed: boolean
 }
+
+export interface RecurringBillInstanceDto {
+  id: string
+  templateId: string
+  year: number
+  month: number
+  dueDay: number
+  description: string
+  area: string
+  note: string
+  nitNumber: string | null
+  minimumWageValue: number | null
+  value: number
+  status: string
+}
+
+export interface UpdateRecurringBillInstanceDto {
+  status: string
+  value: number
+}

--- a/Financial.Web/src/hooks/useMensais.test.ts
+++ b/Financial.Web/src/hooks/useMensais.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FinancialApiClient } from '../api/financialApiClient'
+import type { RecurringBillInstanceDto } from '../api/types'
+import { useMensais } from './useMensais'
+
+const NOW = new Date()
+const CURRENT_YEAR = NOW.getFullYear()
+const CURRENT_MONTH = NOW.getMonth() + 1
+const CURRENT_MONTH_INPUT = `${CURRENT_YEAR}-${String(CURRENT_MONTH).padStart(2, '0')}`
+const NEXT_MONTH = CURRENT_MONTH === 12 ? 1 : CURRENT_MONTH + 1
+const NEXT_MONTH_YEAR = CURRENT_MONTH === 12 ? CURRENT_YEAR + 1 : CURRENT_YEAR
+const NEXT_MONTH_INPUT = `${NEXT_MONTH_YEAR}-${String(NEXT_MONTH).padStart(2, '0')}`
+
+const getMensaisInstancesMock = vi.fn<FinancialApiClient['getMensaisInstances']>()
+const updateMensaisInstanceMock = vi.fn<FinancialApiClient['updateMensaisInstance']>()
+
+vi.mock('../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getMensaisInstances: getMensaisInstancesMock,
+    updateMensaisInstance: updateMensaisInstanceMock,
+  }),
+}))
+
+const INSTANCES: RecurringBillInstanceDto[] = [
+  {
+    id: 'i1',
+    templateId: 't1',
+    year: CURRENT_YEAR,
+    month: CURRENT_MONTH,
+    dueDay: 10,
+    description: 'INSS',
+    area: 'Brasil',
+    note: '',
+    nitNumber: null,
+    minimumWageValue: null,
+    value: 850,
+    status: 'Unset',
+  },
+  {
+    id: 'i2',
+    templateId: 't2',
+    year: CURRENT_YEAR,
+    month: CURRENT_MONTH,
+    dueDay: 15,
+    description: 'Council Tax',
+    area: 'UK',
+    note: '',
+    nitNumber: null,
+    minimumWageValue: null,
+    value: 120,
+    status: 'Unset',
+  },
+]
+
+describe('useMensais', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getMensaisInstancesMock.mockResolvedValue(INSTANCES)
+  })
+
+  it('fetches instances for the current month on mount', async () => {
+    const { result } = renderHook(() => useMensais())
+
+    expect(result.current.isLoading).toBe(true)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(getMensaisInstancesMock).toHaveBeenCalledWith(CURRENT_YEAR, CURRENT_MONTH)
+    expect(result.current.monthInputValue).toBe(CURRENT_MONTH_INPUT)
+  })
+
+  it('groups instances into brasil and uk sections', async () => {
+    const { result } = renderHook(() => useMensais())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.brasilInstances).toHaveLength(1)
+    expect(result.current.brasilInstances[0].description).toBe('INSS')
+    expect(result.current.ukInstances).toHaveLength(1)
+    expect(result.current.ukInstances[0].description).toBe('Council Tax')
+  })
+
+  it('re-fetches for a new month when the month input changes', async () => {
+    const { result } = renderHook(() => useMensais())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setMonthInputValue(NEXT_MONTH_INPUT))
+
+    await waitFor(() => expect(getMensaisInstancesMock).toHaveBeenCalledWith(NEXT_MONTH_YEAR, NEXT_MONTH))
+  })
+
+  it('surfaces a fetch error', async () => {
+    getMensaisInstancesMock.mockRejectedValue(new Error('Network down'))
+    const { result } = renderHook(() => useMensais())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.error).toBe('Network down')
+  })
+
+  it('saves an edit and re-fetches the current month', async () => {
+    updateMensaisInstanceMock.mockResolvedValue({ ...INSTANCES[0], status: 'Paid', value: 900 })
+    const { result } = renderHook(() => useMensais())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditForm(INSTANCES[0]))
+    act(() => result.current.setEditField('editStatus', 'Paid'))
+    act(() => result.current.setEditField('editValue', '900'))
+    act(() => result.current.saveEdit())
+
+    await waitFor(() => expect(updateMensaisInstanceMock).toHaveBeenCalledWith('i1', { status: 'Paid', value: 900 }))
+    await waitFor(() => expect(getMensaisInstancesMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('surfaces a save error without crashing', async () => {
+    updateMensaisInstanceMock.mockRejectedValue(new Error('Status is not recognized.'))
+    const { result } = renderHook(() => useMensais())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditForm(INSTANCES[0]))
+    act(() => result.current.setEditField('editValue', '900'))
+    act(() => result.current.saveEdit())
+
+    await waitFor(() => expect(result.current.saveError).toBe('Status is not recognized.'))
+  })
+})

--- a/Financial.Web/src/hooks/useMensais.ts
+++ b/Financial.Web/src/hooks/useMensais.ts
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react'
+import { createFinancialApiClient } from '../api/financialApiClient'
+import type { RecurringBillInstanceDto } from '../api/types'
+import { pad } from '../utils/formatters'
+
+function currentYearMonth(): { year: number; month: number } {
+  const now = new Date()
+  return { year: now.getFullYear(), month: now.getMonth() + 1 }
+}
+
+export type EditField = 'editStatus' | 'editValue'
+
+interface MensaisState {
+  year: number
+  month: number
+  instances: RecurringBillInstanceDto[]
+  isLoading: boolean
+  error: string | null
+  retryCount: number
+  editingId: string | null
+  editStatus: string
+  editValue: string
+  isSaving: boolean
+  saveError: string | null
+}
+
+type MensaisAction =
+  | { type: 'SET_MONTH'; payload: { year: number; month: number } }
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; payload: RecurringBillInstanceDto[] }
+  | { type: 'FETCH_ERROR'; payload: string }
+  | { type: 'RETRY' }
+  | { type: 'SHOW_EDIT_FORM'; payload: RecurringBillInstanceDto }
+  | { type: 'CANCEL_EDIT' }
+  | { type: 'SET_EDIT_FIELD'; payload: { field: EditField; value: string } }
+  | { type: 'SAVE_START' }
+  | { type: 'SAVE_SUCCESS' }
+  | { type: 'SAVE_ERROR'; payload: string }
+
+const { year: DEFAULT_YEAR, month: DEFAULT_MONTH } = currentYearMonth()
+
+const INITIAL_STATE: MensaisState = {
+  year: DEFAULT_YEAR,
+  month: DEFAULT_MONTH,
+  instances: [],
+  isLoading: true,
+  error: null,
+  retryCount: 0,
+  editingId: null,
+  editStatus: '',
+  editValue: '',
+  isSaving: false,
+  saveError: null,
+}
+
+function reducer(state: MensaisState, action: MensaisAction): MensaisState {
+  switch (action.type) {
+    case 'SET_MONTH':
+      return { ...state, year: action.payload.year, month: action.payload.month }
+    case 'FETCH_START':
+      return { ...state, isLoading: true, error: null }
+    case 'FETCH_SUCCESS':
+      return { ...state, isLoading: false, instances: action.payload }
+    case 'FETCH_ERROR':
+      return { ...state, isLoading: false, error: action.payload }
+    case 'RETRY':
+      return { ...state, retryCount: state.retryCount + 1 }
+    case 'SHOW_EDIT_FORM':
+      return {
+        ...state,
+        editingId: action.payload.id,
+        editStatus: action.payload.status,
+        editValue: String(action.payload.value),
+        saveError: null,
+      }
+    case 'CANCEL_EDIT':
+      return { ...state, editingId: null, editStatus: '', editValue: '', saveError: null }
+    case 'SET_EDIT_FIELD':
+      return { ...state, [action.payload.field]: action.payload.value }
+    case 'SAVE_START':
+      return { ...state, isSaving: true, saveError: null }
+    case 'SAVE_SUCCESS':
+      return { ...state, isSaving: false, editingId: null, editStatus: '', editValue: '' }
+    case 'SAVE_ERROR':
+      return { ...state, isSaving: false, saveError: action.payload }
+    default:
+      return state
+  }
+}
+
+export interface MensaisData {
+  year: number
+  month: number
+  monthInputValue: string
+  setMonthInputValue: (value: string) => void
+  brasilInstances: RecurringBillInstanceDto[]
+  ukInstances: RecurringBillInstanceDto[]
+  isLoading: boolean
+  error: string | null
+  retry: () => void
+  editingId: string | null
+  editStatus: string
+  editValue: string
+  isSaving: boolean
+  saveError: string | null
+  setEditField: (field: EditField, value: string) => void
+  showEditForm: (instance: RecurringBillInstanceDto) => void
+  cancelEdit: () => void
+  saveEdit: () => void
+}
+
+export function useMensais(): MensaisData {
+  const apiClient = useMemo(() => createFinancialApiClient(), [])
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  useEffect(() => {
+    dispatch({ type: 'FETCH_START' })
+    void apiClient
+      .getMensaisInstances(state.year, state.month)
+      .then((instances) => dispatch({ type: 'FETCH_SUCCESS', payload: instances }))
+      .catch((err: unknown) => {
+        dispatch({ type: 'FETCH_ERROR', payload: err instanceof Error ? err.message : 'Unable to load Mensais data' })
+      })
+  }, [apiClient, state.year, state.month, state.retryCount])
+
+  const monthInputValue = `${state.year}-${pad(state.month)}`
+
+  const setMonthInputValue = useCallback((value: string) => {
+    const [yearStr, monthStr] = value.split('-')
+    const year = Number(yearStr)
+    const month = Number(monthStr)
+    if (!Number.isFinite(year) || !Number.isFinite(month)) return
+    dispatch({ type: 'SET_MONTH', payload: { year, month } })
+  }, [])
+
+  const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
+
+  const setEditField = useCallback(
+    (field: EditField, value: string) => dispatch({ type: 'SET_EDIT_FIELD', payload: { field, value } }),
+    [],
+  )
+
+  const showEditForm = useCallback(
+    (instance: RecurringBillInstanceDto) => dispatch({ type: 'SHOW_EDIT_FORM', payload: instance }),
+    [],
+  )
+
+  const cancelEdit = useCallback(() => dispatch({ type: 'CANCEL_EDIT' }), [])
+
+  function saveEdit() {
+    if (!state.editingId) return
+
+    const value = Number(state.editValue)
+    if (!state.editValue.trim() || !isFinite(value)) {
+      dispatch({ type: 'SAVE_ERROR', payload: 'Value must be a number' })
+      return
+    }
+
+    dispatch({ type: 'SAVE_START' })
+
+    void apiClient
+      .updateMensaisInstance(state.editingId, { status: state.editStatus, value })
+      .then(() => {
+        dispatch({ type: 'SAVE_SUCCESS' })
+        dispatch({ type: 'RETRY' })
+      })
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'SAVE_ERROR',
+          payload: err instanceof Error ? err.message : 'Failed to update instance',
+        })
+      })
+  }
+
+  const brasilInstances = useMemo(
+    () => state.instances.filter((i) => i.area === 'Brasil'),
+    [state.instances],
+  )
+  const ukInstances = useMemo(() => state.instances.filter((i) => i.area === 'UK'), [state.instances])
+
+  return {
+    year: state.year,
+    month: state.month,
+    monthInputValue,
+    setMonthInputValue,
+    brasilInstances,
+    ukInstances,
+    isLoading: state.isLoading,
+    error: state.error,
+    retry,
+    editingId: state.editingId,
+    editStatus: state.editStatus,
+    editValue: state.editValue,
+    isSaving: state.isSaving,
+    saveError: state.saveError,
+    setEditField,
+    showEditForm,
+    cancelEdit,
+    saveEdit,
+  }
+}

--- a/Financial.Web/src/main.tsx
+++ b/Financial.Web/src/main.tsx
@@ -11,6 +11,7 @@ import HistoricInvestmentsPage from './pages/HistoricInvestmentsPage'
 import DividendCheckPage from './pages/DividendCheckPage'
 import CurrentValuesPage from './pages/CurrentValuesPage'
 import CashFlowPlaceholderPage from './pages/CashFlowPlaceholderPage'
+import MensaisPage from './pages/MensaisPage'
 import ReservaPage from './pages/ReservaPage'
 import RootRedirect from './pages/RootRedirect'
 
@@ -31,7 +32,7 @@ createRoot(document.getElementById('root')!).render(
             <Route index element={<Navigate to="/cashflow/monthly" replace />} />
             <Route path="monthly" element={<CashFlowPlaceholderPage title="Monthly" />} />
             <Route path="reserva" element={<ReservaPage />} />
-            <Route path="mensais" element={<CashFlowPlaceholderPage title="Mensais" />} />
+            <Route path="mensais" element={<MensaisPage />} />
             <Route path="controle-mae" element={<CashFlowPlaceholderPage title="Controle Mae" />} />
             <Route
               path="investment-snapshots"

--- a/Financial.Web/src/pages/MensaisPage.css
+++ b/Financial.Web/src/pages/MensaisPage.css
@@ -1,0 +1,27 @@
+.mensais-page {
+  padding: 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.mensais-page__month-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mensais-page__section h2 {
+  color: var(--text-h);
+  margin-bottom: 12px;
+}
+
+.mensais-page__table {
+  width: 100%;
+  max-width: 720px;
+}
+
+.mensais-page__error {
+  color: var(--error, #c0392b);
+}

--- a/Financial.Web/src/pages/MensaisPage.tsx
+++ b/Financial.Web/src/pages/MensaisPage.tsx
@@ -1,0 +1,208 @@
+import type { RecurringBillInstanceDto } from '../api/types'
+import ErrorState from '../components/ErrorState'
+import LoadingState from '../components/LoadingState'
+import { useMensais } from '../hooks/useMensais'
+import { formatN2 } from '../utils/formatters'
+import './MensaisPage.css'
+
+const STATUSES = ['Unset', 'Scheduled', 'Paid']
+
+interface InstanceRowProps {
+  instance: RecurringBillInstanceDto
+  isEditing: boolean
+  editStatus: string
+  editValue: string
+  isSaving: boolean
+  onEdit: (instance: RecurringBillInstanceDto) => void
+  onFieldChange: (field: 'editStatus' | 'editValue', value: string) => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+function InstanceRow({
+  instance,
+  isEditing,
+  editStatus,
+  editValue,
+  isSaving,
+  onEdit,
+  onFieldChange,
+  onSave,
+  onCancel,
+}: InstanceRowProps) {
+  if (isEditing) {
+    return (
+      <tr>
+        <td>{instance.dueDay}</td>
+        <td>{instance.description}</td>
+        <td className="data-table__col--numeric">
+          <input
+            type="number"
+            step="0.01"
+            value={editValue}
+            onChange={(e) => onFieldChange('editValue', e.target.value)}
+          />
+        </td>
+        <td>
+          <select value={editStatus} onChange={(e) => onFieldChange('editStatus', e.target.value)}>
+            {STATUSES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </td>
+        <td>
+          <button type="button" disabled={isSaving} onClick={onSave}>
+            {isSaving ? 'Saving...' : 'Save'}
+          </button>
+          <button type="button" onClick={onCancel}>
+            Cancel
+          </button>
+        </td>
+      </tr>
+    )
+  }
+
+  return (
+    <tr>
+      <td>{instance.dueDay}</td>
+      <td>{instance.description}</td>
+      <td className="data-table__col--numeric">{formatN2(instance.value)}</td>
+      <td>{instance.status}</td>
+      <td>
+        <button type="button" onClick={() => onEdit(instance)}>
+          Edit
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+interface InstanceTableProps {
+  title: string
+  instances: RecurringBillInstanceDto[]
+  editingId: string | null
+  editStatus: string
+  editValue: string
+  isSaving: boolean
+  onEdit: (instance: RecurringBillInstanceDto) => void
+  onFieldChange: (field: 'editStatus' | 'editValue', value: string) => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+function InstanceTable({
+  title,
+  instances,
+  editingId,
+  editStatus,
+  editValue,
+  isSaving,
+  onEdit,
+  onFieldChange,
+  onSave,
+  onCancel,
+}: InstanceTableProps) {
+  return (
+    <section className="mensais-page__section">
+      <h2>{title}</h2>
+      <table className="mensais-page__table data-table">
+        <thead>
+          <tr>
+            <th>Due Day</th>
+            <th>Description</th>
+            <th className="data-table__col--numeric">Value</th>
+            <th>Status</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {instances.map((instance) => (
+            <InstanceRow
+              key={instance.id}
+              instance={instance}
+              isEditing={editingId === instance.id}
+              editStatus={editStatus}
+              editValue={editValue}
+              isSaving={isSaving}
+              onEdit={onEdit}
+              onFieldChange={onFieldChange}
+              onSave={onSave}
+              onCancel={onCancel}
+            />
+          ))}
+        </tbody>
+      </table>
+    </section>
+  )
+}
+
+export default function MensaisPage() {
+  const {
+    monthInputValue,
+    setMonthInputValue,
+    brasilInstances,
+    ukInstances,
+    isLoading,
+    error,
+    retry,
+    editingId,
+    editStatus,
+    editValue,
+    isSaving,
+    saveError,
+    setEditField,
+    showEditForm,
+    cancelEdit,
+    saveEdit,
+  } = useMensais()
+
+  return (
+    <div className="mensais-page">
+      <div className="mensais-page__month-picker">
+        <label htmlFor="mensais-month">Month</label>
+        <input
+          id="mensais-month"
+          type="month"
+          value={monthInputValue}
+          onChange={(e) => setMonthInputValue(e.target.value)}
+        />
+      </div>
+
+      {isLoading ? (
+        <LoadingState />
+      ) : error ? (
+        <ErrorState message={error} onRetry={retry} />
+      ) : (
+        <>
+          <InstanceTable
+            title="Brasil"
+            instances={brasilInstances}
+            editingId={editingId}
+            editStatus={editStatus}
+            editValue={editValue}
+            isSaving={isSaving}
+            onEdit={showEditForm}
+            onFieldChange={setEditField}
+            onSave={saveEdit}
+            onCancel={cancelEdit}
+          />
+          <InstanceTable
+            title="UK"
+            instances={ukInstances}
+            editingId={editingId}
+            editStatus={editStatus}
+            editValue={editValue}
+            isSaving={isSaving}
+            onEdit={showEditForm}
+            onFieldChange={setEditField}
+            onSave={saveEdit}
+            onCancel={cancelEdit}
+          />
+          {saveError && <p className="mensais-page__error">{saveError}</p>}
+        </>
+      )}
+    </div>
+  )
+}

--- a/Financial.Web/src/pages/__tests__/MensaisPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MensaisPage.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import MensaisPage from '../MensaisPage'
+import type { FinancialApiClient } from '../../api/financialApiClient'
+import type { RecurringBillInstanceDto } from '../../api/types'
+
+const getMensaisInstancesMock = vi.fn<FinancialApiClient['getMensaisInstances']>()
+const updateMensaisInstanceMock = vi.fn<FinancialApiClient['updateMensaisInstance']>()
+
+vi.mock('../../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getMensaisInstances: getMensaisInstancesMock,
+    updateMensaisInstance: updateMensaisInstanceMock,
+  }),
+}))
+
+const NOW = new Date()
+
+const INSTANCES: RecurringBillInstanceDto[] = [
+  {
+    id: 'i1',
+    templateId: 't1',
+    year: NOW.getFullYear(),
+    month: NOW.getMonth() + 1,
+    dueDay: 10,
+    description: 'INSS',
+    area: 'Brasil',
+    note: '',
+    nitNumber: null,
+    minimumWageValue: null,
+    value: 850,
+    status: 'Unset',
+  },
+  {
+    id: 'i2',
+    templateId: 't2',
+    year: NOW.getFullYear(),
+    month: NOW.getMonth() + 1,
+    dueDay: 15,
+    description: 'Council Tax',
+    area: 'UK',
+    note: '',
+    nitNumber: null,
+    minimumWageValue: null,
+    value: 120,
+    status: 'Unset',
+  },
+]
+
+describe('MensaisPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getMensaisInstancesMock.mockResolvedValue(INSTANCES)
+  })
+
+  it('shows a loading state before data arrives', () => {
+    render(<MensaisPage />)
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('shows an error state with retry when the fetch fails', async () => {
+    getMensaisInstancesMock.mockRejectedValue(new Error('Network down'))
+
+    render(<MensaisPage />)
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByText('Network down')).toBeInTheDocument()
+  })
+
+  it('renders Brasil and UK as two separate grouped sections', async () => {
+    render(<MensaisPage />)
+
+    await waitFor(() => expect(screen.getByText('Brasil')).toBeInTheDocument())
+    expect(screen.getByText('UK')).toBeInTheDocument()
+    expect(screen.getByText('INSS')).toBeInTheDocument()
+    expect(screen.getByText('Council Tax')).toBeInTheDocument()
+  })
+
+  it('edits a row status/value and saves, updating the displayed row', async () => {
+    updateMensaisInstanceMock.mockResolvedValue({ ...INSTANCES[0], status: 'Paid', value: 900 })
+    render(<MensaisPage />)
+
+    await waitFor(() => expect(screen.getByText('INSS')).toBeInTheDocument())
+
+    const editButtons = screen.getAllByRole('button', { name: 'Edit' })
+    fireEvent.click(editButtons[0])
+
+    const valueInput = screen.getByDisplayValue('850')
+    fireEvent.change(valueInput, { target: { value: '900' } })
+    const statusSelect = screen.getByRole('combobox')
+    fireEvent.change(statusSelect, { target: { value: 'Paid' } })
+
+    getMensaisInstancesMock.mockResolvedValue([{ ...INSTANCES[0], status: 'Paid', value: 900 }, INSTANCES[1]])
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(updateMensaisInstanceMock).toHaveBeenCalledWith('i1', { status: 'Paid', value: 900 }),
+    )
+    await waitFor(() => expect(screen.getByText('Paid')).toBeInTheDocument())
+  })
+})

--- a/docs/P11-F14-web-mensais-view/plan.md
+++ b/docs/P11-F14-web-mensais-view/plan.md
@@ -1,0 +1,28 @@
+# Implementation Plan: F14. Web — Mensais View
+
+**Prerequisites:**
+- F06's `/mensais/*` endpoints already exist and are unchanged by this feature
+- F13's `ApiError` and hook/page conventions already established
+- No new npm packages
+
+### Stage 1: API Client Layer
+
+**1. Mensais DTOs and client methods** - Add the recurring bill instance type and the update-request type, plus the two new `financialApiClient` methods that call F06's existing endpoints.
+
+**2. API client tests** - Add tests for the new methods' request shape.
+
+### Stage 2: Page Logic and UI
+
+**3. useMensais hook** - Add the hook that tracks the selected month (defaulting to the current month), fetches and groups instances into Brasil/UK on month change, manages the single-row inline-edit state, and re-fetches after a successful update.
+
+**4. MensaisPage component** - Add the presentational page: month picker, loading/error states, two grouped tables with inline per-row status/value editing, wired to `useMensais`.
+
+**5. Wire up routing** - Replace the `/cashflow/mensais` placeholder route in `main.tsx` with `MensaisPage`.
+
+**6. Hook and component tests** - Add tests for `useMensais`'s fetch/group/edit behavior and for `MensaisPage`'s rendering of both grouped sections and the edit flow.
+
+### Stage 3: Verification
+
+**7. Full-suite validation** - Run the Web project's full test suite and typecheck, confirming no regression to any existing test.
+
+**8. Manual verification** - Run the Web dev server against a locally running `Financial.Api`, navigate to `/cashflow/mensais`, and exercise the view directly (confirm Brasil/UK sections render for the current month, change the month and confirm a fresh set of instances loads, edit an instance's status/value and confirm it updates without affecting other months) to confirm the behavior matches the acceptance criteria end-to-end.

--- a/docs/P11-F14-web-mensais-view/spec.md
+++ b/docs/P11-F14-web-mensais-view/spec.md
@@ -1,0 +1,74 @@
+# F14. Web — Mensais View
+
+## 1. Technical Overview
+
+**What:** Replace F11's `/cashflow/mensais` placeholder with a real page that lets the user pick a month, shows that month's auto-generated recurring bill instances (F06) split into two grouped sections (Brasil/UK), and lets the user update a single instance's status or value inline.
+
+**Why:** This turns F06's backend-only Mensais generation into the actual monthly workflow the user needs — see this month's bills as scheduled/paid, update them as bills clear.
+
+**Scope:**
+- Included: month picker (defaults to the current month); two grouped tables (Brasil/UK) built by client-side grouping of F06's flat instance list, matching F06's own spec decision that grouping is a Web-layer concern; inline per-row status/value editing.
+- Excluded: template creation/management (no UI anywhere in the PRD for this — F06's template creation exists only to unblock testing ahead of F10); any other CashFlow view (F13/F15/F16).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/api/types.ts` — new: `RecurringBillInstanceDto`, `UpdateRecurringBillInstanceDto`
+- `Financial.Web/src/api/financialApiClient.ts` — modified: new methods `getMensaisInstances(year, month)`, `updateMensaisInstance(id, request)`
+- `Financial.Web/src/hooks/useMensais.ts` — new: page business logic
+- `Financial.Web/src/pages/MensaisPage.tsx`, `MensaisPage.css` — new: replaces `CashFlowPlaceholderPage` on `/cashflow/mensais`
+- `Financial.Web/src/main.tsx` — modified: route swap
+
+```mermaid
+graph TD
+  A[MensaisPage] --> B[useMensais hook]
+  B --> C["financialApiClient (getMensaisInstances/updateMensaisInstance)"]
+  C --> D["/api/v1/financial/mensais/*"]
+  B -.->|"group by area client-side"| E["Brasil section / UK section"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Month selection | A native `<input type="month">` bound to hook state, defaulting to the current calendar month on first load | A custom month-picker component | F13 introduced no month concept (Reserva has no per-month data); this is the first CashFlow view needing one. The native control needs no new dependency and matches this app's "no over-engineering" standard for a personal single-user tool. |
+| Grouping | `useMensais` groups the flat `RecurringBillInstanceDto[]` returned by `GET .../mensais/{year}/{month}` into Brasil/UK client-side | Ask the backend to return pre-grouped data | Matches F06's own spec decision exactly: "grouping into Brasil/UK sections is a client-side concern for F14." No backend change needed. |
+| Inline edit pattern | A single `editingId` (one row editable at a time), with per-row Edit/Save/Cancel — same shape as `useCredits`' existing inline-form pattern | Every row independently editable simultaneously | Matches the one established inline-edit precedent in this codebase (`CreditsTab`/`useCredits`) rather than inventing a new multi-row-editable-at-once pattern for a personal app with a handful of bills per month. |
+| Refresh strategy after a successful update | Re-fetch the month's instances after a successful update | Locally patch the edited row in state | Matches F13's precedent (re-fetch keeps displayed state provably in sync with the server) and this list is small (a handful of bills per month), so the extra round trip is negligible. |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/api/types.ts` | Modified | DTO types | `RecurringBillInstanceDto { id, templateId, year, month, dueDay, description, area, note, nitNumber, minimumWageValue, value, status }`, `UpdateRecurringBillInstanceDto { status, value }` |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | HTTP client | `getMensaisInstances(year, month)`, `updateMensaisInstance(id, request)` |
+| `Financial.Web/src/hooks/useMensais.ts` | New | Page business logic | Month/year state (defaults to current month); fetches instances on month change; groups into Brasil/UK; per-row edit state (`editingId`, `editStatus`, `editValue`); submit/re-fetch; loading/error state matching `useReserva`'s reducer pattern |
+| `Financial.Web/src/pages/MensaisPage.tsx`, `MensaisPage.css` | New | Presentational page | Month picker, `LoadingState`/`ErrorState`, two grouped tables (Brasil/UK) each showing due day/description/value/status, inline edit controls per row |
+| `Financial.Web/src/main.tsx` | Modified | Routing | `/cashflow/mensais` renders `MensaisPage` instead of `CashFlowPlaceholderPage` |
+
+## 5. API Contracts
+
+Consumes F06's existing endpoints unchanged (see F06's own spec for full detail):
+
+- `GET /api/v1/financial/mensais/{year}/{month}` → `RecurringBillInstanceDto[]` (generates on first call for that month)
+- `PUT /api/v1/financial/mensais/instances/{id}` (body: `UpdateRecurringBillInstanceDto`) → `RecurringBillInstanceDto`; `400` on an unrecognized status, `404` on an unknown id
+
+No new backend endpoints — this feature is Web-only.
+
+## 6. Data Model
+
+No backend/persisted data model changes — this is a Web-only feature consuming F06's existing `data-cashflow.json`-backed endpoints.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Financial.Web/src/api/financialApiClient.test.ts` | Unit | `financialApiClient` | New Mensais methods call the correct paths/methods/bodies |
+| `Financial.Web/src/hooks/useMensais.test.ts` | Unit | `useMensais` | Fetches instances for the default (current) month on mount; changing the month re-fetches for the new year/month; groups instances into Brasil/UK correctly; submitting an edit calls the update endpoint and re-fetches on success; a backend error is surfaced without crashing |
+| `Financial.Web/src/pages/MensaisPage.test.tsx` | Component | `MensaisPage` | Renders `LoadingState`/`ErrorState`; renders Brasil and UK as two separate sections once loaded; editing a row's status/value and saving updates the displayed row |
+
+**Acceptance tests (from PRD Section 9, F14):**
+- The view shows Brasil and UK bills as two separate grouped sections for the selected month — `MensaisPage.test.tsx`
+- A bill instance's status or value can be updated from this view without affecting other months — `useMensais.test.ts` (re-fetch-after-update assertion scoped to the selected month only), `MensaisPage.test.tsx`

--- a/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
+++ b/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
@@ -619,8 +619,8 @@ graph TD
 - [x] Entering a month's income fields immediately reflects the resulting split in each bucket's displayed balance
 
 ### F14. Web — Mensais View
-- [ ] The view shows Brasil and UK bills as two separate grouped sections for the selected month
-- [ ] A bill instance's status or value can be updated from this view without affecting other months
+- [x] The view shows Brasil and UK bills as two separate grouped sections for the selected month
+- [x] A bill instance's status or value can be updated from this view without affecting other months
 
 ### F15. Web — Controle Mae View
 - [ ] The view shows both BRL and GBP values for every ledger entry


### PR DESCRIPTION
## Summary
- Replaces F11's `/cashflow/mensais` placeholder with a real page: a month picker (native `<input type="month">`, defaults to the current month), two grouped tables (Brasil/UK) built by client-side grouping of F06's flat instance list, and inline per-row status/value editing.
- New `getMensaisInstances(year, month)` / `updateMensaisInstance(id, request)` methods on the shared `financialApiClient`, consuming F06's existing endpoints unchanged.

## Technical decisions (see docs/P11-F14-web-mensais-view/spec.md)
- Grouping into Brasil/UK happens client-side, matching F06's own spec decision that this is a Web-layer concern — no backend change needed.
- A native `<input type="month">` for month selection — no new dependency, first CashFlow view needing a month concept (Reserva/F13 had none).
- Single `editingId` inline-edit pattern (one row editable at a time), reusing the same shape as `useCredits`' existing inline-form precedent rather than inventing simultaneous multi-row editing.
- Re-fetches the month's instances after a successful update, matching F13's precedent of trusting the server's state over local patching.

## Test plan
- [x] `financialApiClient.test.ts` — new Mensais methods call the correct paths/bodies
- [x] `useMensais.test.ts` — fetch-on-mount for the current month, Brasil/UK grouping, re-fetch on month change, backend error surfaced, edit-and-save + re-fetch, save error surfaced without crashing
- [x] `MensaisPage.test.tsx` — loading/error states, both grouped sections render, edit-a-row-and-save updates the displayed row
- [x] Full Web test suite green (443 tests, no regressions), typecheck and lint clean
- [x] Manual smoke test with a real running `Financial.Api` + Vite dev server via a scripted Playwright session: loaded `/cashflow/mensais`, confirmed both Brasil and UK sections render with rows, changed the month and confirmed a fresh set of instances loads, edited a row's value/status and confirmed it saved and displayed correctly, no console errors

## PRD
Acceptance criteria for F14 checked off in `docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md`. The cross-feature checkbox covering F13/F14/F15/F16 together stays unchecked until F15 and F16 also land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)