### PR TITLE
feat(P11-F15): Web — Controle Mae View

### DIFF
--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -5,12 +5,15 @@ import { createFinancialApiClient } from './financialApiClient'
 import type {
   AssetDetailsDto,
   AssetPriceDto,
+  CreateMaeLedgerEntryDto,
   IncomeSplitRequestDto,
   IncomeSplitResultDto,
+  MaeLedgerEntryDto,
   RecurringBillInstanceDto,
   ReserveBucketBalanceDto,
   ReserveMovementDto,
   TreeNodeDto,
+  UpdateMaeLedgerEntryValuesDto,
   UpdateRecurringBillInstanceDto,
   WithdrawalRequestDto,
   XirrResultDto,
@@ -444,6 +447,79 @@ describe('financialApiClient', () => {
     expect(result).toEqual(responseBody)
     const [url, init] = fetchMock.mock.calls[0]
     expect(url).toBe(`${API_BASE_URL}/mensais/instances/i1`)
+    expect(init?.method).toBe('PUT')
+    expect(JSON.parse(init?.body as string)).toEqual(requestBody)
+  })
+
+  it('posts a mae ledger entry create request', async () => {
+    const requestBody: CreateMaeLedgerEntryDto = {
+      date: '2026-07-01',
+      description: 'School supplies',
+      note: 'Term start',
+      sourceCurrency: 'BRL',
+      sourceValue: 350,
+    }
+    const responseBody: MaeLedgerEntryDto = {
+      id: 'e1',
+      date: '2026-07-01',
+      description: 'School supplies',
+      note: 'Term start',
+      sourceCurrency: 'BRL',
+      brlValue: 350,
+      gbpValue: 51.1,
+    }
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.createMaeLedgerEntry(requestBody)
+
+    expect(result).toEqual(responseBody)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/controle-mae/entries`)
+    expect(init?.method).toBe('POST')
+    expect(JSON.parse(init?.body as string)).toEqual(requestBody)
+  })
+
+  it('calls the mae ledger entries-by-month endpoint', async () => {
+    const responseBody: MaeLedgerEntryDto[] = [
+      {
+        id: 'e1',
+        date: '2026-07-01',
+        description: 'School supplies',
+        note: '',
+        sourceCurrency: 'BRL',
+        brlValue: 350,
+        gbpValue: 51.1,
+      },
+    ]
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.getMaeLedgerEntriesByMonth(2026, 7)
+
+    expect(result).toEqual(responseBody)
+    expect(fetchMock.mock.calls[0][0]).toBe(`${API_BASE_URL}/controle-mae/entries/month/2026/7`)
+  })
+
+  it('puts a mae ledger entry values update', async () => {
+    const requestBody: UpdateMaeLedgerEntryValuesDto = { brlValue: 355, gbpValue: 51.6 }
+    const responseBody: MaeLedgerEntryDto = {
+      id: 'e1',
+      date: '2026-07-01',
+      description: 'School supplies',
+      note: '',
+      sourceCurrency: 'BRL',
+      brlValue: 355,
+      gbpValue: 51.6,
+    }
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.updateMaeLedgerEntryValues('e1', requestBody)
+
+    expect(result).toEqual(responseBody)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/controle-mae/entries/e1/values`)
     expect(init?.method).toBe('PUT')
     expect(JSON.parse(init?.body as string)).toEqual(requestBody)
   })

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -7,6 +7,7 @@ import type {
   AssetPriceDto,
   BrokerNodeDto,
   CalculateXirrRequestDto,
+  CreateMaeLedgerEntryDto,
   CreditCreateDto,
   CreditDeleteDto,
   CreditDto,
@@ -16,6 +17,7 @@ import type {
   IncomeSplitRequestDto,
   IncomeSplitResultDto,
   InvestmentScope,
+  MaeLedgerEntryDto,
   PortfolioAssetSummaryItemDto,
   PortfolioBreakdownItemDto,
   PortfolioReferenceDto,
@@ -27,6 +29,7 @@ import type {
   TransactionSummaryItemDto,
   TransactionUpdateDto,
   TreeNodeDto,
+  UpdateMaeLedgerEntryValuesDto,
   UpdateRecurringBillInstanceDto,
   WatchlistItemDto,
   WithdrawalRequestDto,
@@ -69,6 +72,9 @@ export interface FinancialApiClient {
   postWithdrawal: (request: WithdrawalRequestDto) => Promise<ReserveMovementDto>
   getMensaisInstances: (year: number, month: number) => Promise<RecurringBillInstanceDto[]>
   updateMensaisInstance: (id: string, request: UpdateRecurringBillInstanceDto) => Promise<RecurringBillInstanceDto>
+  createMaeLedgerEntry: (request: CreateMaeLedgerEntryDto) => Promise<MaeLedgerEntryDto>
+  getMaeLedgerEntriesByMonth: (year: number, month: number) => Promise<MaeLedgerEntryDto[]>
+  updateMaeLedgerEntryValues: (id: string, request: UpdateMaeLedgerEntryValuesDto) => Promise<MaeLedgerEntryDto>
 }
 
 export interface FinancialApiClientOptions {
@@ -238,6 +244,18 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       request<RecurringBillInstanceDto[]>(`/mensais/${year}/${month}`),
     updateMensaisInstance: (id, requestBody) =>
       request<RecurringBillInstanceDto>(`/mensais/instances/${encodeURIComponent(id)}`, {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+      }),
+    createMaeLedgerEntry: (requestBody) =>
+      request<MaeLedgerEntryDto>('/controle-mae/entries', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      }),
+    getMaeLedgerEntriesByMonth: (year, month) =>
+      request<MaeLedgerEntryDto[]>(`/controle-mae/entries/month/${year}/${month}`),
+    updateMaeLedgerEntryValues: (id, requestBody) =>
+      request<MaeLedgerEntryDto>(`/controle-mae/entries/${encodeURIComponent(id)}/values`, {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       }),

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -319,3 +319,26 @@ export interface UpdateRecurringBillInstanceDto {
   status: string
   value: number
 }
+
+export interface MaeLedgerEntryDto {
+  id: string
+  date: string
+  description: string
+  note: string
+  sourceCurrency: string
+  brlValue: number | null
+  gbpValue: number | null
+}
+
+export interface CreateMaeLedgerEntryDto {
+  date: string
+  description: string
+  note: string
+  sourceCurrency: string
+  sourceValue: number
+}
+
+export interface UpdateMaeLedgerEntryValuesDto {
+  brlValue: number | null
+  gbpValue: number | null
+}

--- a/Financial.Web/src/hooks/useControleMae.test.ts
+++ b/Financial.Web/src/hooks/useControleMae.test.ts
@@ -1,0 +1,120 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FinancialApiClient } from '../api/financialApiClient'
+import type { MaeLedgerEntryDto } from '../api/types'
+import { useControleMae } from './useControleMae'
+
+const NOW = new Date()
+const CURRENT_YEAR = NOW.getFullYear()
+const CURRENT_MONTH = NOW.getMonth() + 1
+const CURRENT_MONTH_INPUT = `${CURRENT_YEAR}-${String(CURRENT_MONTH).padStart(2, '0')}`
+const NEXT_MONTH = CURRENT_MONTH === 12 ? 1 : CURRENT_MONTH + 1
+const NEXT_MONTH_YEAR = CURRENT_MONTH === 12 ? CURRENT_YEAR + 1 : CURRENT_YEAR
+const NEXT_MONTH_INPUT = `${NEXT_MONTH_YEAR}-${String(NEXT_MONTH).padStart(2, '0')}`
+
+const getMaeLedgerEntriesByMonthMock = vi.fn<FinancialApiClient['getMaeLedgerEntriesByMonth']>()
+const createMaeLedgerEntryMock = vi.fn<FinancialApiClient['createMaeLedgerEntry']>()
+const updateMaeLedgerEntryValuesMock = vi.fn<FinancialApiClient['updateMaeLedgerEntryValues']>()
+
+vi.mock('../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getMaeLedgerEntriesByMonth: getMaeLedgerEntriesByMonthMock,
+    createMaeLedgerEntry: createMaeLedgerEntryMock,
+    updateMaeLedgerEntryValues: updateMaeLedgerEntryValuesMock,
+  }),
+}))
+
+const ENTRIES: MaeLedgerEntryDto[] = [
+  {
+    id: 'e1',
+    date: `${CURRENT_YEAR}-${String(CURRENT_MONTH).padStart(2, '0')}-15`,
+    description: 'School supplies',
+    note: 'Term start',
+    sourceCurrency: 'BRL',
+    brlValue: 350,
+    gbpValue: 51.1,
+  },
+]
+
+describe('useControleMae', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getMaeLedgerEntriesByMonthMock.mockResolvedValue(ENTRIES)
+  })
+
+  it('fetches entries for the current month on mount', async () => {
+    const { result } = renderHook(() => useControleMae())
+
+    expect(result.current.isLoading).toBe(true)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(getMaeLedgerEntriesByMonthMock).toHaveBeenCalledWith(CURRENT_YEAR, CURRENT_MONTH)
+    expect(result.current.monthInputValue).toBe(CURRENT_MONTH_INPUT)
+    expect(result.current.entries).toEqual(ENTRIES)
+  })
+
+  it('re-fetches for a new month when the month input changes', async () => {
+    const { result } = renderHook(() => useControleMae())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setMonthInputValue(NEXT_MONTH_INPUT))
+
+    await waitFor(() => expect(getMaeLedgerEntriesByMonthMock).toHaveBeenCalledWith(NEXT_MONTH_YEAR, NEXT_MONTH))
+  })
+
+  it('creates an entry and re-fetches on success', async () => {
+    createMaeLedgerEntryMock.mockResolvedValue({
+      id: 'e2',
+      date: `${CURRENT_YEAR}-07-16`,
+      description: 'Medical appointment',
+      note: '',
+      sourceCurrency: 'GBP',
+      brlValue: null,
+      gbpValue: 40,
+    })
+    const { result } = renderHook(() => useControleMae())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreateField('createDate', `${CURRENT_YEAR}-07-16`))
+    act(() => result.current.setCreateField('createDescription', 'Medical appointment'))
+    act(() => result.current.setCreateField('createSourceCurrency', 'GBP'))
+    act(() => result.current.setCreateField('createSourceValue', '40'))
+    act(() => result.current.submitCreate())
+
+    await waitFor(() =>
+      expect(createMaeLedgerEntryMock).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'Medical appointment', sourceCurrency: 'GBP', sourceValue: 40 }),
+      ),
+    )
+    await waitFor(() => expect(getMaeLedgerEntriesByMonthMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('surfaces a backend validation error on create failure without crashing', async () => {
+    createMaeLedgerEntryMock.mockRejectedValue(new Error('Date must not be in the future.'))
+    const { result } = renderHook(() => useControleMae())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreateField('createDate', '2099-01-01'))
+    act(() => result.current.setCreateField('createDescription', 'Future'))
+    act(() => result.current.setCreateField('createSourceValue', '10'))
+    act(() => result.current.submitCreate())
+
+    await waitFor(() => expect(result.current.createError).toBe('Date must not be in the future.'))
+  })
+
+  it('saves an edit and re-fetches on success', async () => {
+    updateMaeLedgerEntryValuesMock.mockResolvedValue({ ...ENTRIES[0], brlValue: 355, gbpValue: 51.6 })
+    const { result } = renderHook(() => useControleMae())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditForm(ENTRIES[0]))
+    act(() => result.current.setEditField('editBrlValue', '355'))
+    act(() => result.current.setEditField('editGbpValue', '51.6'))
+    act(() => result.current.saveEdit())
+
+    await waitFor(() =>
+      expect(updateMaeLedgerEntryValuesMock).toHaveBeenCalledWith('e1', { brlValue: 355, gbpValue: 51.6 }),
+    )
+    await waitFor(() => expect(getMaeLedgerEntriesByMonthMock).toHaveBeenCalledTimes(2))
+  })
+})

