### PR TITLE
fix(P11): Reserva drops Dizimo as a bucket, adds side-by-side grids

### DIFF
--- a/Financial.CashFlow.Application/DTOs/IncomeSplitResultDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/IncomeSplitResultDTO.cs
@@ -1,7 +1,8 @@
 namespace Financial.CashFlow.Application.DTOs;
 
 /// <summary>
-/// The 5 amounts computed and posted by a monthly income split.
+/// The amounts computed by a monthly income split. Dizimo (tithe) is informational only — it is
+/// not posted as a Reserva bucket movement. The remaining 4 amounts are posted to their buckets.
 /// </summary>
 public sealed class IncomeSplitResultDTO
 {

--- a/Financial.CashFlow.Application/Services/ReserveService.cs
+++ b/Financial.CashFlow.Application/Services/ReserveService.cs
@@ -123,7 +123,7 @@ public sealed class ReserveService : IReserveService
 
     public IReadOnlyList<ReserveMovementDTO> GetMovementHistory() =>
         _repository.GetReserveMovements()
-            .OrderBy(m => m.Date)
+            .OrderByDescending(m => m.Date)
             .Select(ToDto)
             .ToList();
 

--- a/Financial.CashFlow.Application/Services/ReserveService.cs
+++ b/Financial.CashFlow.Application/Services/ReserveService.cs
@@ -35,7 +35,6 @@ public sealed class ReserveService : IReserveService
 
         var movements = new[]
         {
-            ReserveMovement.Create(ReserveBucket.Dizimo, split.Dizimo, request.Date, IncomeSplitDescription),
             ReserveMovement.Create(ReserveBucket.Investimento, split.Investimento, request.Date, IncomeSplitDescription),
             ReserveMovement.Create(ReserveBucket.HouseTreats, split.HouseTreats, request.Date, IncomeSplitDescription),
             ReserveMovement.Create(ReserveBucket.Ariana, split.Ariana, request.Date, IncomeSplitDescription),

--- a/Financial.CashFlow.Domain/Enums/ReserveBucket.cs
+++ b/Financial.CashFlow.Domain/Enums/ReserveBucket.cs
@@ -2,7 +2,6 @@ namespace Financial.CashFlow.Domain.Enums;
 
 public enum ReserveBucket
 {
-    Dizimo,
     Investimento,
     HouseTreats,
     Ariana,

--- a/Financial.CashFlow.Domain/Rules/ReserveSplitCalculator.cs
+++ b/Financial.CashFlow.Domain/Rules/ReserveSplitCalculator.cs
@@ -12,9 +12,12 @@ public static class ReserveSplitCalculator
         decimal lottery,
         decimal dividendoJuros)
     {
-        var combinedNetSalary = gleisonSalaryNet + arianaSalaryNet;
-        var dizimo = Round((combinedNetSalary + lottery + dividendoJuros) * DizimoRate);
-        var limpo = combinedNetSalary - dizimo;
+        // Dizimo (tithe) is computed on the combined household income but is informational only —
+        // it is paid outside the app and never funds the Reserva pool itself.
+        var dizimo = Round((gleisonSalaryNet + arianaSalaryNet + lottery + dividendoJuros) * DizimoRate);
+
+        // Only Ariana's wage, net of her share of the tithe, seeds the Reserva pool.
+        var limpo = arianaSalaryNet - dizimo;
 
         var investimento = Round(limpo / 3m);
         var houseTreats = Round(limpo / 3m);

--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -321,7 +321,7 @@ describe('financialApiClient', () => {
   })
 
   it('calls reserve balances endpoint', async () => {
-    const responseBody: ReserveBucketBalanceDto[] = [{ bucket: 'Dizimo', balance: 637 }]
+    const responseBody: ReserveBucketBalanceDto[] = [{ bucket: 'Investimento', balance: 654.33 }]
     const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
     const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
 
@@ -333,7 +333,7 @@ describe('financialApiClient', () => {
 
   it('calls reserve movements endpoint', async () => {
     const responseBody: ReserveMovementDto[] = [
-      { id: 'm1', bucket: 'Dizimo', amount: 10, date: '2026-07-01', description: 'Test' },
+      { id: 'm1', bucket: 'Investimento', amount: 10, date: '2026-07-01', description: 'Test' },
     ]
     const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
     const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })

--- a/Financial.Web/src/hooks/useReserva.test.ts
+++ b/Financial.Web/src/hooks/useReserva.test.ts
@@ -20,15 +20,14 @@ vi.mock('../api/financialApiClient', () => ({
 }))
 
 const BALANCES: ReserveBucketBalanceDto[] = [
-  { bucket: 'Dizimo', balance: 637 },
-  { bucket: 'Investimento', balance: 1854.33 },
-  { bucket: 'HouseTreats', balance: 1854.33 },
-  { bucket: 'Ariana', balance: 927.17 },
-  { bucket: 'Gleison', balance: 927.17 },
+  { bucket: 'Investimento', balance: 654.33 },
+  { bucket: 'HouseTreats', balance: 654.33 },
+  { bucket: 'Ariana', balance: 327.17 },
+  { bucket: 'Gleison', balance: 327.17 },
 ]
 
 const MOVEMENTS: ReserveMovementDto[] = [
-  { id: 'm1', bucket: 'Dizimo', amount: 637, date: '2026-07-01', description: 'Monthly income split' },
+  { id: 'm1', bucket: 'Investimento', amount: 654.33, date: '2026-07-01', description: 'Monthly income split' },
 ]
 
 describe('useReserva', () => {
@@ -62,10 +61,10 @@ describe('useReserva', () => {
   it('submits an income split and re-fetches balances/movements on success', async () => {
     postIncomeSplitMock.mockResolvedValue({
       dizimo: 637,
-      investimento: 1854.33,
-      houseTreats: 1854.33,
-      ariana: 927.17,
-      gleison: 927.17,
+      investimento: 654.33,
+      houseTreats: 654.33,
+      ariana: 327.17,
+      gleison: 327.17,
     })
     const { result } = renderHook(() => useReserva())
     await waitFor(() => expect(result.current.isLoading).toBe(false))

--- a/Financial.Web/src/hooks/useReserva.test.ts
+++ b/Financial.Web/src/hooks/useReserva.test.ts
@@ -49,6 +49,14 @@ describe('useReserva', () => {
     expect(result.current.error).toBeNull()
   })
 
+  it('computes the total balance across all buckets', async () => {
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // 654.33 + 654.33 + 327.17 + 327.17 = 1963.00
+    expect(result.current.totalBalance).toBeCloseTo(1963, 2)
+  })
+
   it('surfaces a fetch error', async () => {
     getReserveBalancesMock.mockRejectedValue(new Error('Network down'))
     const { result } = renderHook(() => useReserva())

--- a/Financial.Web/src/hooks/useReserva.ts
+++ b/Financial.Web/src/hooks/useReserva.ts
@@ -133,6 +133,7 @@ function reducer(state: ReservaState, action: ReservaAction): ReservaState {
 
 export interface ReservaData {
   balances: ReserveBucketBalanceDto[]
+  totalBalance: number
   movements: ReserveMovementDto[]
   isLoading: boolean
   error: string | null
@@ -180,6 +181,11 @@ export function useReserva(): ReservaData {
   useEffect(() => {
     fetchReservaData()
   }, [fetchReservaData, state.retryCount])
+
+  const totalBalance = useMemo(
+    () => state.balances.reduce((sum, b) => sum + b.balance, 0),
+    [state.balances],
+  )
 
   const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
 
@@ -298,6 +304,7 @@ export function useReserva(): ReservaData {
 
   return {
     balances: state.balances,
+    totalBalance,
     movements: state.movements,
     isLoading: state.isLoading,
     error: state.error,

--- a/Financial.Web/src/hooks/useReserva.ts
+++ b/Financial.Web/src/hooks/useReserva.ts
@@ -3,7 +3,7 @@ import { ApiError } from '../api/apiError'
 import { createFinancialApiClient } from '../api/financialApiClient'
 import type { ReserveBucketBalanceDto, ReserveMovementDto } from '../api/types'
 
-export const RESERVE_BUCKETS = ['Dizimo', 'Investimento', 'HouseTreats', 'Ariana', 'Gleison'] as const
+export const RESERVE_BUCKETS = ['Investimento', 'HouseTreats', 'Ariana', 'Gleison'] as const
 
 export type SplitFormField =
   | 'splitDate'

--- a/Financial.Web/src/pages/ReservaPage.css
+++ b/Financial.Web/src/pages/ReservaPage.css
@@ -79,7 +79,7 @@
 
 .reserva-page__section--grid {
   min-width: 260px;
-  max-height: 420px;
+  max-height: 75vh;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -103,18 +103,26 @@
   overflow: auto;
 }
 
-.reserva-page__section--balances .reserva-page__table {
+.reserva-page__section--grid .reserva-page__table {
   table-layout: fixed;
   border-collapse: separate;
   border-spacing: 0;
 }
 
-.reserva-page__section--balances .reserva-page__table td {
+.reserva-page__section--grid .reserva-page__table td {
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .reserva-page__col-value {
+  width: 120px;
+}
+
+.reserva-page__col-date {
+  width: 100px;
+}
+
+.reserva-page__col-bucket {
   width: 120px;
 }
 

--- a/Financial.Web/src/pages/ReservaPage.css
+++ b/Financial.Web/src/pages/ReservaPage.css
@@ -52,11 +52,10 @@
 .reserva-page__content {
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   gap: 32px;
-  padding-bottom: 24px;
 }
 
 .reserva-page__section h2 {
@@ -67,6 +66,41 @@
 .reserva-page__table {
   width: 100%;
   max-width: 640px;
+}
+
+.reserva-page__grids-row {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  align-items: stretch;
+}
+
+.reserva-page__section--grid {
+  min-width: 260px;
+  max-height: 420px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.reserva-page__section--grid .reserva-page__table {
+  max-width: none;
+}
+
+.reserva-page__section--balances {
+  flex: 1 1 300px;
+}
+
+.reserva-page__section--movements {
+  flex: 2 1 480px;
+}
+
+.reserva-page__table-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
 }
 
 .reserva-page__form {

--- a/Financial.Web/src/pages/ReservaPage.css
+++ b/Financial.Web/src/pages/ReservaPage.css
@@ -103,6 +103,32 @@
   overflow: auto;
 }
 
+.reserva-page__section--balances .reserva-page__table {
+  table-layout: fixed;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.reserva-page__section--balances .reserva-page__table td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.reserva-page__col-value {
+  width: 120px;
+}
+
+.reserva-page__totals-table {
+  flex-shrink: 0;
+  margin-top: 8px;
+}
+
+.reserva-page__totals-row td {
+  background: var(--bg-subtle, #f9f9f9);
+  font-weight: bold;
+  border-top: 2px solid var(--border, #e5e4e7);
+}
+
 .reserva-page__form {
   display: flex;
   flex-wrap: wrap;

--- a/Financial.Web/src/pages/ReservaPage.tsx
+++ b/Financial.Web/src/pages/ReservaPage.tsx
@@ -186,49 +186,55 @@ export default function ReservaPage() {
       )}
 
       <div className="reserva-page__content">
-        <section className="reserva-page__section">
-          <h2>Bucket Balances</h2>
-          <table className="reserva-page__table data-table">
-            <thead>
-              <tr>
-                <th>Bucket</th>
-                <th className="data-table__col--numeric">Balance</th>
-              </tr>
-            </thead>
-            <tbody>
-              {balances.map((b) => (
-                <tr key={b.bucket}>
-                  <td>{b.bucket}</td>
-                  <td className="data-table__col--numeric">{formatN2(b.balance)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </section>
+        <div className="reserva-page__grids-row">
+          <section className="reserva-page__section reserva-page__section--grid reserva-page__section--balances">
+            <h2>Bucket Balances</h2>
+            <div className="reserva-page__table-scroll">
+              <table className="reserva-page__table data-table">
+                <thead>
+                  <tr>
+                    <th>Bucket</th>
+                    <th className="data-table__col--numeric">Balance</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {balances.map((b) => (
+                    <tr key={b.bucket}>
+                      <td>{b.bucket}</td>
+                      <td className="data-table__col--numeric">{formatN2(b.balance)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
 
-        <section className="reserva-page__section reserva-page__section--main">
-          <h2>Movement History</h2>
-          <table className="reserva-page__table data-table">
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th>Bucket</th>
-                <th>Description</th>
-                <th className="data-table__col--numeric">Amount</th>
-              </tr>
-            </thead>
-            <tbody>
-              {movements.map((m) => (
-                <tr key={m.id}>
-                  <td>{formatShortDate(m.date)}</td>
-                  <td>{m.bucket}</td>
-                  <td>{m.description}</td>
-                  <td className="data-table__col--numeric">{formatN2(m.amount)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </section>
+          <section className="reserva-page__section reserva-page__section--grid reserva-page__section--movements">
+            <h2>Movement History</h2>
+            <div className="reserva-page__table-scroll">
+              <table className="reserva-page__table data-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Bucket</th>
+                    <th>Description</th>
+                    <th className="data-table__col--numeric">Amount</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {movements.map((m) => (
+                    <tr key={m.id}>
+                      <td>{formatShortDate(m.date)}</td>
+                      <td>{m.bucket}</td>
+                      <td>{m.description}</td>
+                      <td className="data-table__col--numeric">{formatN2(m.amount)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </div>
       </div>
     </div>
   )

--- a/Financial.Web/src/pages/ReservaPage.tsx
+++ b/Financial.Web/src/pages/ReservaPage.tsx
@@ -5,6 +5,15 @@ import type { SplitFormField, WithdrawalFormField } from '../hooks/useReserva'
 import { formatN2, formatShortDate } from '../utils/formatters'
 import './ReservaPage.css'
 
+function BalanceColumns() {
+  return (
+    <colgroup>
+      <col />
+      <col className="reserva-page__col-value" />
+    </colgroup>
+  )
+}
+
 const SPLIT_FIELDS: { field: SplitFormField; label: string }[] = [
   { field: 'gleisonSalaryGross', label: 'Salario Gleison (gross)' },
   { field: 'gleisonSalaryNet', label: 'Salario Gleison (net)' },
@@ -17,6 +26,7 @@ const SPLIT_FIELDS: { field: SplitFormField; label: string }[] = [
 export default function ReservaPage() {
   const {
     balances,
+    totalBalance,
     movements,
     isLoading,
     error,
@@ -191,6 +201,7 @@ export default function ReservaPage() {
             <h2>Bucket Balances</h2>
             <div className="reserva-page__table-scroll">
               <table className="reserva-page__table data-table">
+                <BalanceColumns />
                 <thead>
                   <tr>
                     <th>Bucket</th>
@@ -207,6 +218,15 @@ export default function ReservaPage() {
                 </tbody>
               </table>
             </div>
+            <table className="reserva-page__table reserva-page__totals-table data-table">
+              <BalanceColumns />
+              <tbody>
+                <tr className="reserva-page__totals-row">
+                  <td>Total</td>
+                  <td className="data-table__col--numeric">{formatN2(totalBalance)}</td>
+                </tr>
+              </tbody>
+            </table>
           </section>
 
           <section className="reserva-page__section reserva-page__section--grid reserva-page__section--movements">

--- a/Financial.Web/src/pages/ReservaPage.tsx
+++ b/Financial.Web/src/pages/ReservaPage.tsx
@@ -14,6 +14,17 @@ function BalanceColumns() {
   )
 }
 
+function MovementColumns() {
+  return (
+    <colgroup>
+      <col className="reserva-page__col-date" />
+      <col className="reserva-page__col-bucket" />
+      <col />
+      <col className="reserva-page__col-value" />
+    </colgroup>
+  )
+}
+
 const SPLIT_FIELDS: { field: SplitFormField; label: string }[] = [
   { field: 'gleisonSalaryGross', label: 'Salario Gleison (gross)' },
   { field: 'gleisonSalaryNet', label: 'Salario Gleison (net)' },
@@ -233,6 +244,7 @@ export default function ReservaPage() {
             <h2>Movement History</h2>
             <div className="reserva-page__table-scroll">
               <table className="reserva-page__table data-table">
+                <MovementColumns />
                 <thead>
                   <tr>
                     <th>Date</th>

--- a/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
@@ -62,6 +62,14 @@ describe('ReservaPage', () => {
     expect(screen.getByText('Monthly income split')).toBeInTheDocument()
   })
 
+  it('renders the total balance across all buckets, bold and always visible', async () => {
+    render(<ReservaPage />)
+
+    await waitFor(() => expect(screen.getByText('Bucket Balances')).toBeInTheDocument())
+    // 654.33 + 654.33 + 327.17 + 327.17 = 1963.00
+    expect(screen.getByText('1,963.00')).toBeInTheDocument()
+  })
+
   it('shows the income-split form only after New Income Split is clicked', async () => {
     render(<ReservaPage />)
 

--- a/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
@@ -19,15 +19,14 @@ vi.mock('../../api/financialApiClient', () => ({
 }))
 
 const BALANCES: ReserveBucketBalanceDto[] = [
-  { bucket: 'Dizimo', balance: 637 },
-  { bucket: 'Investimento', balance: 1854.33 },
-  { bucket: 'HouseTreats', balance: 1854.33 },
-  { bucket: 'Ariana', balance: 927.17 },
-  { bucket: 'Gleison', balance: 927.17 },
+  { bucket: 'Investimento', balance: 654.33 },
+  { bucket: 'HouseTreats', balance: 654.33 },
+  { bucket: 'Ariana', balance: 327.17 },
+  { bucket: 'Gleison', balance: 327.17 },
 ]
 
 const MOVEMENTS: ReserveMovementDto[] = [
-  { id: 'm1', bucket: 'Dizimo', amount: 637, date: '2026-07-01', description: 'Monthly income split' },
+  { id: 'm1', bucket: 'Investimento', amount: 654.33, date: '2026-07-01', description: 'Monthly income split' },
 ]
 
 describe('ReservaPage', () => {
@@ -53,7 +52,7 @@ describe('ReservaPage', () => {
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
   })
 
-  it('renders all 5 bucket balances and the movement history once loaded', async () => {
+  it('renders all 4 bucket balances and the movement history once loaded', async () => {
     render(<ReservaPage />)
 
     await waitFor(() => expect(screen.getByText('Bucket Balances')).toBeInTheDocument())

--- a/Integrations/CashFlowSpreadsheetImport/SheetImporters/ReservasSheetImporter.cs
+++ b/Integrations/CashFlowSpreadsheetImport/SheetImporters/ReservasSheetImporter.cs
@@ -7,11 +7,12 @@ namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowSpreadsheetImpo
 
 /// <summary>
 /// Parses the single continuous "Reservas" sheet (spanning every year) into
-/// <see cref="ReserveMovement"/> entities. Each row can populate any subset of the 5 bucket
+/// <see cref="ReserveMovement"/> entities. Each row can populate any subset of the 4 bucket
 /// columns; one movement is created per populated bucket column on that row, regardless of
-/// whether the row represents an income-split deposit (all 5 populated, proportioned per F05's
+/// whether the row represents an income-split deposit (all 4 populated, proportioned per F05's
 /// tithe-then-thirds/sixths math) or a single-bucket withdrawal (one column populated) — both
 /// shapes reconstruct correct running balances this way without needing to be told apart.
+/// Column 4 (Dizimo/tithe) is a non-bucket intermediate value and is not imported.
 /// </summary>
 public static class ReservasSheetImporter
 {
@@ -21,7 +22,6 @@ public static class ReservasSheetImporter
 
     private static readonly (int Column, ReserveBucket Bucket)[] BucketColumns =
     [
-        (4, ReserveBucket.Dizimo),
         (6, ReserveBucket.Investimento),
         (7, ReserveBucket.HouseTreats),
         (8, ReserveBucket.Ariana),

--- a/Tests/Financial.Api.Tests/ReserveEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/ReserveEndpointsTests.cs
@@ -29,7 +29,7 @@ public class ReserveEndpointsTests
         var result = await response.Content.ReadFromJsonAsync<IncomeSplitResultDTO>();
         result.Should().NotBeNull();
         result!.Dizimo.Should().Be(637m);
-        result.Investimento.Should().Be(1854.33m);
+        result.Investimento.Should().Be(654.33m);
     }
 
     [Fact]
@@ -75,8 +75,8 @@ public class ReserveEndpointsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var balances = await response.Content.ReadFromJsonAsync<List<ReserveBucketBalanceDTO>>();
-        balances.Should().HaveCount(5);
-        balances.Should().ContainSingle(b => b.Bucket == "Dizimo" && b.Balance == 637m);
+        balances.Should().HaveCount(4);
+        balances.Should().ContainSingle(b => b.Bucket == "Investimento" && b.Balance == 654.33m);
     }
 
     [Fact]
@@ -191,6 +191,6 @@ public class ReserveEndpointsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var movements = await response.Content.ReadFromJsonAsync<List<ReserveMovementDTO>>();
-        movements.Should().HaveCount(5);
+        movements.Should().HaveCount(4);
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
@@ -191,7 +191,7 @@ public class ReserveServiceTests
     }
 
     [Fact]
-    public void GetMovementHistory_ReturnsAllMovementsOrderedByDate()
+    public void GetMovementHistory_ReturnsAllMovementsOrderedByDateDescending()
     {
         var repository = new StubCashFlowRepository();
         repository.Seed(ReserveBucket.Investimento, 10m, new DateOnly(2026, 8, 1));
@@ -201,7 +201,7 @@ public class ReserveServiceTests
         var history = service.GetMovementHistory();
 
         history.Should().HaveCount(2);
-        history.Select(m => m.Date).Should().BeInAscendingOrder();
+        history.Select(m => m.Date).Should().BeInDescendingOrder();
     }
 
     private static IncomeSplitRequestDTO ValidIncomeSplitRequest() => new()

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
@@ -18,19 +18,19 @@ public class ReserveServiceTests
     }
 
     [Fact]
-    public async Task PostIncomeSplitAsync_WithValidRequest_PostsExactlyFiveMovementsAndReturnsAmounts()
+    public async Task PostIncomeSplitAsync_WithValidRequest_PostsExactlyFourMovementsAndReturnsAmounts()
     {
         var repository = new StubCashFlowRepository();
         var service = new ReserveService(repository);
 
         var result = await service.PostIncomeSplitAsync(ValidIncomeSplitRequest());
 
-        repository.ReserveMovements.Should().HaveCount(5);
+        repository.ReserveMovements.Should().HaveCount(4);
         result.Dizimo.Should().Be(637m);
-        result.Investimento.Should().Be(1854.33m);
-        result.HouseTreats.Should().Be(1854.33m);
-        result.Ariana.Should().Be(927.17m);
-        result.Gleison.Should().Be(927.17m);
+        result.Investimento.Should().Be(654.33m);
+        result.HouseTreats.Should().Be(654.33m);
+        result.Ariana.Should().Be(327.17m);
+        result.Gleison.Should().Be(327.17m);
         repository.SaveChangesCallCount.Should().Be(1);
     }
 
@@ -63,7 +63,7 @@ public class ReserveServiceTests
     }
 
     [Fact]
-    public async Task PostIncomeSplitAsync_WhenSaveFails_RollsBackAllFiveMovements()
+    public async Task PostIncomeSplitAsync_WhenSaveFails_RollsBackAllFourMovements()
     {
         var repository = new StubCashFlowRepository { ThrowOnSave = true };
         var service = new ReserveService(repository);
@@ -141,7 +141,7 @@ public class ReserveServiceTests
 
         var act = async () => await service.PostWithdrawalAsync(new WithdrawalRequestDTO
         {
-            Bucket = "Dizimo",
+            Bucket = "Investimento",
             Amount = 0m,
             Date = new DateOnly(2026, 7, 1),
             Description = "Nothing"
@@ -167,14 +167,14 @@ public class ReserveServiceTests
     }
 
     [Fact]
-    public void GetBucketBalances_AlwaysReturnsExactlyFiveBuckets()
+    public void GetBucketBalances_AlwaysReturnsExactlyFourBuckets()
     {
         var repository = new StubCashFlowRepository();
         var service = new ReserveService(repository);
 
         var balances = service.GetBucketBalances();
 
-        balances.Should().HaveCount(5);
+        balances.Should().HaveCount(4);
         balances.Should().OnlyContain(b => b.Balance == 0m);
     }
 
@@ -187,16 +187,15 @@ public class ReserveServiceTests
 
         var balances = service.GetBucketBalances();
 
-        balances.Should().ContainSingle(b => b.Bucket == "Dizimo" && b.Balance == 637m);
-        balances.Should().ContainSingle(b => b.Bucket == "Investimento" && b.Balance == 1854.33m);
+        balances.Should().ContainSingle(b => b.Bucket == "Investimento" && b.Balance == 654.33m);
     }
 
     [Fact]
     public void GetMovementHistory_ReturnsAllMovementsOrderedByDate()
     {
         var repository = new StubCashFlowRepository();
-        repository.Seed(ReserveBucket.Dizimo, 10m, new DateOnly(2026, 8, 1));
-        repository.Seed(ReserveBucket.Dizimo, 5m, new DateOnly(2026, 7, 1));
+        repository.Seed(ReserveBucket.Investimento, 10m, new DateOnly(2026, 8, 1));
+        repository.Seed(ReserveBucket.Investimento, 5m, new DateOnly(2026, 7, 1));
         var service = new ReserveService(repository);
 
         var history = service.GetMovementHistory();

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/CashFlowDataTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/CashFlowDataTests.cs
@@ -96,7 +96,7 @@ public class CashFlowDataTests
     }
 
     private static ReserveMovement CreateReserveMovement() =>
-        ReserveMovement.Create(ReserveBucket.Dizimo, 10m, new DateOnly(2026, 7, 1), "Test movement");
+        ReserveMovement.Create(ReserveBucket.Investimento, 10m, new DateOnly(2026, 7, 1), "Test movement");
 
     [Fact]
     public void AddCardStatement_AddsOnlyToCardStatementsCollection()

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/ReserveMovementTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/ReserveMovementTests.cs
@@ -31,8 +31,8 @@ public class ReserveMovementTests
     [Fact]
     public void Create_TwoMovements_HaveDifferentIds()
     {
-        var first = ReserveMovement.Create(ReserveBucket.Dizimo, 10m, new DateOnly(2026, 7, 1), "A");
-        var second = ReserveMovement.Create(ReserveBucket.Dizimo, 10m, new DateOnly(2026, 7, 1), "B");
+        var first = ReserveMovement.Create(ReserveBucket.Investimento, 10m, new DateOnly(2026, 7, 1), "A");
+        var second = ReserveMovement.Create(ReserveBucket.Investimento, 10m, new DateOnly(2026, 7, 1), "B");
 
         first.Id.Should().NotBe(second.Id);
     }

--- a/Tests/Financial.CashFlow.Domain.Tests/Rules/ReserveSplitCalculatorTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Rules/ReserveSplitCalculatorTests.cs
@@ -27,29 +27,29 @@ public class ReserveSplitCalculatorTests
             lottery: 50m,
             dividendoJuros: 120m);
 
-        // Limpo = (3600 + 2600) - 637 = 5563
-        result.Investimento.Should().Be(1854.33m);
-        result.HouseTreats.Should().Be(1854.33m);
-        result.Ariana.Should().Be(927.17m);
-        result.Gleison.Should().Be(927.17m);
+        // Limpo = ArianaNet(2600) - Dizimo(637) = 1963
+        result.Investimento.Should().Be(654.33m);
+        result.HouseTreats.Should().Be(654.33m);
+        result.Ariana.Should().Be(327.17m);
+        result.Gleison.Should().Be(327.17m);
     }
 
     [Fact]
     public void Calculate_LotteryAndDividendoJuros_AreNeverDirectlyAddedToTheSplitPool()
     {
         // Lottery/Dividendo/Juros are not part of the 1/3-1/3-1/6-1/6 split pool itself (Limpo is
-        // combined net salary minus Dizimo, full stop) - but since Dizimo grows with Lottery/Dividendo,
+        // Ariana's net wage minus Dizimo, full stop) - but since Dizimo grows with Lottery/Dividendo,
         // Limpo (and therefore the four splits) shrinks correspondingly. This proves the splits are
-        // always derived from Limpo alone, never from (net salary + Lottery + Dividendo) directly.
-        const decimal combinedNetSalary = 3600m + 2600m;
+        // always derived from Limpo alone, never from (Ariana net + Lottery + Dividendo) directly.
+        const decimal arianaSalaryNet = 2600m;
 
         var withoutExtraIncome = ReserveSplitCalculator.Calculate(3600m, 2600m, lottery: 0m, dividendoJuros: 0m);
         var withExtraIncome = ReserveSplitCalculator.Calculate(3600m, 2600m, lottery: 500m, dividendoJuros: 300m);
 
         withExtraIncome.Dizimo.Should().BeGreaterThan(withoutExtraIncome.Dizimo);
 
-        var limpoWithout = combinedNetSalary - withoutExtraIncome.Dizimo;
-        var limpoWith = combinedNetSalary - withExtraIncome.Dizimo;
+        var limpoWithout = arianaSalaryNet - withoutExtraIncome.Dizimo;
+        var limpoWith = arianaSalaryNet - withExtraIncome.Dizimo;
         (withoutExtraIncome.Investimento + withoutExtraIncome.HouseTreats + withoutExtraIncome.Ariana + withoutExtraIncome.Gleison)
             .Should().BeApproximately(limpoWithout, 0.02m);
         (withExtraIncome.Investimento + withExtraIncome.HouseTreats + withExtraIncome.Ariana + withExtraIncome.Gleison)

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Repositories/CashFlowJsonRepositoryTests.cs
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Repositories/CashFlowJsonRepositoryTests.cs
@@ -83,7 +83,7 @@ public class CashFlowJsonRepositoryTests
     {
         var data = CashFlowData.Create();
         var repository = new CashFlowJsonRepository(data, new LocalJsonStorage(Path.GetTempFileName()), new CashFlowSerializerAdapter());
-        var movement = ReserveMovement.Create(ReserveBucket.Dizimo, 10m, new DateOnly(2026, 7, 1), "Test movement");
+        var movement = ReserveMovement.Create(ReserveBucket.Investimento, 10m, new DateOnly(2026, 7, 1), "Test movement");
         repository.AddReserveMovement(movement);
 
         repository.DeleteReserveMovement(movement.Id);

--- a/Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/ReservasSheetImporterTests.cs
+++ b/Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/ReservasSheetImporterTests.cs
@@ -8,7 +8,7 @@ namespace Financial.CashFlowSpreadsheetImport.Tests.SheetImporters;
 public class ReservasSheetImporterTests
 {
     [Fact]
-    public void Import_RowWithAllFiveBucketsPopulated_CreatesOneMovementPerBucket()
+    public void Import_RowWithAllFourBucketsPopulated_CreatesOneMovementPerBucket()
     {
         using var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Reservas");
@@ -25,13 +25,27 @@ public class ReservasSheetImporterTests
 
         var movements = ReservasSheetImporter.Import(sheet);
 
-        movements.Should().HaveCount(5);
-        movements.Should().Contain(m => m.Bucket == ReserveBucket.Dizimo && m.Amount == 50.0m);
+        movements.Should().HaveCount(4);
         movements.Should().Contain(m => m.Bucket == ReserveBucket.Investimento && m.Amount == 100.0m);
         movements.Should().Contain(m => m.Bucket == ReserveBucket.HouseTreats && m.Amount == 30.0m);
         movements.Should().Contain(m => m.Bucket == ReserveBucket.Ariana && m.Amount == 20.0m);
         movements.Should().Contain(m => m.Bucket == ReserveBucket.Gleison && m.Amount == 20.0m);
         movements.Should().OnlyContain(m => m.Date == new DateOnly(2020, 3, 15) && m.Description == "Ramsay");
+    }
+
+    [Fact]
+    public void Import_DizimoColumnPopulated_IsIgnoredAsNonBucketIntermediateValue()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Reservas");
+        sheet.Cell(1, 1).Value = "Data";
+
+        sheet.Cell(2, 1).Value = new DateTime(2021, 1, 1);
+        sheet.Cell(2, 4).Value = 50.0;
+
+        var movements = ReservasSheetImporter.Import(sheet);
+
+        movements.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- **Dizimo is no longer a Reserva bucket.** It was a personal spreadsheet tithe calculation, not a real reserve pool — it no longer has a running balance, appears in the withdrawal dropdown, or gets its own `ReserveMovement` entries. `ReserveBucket` now has 4 members (Investimento, HouseTreats, Ariana, Gleison).
- **Reserva pool formula corrected.** Dizimo (tithe) is still computed the same way as before — 10% of combined household net income (Gleison + Ariana + Lottery + Dividendo/Juros) — and is still returned from the income-split endpoint as an informational figure, but it's no longer subtracted from the *combined* salary to seed the split pool. Only **Ariana's net wage, minus that tithe**, now funds the pool that splits 1/3 Investimento, 1/3 HouseTreats, 1/6 Ariana, 1/6 Gleison.
- **Historical spreadsheet importer** no longer imports the Dizimo column as a bucket movement (still skips it, like the pre-existing "Limpo" intermediate column).
- **Layout**: Bucket Balances and Movement History now render side by side (same `*-grids-row` pattern just established on the Monthly view) instead of stacked, each independently scrollable.
- **Real data migration**: removed the 22 historical `Dizimo` `ReserveMovement` entries from `data/data-cashflow.json` (totaling 594.52) — this was required, not optional, since a single unparseable `"Bucket": "Dizimo"` value throws a hard `JsonException` on load and takes down every CashFlow endpoint, not just Reserva. A timestamped backup (`data/data-cashflow.backup-before-dizimo-removal-*.json`) was made first. `data/` is gitignored so this isn't part of the diff.

## Why
Confirmed directly with the user: Dizimo was a spreadsheet-only tithe helper, never meant to be tracked as an app bucket. The corrected formula and example they gave (Gleison net 1000, Ariana net 500 → tithe 150 on the combined total → Reserva pool = 500 − 150 = 350) matches `ArianaNet − Dizimo` exactly.

## Test plan
- [x] `ReserveSplitCalculatorTests`: formula updated to derive the pool from Ariana's net wage minus Dizimo, not combined salary.
- [x] `ReserveServiceTests`, `ReserveEndpointsTests`: income-split now posts exactly 4 movements (Dizimo still returned informationally in the response DTO), balances always return exactly 4 buckets.
- [x] `ReservasSheetImporterTests`: Dizimo column import removed; added a test asserting it's ignored like the existing "Limpo" column.
- [x] Domain/Infrastructure sample-data tests (`ReserveMovementTests`, `CashFlowDataTests`, `CashFlowJsonRepositoryTests`) swapped their `Dizimo` sample bucket to `Investimento`.
- [x] Frontend: `useReserva.test.ts`, `ReservaPage.test.tsx`, `financialApiClient.test.ts` fixtures updated to the 4-bucket model.
- [x] `dotnet test` passes across all 5 affected backend projects (401 tests total).
- [x] `vitest run` passes for the full frontend suite (502 tests).
- [x] `tsc -b --noEmit` passes with no type errors.
- [x] Manually verified in browser (Playwright, against a scratch copy of real data, plus a final read-only check directly against the real fixed data file): 4 bucket balances, side-by-side grid layout, withdrawal dropdown lists only the 4 real buckets, real data loads without the previous `JsonException` crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)