### PR TITLE
fix: Controle Mae importer reads Note from wrong column

### DIFF
--- a/Integrations/CashFlowSpreadsheetImport/SheetImporters/ControleMaeSheetImporter.cs
+++ b/Integrations/CashFlowSpreadsheetImport/SheetImporters/ControleMaeSheetImporter.cs
@@ -22,7 +22,7 @@ public static partial class ControleMaeSheetImporter
     private const int DescriptionColumn = 1;
     private const int BrlValueColumn = 2;
     private const int GbpValueColumn = 3;
-    private const int NoteColumn = 5;
+    private const int NoteColumn = 4;
 
     private static readonly Regex FullDatePattern = BuildFullDatePattern();
     private static readonly Regex MonthYearPattern = BuildMonthYearPattern();


### PR DESCRIPTION
## Summary
- Note text in the Controle Mae spreadsheet import was being read from column 5, but the actual Note text is in column 4 (0-indexed).
- Updates `NoteColumn` constant from 5 to 4 so imported notes match the source spreadsheet.

## Test plan
- [ ] Re-import a Controle Mae sheet and confirm imported notes match the spreadsheet's Note column content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)