--- a/Financial.Web/src/hooks/useControleMae.ts
+++ b/Financial.Web/src/hooks/useControleMae.ts
@@ -1,0 +1,281 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react'
+import { createFinancialApiClient } from '../api/financialApiClient'
+import type { MaeLedgerEntryDto } from '../api/types'
+import { pad } from '../utils/formatters'
+
+function currentYearMonth(): { year: number; month: number } {
+  const now = new Date()
+  return { year: now.getFullYear(), month: now.getMonth() + 1 }
+}
+
+export type CreateFormField = 'createDate' | 'createDescription' | 'createNote' | 'createSourceCurrency' | 'createSourceValue'
+export type EditField = 'editBrlValue' | 'editGbpValue'
+
+interface ControleMaeState {
+  year: number
+  month: number
+  entries: MaeLedgerEntryDto[]
+  isLoading: boolean
+  error: string | null
+  retryCount: number
+  createDate: string
+  createDescription: string
+  createNote: string
+  createSourceCurrency: string
+  createSourceValue: string
+  isCreating: boolean
+  createError: string | null
+  editingId: string | null
+  editBrlValue: string
+  editGbpValue: string
+  isSaving: boolean
+  saveError: string | null
+}
+
+type ControleMaeAction =
+  | { type: 'SET_MONTH'; payload: { year: number; month: number } }
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; payload: MaeLedgerEntryDto[] }
+  | { type: 'FETCH_ERROR'; payload: string }
+  | { type: 'RETRY' }
+  | { type: 'SET_CREATE_FIELD'; payload: { field: CreateFormField; value: string } }
+  | { type: 'CREATE_START' }
+  | { type: 'CREATE_SUCCESS' }
+  | { type: 'CREATE_ERROR'; payload: string }
+  | { type: 'SHOW_EDIT_FORM'; payload: MaeLedgerEntryDto }
+  | { type: 'CANCEL_EDIT' }
+  | { type: 'SET_EDIT_FIELD'; payload: { field: EditField; value: string } }
+  | { type: 'SAVE_START' }
+  | { type: 'SAVE_SUCCESS' }
+  | { type: 'SAVE_ERROR'; payload: string }
+
+const { year: DEFAULT_YEAR, month: DEFAULT_MONTH } = currentYearMonth()
+
+const BLANK_CREATE_FORM = {
+  createDate: '',
+  createDescription: '',
+  createNote: '',
+  createSourceCurrency: 'BRL',
+  createSourceValue: '',
+} as const
+
+const INITIAL_STATE: ControleMaeState = {
+  year: DEFAULT_YEAR,
+  month: DEFAULT_MONTH,
+  entries: [],
+  isLoading: true,
+  error: null,
+  retryCount: 0,
+  ...BLANK_CREATE_FORM,
+  isCreating: false,
+  createError: null,
+  editingId: null,
+  editBrlValue: '',
+  editGbpValue: '',
+  isSaving: false,
+  saveError: null,
+}
+
+function reducer(state: ControleMaeState, action: ControleMaeAction): ControleMaeState {
+  switch (action.type) {
+    case 'SET_MONTH':
+      return { ...state, year: action.payload.year, month: action.payload.month }
+    case 'FETCH_START':
+      return { ...state, isLoading: true, error: null }
+    case 'FETCH_SUCCESS':
+      return { ...state, isLoading: false, entries: action.payload }
+    case 'FETCH_ERROR':
+      return { ...state, isLoading: false, error: action.payload }
+    case 'RETRY':
+      return { ...state, retryCount: state.retryCount + 1 }
+    case 'SET_CREATE_FIELD':
+      return { ...state, [action.payload.field]: action.payload.value }
+    case 'CREATE_START':
+      return { ...state, isCreating: true, createError: null }
+    case 'CREATE_SUCCESS':
+      return { ...state, ...BLANK_CREATE_FORM, isCreating: false }
+    case 'CREATE_ERROR':
+      return { ...state, isCreating: false, createError: action.payload }
+    case 'SHOW_EDIT_FORM':
+      return {
+        ...state,
+        editingId: action.payload.id,
+        editBrlValue: action.payload.brlValue !== null ? String(action.payload.brlValue) : '',
+        editGbpValue: action.payload.gbpValue !== null ? String(action.payload.gbpValue) : '',
+        saveError: null,
+      }
+    case 'CANCEL_EDIT':
+      return { ...state, editingId: null, editBrlValue: '', editGbpValue: '', saveError: null }
+    case 'SET_EDIT_FIELD':
+      return { ...state, [action.payload.field]: action.payload.value }
+    case 'SAVE_START':
+      return { ...state, isSaving: true, saveError: null }
+    case 'SAVE_SUCCESS':
+      return { ...state, isSaving: false, editingId: null, editBrlValue: '', editGbpValue: '' }
+    case 'SAVE_ERROR':
+      return { ...state, isSaving: false, saveError: action.payload }
+    default:
+      return state
+  }
+}
+
+export interface ControleMaeData {
+  monthInputValue: string
+  setMonthInputValue: (value: string) => void
+  entries: MaeLedgerEntryDto[]
+  isLoading: boolean
+  error: string | null
+  retry: () => void
+  createDate: string
+  createDescription: string
+  createNote: string
+  createSourceCurrency: string
+  createSourceValue: string
+  isCreating: boolean
+  createError: string | null
+  setCreateField: (field: CreateFormField, value: string) => void
+  submitCreate: () => void
+  editingId: string | null
+  editBrlValue: string
+  editGbpValue: string
+  isSaving: boolean
+  saveError: string | null
+  setEditField: (field: EditField, value: string) => void
+  showEditForm: (entry: MaeLedgerEntryDto) => void
+  cancelEdit: () => void
+  saveEdit: () => void
+}
+
+export function useControleMae(): ControleMaeData {
+  const apiClient = useMemo(() => createFinancialApiClient(), [])
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  useEffect(() => {
+    dispatch({ type: 'FETCH_START' })
+    void apiClient
+      .getMaeLedgerEntriesByMonth(state.year, state.month)
+      .then((entries) => dispatch({ type: 'FETCH_SUCCESS', payload: entries }))
+      .catch((err: unknown) => {
+        dispatch({ type: 'FETCH_ERROR', payload: err instanceof Error ? err.message : 'Unable to load Controle Mae data' })
+      })
+  }, [apiClient, state.year, state.month, state.retryCount])
+
+  const monthInputValue = `${state.year}-${pad(state.month)}`
+
+  const setMonthInputValue = useCallback((value: string) => {
+    const [yearStr, monthStr] = value.split('-')
+    const year = Number(yearStr)
+    const month = Number(monthStr)
+    if (!Number.isFinite(year) || !Number.isFinite(month)) return
+    dispatch({ type: 'SET_MONTH', payload: { year, month } })
+  }, [])
+
+  const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
+
+  const setCreateField = useCallback(
+    (field: CreateFormField, value: string) => dispatch({ type: 'SET_CREATE_FIELD', payload: { field, value } }),
+    [],
+  )
+
+  function submitCreate() {
+    const { createDate, createDescription, createSourceCurrency, createSourceValue, createNote } = state
+
+    if (!createDate.trim()) {
+      dispatch({ type: 'CREATE_ERROR', payload: 'Date is required' })
+      return
+    }
+
+    if (!createDescription.trim()) {
+      dispatch({ type: 'CREATE_ERROR', payload: 'Description is required' })
+      return
+    }
+
+    const sourceValue = Number(createSourceValue)
+    if (!createSourceValue.trim() || !isFinite(sourceValue) || sourceValue === 0) {
+      dispatch({ type: 'CREATE_ERROR', payload: 'Value must be a non-zero number' })
+      return
+    }
+
+    dispatch({ type: 'CREATE_START' })
+
+    void apiClient
+      .createMaeLedgerEntry({
+        date: createDate,
+        description: createDescription,
+        note: createNote,
+        sourceCurrency: createSourceCurrency,
+        sourceValue,
+      })
+      .then(() => {
+        dispatch({ type: 'CREATE_SUCCESS' })
+        dispatch({ type: 'RETRY' })
+      })
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'CREATE_ERROR',
+          payload: err instanceof Error ? err.message : 'Failed to create entry',
+        })
+      })
+  }
+
+  const setEditField = useCallback(
+    (field: EditField, value: string) => dispatch({ type: 'SET_EDIT_FIELD', payload: { field, value } }),
+    [],
+  )
+
+  const showEditForm = useCallback(
+    (entry: MaeLedgerEntryDto) => dispatch({ type: 'SHOW_EDIT_FORM', payload: entry }),
+    [],
+  )
+
+  const cancelEdit = useCallback(() => dispatch({ type: 'CANCEL_EDIT' }), [])
+
+  function saveEdit() {
+    if (!state.editingId) return
+
+    const brlValue = state.editBrlValue.trim() === '' ? null : Number(state.editBrlValue)
+    const gbpValue = state.editGbpValue.trim() === '' ? null : Number(state.editGbpValue)
+
+    dispatch({ type: 'SAVE_START' })
+
+    void apiClient
+      .updateMaeLedgerEntryValues(state.editingId, { brlValue, gbpValue })
+      .then(() => {
+        dispatch({ type: 'SAVE_SUCCESS' })
+        dispatch({ type: 'RETRY' })
+      })
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'SAVE_ERROR',
+          payload: err instanceof Error ? err.message : 'Failed to update entry',
+        })
+      })
+  }
+
+  return {
+    monthInputValue,
+    setMonthInputValue,
+    entries: state.entries,
+    isLoading: state.isLoading,
+    error: state.error,
+    retry,
+    createDate: state.createDate,
+    createDescription: state.createDescription,
+    createNote: state.createNote,
+    createSourceCurrency: state.createSourceCurrency,
+    createSourceValue: state.createSourceValue,
+    isCreating: state.isCreating,
+    createError: state.createError,
+    setCreateField,
+    submitCreate,
+    editingId: state.editingId,
+    editBrlValue: state.editBrlValue,
+    editGbpValue: state.editGbpValue,
+    isSaving: state.isSaving,
+    saveError: state.saveError,
+    setEditField,
+    showEditForm,
+    cancelEdit,
+    saveEdit,
+  }
+}

