### PR TITLE
chore(P11): simplify duplication and O(n) rescans across CashFlow

### DIFF
--- a/Financial.CashFlow.Application/Services/CardStatementService.cs
+++ b/Financial.CashFlow.Application/Services/CardStatementService.cs
@@ -41,7 +41,12 @@ public sealed class CardStatementService : ICardStatementService
             await _repository.SaveChangesAsync().ConfigureAwait(false);
         }
 
-        return existingStatements.Select(ToDto).ToList();
+        var outstandingByCard = _repository.GetExpenses()
+            .Where(e => e.Date.Year == year && e.Date.Month == month && e.CardTag.HasValue)
+            .GroupBy(e => e.CardTag!.Value)
+            .ToDictionary(g => g.Key, g => g.Sum(e => e.Value));
+
+        return existingStatements.Select(s => ToDto(s, outstandingByCard)).ToList();
     }
 
     public async Task<CardStatementDTO> MarkStatementPaidAsync(Guid id)
@@ -66,14 +71,17 @@ public sealed class CardStatementService : ICardStatementService
             throw;
         }
 
-        return ToDto(statement);
+        return ToDto(statement, outstandingByCard: null);
     }
 
-    private CardStatementDTO ToDto(CardStatement statement)
+    private CardStatementDTO ToDto(CardStatement statement, IReadOnlyDictionary<CreditCard, decimal>? outstandingByCard = null)
     {
-        var outstandingTotal = statement.IsPaid ? 0m : _repository.GetExpenses()
-            .Where(e => e.CardTag == statement.Card && e.Date.Year == statement.Year && e.Date.Month == statement.Month)
-            .Sum(e => e.Value);
+        var outstandingTotal = statement.IsPaid
+            ? 0m
+            : outstandingByCard?.GetValueOrDefault(statement.Card)
+                ?? _repository.GetExpenses()
+                    .Where(e => e.CardTag == statement.Card && e.Date.Year == statement.Year && e.Date.Month == statement.Month)
+                    .Sum(e => e.Value);
 
         return new CardStatementDTO
         {

--- a/Financial.CashFlow.Application/Services/YearlySummaryService.cs
+++ b/Financial.CashFlow.Application/Services/YearlySummaryService.cs
@@ -18,7 +18,10 @@ public sealed class YearlySummaryService : IYearlySummaryService
 
     public IReadOnlyList<CategoryYearlyTotalDTO> GetCategoryTotalsForYear(int year)
     {
-        var expenses = _repository.GetExpenses().Where(e => e.Date.Year == year).ToList();
+        var totalsByCategoryAndMonth = _repository.GetExpenses()
+            .Where(e => e.Date.Year == year)
+            .GroupBy(e => (e.Category, e.Date.Month))
+            .ToDictionary(g => g.Key, g => g.Sum(e => e.Value));
 
         return Enum.GetValues<Category>()
             .Select(category =>
@@ -26,9 +29,7 @@ public sealed class YearlySummaryService : IYearlySummaryService
                 var monthlyTotals = new decimal[MonthsInYear];
                 for (var month = 1; month <= MonthsInYear; month++)
                 {
-                    monthlyTotals[month - 1] = expenses
-                        .Where(e => e.Category == category && e.Date.Month == month)
-                        .Sum(e => e.Value);
+                    monthlyTotals[month - 1] = totalsByCategoryAndMonth.GetValueOrDefault((category, month));
                 }
 
                 return new CategoryYearlyTotalDTO
@@ -43,7 +44,10 @@ public sealed class YearlySummaryService : IYearlySummaryService
 
     public InvestmentDiffsYearlyDTO GetInvestmentDiffsForYear(int year)
     {
-        var snapshots = _repository.GetInvestmentSnapshots().Where(s => s.Year == year).ToList();
+        var valueByAccountAndMonth = _repository.GetInvestmentSnapshots()
+            .Where(s => s.Year == year)
+            .GroupBy(s => (s.Account, s.Month))
+            .ToDictionary(g => g.Key, g => g.First().Value);
 
         var accounts = Enum.GetValues<InvestmentAccount>()
             .Select(account =>
@@ -51,8 +55,7 @@ public sealed class YearlySummaryService : IYearlySummaryService
                 var monthlyValues = new decimal[MonthsInYear];
                 for (var month = 1; month <= MonthsInYear; month++)
                 {
-                    monthlyValues[month - 1] = snapshots
-                        .FirstOrDefault(s => s.Account == account && s.Month == month)?.Value ?? 0m;
+                    monthlyValues[month - 1] = valueByAccountAndMonth.GetValueOrDefault((account, month));
                 }
 
                 return new InvestmentAccountYearlyDiffDTO

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -134,8 +134,19 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
     : API_BASE_URL
   const fetcher = options.fetch ?? fetch
 
-  const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
+  const sendRequest = async (path: string, init?: RequestInit): Promise<Response> => {
     const url = `${baseUrl}${path}`
+    const response = await fetcher(url, init)
+
+    if (!response.ok) {
+      const method = init?.method ?? 'GET'
+      throw new ApiError(await buildErrorMessage(response, method, url), response.status)
+    }
+
+    return response
+  }
+
+  const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
     const headers = new Headers(init?.headers)
     if (!headers.has('Accept')) {
       headers.set('Accept', 'application/json')
@@ -144,27 +155,12 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       headers.set('Content-Type', 'application/json')
     }
 
-    const response = await fetcher(url, {
-      ...init,
-      headers,
-    })
-
-    if (!response.ok) {
-      const method = init?.method ?? 'GET'
-      throw new ApiError(await buildErrorMessage(response, method, url), response.status)
-    }
-
+    const response = await sendRequest(path, { ...init, headers })
     return (await response.json()) as T
   }
 
   const requestVoid = async (path: string, init?: RequestInit): Promise<void> => {
-    const url = `${baseUrl}${path}`
-    const response = await fetcher(url, init)
-
-    if (!response.ok) {
-      const method = init?.method ?? 'GET'
-      throw new ApiError(await buildErrorMessage(response, method, url), response.status)
-    }
+    await sendRequest(path, init)
   }
 
   const buildExchangeQuery = (exchange?: string) => {

--- a/Financial.Web/src/components/EditRowActions.tsx
+++ b/Financial.Web/src/components/EditRowActions.tsx
@@ -1,0 +1,18 @@
+interface EditRowActionsProps {
+  isSaving: boolean
+  onSave: () => void
+  onCancel: () => void
+}
+
+export default function EditRowActions({ isSaving, onSave, onCancel }: EditRowActionsProps) {
+  return (
+    <>
+      <button type="button" disabled={isSaving} onClick={onSave}>
+        {isSaving ? 'Saving...' : 'Save'}
+      </button>
+      <button type="button" onClick={onCancel}>
+        Cancel
+      </button>
+    </>
+  )
+}

--- a/Financial.Web/src/hooks/useControleMae.ts
+++ b/Financial.Web/src/hooks/useControleMae.ts
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { createFinancialApiClient } from '../api/financialApiClient'
 import type { MaeLedgerEntryDto } from '../api/types'
-import { pad } from '../utils/formatters'
-
-function currentYearMonth(): { year: number; month: number } {
-  const now = new Date()
-  return { year: now.getFullYear(), month: now.getMonth() + 1 }
-}
+import { currentYearMonth, formatMonthInputValue, parseMonthInputValue } from '../utils/formatters'
 
 export type CreateFormField = 'createDate' | 'createDescription' | 'createNote' | 'createSourceCurrency' | 'createSourceValue'
 export type EditField = 'editBrlValue' | 'editGbpValue'
@@ -160,14 +155,12 @@ export function useControleMae(): ControleMaeData {
       })
   }, [apiClient, state.year, state.month, state.retryCount])
 
-  const monthInputValue = `${state.year}-${pad(state.month)}`
+  const monthInputValue = formatMonthInputValue(state.year, state.month)
 
   const setMonthInputValue = useCallback((value: string) => {
-    const [yearStr, monthStr] = value.split('-')
-    const year = Number(yearStr)
-    const month = Number(monthStr)
-    if (!Number.isFinite(year) || !Number.isFinite(month)) return
-    dispatch({ type: 'SET_MONTH', payload: { year, month } })
+    const parsed = parseMonthInputValue(value)
+    if (!parsed) return
+    dispatch({ type: 'SET_MONTH', payload: parsed })
   }, [])
 
   const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])

--- a/Financial.Web/src/hooks/useInvestmentSnapshots.ts
+++ b/Financial.Web/src/hooks/useInvestmentSnapshots.ts
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { createFinancialApiClient } from '../api/financialApiClient'
 import type { InvestmentSnapshotDto } from '../api/types'
-import { pad } from '../utils/formatters'
-
-function currentYearMonth(): { year: number; month: number } {
-  const now = new Date()
-  return { year: now.getFullYear(), month: now.getMonth() + 1 }
-}
+import { currentYearMonth, formatMonthInputValue, parseMonthInputValue } from '../utils/formatters'
 
 interface InvestmentSnapshotsState {
   year: number
@@ -112,14 +107,12 @@ export function useInvestmentSnapshots(): InvestmentSnapshotsData {
       })
   }, [apiClient, state.year, state.month, state.retryCount])
 
