### PR TITLE
feat(P11-F16): Web — Investment Snapshots View

### DIFF
--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -8,11 +8,13 @@ import type {
   CreateMaeLedgerEntryDto,
   IncomeSplitRequestDto,
   IncomeSplitResultDto,
+  InvestmentSnapshotDto,
   MaeLedgerEntryDto,
   RecurringBillInstanceDto,
   ReserveBucketBalanceDto,
   ReserveMovementDto,
   TreeNodeDto,
+  UpdateInvestmentSnapshotValueDto,
   UpdateMaeLedgerEntryValuesDto,
   UpdateRecurringBillInstanceDto,
   WithdrawalRequestDto,
@@ -520,6 +522,41 @@ describe('financialApiClient', () => {
     expect(result).toEqual(responseBody)
     const [url, init] = fetchMock.mock.calls[0]
     expect(url).toBe(`${API_BASE_URL}/controle-mae/entries/e1/values`)
+    expect(init?.method).toBe('PUT')
+    expect(JSON.parse(init?.body as string)).toEqual(requestBody)
+  })
+
+  it('calls the investment snapshots endpoint for a given year/month', async () => {
+    const responseBody: InvestmentSnapshotDto[] = [
+      { id: 's1', account: 'ChaseSave', isLiability: false, year: 2026, month: 7, value: 1000 },
+    ]
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.getInvestmentSnapshots(2026, 7)
+
+    expect(result).toEqual(responseBody)
+    expect(fetchMock.mock.calls[0][0]).toBe(`${API_BASE_URL}/investment-snapshots/2026/7`)
+  })
+
+  it('puts an investment snapshot value update', async () => {
+    const requestBody: UpdateInvestmentSnapshotValueDto = { value: 1200 }
+    const responseBody: InvestmentSnapshotDto = {
+      id: 's1',
+      account: 'ChaseSave',
+      isLiability: false,
+      year: 2026,
+      month: 7,
+      value: 1200,
+    }
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.updateInvestmentSnapshotValue('s1', requestBody)
+
+    expect(result).toEqual(responseBody)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/investment-snapshots/s1`)
     expect(init?.method).toBe('PUT')
     expect(JSON.parse(init?.body as string)).toEqual(requestBody)
   })

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -17,6 +17,7 @@ import type {
   IncomeSplitRequestDto,
   IncomeSplitResultDto,
   InvestmentScope,
+  InvestmentSnapshotDto,
   MaeLedgerEntryDto,
   PortfolioAssetSummaryItemDto,
   PortfolioBreakdownItemDto,
@@ -29,6 +30,7 @@ import type {
   TransactionSummaryItemDto,
   TransactionUpdateDto,
   TreeNodeDto,
+  UpdateInvestmentSnapshotValueDto,
   UpdateMaeLedgerEntryValuesDto,
   UpdateRecurringBillInstanceDto,
   WatchlistItemDto,
@@ -75,6 +77,8 @@ export interface FinancialApiClient {
   createMaeLedgerEntry: (request: CreateMaeLedgerEntryDto) => Promise<MaeLedgerEntryDto>
   getMaeLedgerEntriesByMonth: (year: number, month: number) => Promise<MaeLedgerEntryDto[]>
   updateMaeLedgerEntryValues: (id: string, request: UpdateMaeLedgerEntryValuesDto) => Promise<MaeLedgerEntryDto>
+  getInvestmentSnapshots: (year: number, month: number) => Promise<InvestmentSnapshotDto[]>
+  updateInvestmentSnapshotValue: (id: string, request: UpdateInvestmentSnapshotValueDto) => Promise<InvestmentSnapshotDto>
 }
 
 export interface FinancialApiClientOptions {
@@ -256,6 +260,13 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       request<MaeLedgerEntryDto[]>(`/controle-mae/entries/month/${year}/${month}`),
     updateMaeLedgerEntryValues: (id, requestBody) =>
       request<MaeLedgerEntryDto>(`/controle-mae/entries/${encodeURIComponent(id)}/values`, {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+      }),
+    getInvestmentSnapshots: (year, month) =>
+      request<InvestmentSnapshotDto[]>(`/investment-snapshots/${year}/${month}`),
+    updateInvestmentSnapshotValue: (id, requestBody) =>
+      request<InvestmentSnapshotDto>(`/investment-snapshots/${encodeURIComponent(id)}`, {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       }),

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -342,3 +342,16 @@ export interface UpdateMaeLedgerEntryValuesDto {
   brlValue: number | null
   gbpValue: number | null
 }
+
+export interface InvestmentSnapshotDto {
+  id: string
+  account: string
+  isLiability: boolean
+  year: number
+  month: number
+  value: number
+}
+
+export interface UpdateInvestmentSnapshotValueDto {
+  value: number
+}

--- a/Financial.Web/src/hooks/useInvestmentSnapshots.test.ts
+++ b/Financial.Web/src/hooks/useInvestmentSnapshots.test.ts
@@ -1,0 +1,89 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FinancialApiClient } from '../api/financialApiClient'
+import type { InvestmentSnapshotDto } from '../api/types'
+import { useInvestmentSnapshots } from './useInvestmentSnapshots'
+
+const NOW = new Date()
+const CURRENT_YEAR = NOW.getFullYear()
+const CURRENT_MONTH = NOW.getMonth() + 1
+const CURRENT_MONTH_INPUT = `${CURRENT_YEAR}-${String(CURRENT_MONTH).padStart(2, '0')}`
+const NEXT_MONTH = CURRENT_MONTH === 12 ? 1 : CURRENT_MONTH + 1
+const NEXT_MONTH_YEAR = CURRENT_MONTH === 12 ? CURRENT_YEAR + 1 : CURRENT_YEAR
+const NEXT_MONTH_INPUT = `${NEXT_MONTH_YEAR}-${String(NEXT_MONTH).padStart(2, '0')}`
+
+const getInvestmentSnapshotsMock = vi.fn<FinancialApiClient['getInvestmentSnapshots']>()
+const updateInvestmentSnapshotValueMock = vi.fn<FinancialApiClient['updateInvestmentSnapshotValue']>()
+
+vi.mock('../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getInvestmentSnapshots: getInvestmentSnapshotsMock,
+    updateInvestmentSnapshotValue: updateInvestmentSnapshotValueMock,
+  }),
+}))
+
+const SNAPSHOTS: InvestmentSnapshotDto[] = [
+  { id: 's1', account: 'ChaseSave', isLiability: false, year: CURRENT_YEAR, month: CURRENT_MONTH, value: 1000 },
+  { id: 's2', account: 'PlatinumVisa8003', isLiability: true, year: CURRENT_YEAR, month: CURRENT_MONTH, value: 250 },
+]
+
+describe('useInvestmentSnapshots', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getInvestmentSnapshotsMock.mockResolvedValue(SNAPSHOTS)
+  })
+
+  it('fetches the current month snapshots on mount', async () => {
+    const { result } = renderHook(() => useInvestmentSnapshots())
+
+    expect(result.current.isLoading).toBe(true)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(getInvestmentSnapshotsMock).toHaveBeenCalledWith(CURRENT_YEAR, CURRENT_MONTH)
+    expect(result.current.monthInputValue).toBe(CURRENT_MONTH_INPUT)
+    expect(result.current.snapshots).toEqual(SNAPSHOTS)
+  })
+
+  it('re-fetches for a new month when the month input changes', async () => {
+    const { result } = renderHook(() => useInvestmentSnapshots())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setMonthInputValue(NEXT_MONTH_INPUT))
+
+    await waitFor(() => expect(getInvestmentSnapshotsMock).toHaveBeenCalledWith(NEXT_MONTH_YEAR, NEXT_MONTH))
+  })
+
+  it('surfaces a fetch error', async () => {
+    getInvestmentSnapshotsMock.mockRejectedValue(new Error('Network down'))
+    const { result } = renderHook(() => useInvestmentSnapshots())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.error).toBe('Network down')
+  })
+
+  it('saves an edit and re-fetches, leaving other snapshots untouched', async () => {
+    updateInvestmentSnapshotValueMock.mockResolvedValue({ ...SNAPSHOTS[0], value: 1500 })
+    const { result } = renderHook(() => useInvestmentSnapshots())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditForm(SNAPSHOTS[0]))
+    act(() => result.current.setEditValue('1500'))
+    act(() => result.current.saveEdit())
+
+    await waitFor(() => expect(updateInvestmentSnapshotValueMock).toHaveBeenCalledWith('s1', { value: 1500 }))
+    await waitFor(() => expect(getInvestmentSnapshotsMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('surfaces a save error without crashing', async () => {
+    updateInvestmentSnapshotValueMock.mockRejectedValue(new Error('Value must not be negative.'))
+    const { result } = renderHook(() => useInvestmentSnapshots())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditForm(SNAPSHOTS[0]))
+    act(() => result.current.setEditValue('-5'))
+    act(() => result.current.saveEdit())
+
+    await waitFor(() => expect(result.current.saveError).toBeTruthy())
+  })
+})

--- a/Financial.Web/src/hooks/useInvestmentSnapshots.ts
+++ b/Financial.Web/src/hooks/useInvestmentSnapshots.ts
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react'
+import { createFinancialApiClient } from '../api/financialApiClient'
+import type { InvestmentSnapshotDto } from '../api/types'
+import { pad } from '../utils/formatters'
+
+function currentYearMonth(): { year: number; month: number } {
+  const now = new Date()
+  return { year: now.getFullYear(), month: now.getMonth() + 1 }
+}
+
+interface InvestmentSnapshotsState {
+  year: number
+  month: number
+  snapshots: InvestmentSnapshotDto[]
+  isLoading: boolean
+  error: string | null
+  retryCount: number
+  editingId: string | null
+  editValue: string
+  isSaving: boolean
+  saveError: string | null
+}
+
+type InvestmentSnapshotsAction =
+  | { type: 'SET_MONTH'; payload: { year: number; month: number } }
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; payload: InvestmentSnapshotDto[] }
+  | { type: 'FETCH_ERROR'; payload: string }
+  | { type: 'RETRY' }
+  | { type: 'SHOW_EDIT_FORM'; payload: InvestmentSnapshotDto }
+  | { type: 'CANCEL_EDIT' }
+  | { type: 'SET_EDIT_VALUE'; payload: string }
+  | { type: 'SAVE_START' }
+  | { type: 'SAVE_SUCCESS' }
+  | { type: 'SAVE_ERROR'; payload: string }
+
+const { year: DEFAULT_YEAR, month: DEFAULT_MONTH } = currentYearMonth()
+
+const INITIAL_STATE: InvestmentSnapshotsState = {
+  year: DEFAULT_YEAR,
+  month: DEFAULT_MONTH,
+  snapshots: [],
+  isLoading: true,
+  error: null,
+  retryCount: 0,
+  editingId: null,
+  editValue: '',
+  isSaving: false,
+  saveError: null,
+}
+
+function reducer(state: InvestmentSnapshotsState, action: InvestmentSnapshotsAction): InvestmentSnapshotsState {
+  switch (action.type) {
+    case 'SET_MONTH':
+      return { ...state, year: action.payload.year, month: action.payload.month }
+    case 'FETCH_START':
+      return { ...state, isLoading: true, error: null }
+    case 'FETCH_SUCCESS':
+      return { ...state, isLoading: false, snapshots: action.payload }
+    case 'FETCH_ERROR':
+      return { ...state, isLoading: false, error: action.payload }
+    case 'RETRY':
+      return { ...state, retryCount: state.retryCount + 1 }
+    case 'SHOW_EDIT_FORM':
+      return { ...state, editingId: action.payload.id, editValue: String(action.payload.value), saveError: null }
+    case 'CANCEL_EDIT':
+      return { ...state, editingId: null, editValue: '', saveError: null }
+    case 'SET_EDIT_VALUE':
+      return { ...state, editValue: action.payload }
+    case 'SAVE_START':
+      return { ...state, isSaving: true, saveError: null }
+    case 'SAVE_SUCCESS':
+      return { ...state, isSaving: false, editingId: null, editValue: '' }
+    case 'SAVE_ERROR':
+      return { ...state, isSaving: false, saveError: action.payload }
+    default:
+      return state
+  }
+}
+
+export interface InvestmentSnapshotsData {
+  monthInputValue: string
+  setMonthInputValue: (value: string) => void
+  snapshots: InvestmentSnapshotDto[]
+  isLoading: boolean
+  error: string | null
+  retry: () => void
+  editingId: string | null
+  editValue: string
+  isSaving: boolean
+  saveError: string | null
+  setEditValue: (value: string) => void
+  showEditForm: (snapshot: InvestmentSnapshotDto) => void
+  cancelEdit: () => void
+  saveEdit: () => void
+}
+
+export function useInvestmentSnapshots(): InvestmentSnapshotsData {
+  const apiClient = useMemo(() => createFinancialApiClient(), [])
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  useEffect(() => {
+    dispatch({ type: 'FETCH_START' })
+    void apiClient
+      .getInvestmentSnapshots(state.year, state.month)
+      .then((snapshots) => dispatch({ type: 'FETCH_SUCCESS', payload: snapshots }))
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'FETCH_ERROR',
+          payload: err instanceof Error ? err.message : 'Unable to load investment snapshots',
+        })
+      })
+  }, [apiClient, state.year, state.month, state.retryCount])
+
+  const monthInputValue = `${state.year}-${pad(state.month)}`
+
+  const setMonthInputValue = useCallback((value: string) => {
+    const [yearStr, monthStr] = value.split('-')
+    const year = Number(yearStr)
+    const month = Number(monthStr)
+    if (!Number.isFinite(year) || !Number.isFinite(month)) return
+    dispatch({ type: 'SET_MONTH', payload: { year, month } })
+  }, [])
+
+  const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
+
+  const setEditValue = useCallback((value: string) => dispatch({ type: 'SET_EDIT_VALUE', payload: value }), [])
+
+  const showEditForm = useCallback(
+    (snapshot: InvestmentSnapshotDto) => dispatch({ type: 'SHOW_EDIT_FORM', payload: snapshot }),
+    [],
+  )
+
+  const cancelEdit = useCallback(() => dispatch({ type: 'CANCEL_EDIT' }), [])
+
+  function saveEdit() {
+    if (!state.editingId) return
+
+    const value = Number(state.editValue)
+    if (!state.editValue.trim() || !isFinite(value) || value < 0) {
+      dispatch({ type: 'SAVE_ERROR', payload: 'Value must be a non-negative number' })
+      return
+    }
+
+    dispatch({ type: 'SAVE_START' })
+
+    void apiClient
+      .updateInvestmentSnapshotValue(state.editingId, { value })
+      .then(() => {
+        dispatch({ type: 'SAVE_SUCCESS' })
+        dispatch({ type: 'RETRY' })
+      })
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'SAVE_ERROR',
+          payload: err instanceof Error ? err.message : 'Failed to update snapshot',
+        })
+      })
+  }
+
+  return {
+    monthInputValue,
+    setMonthInputValue,
+    snapshots: state.snapshots,
+    isLoading: state.isLoading,
+    error: state.error,
+    retry,
+    editingId: state.editingId,
+    editValue: state.editValue,
+    isSaving: state.isSaving,
+    saveError: state.saveError,
+    setEditValue,
+    showEditForm,
+    cancelEdit,
+    saveEdit,
+  }
+}

--- a/Financial.Web/src/main.tsx
+++ b/Financial.Web/src/main.tsx
@@ -12,6 +12,7 @@ import DividendCheckPage from './pages/DividendCheckPage'
 import CurrentValuesPage from './pages/CurrentValuesPage'
 import CashFlowPlaceholderPage from './pages/CashFlowPlaceholderPage'
 import ControleMaePage from './pages/ControleMaePage'
+import InvestmentSnapshotsPage from './pages/InvestmentSnapshotsPage'
 import MensaisPage from './pages/MensaisPage'
 import ReservaPage from './pages/ReservaPage'
 import RootRedirect from './pages/RootRedirect'
@@ -35,10 +36,7 @@ createRoot(document.getElementById('root')!).render(
             <Route path="reserva" element={<ReservaPage />} />
             <Route path="mensais" element={<MensaisPage />} />
             <Route path="controle-mae" element={<ControleMaePage />} />
-            <Route
-              path="investment-snapshots"
-              element={<CashFlowPlaceholderPage title="Investment Snapshots" />}
-            />
+            <Route path="investment-snapshots" element={<InvestmentSnapshotsPage />} />
             <Route path="yearly-summary" element={<CashFlowPlaceholderPage title="Yearly Summary" />} />
           </Route>
           <Route path="*" element={<div>Page not found.</div>} />

--- a/Financial.Web/src/pages/InvestmentSnapshotsPage.css
+++ b/Financial.Web/src/pages/InvestmentSnapshotsPage.css
@@ -1,0 +1,22 @@
+.investment-snapshots-page {
+  padding: 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.investment-snapshots-page__month-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.investment-snapshots-page__table {
+  width: 100%;
+  max-width: 640px;
+}
+
+.investment-snapshots-page__error {
+  color: var(--error, #c0392b);
+}

--- a/Financial.Web/src/pages/InvestmentSnapshotsPage.tsx
+++ b/Financial.Web/src/pages/InvestmentSnapshotsPage.tsx
@@ -1,0 +1,128 @@
+import type { InvestmentSnapshotDto } from '../api/types'
+import ErrorState from '../components/ErrorState'
+import LoadingState from '../components/LoadingState'
+import { useInvestmentSnapshots } from '../hooks/useInvestmentSnapshots'
+import { formatN2 } from '../utils/formatters'
+import './InvestmentSnapshotsPage.css'
+
+interface SnapshotRowProps {
+  snapshot: InvestmentSnapshotDto
+  isEditing: boolean
+  editValue: string
+  isSaving: boolean
+  onEdit: (snapshot: InvestmentSnapshotDto) => void
+  onValueChange: (value: string) => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+function SnapshotRow({
+  snapshot,
+  isEditing,
+  editValue,
+  isSaving,
+  onEdit,
+  onValueChange,
+  onSave,
+  onCancel,
+}: SnapshotRowProps) {
+  const label = snapshot.isLiability ? `${snapshot.account} (liability)` : snapshot.account
+
+  if (isEditing) {
+    return (
+      <tr>
+        <td>{label}</td>
+        <td className="data-table__col--numeric">
+          <input type="number" step="0.01" min="0" value={editValue} onChange={(e) => onValueChange(e.target.value)} />
+        </td>
+        <td>
+          <button type="button" disabled={isSaving} onClick={onSave}>
+            {isSaving ? 'Saving...' : 'Save'}
+          </button>
+          <button type="button" onClick={onCancel}>
+            Cancel
+          </button>
+        </td>
+      </tr>
+    )
+  }
+
+  return (
+    <tr>
+      <td>{label}</td>
+      <td className="data-table__col--numeric">{formatN2(snapshot.value)}</td>
+      <td>
+        <button type="button" onClick={() => onEdit(snapshot)}>
+          Edit
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+export default function InvestmentSnapshotsPage() {
+  const {
+    monthInputValue,
+    setMonthInputValue,
+    snapshots,
+    isLoading,
+    error,
+    retry,
+    editingId,
+    editValue,
+    isSaving,
+    saveError,
+    setEditValue,
+    showEditForm,
+    cancelEdit,
+    saveEdit,
+  } = useInvestmentSnapshots()
+
+  return (
+    <div className="investment-snapshots-page">
+      <div className="investment-snapshots-page__month-picker">
+        <label htmlFor="investment-snapshots-month">Month</label>
+        <input
+          id="investment-snapshots-month"
+          type="month"
+          value={monthInputValue}
+          onChange={(e) => setMonthInputValue(e.target.value)}
+        />
+      </div>
+
+      {isLoading ? (
+        <LoadingState />
+      ) : error ? (
+        <ErrorState message={error} onRetry={retry} />
+      ) : (
+        <section className="investment-snapshots-page__section">
+          <table className="investment-snapshots-page__table data-table">
+            <thead>
+              <tr>
+                <th>Account</th>
+                <th className="data-table__col--numeric">Value</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {snapshots.map((snapshot) => (
+                <SnapshotRow
+                  key={snapshot.id}
+                  snapshot={snapshot}
+                  isEditing={editingId === snapshot.id}
+                  editValue={editValue}
+                  isSaving={isSaving}
+                  onEdit={showEditForm}
+                  onValueChange={setEditValue}
+                  onSave={saveEdit}
+                  onCancel={cancelEdit}
+                />
+              ))}
+            </tbody>
+          </table>
+          {saveError && <p className="investment-snapshots-page__error">{saveError}</p>}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/Financial.Web/src/pages/__tests__/InvestmentSnapshotsPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/InvestmentSnapshotsPage.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import InvestmentSnapshotsPage from '../InvestmentSnapshotsPage'
+import type { FinancialApiClient } from '../../api/financialApiClient'
+import type { InvestmentSnapshotDto } from '../../api/types'
+
+const getInvestmentSnapshotsMock = vi.fn<FinancialApiClient['getInvestmentSnapshots']>()
+const updateInvestmentSnapshotValueMock = vi.fn<FinancialApiClient['updateInvestmentSnapshotValue']>()
+
+vi.mock('../../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getInvestmentSnapshots: getInvestmentSnapshotsMock,
+    updateInvestmentSnapshotValue: updateInvestmentSnapshotValueMock,
+  }),
+}))
+
+const SNAPSHOTS: InvestmentSnapshotDto[] = Array.from({ length: 11 }, (_, i) => ({
+  id: `s${i}`,
+  account: `Account${i}`,
+  isLiability: i === 1,
+  year: 2026,
+  month: 7,
+  value: 100 * i,
+}))
+
+describe('InvestmentSnapshotsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getInvestmentSnapshotsMock.mockResolvedValue(SNAPSHOTS)
+  })
+
+  it('shows a loading state before data arrives', () => {
+    render(<InvestmentSnapshotsPage />)
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('shows an error state with retry when the fetch fails', async () => {
+    getInvestmentSnapshotsMock.mockRejectedValue(new Error('Network down'))
+
+    render(<InvestmentSnapshotsPage />)
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByText('Network down')).toBeInTheDocument()
+  })
+
+  it('renders all 11 accounts with their values once loaded', async () => {
+    render(<InvestmentSnapshotsPage />)
+
+    await waitFor(() => expect(screen.getByText('Account0')).toBeInTheDocument())
+    expect(screen.getAllByRole('row')).toHaveLength(12) // header + 11 accounts
+    expect(screen.getByText('Account1 (liability)')).toBeInTheDocument()
+  })
+
+  it('edits a row value and saves, updating the displayed row', async () => {
+    updateInvestmentSnapshotValueMock.mockResolvedValue({ ...SNAPSHOTS[0], value: 999 })
+    render(<InvestmentSnapshotsPage />)
+
+    await waitFor(() => expect(screen.getByText('Account0')).toBeInTheDocument())
+
+    const editButtons = screen.getAllByRole('button', { name: 'Edit' })
+    fireEvent.click(editButtons[0])
+
+    const valueInput = screen.getByDisplayValue('0')
+    fireEvent.change(valueInput, { target: { value: '999' } })
+
+    getInvestmentSnapshotsMock.mockResolvedValue([{ ...SNAPSHOTS[0], value: 999 }, ...SNAPSHOTS.slice(1)])
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(updateInvestmentSnapshotValueMock).toHaveBeenCalledWith('s0', { value: 999 }))
+    await waitFor(() => expect(screen.getByText('999.00')).toBeInTheDocument())
+  })
+})

--- a/docs/P11-F16-web-investment-snapshots-view/plan.md
+++ b/docs/P11-F16-web-investment-snapshots-view/plan.md
@@ -1,0 +1,28 @@
+# Implementation Plan: F16. Web — Investment Snapshots View
+
+**Prerequisites:**
+- F08's `/investment-snapshots/*` endpoints already exist and are unchanged by this feature
+- F13/F14/F15's `ApiError` and hook/page conventions already established
+- No new npm packages
+
+### Stage 1: API Client Layer
+
+**1. Investment snapshot DTOs and client methods** - Add the snapshot type and the value-only update-request type, plus the two new `financialApiClient` methods that call F08's existing endpoints.
+
+**2. API client tests** - Add tests for the new methods' request shape.
+
+### Stage 2: Page Logic and UI
+
+**3. useInvestmentSnapshots hook** - Add the hook that tracks the selected month (defaulting to the current month), fetches the month's 11 snapshots on month change, manages the single-row inline value-edit state, and re-fetches after a successful update.
+
+**4. InvestmentSnapshotsPage component** - Add the presentational page: month picker, loading/error states, a single table of all 11 accounts with inline per-row value editing, wired to `useInvestmentSnapshots`.
+
+**5. Wire up routing** - Replace the `/cashflow/investment-snapshots` placeholder route in `main.tsx` with `InvestmentSnapshotsPage`.
+
+**6. Hook and component tests** - Add tests for `useInvestmentSnapshots`'s fetch/edit behavior and for `InvestmentSnapshotsPage`'s rendering of all 11 accounts and the edit flow.
+
+### Stage 3: Verification
+
+**7. Full-suite validation** - Run the Web project's full test suite and typecheck, confirming no regression to any existing test.
+
+**8. Manual verification** - Run the Web dev server against a locally running `Financial.Api`, navigate to `/cashflow/investment-snapshots`, and exercise the view directly (confirm all 11 accounts render for the current month, edit one account's value and confirm it saves without affecting other accounts, change the month and confirm a fresh set of snapshots loads) to confirm the behavior matches the acceptance criteria end-to-end.

--- a/docs/P11-F16-web-investment-snapshots-view/spec.md
+++ b/docs/P11-F16-web-investment-snapshots-view/spec.md
@@ -1,0 +1,73 @@
+# F16. Web — Investment Snapshots View
+
+## 1. Technical Overview
+
+**What:** Replace F11's `/cashflow/investment-snapshots` placeholder with a real page that lets the user pick a month, shows that month's auto-generated 11-account snapshot (F08), and lets the user update a single account's value inline.
+
+**Why:** This turns F08's backend-only monthly snapshot generation into the actual first-of-month workflow — enter each account's balance once a month, independent of the Financial.Investments domain.
+
+**Scope:**
+- Included: month picker (reusing F14's pattern, defaults to the current month); a flat table of all 11 accounts (always exactly 11, per F08) showing account name, liability indicator, and value; inline per-row value editing.
+- Excluded: status/date fields (F08 has none — value is the only per-instance field); any other CashFlow view (F13/F14/F15).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/api/types.ts` — new: `InvestmentSnapshotDto`, `UpdateInvestmentSnapshotValueDto`
+- `Financial.Web/src/api/financialApiClient.ts` — modified: new methods `getInvestmentSnapshots(year, month)`, `updateInvestmentSnapshotValue(id, request)`
+- `Financial.Web/src/hooks/useInvestmentSnapshots.ts` — new: page business logic
+- `Financial.Web/src/pages/InvestmentSnapshotsPage.tsx`, `InvestmentSnapshotsPage.css` — new: replaces `CashFlowPlaceholderPage` on `/cashflow/investment-snapshots`
+- `Financial.Web/src/main.tsx` — modified: route swap
+
+```mermaid
+graph TD
+  A[InvestmentSnapshotsPage] --> B[useInvestmentSnapshots hook]
+  B --> C["financialApiClient (getInvestmentSnapshots/updateInvestmentSnapshotValue)"]
+  C --> D["/api/v1/financial/investment-snapshots/*"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Month selection | Reuse F14's `<input type="month">` pattern, defaulting to the current month | A new/different picker | Consistent with the established per-month CashFlow view precedent; no reason to diverge. |
+| Layout | A single flat table of all 11 accounts (no grouping) | Group by liability/asset | F08's own spec never groups accounts — it always returns a flat 11-row list — and the PRD's Experience text describes "sees all 11 accounts" with no grouping mentioned, unlike F06's explicit Brasil/UK split. |
+| Liability indicator | A `(liability)` suffix appended to the account name when `isLiability` is true, matching the historical spreadsheet's own labeling convention (e.g. "Platinum Visa 8003 (liability)") | A separate boolean column/badge | Cheapest way to surface the classification already returned by the API without adding a whole extra column for a single boolean, and matches the exact wording the PRD itself uses when listing the canonical account list. |
+| Refresh strategy after a successful edit | Re-fetch the month's 11 snapshots after a successful update | Locally patch the edited row | Same precedent as F13/F14/F15 — keeps displayed state provably in sync with the server. |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/api/types.ts` | Modified | DTO types | `InvestmentSnapshotDto { id, account, isLiability, year, month, value }`, `UpdateInvestmentSnapshotValueDto { value }` |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | HTTP client | `getInvestmentSnapshots(year, month)`, `updateInvestmentSnapshotValue(id, request)` |
+| `Financial.Web/src/hooks/useInvestmentSnapshots.ts` | New | Page business logic | Month state (defaults to current month); fetches the month's 11 snapshots on month change; per-row inline edit state (`editingId`, `editValue`); submit/re-fetch; loading/error state matching `useMensais`'s reducer pattern |
+| `Financial.Web/src/pages/InvestmentSnapshotsPage.tsx`, `InvestmentSnapshotsPage.css` | New | Presentational page | Month picker, `LoadingState`/`ErrorState`, a single table of all 11 accounts with inline value edit per row |
+| `Financial.Web/src/main.tsx` | Modified | Routing | `/cashflow/investment-snapshots` renders `InvestmentSnapshotsPage` instead of `CashFlowPlaceholderPage` |
+
+## 5. API Contracts
+
+Consumes F08's existing endpoints unchanged (see F08's own spec for full detail):
+
+- `GET /api/v1/financial/investment-snapshots/{year}/{month}` → `InvestmentSnapshotDto[]` (always exactly 11 rows, generated on first call for that month)
+- `PUT /api/v1/financial/investment-snapshots/{id}` (body: `UpdateInvestmentSnapshotValueDto`) → `InvestmentSnapshotDto`; `400` on a negative value, `404` on an unknown id
+
+No new backend endpoints — this feature is Web-only.
+
+## 6. Data Model
+
+No backend/persisted data model changes — this is a Web-only feature consuming F08's existing `data-cashflow.json`-backed endpoints.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Financial.Web/src/api/financialApiClient.test.ts` | Unit | `financialApiClient` | New Investment Snapshots methods call the correct paths/methods/bodies |
+| `Financial.Web/src/hooks/useInvestmentSnapshots.test.ts` | Unit | `useInvestmentSnapshots` | Fetches the current month's 11 snapshots on mount; changing the month re-fetches for the new year/month; edit-and-submit calls the update endpoint and re-fetches on success; a backend error is surfaced without crashing |
+| `Financial.Web/src/pages/InvestmentSnapshotsPage.test.tsx` | Component | `InvestmentSnapshotsPage` | Renders `LoadingState`/`ErrorState`; renders all 11 accounts with their values once loaded; editing a row's value and saving updates the displayed row |
+
+**Acceptance tests (from PRD Section 9, F16):**
+- The view shows all 11 tracked accounts for the selected month with their current values — `InvestmentSnapshotsPage.test.tsx`
+- Editing one account's value for a month does not affect other months or other accounts — `useInvestmentSnapshots.test.ts` (re-fetch-after-update assertion scoped to the selected month; other rows' values unchanged), `InvestmentSnapshotsPage.test.tsx`

--- a/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
+++ b/docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md
@@ -627,8 +627,8 @@ graph TD
 - [x] A new entry can be created with automatic FX conversion, and either currency value can be manually adjusted before saving
 
 ### F16. Web — Investment Snapshots View
-- [ ] The view shows all 11 tracked accounts for the selected month with their current values
-- [ ] Editing one account's value for a month does not affect other months or other accounts
+- [x] The view shows all 11 tracked accounts for the selected month with their current values
+- [x] Editing one account's value for a month does not affect other months or other accounts
 
 ### F17. Web — Yearly Summary View
 - [ ] Selecting a year shows a monthly-totals-per-expense-category table with a yearly total column
@@ -643,5 +643,5 @@ graph TD
 - [x] F09's yearly expense-category totals correctly reflect the underlying monthly expense totals (F03), and its month-over-month investment-account diffs correctly reflect F08's monthly snapshots
 - [ ] F10's historical import correctly populates every one of F02's six storage collections, matching the shapes defined by F03, F04, F05, F06, F07, and F08
 - [ ] F12's Web Monthly View correctly displays expense data from F03 and card data from F04, and its Investments-domain content is correctly scoped by F11's domain switcher
-- [ ] F13, F14, F15, and F16 each correctly display data from F05, F06, F07, and F08 respectively, all nested inside F11's CashFlow selection
+- [x] F13, F14, F15, and F16 each correctly display data from F05, F06, F07, and F08 respectively, all nested inside F11's CashFlow selection
 - [ ] F17's Web Yearly Summary View correctly displays the totals and diffs computed by F09


### PR DESCRIPTION
## Summary
- Replaces F11's `/cashflow/investment-snapshots` placeholder with a real page: a month picker (reusing F14's pattern) and a single flat table of all 11 tracked accounts (F08) with inline per-row value editing.
- New `getInvestmentSnapshots(year, month)` / `updateInvestmentSnapshotValue(id, request)` methods on the shared `financialApiClient`, consuming F08's existing endpoints unchanged.

## Technical decisions (see docs/P11-F16-web-investment-snapshots-view/spec.md)
- No grouping — F08's own spec always returns a flat 11-row list, and the PRD's Experience text describes "sees all 11 accounts" with no grouping, unlike F06's explicit Brasil/UK split.
- A `(liability)` suffix appended to the account name (matching the historical spreadsheet's own labeling convention, e.g. "Platinum Visa 8003 (liability)") rather than a separate column, for the single boolean the API returns.
- Reuses F14's month-picker and F13/F14/F15's re-fetch-after-success precedent.

## Test plan
- [x] `financialApiClient.test.ts` — new Investment Snapshots methods call the correct paths/bodies
- [x] `useInvestmentSnapshots.test.ts` — fetch-on-mount for the current month, re-fetch on month change, backend error surfaced, edit-and-save + re-fetch leaving other snapshots untouched, save error surfaced without crashing
- [x] `InvestmentSnapshotsPage.test.tsx` — loading/error states, all 11 accounts render (including the liability label), edit-and-save updates the displayed row
- [x] Full Web test suite green (467 tests, no regressions), typecheck and lint clean
- [x] Manual smoke test with a real running `Financial.Api` + Vite dev server via a scripted Playwright session: confirmed exactly 11 accounts render with correct liability labels, edited ChaseSave's value and confirmed it saved, switched to a different month and confirmed ChaseSave there was independently generated at 0 (unaffected), no console errors

## PRD
Acceptance criteria for F16 checked off in `docs/prd/P11-prd-cashflow-tracking/prd-cashflow-tracking.md`. The cross-feature integration checkbox covering F13/F14/F15/F16 together is also checked off now that all four Web views are implemented — this completes Wave 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)