--- a/Financial.Web/src/main.tsx
+++ b/Financial.Web/src/main.tsx
@@ -11,6 +11,7 @@ import HistoricInvestmentsPage from './pages/HistoricInvestmentsPage'
 import DividendCheckPage from './pages/DividendCheckPage'
 import CurrentValuesPage from './pages/CurrentValuesPage'
 import CashFlowPlaceholderPage from './pages/CashFlowPlaceholderPage'
+import ControleMaePage from './pages/ControleMaePage'
 import MensaisPage from './pages/MensaisPage'
 import ReservaPage from './pages/ReservaPage'
 import RootRedirect from './pages/RootRedirect'
@@ -33,7 +34,7 @@ createRoot(document.getElementById('root')!).render(
             <Route path="monthly" element={<CashFlowPlaceholderPage title="Monthly" />} />
             <Route path="reserva" element={<ReservaPage />} />
             <Route path="mensais" element={<MensaisPage />} />
-            <Route path="controle-mae" element={<CashFlowPlaceholderPage title="Controle Mae" />} />
+            <Route path="controle-mae" element={<ControleMaePage />} />
             <Route
               path="investment-snapshots"
               element={<CashFlowPlaceholderPage title="Investment Snapshots" />}

--- a/Financial.Web/src/pages/ControleMaePage.css
+++ b/Financial.Web/src/pages/ControleMaePage.css
@@ -1,0 +1,41 @@
+.controle-mae-page {
+  padding: 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.controle-mae-page__month-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.controle-mae-page__section h2 {
+  color: var(--text-h);
+  margin-bottom: 12px;
+}
+
+.controle-mae-page__table {
+  width: 100%;
+  max-width: 840px;
+}
+
+.controle-mae-page__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  max-width: 720px;
+}
+
+.controle-mae-page__form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.controle-mae-page__error {
+  color: var(--error, #c0392b);
+}

--- a/Financial.Web/src/pages/ControleMaePage.tsx
+++ b/Financial.Web/src/pages/ControleMaePage.tsx
@@ -1,0 +1,219 @@
+import type { MaeLedgerEntryDto } from '../api/types'
+import ErrorState from '../components/ErrorState'
+import LoadingState from '../components/LoadingState'
+import { useControleMae } from '../hooks/useControleMae'
+import { formatN2, formatShortDate } from '../utils/formatters'
+import './ControleMaePage.css'
+
+interface EntryRowProps {
+  entry: MaeLedgerEntryDto
+  isEditing: boolean
+  editBrlValue: string
+  editGbpValue: string
+  isSaving: boolean
+  onEdit: (entry: MaeLedgerEntryDto) => void
+  onFieldChange: (field: 'editBrlValue' | 'editGbpValue', value: string) => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+function EntryRow({
+  entry,
+  isEditing,
+  editBrlValue,
+  editGbpValue,
+  isSaving,
+  onEdit,
+  onFieldChange,
+  onSave,
+  onCancel,
+}: EntryRowProps) {
+  if (isEditing) {
+    return (
+      <tr>
+        <td>{formatShortDate(entry.date)}</td>
+        <td>{entry.description}</td>
+        <td>{entry.note}</td>
+        <td className="data-table__col--numeric">
+          <input
+            type="number"
+            step="0.01"
+            value={editBrlValue}
+            onChange={(e) => onFieldChange('editBrlValue', e.target.value)}
+          />
+        </td>
+        <td className="data-table__col--numeric">
+          <input
+            type="number"
+            step="0.01"
+            value={editGbpValue}
+            onChange={(e) => onFieldChange('editGbpValue', e.target.value)}
+          />
+        </td>
+        <td>
+          <button type="button" disabled={isSaving} onClick={onSave}>
+            {isSaving ? 'Saving...' : 'Save'}
+          </button>
+          <button type="button" onClick={onCancel}>
+            Cancel
+          </button>
+        </td>
+      </tr>
+    )
+  }
+
+  return (
+    <tr>
+      <td>{formatShortDate(entry.date)}</td>
+      <td>{entry.description}</td>
+      <td>{entry.note}</td>
+      <td className="data-table__col--numeric">{entry.brlValue !== null ? formatN2(entry.brlValue) : '—'}</td>
+      <td className="data-table__col--numeric">{entry.gbpValue !== null ? formatN2(entry.gbpValue) : '—'}</td>
+      <td>
+        <button type="button" onClick={() => onEdit(entry)}>
+          Edit
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+export default function ControleMaePage() {
+  const {
+    monthInputValue,
+    setMonthInputValue,
+    entries,
+    isLoading,
+    error,
+    retry,
+    createDate,
+    createDescription,
+    createNote,
+    createSourceCurrency,
+    createSourceValue,
+    isCreating,
+    createError,
+    setCreateField,
+    submitCreate,
+    editingId,
+    editBrlValue,
+    editGbpValue,
+    isSaving,
+    saveError,
+    setEditField,
+    showEditForm,
+    cancelEdit,
+    saveEdit,
+  } = useControleMae()
+
+  return (
+    <div className="controle-mae-page">
+      <div className="controle-mae-page__month-picker">
+        <label htmlFor="controle-mae-month">Month</label>
+        <input
+          id="controle-mae-month"
+          type="month"
+          value={monthInputValue}
+          onChange={(e) => setMonthInputValue(e.target.value)}
+        />
+      </div>
+
+      <section className="controle-mae-page__section">
+        <h2>New Entry</h2>
+        <div className="controle-mae-page__form">
+          <div className="controle-mae-page__form-field">
+            <label htmlFor="create-date">Date</label>
+            <input
+              id="create-date"
+              type="date"
+              value={createDate}
+              onChange={(e) => setCreateField('createDate', e.target.value)}
+            />
+          </div>
+          <div className="controle-mae-page__form-field">
+            <label htmlFor="create-description">Description</label>
+            <input
+              id="create-description"
+              type="text"
+              value={createDescription}
+              onChange={(e) => setCreateField('createDescription', e.target.value)}
+            />
+          </div>
+          <div className="controle-mae-page__form-field">
+            <label htmlFor="create-note">Note</label>
+            <input
+              id="create-note"
+              type="text"
+              value={createNote}
+              onChange={(e) => setCreateField('createNote', e.target.value)}
+            />
+          </div>
+          <div className="controle-mae-page__form-field">
+            <label htmlFor="create-currency">Currency</label>
+            <select
+              id="create-currency"
+              value={createSourceCurrency}
+              onChange={(e) => setCreateField('createSourceCurrency', e.target.value)}
+            >
+              <option value="BRL">BRL</option>
+              <option value="GBP">GBP</option>
+            </select>
+          </div>
+          <div className="controle-mae-page__form-field">
+            <label htmlFor="create-value">Value</label>
+            <input
+              id="create-value"
+              type="number"
+              step="0.01"
+              value={createSourceValue}
+              onChange={(e) => setCreateField('createSourceValue', e.target.value)}
+            />
+          </div>
+          <button type="button" disabled={isCreating} onClick={submitCreate}>
+            {isCreating ? 'Saving...' : 'Add Entry'}
+          </button>
+          {createError && <p className="controle-mae-page__error">{createError}</p>}
+        </div>
+      </section>
+
+      {isLoading ? (
+        <LoadingState />
+      ) : error ? (
+        <ErrorState message={error} onRetry={retry} />
+      ) : (
+        <section className="controle-mae-page__section">
+          <h2>Ledger</h2>
+          <table className="controle-mae-page__table data-table">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Description</th>
+                <th>Note</th>
+                <th className="data-table__col--numeric">BRL</th>
+                <th className="data-table__col--numeric">GBP</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => (
+                <EntryRow
+                  key={entry.id}
+                  entry={entry}
+                  isEditing={editingId === entry.id}
+                  editBrlValue={editBrlValue}
+                  editGbpValue={editGbpValue}
+                  isSaving={isSaving}
+                  onEdit={showEditForm}
+                  onFieldChange={setEditField}
+                  onSave={saveEdit}
+                  onCancel={cancelEdit}
+                />
+              ))}
+            </tbody>
+          </table>
+          {saveError && <p className="controle-mae-page__error">{saveError}</p>}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/Financial.Web/src/pages/__tests__/ControleMaePage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/ControleMaePage.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ControleMaePage from '../ControleMaePage'
+import type { FinancialApiClient } from '../../api/financialApiClient'
+import type { MaeLedgerEntryDto } from '../../api/types'
+
+const getMaeLedgerEntriesByMonthMock = vi.fn<FinancialApiClient['getMaeLedgerEntriesByMonth']>()
+const createMaeLedgerEntryMock = vi.fn<FinancialApiClient['createMaeLedgerEntry']>()
+const updateMaeLedgerEntryValuesMock = vi.fn<FinancialApiClient['updateMaeLedgerEntryValues']>()
+
+vi.mock('../../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getMaeLedgerEntriesByMonth: getMaeLedgerEntriesByMonthMock,
+    createMaeLedgerEntry: createMaeLedgerEntryMock,
+    updateMaeLedgerEntryValues: updateMaeLedgerEntryValuesMock,
+  }),
+}))
+
+const ENTRIES: MaeLedgerEntryDto[] = [
+  {
+    id: 'e1',
+    date: '2026-07-15',
+    description: 'School supplies',
+    note: 'Term start',
+    sourceCurrency: 'BRL',
+    brlValue: 350,
+    gbpValue: 51.1,
+  },
+]
+
+describe('ControleMaePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getMaeLedgerEntriesByMonthMock.mockResolvedValue(ENTRIES)
+  })
+
+  it('shows a loading state before data arrives', () => {
+    render(<ControleMaePage />)
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('shows an error state with retry when the fetch fails', async () => {
+    getMaeLedgerEntriesByMonthMock.mockRejectedValue(new Error('Network down'))
+
+    render(<ControleMaePage />)
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByText('Network down')).toBeInTheDocument()
+  })
+
+  it('renders both BRL and GBP values for every ledger entry once loaded', async () => {
+    render(<ControleMaePage />)
+
+    await waitFor(() => expect(screen.getByText('School supplies')).toBeInTheDocument())
+    expect(screen.getByText('350.00')).toBeInTheDocument()
+    expect(screen.getByText('51.10')).toBeInTheDocument()
+  })
+
+  it('renders the create-entry form', async () => {
+    render(<ControleMaePage />)
+
+    await waitFor(() => expect(screen.getByText('New Entry')).toBeInTheDocument())
+    expect(screen.getByLabelText('Date')).toBeInTheDocument()
+    expect(screen.getByLabelText('Description')).toBeInTheDocument()
+    expect(screen.getByLabelText('Currency')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add Entry' })).toBeInTheDocument()
+  })
+
+  it('edits an entry values and saves, updating the displayed row', async () => {
+    updateMaeLedgerEntryValuesMock.mockResolvedValue({ ...ENTRIES[0], brlValue: 355, gbpValue: 51.6 })
+    render(<ControleMaePage />)
+
+    await waitFor(() => expect(screen.getByText('School supplies')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    const brlInput = screen.getByDisplayValue('350')
+    fireEvent.change(brlInput, { target: { value: '355' } })
+
+    getMaeLedgerEntriesByMonthMock.mockResolvedValue([{ ...ENTRIES[0], brlValue: 355, gbpValue: 51.6 }])
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(updateMaeLedgerEntryValuesMock).toHaveBeenCalledWith('e1', { brlValue: 355, gbpValue: 51.1 }),
+    )
+    await waitFor(() => expect(screen.getByText('355.00')).toBeInTheDocument())
+  })
+})

--- a/docs/P11-F15-web-controle-mae-view/plan.md
+++ b/docs/P11-F15-web-controle-mae-view/plan.md
@@ -1,0 +1,28 @@
+# Implementation Plan: F15. Web — Controle Mae View
+
+**Prerequisites:**
+- F07's `/controle-mae/*` endpoints already exist and are unchanged by this feature
+- F13/F14's `ApiError` and hook/page conventions already established
+- No new npm packages
+
+### Stage 1: API Client Layer
+
+**1. Controle Mae DTOs and client methods** - Add the ledger entry type, the create-request type, and the values-only update-request type, plus the three new `financialApiClient` methods that call F07's existing endpoints.
+
+**2. API client tests** - Add tests for the new methods' request shape.
+
+### Stage 2: Page Logic and UI
+
+**3. useControleMae hook** - Add the hook that tracks the selected month (defaulting to the current month), fetches entries on month change, manages the create-entry form state/submit, manages the single-row inline values-edit state/submit, and re-fetches after each successful action.
+
+**4. ControleMaePage component** - Add the presentational page: month picker, loading/error states, create-entry form, and the entry table with inline BRL/GBP edit per row, wired to `useControleMae`.
+
+**5. Wire up routing** - Replace the `/cashflow/controle-mae` placeholder route in `main.tsx` with `ControleMaePage`.
+
+**6. Hook and component tests** - Add tests for `useControleMae`'s fetch/create/edit behavior and for `ControleMaePage`'s rendering of both currencies and both forms.
+
+### Stage 3: Verification
+
+**7. Full-suite validation** - Run the Web project's full test suite and typecheck, confirming no regression to any existing test.
+
+**8. Manual verification** - Run the Web dev server against a locally running `Financial.Api`, navigate to `/cashflow/controle-mae`, and exercise the view directly (create an entry with a real past date and confirm both currencies populate via the live FX lookup, manually adjust one entry's values and confirm it saves, change the month and confirm a fresh set of entries loads) to confirm the behavior matches the acceptance criteria end-to-end.

--- a/docs/P11-F15-web-controle-mae-view/spec.md
+++ b/docs/P11-F15-web-controle-mae-view/spec.md
@@ -1,0 +1,74 @@
+# F15. Web — Controle Mae View
+
+## 1. Technical Overview
+
+**What:** Replace F11's `/cashflow/controle-mae` placeholder with a real page that shows a selected month's mae ledger entries (F07) with both BRL and GBP values, lets the user create a new entry (entering one currency and getting the other auto-converted), and lets the user manually adjust either currency value on an existing entry.
+
+**Why:** This turns F07's backend-only historical-rate lookup and ledger into the actual monthly family cash-flow workflow — enter an expense once, see both currencies, correct a fetched rate when it's wrong.
+
+**Scope:**
+- Included: month picker (defaults to the current month, reusing F14's pattern); chronological entry list showing both currencies, description, and note; a create-entry form (date, description, note, source currency, source value); inline editing of an existing entry's BRL/GBP values only, matching F07's own update scope.
+- Excluded: editing an entry's date/description/note (F07's backend only supports a values-only update — see F07's own spec decision); any other CashFlow view (F13/F14/F16).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/api/types.ts` — new: `MaeLedgerEntryDto`, `CreateMaeLedgerEntryDto`, `UpdateMaeLedgerEntryValuesDto`
+- `Financial.Web/src/api/financialApiClient.ts` — modified: new methods `createMaeLedgerEntry`, `getMaeLedgerEntriesByMonth`, `updateMaeLedgerEntryValues`
+- `Financial.Web/src/hooks/useControleMae.ts` — new: page business logic
+- `Financial.Web/src/pages/ControleMaePage.tsx`, `ControleMaePage.css` — new: replaces `CashFlowPlaceholderPage` on `/cashflow/controle-mae`
+- `Financial.Web/src/main.tsx` — modified: route swap
+
+```mermaid
+graph TD
+  A[ControleMaePage] --> B[useControleMae hook]
+  B --> C["financialApiClient (createMaeLedgerEntry/getMaeLedgerEntriesByMonth/updateMaeLedgerEntryValues)"]
+  C --> D["/api/v1/financial/controle-mae/*"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Month selection | Reuse F14's `<input type="month">` pattern, defaulting to the current month | A new/different picker | Consistent with the one precedent this app already has for a per-month CashFlow view; no reason to diverge. |
+| Editable fields on an existing entry | Only `brlValue`/`gbpValue` are editable inline, matching F07's `UpdateEntryValuesAsync` exactly | Allow editing date/description/note too | F07's backend only ever supports a values-only update (its own spec explicitly scoped this to mirror the PRD's "manual override" capability) — there is no endpoint to edit anything else, so the UI can't offer it. |
+| Create-entry currency input | A single "source value" field paired with a source-currency selector (BRL/GBP), matching F07's `CreateMaeLedgerEntryDTO` exactly; both currency values then display once the response returns (the other populated by the fetched rate, or blank if the lookup failed) | Two separate value inputs shown up front | Matches the PRD's Experience text exactly: "a user enters one currency value and a date, sees both currency values populate automatically" — a single entry field is what triggers the conversion; a second up-front field would misrepresent the one-value-in flow. |
+| Refresh strategy after create/update | Re-fetch the month's entries after a successful create or update | Locally patch state | Same precedent as F13/F14 — keeps displayed data provably in sync with the server, and this list is small enough that the extra round trip is negligible. |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/api/types.ts` | Modified | DTO types | `MaeLedgerEntryDto { id, date, description, note, sourceCurrency, brlValue, gbpValue }` (`brlValue`/`gbpValue` nullable), `CreateMaeLedgerEntryDto { date, description, note, sourceCurrency, sourceValue }`, `UpdateMaeLedgerEntryValuesDto { brlValue, gbpValue }` (both nullable) |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | HTTP client | `createMaeLedgerEntry(request)`, `getMaeLedgerEntriesByMonth(year, month)`, `updateMaeLedgerEntryValues(id, request)` |
+| `Financial.Web/src/hooks/useControleMae.ts` | New | Page business logic | Month state (defaults to current month); fetches entries on month change; create-form state/submit; per-row inline edit state (`editingId`, `editBrlValue`, `editGbpValue`) and submit; re-fetch on success; loading/error state matching `useMensais`'s reducer pattern |
+| `Financial.Web/src/pages/ControleMaePage.tsx`, `ControleMaePage.css` | New | Presentational page | Month picker, `LoadingState`/`ErrorState`, create-entry form, chronological entry table with inline BRL/GBP edit per row |
+| `Financial.Web/src/main.tsx` | Modified | Routing | `/cashflow/controle-mae` renders `ControleMaePage` instead of `CashFlowPlaceholderPage` |
+
+## 5. API Contracts
+
+Consumes F07's existing endpoints unchanged (see F07's own spec for full detail):
+
+- `POST /api/v1/financial/controle-mae/entries` (body: `CreateMaeLedgerEntryDto`) → `MaeLedgerEntryDto`; `400` on blank description, unrecognized currency, zero value, or a future date
+- `GET /api/v1/financial/controle-mae/entries/month/{year}/{month}` → `MaeLedgerEntryDto[]`
+- `PUT /api/v1/financial/controle-mae/entries/{id}/values` (body: `UpdateMaeLedgerEntryValuesDto`) → `MaeLedgerEntryDto`; `404` on an unknown id
+
+No new backend endpoints — this feature is Web-only.
+
+## 6. Data Model
+
+No backend/persisted data model changes — this is a Web-only feature consuming F07's existing `data-cashflow.json`-backed endpoints.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Financial.Web/src/api/financialApiClient.test.ts` | Unit | `financialApiClient` | New Controle Mae methods call the correct paths/methods/bodies |
+| `Financial.Web/src/hooks/useControleMae.test.ts` | Unit | `useControleMae` | Fetches entries for the default (current) month on mount; changing the month re-fetches; create-entry submit calls the endpoint and re-fetches on success, surfacing a backend validation error (e.g. future date) without crashing; edit-values submit calls the endpoint and re-fetches on success |
+| `Financial.Web/src/pages/ControleMaePage.test.tsx` | Component | `ControleMaePage` | Renders `LoadingState`/`ErrorState`; renders both BRL and GBP values per entry once loaded; the create form is present and submittable; editing an entry's values and saving updates the displayed row |
+
+**Acceptance tests (from PRD Section 9, F15):**
+- The view shows both BRL and GBP values for every ledger entry — `ControleMaePage.test.tsx`
+- A new entry can be created with automatic FX conversion, and either currency value can be manually adjusted before saving — `useControleMae.test.ts` (create + re-fetch, then edit-values + re-fetch), `ControleMaePage.test.tsx`

--- a/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
+++ b/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
@@ -623,8 +623,8 @@ graph TD
 - [x] A bill instance's status or value can be updated from this view without affecting other months
 
 ### F15. Web — Controle Mae View
-- [ ] The view shows both BRL and GBP values for every ledger entry
-- [ ] A new entry can be created with automatic FX conversion, and either currency value can be manually adjusted before saving
+- [x] The view shows both BRL and GBP values for every ledger entry
+- [x] A new entry can be created with automatic FX conversion, and either currency value can be manually adjusted before saving
 
 ### F16. Web — Investment Snapshots View
 - [ ] The view shows all 11 tracked accounts for the selected month with their current values


### PR DESCRIPTION
## Summary
- Replaces F11's `/cashflow/controle-mae` placeholder with a real page: a month picker (reusing F14's pattern), a create-entry form (date, description, note, source currency, source value), and a chronological ledger table showing both BRL and GBP values with inline per-row values editing.
- New `createMaeLedgerEntry` / `getMaeLedgerEntriesByMonth` / `updateMaeLedgerEntryValues` methods on the shared `financialApiClient`, consuming F07's existing endpoints unchanged.

## Technical decisions (see docs/P11-F15-web-controle-mae-view/spec.md)
- Only `brlValue`/`gbpValue` are editable inline, matching F07's `UpdateEntryValuesAsync` exactly — there's no backend endpoint to edit date/description/note, so the UI can't offer it.
- A single "source value + currency selector" input for entry creation, matching F07's `CreateMaeLedgerEntryDTO` and the PRD's "enters one currency value... sees both currency values populate automatically" flow precisely.
- Reuses F14's month-picker pattern and F13/F14's re-fetch-after-success precedent.

## Test plan
- [x] `financialApiClient.test.ts` — new Controle Mae methods call the correct paths/bodies
- [x] `useControleMae.test.ts` — fetch-on-mount for the current month, re-fetch on month change, create + re-fetch, backend validation error surfaced without crashing, edit-values + re-fetch
- [x] `ControleMaePage.test.tsx` — loading/error states, both BRL/GBP columns render, create form present, edit-and-save updates the displayed row
- [x] Full Web test suite green (456 tests, no regressions), typecheck and lint clean
- [x] Manual smoke test with a real running `Financial.Api` + Vite dev server via a scripted Playwright session: created an entry with a real past date and confirmed the **live** Frankfurter FX lookup populated the other currency automatically, manually edited one entry's BRL value and confirmed only that field changed (GBP untouched), no console errors

## PRD
Acceptance criteria for F15 checked off in `docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md`. The cross-feature checkbox covering F13/F14/F15/F16 together stays unchecked until F16 also lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)