-  const monthInputValue = `${state.year}-${pad(state.month)}`
+  const monthInputValue = formatMonthInputValue(state.year, state.month)
 
   const setMonthInputValue = useCallback((value: string) => {
-    const [yearStr, monthStr] = value.split('-')
-    const year = Number(yearStr)
-    const month = Number(monthStr)
-    if (!Number.isFinite(year) || !Number.isFinite(month)) return
-    dispatch({ type: 'SET_MONTH', payload: { year, month } })
+    const parsed = parseMonthInputValue(value)
+    if (!parsed) return
+    dispatch({ type: 'SET_MONTH', payload: parsed })
   }, [])
 
   const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])

--- a/Financial.Web/src/hooks/useMensais.ts
+++ b/Financial.Web/src/hooks/useMensais.ts
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { createFinancialApiClient } from '../api/financialApiClient'
 import type { RecurringBillInstanceDto } from '../api/types'
-import { pad } from '../utils/formatters'
-
-function currentYearMonth(): { year: number; month: number } {
-  const now = new Date()
-  return { year: now.getFullYear(), month: now.getMonth() + 1 }
-}
+import { currentYearMonth, formatMonthInputValue, parseMonthInputValue } from '../utils/formatters'
 
 export type EditField = 'editStatus' | 'editValue'
 
@@ -123,14 +118,12 @@ export function useMensais(): MensaisData {
       })
   }, [apiClient, state.year, state.month, state.retryCount])
 
-  const monthInputValue = `${state.year}-${pad(state.month)}`
+  const monthInputValue = formatMonthInputValue(state.year, state.month)
 
   const setMonthInputValue = useCallback((value: string) => {
-    const [yearStr, monthStr] = value.split('-')
-    const year = Number(yearStr)
-    const month = Number(monthStr)
-    if (!Number.isFinite(year) || !Number.isFinite(month)) return
-    dispatch({ type: 'SET_MONTH', payload: { year, month } })
+    const parsed = parseMonthInputValue(value)
+    if (!parsed) return
+    dispatch({ type: 'SET_MONTH', payload: parsed })
   }, [])
 
   const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])

--- a/Financial.Web/src/hooks/useMonthly.ts
+++ b/Financial.Web/src/hooks/useMonthly.ts
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { createFinancialApiClient } from '../api/financialApiClient'
 import type { CardStatementDto, CategoryTotalDto, ExpenseDto } from '../api/types'
-import { pad } from '../utils/formatters'
-
-function currentYearMonth(): { year: number; month: number } {
-  const now = new Date()
-  return { year: now.getFullYear(), month: now.getMonth() + 1 }
-}
+import { currentYearMonth, formatMonthInputValue, parseMonthInputValue } from '../utils/formatters'
 
 export type CreateFormField =
   | 'createDate'
@@ -49,7 +44,6 @@ interface MonthlyState {
   editCardTag: string
   isSaving: boolean
   saveError: string | null
-  markPaidError: string | null
 }
 
 type MonthlyAction =
@@ -105,7 +99,6 @@ const INITIAL_STATE: MonthlyState = {
   editCardTag: '',
   isSaving: false,
   saveError: null,
-  markPaidError: null,
 }
 
 function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
@@ -239,14 +232,12 @@ export function useMonthly(): MonthlyData {
       })
   }, [apiClient, state.year, state.month, state.retryCount])
 
-  const monthInputValue = `${state.year}-${pad(state.month)}`
+  const monthInputValue = formatMonthInputValue(state.year, state.month)
 
   const setMonthInputValue = useCallback((value: string) => {
-    const [yearStr, monthStr] = value.split('-')
-    const year = Number(yearStr)
-    const month = Number(monthStr)
-    if (!Number.isFinite(year) || !Number.isFinite(month)) return
-    dispatch({ type: 'SET_MONTH', payload: { year, month } })
+    const parsed = parseMonthInputValue(value)
+    if (!parsed) return
+    dispatch({ type: 'SET_MONTH', payload: parsed })
   }, [])
 
   const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])

--- a/Financial.Web/src/pages/ControleMaePage.tsx
+++ b/Financial.Web/src/pages/ControleMaePage.tsx
@@ -1,4 +1,5 @@
 import type { MaeLedgerEntryDto } from '../api/types'
+import EditRowActions from '../components/EditRowActions'
 import ErrorState from '../components/ErrorState'
 import LoadingState from '../components/LoadingState'
 import { useControleMae } from '../hooks/useControleMae'
@@ -51,12 +52,7 @@ function EntryRow({
           />
         </td>
         <td>
-          <button type="button" disabled={isSaving} onClick={onSave}>
-            {isSaving ? 'Saving...' : 'Save'}
-          </button>
-          <button type="button" onClick={onCancel}>
-            Cancel
-          </button>
+          <EditRowActions isSaving={isSaving} onSave={onSave} onCancel={onCancel} />
         </td>
       </tr>
     )

--- a/Financial.Web/src/pages/InvestmentSnapshotsPage.tsx
+++ b/Financial.Web/src/pages/InvestmentSnapshotsPage.tsx
@@ -1,4 +1,5 @@
 import type { InvestmentSnapshotDto } from '../api/types'
+import EditRowActions from '../components/EditRowActions'
 import ErrorState from '../components/ErrorState'
 import LoadingState from '../components/LoadingState'
 import { useInvestmentSnapshots } from '../hooks/useInvestmentSnapshots'
@@ -36,12 +37,7 @@ function SnapshotRow({
           <input type="number" step="0.01" min="0" value={editValue} onChange={(e) => onValueChange(e.target.value)} />
         </td>
         <td>
-          <button type="button" disabled={isSaving} onClick={onSave}>
-            {isSaving ? 'Saving...' : 'Save'}
-          </button>
-          <button type="button" onClick={onCancel}>
-            Cancel
-          </button>
+          <EditRowActions isSaving={isSaving} onSave={onSave} onCancel={onCancel} />
         </td>
       </tr>
     )

--- a/Financial.Web/src/pages/MensaisPage.tsx
+++ b/Financial.Web/src/pages/MensaisPage.tsx
@@ -1,4 +1,5 @@
 import type { RecurringBillInstanceDto } from '../api/types'
+import EditRowActions from '../components/EditRowActions'
 import ErrorState from '../components/ErrorState'
 import LoadingState from '../components/LoadingState'
 import { useMensais } from '../hooks/useMensais'
@@ -53,12 +54,7 @@ function InstanceRow({
           </select>
         </td>
         <td>
-          <button type="button" disabled={isSaving} onClick={onSave}>
-            {isSaving ? 'Saving...' : 'Save'}
-          </button>
-          <button type="button" onClick={onCancel}>
-            Cancel
-          </button>
+          <EditRowActions isSaving={isSaving} onSave={onSave} onCancel={onCancel} />
         </td>
       </tr>
     )

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -1,7 +1,8 @@
 import type { ExpenseDto } from '../api/types'
+import EditRowActions from '../components/EditRowActions'
 import ErrorState from '../components/ErrorState'
 import LoadingState from '../components/LoadingState'
-import { useMonthly } from '../hooks/useMonthly'
+import { useMonthly, type EditField } from '../hooks/useMonthly'
 import { formatN2, formatShortDate } from '../utils/formatters'
 import './MonthlyPage.css'
 
@@ -37,10 +38,7 @@ interface ExpenseRowProps {
   editCardTag: string
   isSaving: boolean
   onEdit: (expense: ExpenseDto) => void
-  onFieldChange: (
-    field: 'editDate' | 'editDescription' | 'editValue' | 'editCategory' | 'editPaymentSource' | 'editCardTag',
-    value: string,
-  ) => void
+  onFieldChange: (field: EditField, value: string) => void
   onSave: () => void
   onCancel: () => void
   onDelete: (id: string) => void
@@ -107,12 +105,7 @@ function ExpenseRow({
           </select>
         </td>
         <td>
-          <button type="button" disabled={isSaving} onClick={onSave}>
-            {isSaving ? 'Saving...' : 'Save'}
-          </button>
-          <button type="button" onClick={onCancel}>
-            Cancel
-          </button>
+          <EditRowActions isSaving={isSaving} onSave={onSave} onCancel={onCancel} />
         </td>
       </tr>
     )

--- a/Financial.Web/src/utils/formatters.ts
+++ b/Financial.Web/src/utils/formatters.ts
@@ -41,3 +41,19 @@ export function formatShortDate(isoString: string | null | undefined): string {
 export function toInputDate(isoString: string): string {
   return isoString.split('T')[0]
 }
+
+export function currentYearMonth(): { year: number; month: number } {
+  const now = new Date()
+  return { year: now.getFullYear(), month: now.getMonth() + 1 }
+}
+
+export function formatMonthInputValue(year: number, month: number): string {
+  return `${year}-${pad(month)}`
+}
+
+export function parseMonthInputValue(value: string): { year: number; month: number } | null {
+  const [yearStr, monthStr] = value.split('-')
+  const year = Number(yearStr)
+  const month = Number(monthStr)
+  return Number.isFinite(year) && Number.isFinite(month) ? { year, month } : null
+}

--- a/Integrations/CashFlowSpreadsheetImport/Parsing/PortugueseMonthAbbreviations.cs
+++ b/Integrations/CashFlowSpreadsheetImport/Parsing/PortugueseMonthAbbreviations.cs
@@ -1,0 +1,26 @@
+namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowSpreadsheetImport.Parsing;
+
+/// <summary>
+/// Maps the 3-letter Portuguese month abbreviations used throughout the source spreadsheet (sheet
+/// names, free-text dates) to their calendar month number, plus the one full-spelled variant
+/// ("Maio") confirmed present in the real "Controle mae" sheet.
+/// </summary>
+public static class PortugueseMonthAbbreviations
+{
+    public static readonly IReadOnlyDictionary<string, int> Map = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Jan"] = 1,
+        ["Fev"] = 2,
+        ["Mar"] = 3,
+        ["Abr"] = 4,
+        ["Mai"] = 5,
+        ["Maio"] = 5,
+        ["Jun"] = 6,
+        ["Jul"] = 7,
+        ["Ago"] = 8,
+        ["Set"] = 9,
+        ["Out"] = 10,
+        ["Nov"] = 11,
+        ["Dez"] = 12,
+    };
+}

--- a/Integrations/CashFlowSpreadsheetImport/Parsing/SheetNameParser.cs
+++ b/Integrations/CashFlowSpreadsheetImport/Parsing/SheetNameParser.cs
@@ -9,21 +9,8 @@ namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowSpreadsheetImpo
 /// </summary>
 public static partial class SheetNameParser
 {
-    private static readonly Dictionary<string, int> MonthAbbreviations = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["Jan"] = 1,
-        ["Fev"] = 2,
-        ["Mar"] = 3,
-        ["Abr"] = 4,
-        ["Mai"] = 5,
-        ["Jun"] = 6,
-        ["Jul"] = 7,
-        ["Ago"] = 8,
-        ["Set"] = 9,
-        ["Out"] = 10,
-        ["Nov"] = 11,
-        ["Dez"] = 12,
-    };
+    public const int FirstInScopeYear = 2017;
+    public const int LastInScopeYear = 2026;
 
     private static readonly Regex MonthlySheetNamePattern = BuildMonthlySheetNamePattern();
 
@@ -38,7 +25,7 @@ public static partial class SheetNameParser
             return false;
         }
 
-        if (!MonthAbbreviations.TryGetValue(match.Groups["month"].Value, out month))
+        if (!PortugueseMonthAbbreviations.Map.TryGetValue(match.Groups["month"].Value, out month))
         {
             return false;
         }
@@ -48,7 +35,7 @@ public static partial class SheetNameParser
     }
 
     public static bool IsInScope(int year, int month) =>
-        year <= 2026 && (year > 2017 || (year == 2017 && month >= 2));
+        year <= LastInScopeYear && (year > FirstInScopeYear || (year == FirstInScopeYear && month >= 2));
 
     [GeneratedRegex(@"^(?<month>Jan|Fev|Mar|Abr|Mai|Jun|Jul|Ago|Set|Out|Nov|Dez)(?<year>\d{4})$", RegexOptions.IgnoreCase)]
     private static partial Regex BuildMonthlySheetNamePattern();

--- a/Integrations/CashFlowSpreadsheetImport/Program.cs
+++ b/Integrations/CashFlowSpreadsheetImport/Program.cs
@@ -120,9 +120,6 @@ static void ImportControleMaeSheet(XLWorkbook workbook, CashFlowData data, Impor
 
 static void ImportResumoSheets(XLWorkbook workbook, CashFlowData data, ImportReport report)
 {
-    const int FirstInScopeYear = 2017;
-    const int LastInScopeYear = 2026;
-
     var resumoSheets = workbook.Worksheets
         .Where(sheet => sheet.Name.StartsWith(ResumoSheetPrefix, StringComparison.OrdinalIgnoreCase))
         .Select(sheet => (Sheet: sheet, Parsed: int.TryParse(sheet.Name[ResumoSheetPrefix.Length..], out var year), Year: year))
@@ -131,9 +128,11 @@ static void ImportResumoSheets(XLWorkbook workbook, CashFlowData data, ImportRep
 
     foreach (var (sheet, _, year) in resumoSheets)
     {
-        if (year < FirstInScopeYear || year > LastInScopeYear)
+        if (year < SheetNameParser.FirstInScopeYear || year > SheetNameParser.LastInScopeYear)
         {
-            report.SheetSkipped(sheet.Name, $"Year {year} predates the import's Feb {FirstInScopeYear}-{LastInScopeYear} scope");
+            report.SheetSkipped(
+                sheet.Name,
+                $"Year {year} predates the import's Feb {SheetNameParser.FirstInScopeYear}-{SheetNameParser.LastInScopeYear} scope");
             continue;
         }
 

--- a/Integrations/CashFlowSpreadsheetImport/SheetImporters/ControleMaeSheetImporter.cs
+++ b/Integrations/CashFlowSpreadsheetImport/SheetImporters/ControleMaeSheetImporter.cs
@@ -24,23 +24,6 @@ public static partial class ControleMaeSheetImporter
     private const int GbpValueColumn = 3;
     private const int NoteColumn = 5;
 
-    private static readonly Dictionary<string, int> MonthAbbreviations = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["Jan"] = 1,
-        ["Fev"] = 2,
-        ["Mar"] = 3,
-        ["Abr"] = 4,
-        ["Mai"] = 5,
-        ["Maio"] = 5,
-        ["Jun"] = 6,
-        ["Jul"] = 7,
-        ["Ago"] = 8,
-        ["Set"] = 9,
-        ["Out"] = 10,
-        ["Nov"] = 11,
-        ["Dez"] = 12,
-    };
-
     private static readonly Regex FullDatePattern = BuildFullDatePattern();
     private static readonly Regex MonthYearPattern = BuildMonthYearPattern();
     private static readonly Regex YearMonthPattern = BuildYearMonthPattern();
@@ -118,7 +101,7 @@ public static partial class ControleMaeSheetImporter
             // A range like "Jan/2020-Dez/2020" matches twice - the last match is the end of the
             // period (or the only match, when there is no range), so it wins either way.
             var lastMatch = monthYearMatches[^1];
-            if (MonthAbbreviations.TryGetValue(lastMatch.Groups["month"].Value, out var monthNumber))
+            if (PortugueseMonthAbbreviations.Map.TryGetValue(lastMatch.Groups["month"].Value, out var monthNumber))
             {
                 date = new DateOnly(int.Parse(lastMatch.Groups["year"].Value), monthNumber, 1);
                 return true;

--- a/Integrations/CashFlowSpreadsheetImport/SheetImporters/MensaisSheetImporter.cs
+++ b/Integrations/CashFlowSpreadsheetImport/SheetImporters/MensaisSheetImporter.cs
@@ -1,4 +1,5 @@
 using ClosedXML.Excel;
+using Financial.CashFlow.Application.Validation;
 using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Domain.Enums;
 using Financial.CashFlow.Infrastructure.Integrations.CashFlowSpreadsheetImport.Parsing;
@@ -35,7 +36,7 @@ public static class MensaisSheetImporter
             var dueDayCell = sheet.Cell(row, DueDayColumn);
             var descriptionCell = sheet.Cell(row, DescriptionColumn);
 
-            if (dueDayCell.IsEmpty() && TryResolveAreaLabel(descriptionCell.GetString(), out var area))
+            if (dueDayCell.IsEmpty() && AreaParser.TryParse(descriptionCell.GetString(), out var area))
             {
                 currentArea = area;
                 continue;
@@ -68,25 +69,6 @@ public static class MensaisSheetImporter
         }
 
         return (templates, instances);
-    }
-
-    private static bool TryResolveAreaLabel(string label, out Area area)
-    {
-        var trimmed = label.Trim();
-        if (string.Equals(trimmed, "Brasil", StringComparison.OrdinalIgnoreCase))
-        {
-            area = Area.Brasil;
-            return true;
-        }
-
-        if (string.Equals(trimmed, "UK", StringComparison.OrdinalIgnoreCase))
-        {
-            area = Area.UK;
-            return true;
-        }
-
-        area = default;
-        return false;
     }
 
     private static BillStatus ResolveStatus(string? tag) =>


### PR DESCRIPTION
## Summary
A `/simplify` cleanup pass across the entire P11 CashFlow Tracking initiative (all 17 merged feature PRs, `d8fa381...main`). 4 parallel review agents (reuse, simplification, efficiency, altitude) reviewed the full diff; this PR applies the fixes that were safe, contained, and behavior-preserving. No functional/UX change — every fix is a refactor with the existing test suites (backend 1148 tests, web 490 tests) confirming identical behavior.

## Backend
- **`YearlySummaryService`**: `GetCategoryTotalsForYear`/`GetInvestmentDiffsForYear` were re-filtering the full expense/snapshot list on every one of the 12×14 (or 12×11) grid cells. Now builds a `(category,month)`/`(account,month)` lookup once per call.
- **`CardStatementService.GetStatementsForMonthAsync`**: was re-scanning every expense ever recorded, once per card (×5), just to compute each card's outstanding total. Now groups expenses by card once for the target month.
- **Consolidated a real, silently-drifted duplication**: the Portuguese month-abbreviation dictionary existed in both `SheetNameParser.cs` and `ControleMaeSheetImporter.cs` — only the latter had the `"Maio"` alias (added to fix a real historical-import bug last week). Now one shared `PortugueseMonthAbbreviations.Map`.
- Consolidated the import's "2017-2026" scope cutoff, previously hardcoded independently in two files, into `SheetNameParser`'s constants.
- `MensaisSheetImporter` now reuses `AreaParser.TryParse` instead of hand-rolling the same case-insensitive Brasil/UK match.

## Web
- `currentYearMonth()` / month-input parse+format logic was byte-for-byte duplicated across 4 hooks (`useMonthly`, `useMensais`, `useControleMae`, `useInvestmentSnapshots`) — extracted to `utils/formatters.ts`.
- The identical isEditing Save/Cancel button pair, duplicated across 4 page `Row` components, extracted into a shared `EditRowActions` component.
- `financialApiClient`'s `requestVoid` duplicated `request<T>`'s entire fetch+error-handling body — both now share a `sendRequest` helper.
- Removed `useMonthly`'s dead `markPaidError` field (never read; the action already correctly writes to `saveError`).
- `MonthlyPage` now imports the hook's exported `EditField` type instead of re-declaring the same union inline.

## Explicitly NOT changed (flagged by the review agents, judged out of scope for a cleanup pass)
- **Domain entities have no invariants** (validation lives entirely in Application services, duplicated per-service) — a real architectural gap relative to CLAUDE.md's Domain-layer mandate, but fixing it means moving validation across 7 entities + 4 services + their test suites. Flagged as a good candidate for a dedicated follow-up, not a safe mechanical fix.
- **A generic `useAsyncData` hook** to collapse the FETCH_START/SUCCESS/ERROR/RETRY reducer boilerplate repeated across all 6 CashFlow hooks — real duplication, but replacing 6 already-shipped, tested hooks' internals carries more regression risk than this pass's other fixes for the same category of benefit.
- **`CashFlowRepositoryFactory` vs. Investment's `RepositoryFactory`** (~55 near-identical lines) — real duplication, but consolidating into a generic `Financial.Shared.Infrastructure` factory touches the Investment side's working, shipped repository plumbing too, outside this PR's blast radius.
- 8 one-line enum-parser wrapper classes (`CategoryParser`, `PaymentSourceParser`, etc.) — technically duplicated boilerplate, but each gives a readable, type-specific name at call sites; judged not clearly worth the wide rename across every caller.
- Test-fixture duplication across 4 hook test files — test-only, lower value than the production-code fixes.
- A couple of minor findings (silent unrecognized-tag defaults in two importers not routed through the error report) — judged low value given the real spreadsheet has already been successfully imported with these exact code paths.

## Test plan
- [x] `dotnet build Financial.slnx` — clean
- [x] `dotnet test Financial.slnx` — all 10 backend test projects pass (1148 tests total), no regressions
- [x] `npx tsc -b --noEmit` — clean
- [x] `npx eslint .` — clean
- [x] `npx vitest run` — 490/490 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)