### PR TITLE
feat(P11): Reserva income split takes a direct amount, shows total

### DIFF
--- a/Financial.CashFlow.Application/DTOs/IncomeSplitRequestDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/IncomeSplitRequestDTO.cs
@@ -1,28 +1,13 @@
 namespace Financial.CashFlow.Application.DTOs;
 
 /// <summary>
-/// Request to post a month's income and trigger the automated Dizimo/Limpo split.
+/// Request to split a single already-net amount across the Reserva buckets.
 /// </summary>
 public sealed class IncomeSplitRequestDTO
 {
     /// <summary>Date to post the resulting movements under.</summary>
     public required DateOnly Date { get; init; }
 
-    /// <summary>Gleison's gross salary. Display/record only - not used in the split math.</summary>
-    public required decimal GleisonSalaryGross { get; init; }
-
-    /// <summary>Gleison's net-of-tax salary.</summary>
-    public required decimal GleisonSalaryNet { get; init; }
-
-    /// <summary>Ariana's gross salary. Display/record only - not used in the split math.</summary>
-    public required decimal ArianaSalaryGross { get; init; }
-
-    /// <summary>Ariana's net-of-tax salary.</summary>
-    public required decimal ArianaSalaryNet { get; init; }
-
-    /// <summary>Gross Lottery income.</summary>
-    public required decimal Lottery { get; init; }
-
-    /// <summary>Gross Dividendo/Juros income.</summary>
-    public required decimal DividendoJuros { get; init; }
+    /// <summary>The amount to split across the Reserva buckets.</summary>
+    public required decimal Amount { get; init; }
 }

--- a/Financial.CashFlow.Application/DTOs/IncomeSplitRequestDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/IncomeSplitRequestDTO.cs
@@ -10,4 +10,7 @@ public sealed class IncomeSplitRequestDTO
 
     /// <summary>The amount to split across the Reserva buckets.</summary>
     public required decimal Amount { get; init; }
+
+    /// <summary>Description to record on each of the 4 posted movements.</summary>
+    public required string Description { get; init; }
 }

--- a/Financial.CashFlow.Application/DTOs/IncomeSplitResultDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/IncomeSplitResultDTO.cs
@@ -1,14 +1,14 @@
 namespace Financial.CashFlow.Application.DTOs;
 
 /// <summary>
-/// The amounts computed by a monthly income split. Dizimo (tithe) is informational only — it is
-/// not posted as a Reserva bucket movement. The remaining 4 amounts are posted to their buckets.
+/// The amounts posted to each Reserva bucket by an income split, plus their total for
+/// immediate display — no need to re-sum the movement history to know how much was split.
 /// </summary>
 public sealed class IncomeSplitResultDTO
 {
-    public required decimal Dizimo { get; init; }
     public required decimal Investimento { get; init; }
     public required decimal HouseTreats { get; init; }
     public required decimal Ariana { get; init; }
     public required decimal Gleison { get; init; }
+    public required decimal Total { get; init; }
 }

--- a/Financial.CashFlow.Application/Services/ReserveService.cs
+++ b/Financial.CashFlow.Application/Services/ReserveService.cs
@@ -10,8 +10,6 @@ namespace Financial.CashFlow.Application.Services;
 
 public sealed class ReserveService : IReserveService
 {
-    private const string IncomeSplitDescription = "Monthly income split";
-
     private readonly ICashFlowRepository _repository;
 
     public ReserveService(ICashFlowRepository repository)
@@ -28,14 +26,19 @@ public sealed class ReserveService : IReserveService
             throw new ArgumentException("Amount must be greater than zero.", nameof(request.Amount));
         }
 
+        if (string.IsNullOrWhiteSpace(request.Description))
+        {
+            throw new ArgumentException("Description is required.", nameof(request.Description));
+        }
+
         var split = ReserveSplitCalculator.Calculate(request.Amount);
 
         var movements = new[]
         {
-            ReserveMovement.Create(ReserveBucket.Investimento, split.Investimento, request.Date, IncomeSplitDescription),
-            ReserveMovement.Create(ReserveBucket.HouseTreats, split.HouseTreats, request.Date, IncomeSplitDescription),
-            ReserveMovement.Create(ReserveBucket.Ariana, split.Ariana, request.Date, IncomeSplitDescription),
-            ReserveMovement.Create(ReserveBucket.Gleison, split.Gleison, request.Date, IncomeSplitDescription)
+            ReserveMovement.Create(ReserveBucket.Investimento, split.Investimento, request.Date, request.Description),
+            ReserveMovement.Create(ReserveBucket.HouseTreats, split.HouseTreats, request.Date, request.Description),
+            ReserveMovement.Create(ReserveBucket.Ariana, split.Ariana, request.Date, request.Description),
+            ReserveMovement.Create(ReserveBucket.Gleison, split.Gleison, request.Date, request.Description)
         };
 
         foreach (var movement in movements)

--- a/Financial.CashFlow.Application/Services/ReserveService.cs
+++ b/Financial.CashFlow.Application/Services/ReserveService.cs
@@ -23,15 +23,12 @@ public sealed class ReserveService : IReserveService
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        ValidateNonNegative(request.GleisonSalaryGross, nameof(request.GleisonSalaryGross));
-        ValidateNonNegative(request.GleisonSalaryNet, nameof(request.GleisonSalaryNet));
-        ValidateNonNegative(request.ArianaSalaryGross, nameof(request.ArianaSalaryGross));
-        ValidateNonNegative(request.ArianaSalaryNet, nameof(request.ArianaSalaryNet));
-        ValidateNonNegative(request.Lottery, nameof(request.Lottery));
-        ValidateNonNegative(request.DividendoJuros, nameof(request.DividendoJuros));
+        if (request.Amount <= 0)
+        {
+            throw new ArgumentException("Amount must be greater than zero.", nameof(request.Amount));
+        }
 
-        var split = ReserveSplitCalculator.Calculate(
-            request.GleisonSalaryNet, request.ArianaSalaryNet, request.Lottery, request.DividendoJuros);
+        var split = ReserveSplitCalculator.Calculate(request.Amount);
 
         var movements = new[]
         {
@@ -62,11 +59,11 @@ public sealed class ReserveService : IReserveService
 
         return new IncomeSplitResultDTO
         {
-            Dizimo = split.Dizimo,
             Investimento = split.Investimento,
             HouseTreats = split.HouseTreats,
             Ariana = split.Ariana,
-            Gleison = split.Gleison
+            Gleison = split.Gleison,
+            Total = split.Investimento + split.HouseTreats + split.Ariana + split.Gleison
         };
     }
 
@@ -129,14 +126,6 @@ public sealed class ReserveService : IReserveService
 
     private decimal GetBalance(ReserveBucket bucket) =>
         _repository.GetReserveMovements().Where(m => m.Bucket == bucket).Sum(m => m.Amount);
-
-    private static void ValidateNonNegative(decimal value, string fieldName)
-    {
-        if (value < 0)
-        {
-            throw new ArgumentException($"{fieldName} must not be negative.");
-        }
-    }
 
     private static ReserveMovementDTO ToDto(ReserveMovement movement) => new()
     {

--- a/Financial.CashFlow.Domain/Rules/ReserveSplitCalculator.cs
+++ b/Financial.CashFlow.Domain/Rules/ReserveSplitCalculator.cs
@@ -4,27 +4,14 @@ namespace Financial.CashFlow.Domain.Rules;
 
 public static class ReserveSplitCalculator
 {
-    private const decimal DizimoRate = 0.10m;
-
-    public static ReserveSplitResult Calculate(
-        decimal gleisonSalaryNet,
-        decimal arianaSalaryNet,
-        decimal lottery,
-        decimal dividendoJuros)
+    public static ReserveSplitResult Calculate(decimal amount)
     {
-        // Dizimo (tithe) is computed on the combined household income but is informational only —
-        // it is paid outside the app and never funds the Reserva pool itself.
-        var dizimo = Round((gleisonSalaryNet + arianaSalaryNet + lottery + dividendoJuros) * DizimoRate);
+        var investimento = Round(amount / 3m);
+        var houseTreats = Round(amount / 3m);
+        var ariana = Round(amount / 6m);
+        var gleison = Round(amount / 6m);
 
-        // Only Ariana's wage, net of her share of the tithe, seeds the Reserva pool.
-        var limpo = arianaSalaryNet - dizimo;
-
-        var investimento = Round(limpo / 3m);
-        var houseTreats = Round(limpo / 3m);
-        var ariana = Round(limpo / 6m);
-        var gleison = Round(limpo / 6m);
-
-        return new ReserveSplitResult(dizimo, investimento, houseTreats, ariana, gleison);
+        return new ReserveSplitResult(investimento, houseTreats, ariana, gleison);
     }
 
     private static decimal Round(decimal value) => Math.Round(value, 2, MidpointRounding.AwayFromZero);

--- a/Financial.CashFlow.Domain/Rules/ReserveSplitResult.cs
+++ b/Financial.CashFlow.Domain/Rules/ReserveSplitResult.cs
@@ -1,7 +1,6 @@
 namespace Financial.CashFlow.Domain.Rules;
 
 public sealed record ReserveSplitResult(
-    decimal Dizimo,
     decimal Investimento,
     decimal HouseTreats,
     decimal Ariana,

--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -348,19 +348,14 @@ describe('financialApiClient', () => {
   it('posts an income split request', async () => {
     const requestBody: IncomeSplitRequestDto = {
       date: '2026-07-01',
-      gleisonSalaryGross: 4500,
-      gleisonSalaryNet: 3600,
-      arianaSalaryGross: 3200,
-      arianaSalaryNet: 2600,
-      lottery: 50,
-      dividendoJuros: 120,
+      amount: 1963,
     }
     const responseBody: IncomeSplitResultDto = {
-      dizimo: 637,
-      investimento: 1854.33,
-      houseTreats: 1854.33,
-      ariana: 927.17,
-      gleison: 927.17,
+      investimento: 654.33,
+      houseTreats: 654.33,
+      ariana: 327.17,
+      gleison: 327.17,
+      total: 1963,
     }
     const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
     const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })

--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -349,6 +349,7 @@ describe('financialApiClient', () => {
     const requestBody: IncomeSplitRequestDto = {
       date: '2026-07-01',
       amount: 1963,
+      description: 'Ramsay',
     }
     const responseBody: IncomeSplitResultDto = {
       investimento: 654.33,

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -277,6 +277,7 @@ export interface ReserveMovementDto {
 export interface IncomeSplitRequestDto {
   date: string
   amount: number
+  description: string
 }
 
 export interface IncomeSplitResultDto {

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -276,20 +276,15 @@ export interface ReserveMovementDto {
 
 export interface IncomeSplitRequestDto {
   date: string
-  gleisonSalaryGross: number
-  gleisonSalaryNet: number
-  arianaSalaryGross: number
-  arianaSalaryNet: number
-  lottery: number
-  dividendoJuros: number
+  amount: number
 }
 
 export interface IncomeSplitResultDto {
-  dizimo: number
   investimento: number
   houseTreats: number
   ariana: number
   gleison: number
+  total: number
 }
 
 export interface WithdrawalRequestDto {

--- a/Financial.Web/src/hooks/useReserva.test.ts
+++ b/Financial.Web/src/hooks/useReserva.test.ts
@@ -68,35 +68,53 @@ describe('useReserva', () => {
 
   it('submits an income split and re-fetches balances/movements on success', async () => {
     postIncomeSplitMock.mockResolvedValue({
-      dizimo: 637,
       investimento: 654.33,
       houseTreats: 654.33,
       ariana: 327.17,
       gleison: 327.17,
+      total: 1963,
     })
     const { result } = renderHook(() => useReserva())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     act(() => result.current.setSplitField('splitDate', '2026-07-01'))
-    act(() => result.current.setSplitField('gleisonSalaryNet', '3600'))
+    act(() => result.current.setSplitField('splitAmount', '1963'))
     act(() => result.current.submitIncomeSplit())
 
     await waitFor(() => expect(postIncomeSplitMock).toHaveBeenCalledTimes(1))
-    expect(postIncomeSplitMock).toHaveBeenCalledWith(
-      expect.objectContaining({ date: '2026-07-01', gleisonSalaryNet: 3600 }),
-    )
+    expect(postIncomeSplitMock).toHaveBeenCalledWith({ date: '2026-07-01', amount: 1963 })
     await waitFor(() => expect(getReserveBalancesMock).toHaveBeenCalledTimes(2))
+    expect(result.current.lastSplitResult).toEqual({
+      investimento: 654.33,
+      houseTreats: 654.33,
+      ariana: 327.17,
+      gleison: 327.17,
+      total: 1963,
+    })
   })
 
-  it('surfaces a validation error from the backend on income split failure', async () => {
-    postIncomeSplitMock.mockRejectedValue(new Error('GleisonSalaryNet must not be negative.'))
+  it('rejects an income split with a non-positive amount before calling the API', async () => {
     const { result } = renderHook(() => useReserva())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     act(() => result.current.setSplitField('splitDate', '2026-07-01'))
+    act(() => result.current.setSplitField('splitAmount', '0'))
     act(() => result.current.submitIncomeSplit())
 
-    await waitFor(() => expect(result.current.splitError).toBe('GleisonSalaryNet must not be negative.'))
+    await waitFor(() => expect(result.current.splitError).toBe('Amount must be a positive number'))
+    expect(postIncomeSplitMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a validation error from the backend on income split failure', async () => {
+    postIncomeSplitMock.mockRejectedValue(new Error('Amount must be greater than zero.'))
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setSplitField('splitDate', '2026-07-01'))
+    act(() => result.current.setSplitField('splitAmount', '1963'))
+    act(() => result.current.submitIncomeSplit())
+
+    await waitFor(() => expect(result.current.splitError).toBe('Amount must be greater than zero.'))
   })
 
   it('submits a withdrawal and re-fetches on success', async () => {

--- a/Financial.Web/src/hooks/useReserva.test.ts
+++ b/Financial.Web/src/hooks/useReserva.test.ts
@@ -27,7 +27,10 @@ const BALANCES: ReserveBucketBalanceDto[] = [
 ]
 
 const MOVEMENTS: ReserveMovementDto[] = [
-  { id: 'm1', bucket: 'Investimento', amount: 654.33, date: '2026-07-01', description: 'Monthly income split' },
+  { id: 'm1', bucket: 'Investimento', amount: 654.33, date: '2026-07-17', description: 'Ramsay' },
+  { id: 'm2', bucket: 'HouseTreats', amount: 654.33, date: '2026-07-17', description: 'Ramsay' },
+  { id: 'm3', bucket: 'Ariana', amount: 327.17, date: '2026-07-17', description: 'Ramsay' },
+  { id: 'm4', bucket: 'Gleison', amount: 327.17, date: '2026-07-17', description: 'Ramsay' },
 ]
 
 describe('useReserva', () => {
@@ -47,6 +50,25 @@ describe('useReserva', () => {
     expect(result.current.balances).toEqual(BALANCES)
     expect(result.current.movements).toEqual(MOVEMENTS)
     expect(result.current.error).toBeNull()
+  })
+
+  it('marks the last movement of a same date+description group with the group total', async () => {
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const groupTotals = result.current.movementRows.map((m) => m.groupTotal)
+    expect(groupTotals.slice(0, 3)).toEqual([null, null, null])
+    expect(groupTotals[3]).toBeCloseTo(1963, 2)
+  })
+
+  it('does not attach a group total to a lone movement', async () => {
+    getReserveMovementsMock.mockResolvedValue([
+      { id: 'm5', bucket: 'Investimento', amount: -30, date: '2026-07-18', description: 'Groceries top-up' },
+    ])
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.movementRows[0].groupTotal).toBeNull()
   })
 
   it('computes the total balance across all buckets', async () => {
@@ -79,10 +101,11 @@ describe('useReserva', () => {
 
     act(() => result.current.setSplitField('splitDate', '2026-07-01'))
     act(() => result.current.setSplitField('splitAmount', '1963'))
+    act(() => result.current.setSplitField('splitDescription', 'Ramsay'))
     act(() => result.current.submitIncomeSplit())
 
     await waitFor(() => expect(postIncomeSplitMock).toHaveBeenCalledTimes(1))
-    expect(postIncomeSplitMock).toHaveBeenCalledWith({ date: '2026-07-01', amount: 1963 })
+    expect(postIncomeSplitMock).toHaveBeenCalledWith({ date: '2026-07-01', amount: 1963, description: 'Ramsay' })
     await waitFor(() => expect(getReserveBalancesMock).toHaveBeenCalledTimes(2))
     expect(result.current.lastSplitResult).toEqual({
       investimento: 654.33,
@@ -105,6 +128,18 @@ describe('useReserva', () => {
     expect(postIncomeSplitMock).not.toHaveBeenCalled()
   })
 
+  it('rejects an income split with a missing description before calling the API', async () => {
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setSplitField('splitDate', '2026-07-01'))
+    act(() => result.current.setSplitField('splitAmount', '1963'))
+    act(() => result.current.submitIncomeSplit())
+
+    await waitFor(() => expect(result.current.splitError).toBe('Description is required'))
+    expect(postIncomeSplitMock).not.toHaveBeenCalled()
+  })
+
   it('surfaces a validation error from the backend on income split failure', async () => {
     postIncomeSplitMock.mockRejectedValue(new Error('Amount must be greater than zero.'))
     const { result } = renderHook(() => useReserva())
@@ -112,6 +147,7 @@ describe('useReserva', () => {
 
     act(() => result.current.setSplitField('splitDate', '2026-07-01'))
     act(() => result.current.setSplitField('splitAmount', '1963'))
+    act(() => result.current.setSplitField('splitDescription', 'Ramsay'))
     act(() => result.current.submitIncomeSplit())
 
     await waitFor(() => expect(result.current.splitError).toBe('Amount must be greater than zero.'))

--- a/Financial.Web/src/hooks/useReserva.ts
+++ b/Financial.Web/src/hooks/useReserva.ts
@@ -5,9 +5,17 @@ import type { IncomeSplitResultDto, ReserveBucketBalanceDto, ReserveMovementDto 
 
 export const RESERVE_BUCKETS = ['Investimento', 'HouseTreats', 'Ariana', 'Gleison'] as const
 
-export type SplitFormField = 'splitDate' | 'splitAmount'
+export type SplitFormField = 'splitDate' | 'splitAmount' | 'splitDescription'
 
 export type WithdrawalFormField = 'withdrawalBucket' | 'withdrawalAmount' | 'withdrawalDate' | 'withdrawalDescription'
+
+/**
+ * A movement row for display, with `groupTotal` set on the last movement of a same
+ * date+description group (2+ movements) — how a split's total is found when browsing history.
+ */
+export interface ReserveMovementRow extends ReserveMovementDto {
+  groupTotal: number | null
+}
 
 interface ReservaState {
   balances: ReserveBucketBalanceDto[]
@@ -18,6 +26,7 @@ interface ReservaState {
   isSplitFormOpen: boolean
   splitDate: string
   splitAmount: string
+  splitDescription: string
   isSubmittingSplit: boolean
   splitError: string | null
   lastSplitResult: IncomeSplitResultDto | null
@@ -52,6 +61,7 @@ type ReservaAction =
 const BLANK_SPLIT_FORM = {
   splitDate: '',
   splitAmount: '',
+  splitDescription: '',
 } as const
 
 const BLANK_WITHDRAWAL_FORM = {
@@ -129,12 +139,14 @@ export interface ReservaData {
   balances: ReserveBucketBalanceDto[]
   totalBalance: number
   movements: ReserveMovementDto[]
+  movementRows: ReserveMovementRow[]
   isLoading: boolean
   error: string | null
   retry: () => void
   isSplitFormOpen: boolean
   splitDate: string
   splitAmount: string
+  splitDescription: string
   isSubmittingSplit: boolean
   splitError: string | null
   lastSplitResult: IncomeSplitResultDto | null
@@ -154,6 +166,23 @@ export interface ReservaData {
   cancelWithdrawalForm: () => void
   setWithdrawalField: (field: WithdrawalFormField, value: string) => void
   submitWithdrawal: () => void
+}
+
+function buildMovementRows(movements: ReserveMovementDto[]): ReserveMovementRow[] {
+  const groups = new Map<string, { total: number; count: number; lastIndex: number }>()
+  movements.forEach((m, index) => {
+    const key = `${m.date}|${m.description}`
+    const group = groups.get(key) ?? { total: 0, count: 0, lastIndex: index }
+    group.total += m.amount
+    group.count += 1
+    group.lastIndex = index
+    groups.set(key, group)
+  })
+
+  return movements.map((m, index) => {
+    const group = groups.get(`${m.date}|${m.description}`)!
+    return { ...m, groupTotal: group.count > 1 && group.lastIndex === index ? group.total : null }
+  })
 }
 
 export function useReserva(): ReservaData {
@@ -178,6 +207,8 @@ export function useReserva(): ReservaData {
     [state.balances],
   )
 
+  const movementRows = useMemo(() => buildMovementRows(state.movements), [state.movements])
+
   const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
 
   const showSplitForm = useCallback(() => dispatch({ type: 'SHOW_SPLIT_FORM' }), [])
@@ -201,7 +232,7 @@ export function useReserva(): ReservaData {
   )
 
   function submitIncomeSplit() {
-    const { splitDate, splitAmount } = state
+    const { splitDate, splitAmount, splitDescription } = state
 
     if (!splitDate.trim()) {
       dispatch({ type: 'SPLIT_ERROR', payload: 'Date is required' })
@@ -214,10 +245,15 @@ export function useReserva(): ReservaData {
       return
     }
 
+    if (!splitDescription.trim()) {
+      dispatch({ type: 'SPLIT_ERROR', payload: 'Description is required' })
+      return
+    }
+
     dispatch({ type: 'SPLIT_START' })
 
     void apiClient
-      .postIncomeSplit({ date: splitDate, amount })
+      .postIncomeSplit({ date: splitDate, amount, description: splitDescription })
       .then((result) => {
         dispatch({ type: 'SPLIT_SUCCESS', payload: result })
         fetchReservaData()
@@ -289,12 +325,14 @@ export function useReserva(): ReservaData {
     balances: state.balances,
     totalBalance,
     movements: state.movements,
+    movementRows,
     isLoading: state.isLoading,
     error: state.error,
     retry,
     isSplitFormOpen: state.isSplitFormOpen,
     splitDate: state.splitDate,
     splitAmount: state.splitAmount,
+    splitDescription: state.splitDescription,
     isSubmittingSplit: state.isSubmittingSplit,
     splitError: state.splitError,
     lastSplitResult: state.lastSplitResult,

--- a/Financial.Web/src/hooks/useReserva.ts
+++ b/Financial.Web/src/hooks/useReserva.ts
@@ -1,18 +1,11 @@
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { ApiError } from '../api/apiError'
 import { createFinancialApiClient } from '../api/financialApiClient'
-import type { ReserveBucketBalanceDto, ReserveMovementDto } from '../api/types'
+import type { IncomeSplitResultDto, ReserveBucketBalanceDto, ReserveMovementDto } from '../api/types'
 
 export const RESERVE_BUCKETS = ['Investimento', 'HouseTreats', 'Ariana', 'Gleison'] as const
 
-export type SplitFormField =
-  | 'splitDate'
-  | 'gleisonSalaryGross'
-  | 'gleisonSalaryNet'
-  | 'arianaSalaryGross'
-  | 'arianaSalaryNet'
-  | 'lottery'
-  | 'dividendoJuros'
+export type SplitFormField = 'splitDate' | 'splitAmount'
 
 export type WithdrawalFormField = 'withdrawalBucket' | 'withdrawalAmount' | 'withdrawalDate' | 'withdrawalDescription'
 
@@ -24,14 +17,10 @@ interface ReservaState {
   retryCount: number
   isSplitFormOpen: boolean
   splitDate: string
-  gleisonSalaryGross: string
-  gleisonSalaryNet: string
-  arianaSalaryGross: string
-  arianaSalaryNet: string
-  lottery: string
-  dividendoJuros: string
+  splitAmount: string
   isSubmittingSplit: boolean
   splitError: string | null
+  lastSplitResult: IncomeSplitResultDto | null
   isWithdrawalFormOpen: boolean
   withdrawalBucket: string
   withdrawalAmount: string
@@ -50,8 +39,9 @@ type ReservaAction =
   | { type: 'CANCEL_SPLIT_FORM' }
   | { type: 'SET_SPLIT_FIELD'; payload: { field: SplitFormField; value: string } }
   | { type: 'SPLIT_START' }
-  | { type: 'SPLIT_SUCCESS' }
+  | { type: 'SPLIT_SUCCESS'; payload: IncomeSplitResultDto }
   | { type: 'SPLIT_ERROR'; payload: string }
+  | { type: 'DISMISS_SPLIT_RESULT' }
   | { type: 'SHOW_WITHDRAWAL_FORM' }
   | { type: 'CANCEL_WITHDRAWAL_FORM' }
   | { type: 'SET_WITHDRAWAL_FIELD'; payload: { field: WithdrawalFormField; value: string } }
@@ -61,12 +51,7 @@ type ReservaAction =
 
 const BLANK_SPLIT_FORM = {
   splitDate: '',
-  gleisonSalaryGross: '',
-  gleisonSalaryNet: '',
-  arianaSalaryGross: '',
-  arianaSalaryNet: '',
-  lottery: '',
-  dividendoJuros: '',
+  splitAmount: '',
 } as const
 
 const BLANK_WITHDRAWAL_FORM = {
@@ -86,6 +71,7 @@ const INITIAL_STATE: ReservaState = {
   ...BLANK_SPLIT_FORM,
   isSubmittingSplit: false,
   splitError: null,
+  lastSplitResult: null,
   isWithdrawalFormOpen: false,
   ...BLANK_WITHDRAWAL_FORM,
   isSubmittingWithdrawal: false,
@@ -103,7 +89,7 @@ function reducer(state: ReservaState, action: ReservaAction): ReservaState {
     case 'RETRY':
       return { ...state, retryCount: state.retryCount + 1 }
     case 'SHOW_SPLIT_FORM':
-      return { ...state, isSplitFormOpen: true }
+      return { ...state, isSplitFormOpen: true, lastSplitResult: null }
     case 'CANCEL_SPLIT_FORM':
       return { ...state, ...BLANK_SPLIT_FORM, isSplitFormOpen: false, splitError: null }
     case 'SET_SPLIT_FIELD':
@@ -111,9 +97,17 @@ function reducer(state: ReservaState, action: ReservaAction): ReservaState {
     case 'SPLIT_START':
       return { ...state, isSubmittingSplit: true, splitError: null }
     case 'SPLIT_SUCCESS':
-      return { ...state, ...BLANK_SPLIT_FORM, isSplitFormOpen: false, isSubmittingSplit: false }
+      return {
+        ...state,
+        ...BLANK_SPLIT_FORM,
+        isSplitFormOpen: false,
+        isSubmittingSplit: false,
+        lastSplitResult: action.payload,
+      }
     case 'SPLIT_ERROR':
       return { ...state, isSubmittingSplit: false, splitError: action.payload }
+    case 'DISMISS_SPLIT_RESULT':
+      return { ...state, lastSplitResult: null }
     case 'SHOW_WITHDRAWAL_FORM':
       return { ...state, isWithdrawalFormOpen: true }
     case 'CANCEL_WITHDRAWAL_FORM':
@@ -140,18 +134,15 @@ export interface ReservaData {
   retry: () => void
   isSplitFormOpen: boolean
   splitDate: string
-  gleisonSalaryGross: string
-  gleisonSalaryNet: string
-  arianaSalaryGross: string
-  arianaSalaryNet: string
-  lottery: string
-  dividendoJuros: string
+  splitAmount: string
   isSubmittingSplit: boolean
   splitError: string | null
+  lastSplitResult: IncomeSplitResultDto | null
   showSplitForm: () => void
   cancelSplitForm: () => void
   setSplitField: (field: SplitFormField, value: string) => void
   submitIncomeSplit: () => void
+  dismissSplitResult: () => void
   isWithdrawalFormOpen: boolean
   withdrawalBucket: string
   withdrawalAmount: string
@@ -193,6 +184,8 @@ export function useReserva(): ReservaData {
 
   const cancelSplitForm = useCallback(() => dispatch({ type: 'CANCEL_SPLIT_FORM' }), [])
 
+  const dismissSplitResult = useCallback(() => dispatch({ type: 'DISMISS_SPLIT_RESULT' }), [])
+
   const showWithdrawalForm = useCallback(() => dispatch({ type: 'SHOW_WITHDRAWAL_FORM' }), [])
 
   const cancelWithdrawalForm = useCallback(() => dispatch({ type: 'CANCEL_WITHDRAWAL_FORM' }), [])
@@ -208,35 +201,25 @@ export function useReserva(): ReservaData {
   )
 
   function submitIncomeSplit() {
-    const {
-      splitDate,
-      gleisonSalaryGross,
-      gleisonSalaryNet,
-      arianaSalaryGross,
-      arianaSalaryNet,
-      lottery,
-      dividendoJuros,
-    } = state
+    const { splitDate, splitAmount } = state
 
     if (!splitDate.trim()) {
       dispatch({ type: 'SPLIT_ERROR', payload: 'Date is required' })
       return
     }
 
+    const amount = Number(splitAmount)
+    if (!splitAmount.trim() || !isFinite(amount) || amount <= 0) {
+      dispatch({ type: 'SPLIT_ERROR', payload: 'Amount must be a positive number' })
+      return
+    }
+
     dispatch({ type: 'SPLIT_START' })
 
     void apiClient
-      .postIncomeSplit({
-        date: splitDate,
-        gleisonSalaryGross: Number(gleisonSalaryGross) || 0,
-        gleisonSalaryNet: Number(gleisonSalaryNet) || 0,
-        arianaSalaryGross: Number(arianaSalaryGross) || 0,
-        arianaSalaryNet: Number(arianaSalaryNet) || 0,
-        lottery: Number(lottery) || 0,
-        dividendoJuros: Number(dividendoJuros) || 0,
-      })
-      .then(() => {
-        dispatch({ type: 'SPLIT_SUCCESS' })
+      .postIncomeSplit({ date: splitDate, amount })
+      .then((result) => {
+        dispatch({ type: 'SPLIT_SUCCESS', payload: result })
         fetchReservaData()
       })
       .catch((err: unknown) => {
@@ -311,18 +294,15 @@ export function useReserva(): ReservaData {
     retry,
     isSplitFormOpen: state.isSplitFormOpen,
     splitDate: state.splitDate,
-    gleisonSalaryGross: state.gleisonSalaryGross,
-    gleisonSalaryNet: state.gleisonSalaryNet,
-    arianaSalaryGross: state.arianaSalaryGross,
-    arianaSalaryNet: state.arianaSalaryNet,
-    lottery: state.lottery,
-    dividendoJuros: state.dividendoJuros,
+    splitAmount: state.splitAmount,
     isSubmittingSplit: state.isSubmittingSplit,
     splitError: state.splitError,
+    lastSplitResult: state.lastSplitResult,
     showSplitForm,
     cancelSplitForm,
     setSplitField,
     submitIncomeSplit,
+    dismissSplitResult,
     isWithdrawalFormOpen: state.isWithdrawalFormOpen,
     withdrawalBucket: state.withdrawalBucket,
     withdrawalAmount: state.withdrawalAmount,

--- a/Financial.Web/src/pages/ReservaPage.tsx
+++ b/Financial.Web/src/pages/ReservaPage.tsx
@@ -1,7 +1,8 @@
+import { Fragment } from 'react'
 import ErrorState from '../components/ErrorState'
 import LoadingState from '../components/LoadingState'
 import { RESERVE_BUCKETS, useReserva } from '../hooks/useReserva'
-import type { SplitFormField, WithdrawalFormField } from '../hooks/useReserva'
+import type { WithdrawalFormField } from '../hooks/useReserva'
 import { formatN2, formatShortDate } from '../utils/formatters'
 import './ReservaPage.css'
 
@@ -25,19 +26,18 @@ function MovementColumns() {
   )
 }
 
-const SPLIT_FIELDS: { field: SplitFormField; label: string }[] = [{ field: 'splitAmount', label: 'Amount to Split' }]
-
 export default function ReservaPage() {
   const {
     balances,
     totalBalance,
-    movements,
+    movementRows,
     isLoading,
     error,
     retry,
     isSplitFormOpen,
     splitDate,
     splitAmount,
+    splitDescription,
     isSubmittingSplit,
     splitError,
     lastSplitResult,
@@ -65,11 +65,6 @@ export default function ReservaPage() {
 
   if (error) {
     return <ErrorState message={error} onRetry={retry} />
-  }
-
-  const splitValues: Record<SplitFormField, string> = {
-    splitDate,
-    splitAmount,
   }
 
   const withdrawalValues: Record<WithdrawalFormField, string> = {
@@ -106,18 +101,25 @@ export default function ReservaPage() {
                 onChange={(e) => setSplitField('splitDate', e.target.value)}
               />
             </div>
-            {SPLIT_FIELDS.map(({ field, label }) => (
-              <div className="reserva-page__form-field" key={field}>
-                <label htmlFor={`split-${field}`}>{label}</label>
-                <input
-                  id={`split-${field}`}
-                  type="number"
-                  step="0.01"
-                  value={splitValues[field]}
-                  onChange={(e) => setSplitField(field, e.target.value)}
-                />
-              </div>
-            ))}
+            <div className="reserva-page__form-field">
+              <label htmlFor="split-amount">Amount to Split</label>
+              <input
+                id="split-amount"
+                type="number"
+                step="0.01"
+                value={splitAmount}
+                onChange={(e) => setSplitField('splitAmount', e.target.value)}
+              />
+            </div>
+            <div className="reserva-page__form-field">
+              <label htmlFor="split-description">Description</label>
+              <input
+                id="split-description"
+                type="text"
+                value={splitDescription}
+                onChange={(e) => setSplitField('splitDescription', e.target.value)}
+              />
+            </div>
           </div>
           <div className="reserva-page__form-actions">
             <button type="button" disabled={isSubmittingSplit} onClick={submitIncomeSplit}>
@@ -275,13 +277,21 @@ export default function ReservaPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {movements.map((m) => (
-                    <tr key={m.id}>
-                      <td>{formatShortDate(m.date)}</td>
-                      <td>{m.bucket}</td>
-                      <td>{m.description}</td>
-                      <td className="data-table__col--numeric">{formatN2(m.amount)}</td>
-                    </tr>
+                  {movementRows.map((m) => (
+                    <Fragment key={m.id}>
+                      <tr>
+                        <td>{formatShortDate(m.date)}</td>
+                        <td>{m.bucket}</td>
+                        <td>{m.description}</td>
+                        <td className="data-table__col--numeric">{formatN2(m.amount)}</td>
+                      </tr>
+                      {m.groupTotal !== null && (
+                        <tr className="reserva-page__totals-row">
+                          <td colSpan={3}>Total</td>
+                          <td className="data-table__col--numeric">{formatN2(m.groupTotal)}</td>
+                        </tr>
+                      )}
+                    </Fragment>
                   ))}
                 </tbody>
               </table>

--- a/Financial.Web/src/pages/ReservaPage.tsx
+++ b/Financial.Web/src/pages/ReservaPage.tsx
@@ -25,14 +25,7 @@ function MovementColumns() {
   )
 }
 
-const SPLIT_FIELDS: { field: SplitFormField; label: string }[] = [
-  { field: 'gleisonSalaryGross', label: 'Salario Gleison (gross)' },
-  { field: 'gleisonSalaryNet', label: 'Salario Gleison (net)' },
-  { field: 'arianaSalaryGross', label: 'Salario Ariana (gross)' },
-  { field: 'arianaSalaryNet', label: 'Salario Ariana (net)' },
-  { field: 'lottery', label: 'Lottery' },
-  { field: 'dividendoJuros', label: 'Dividendo/Juros' },
-]
+const SPLIT_FIELDS: { field: SplitFormField; label: string }[] = [{ field: 'splitAmount', label: 'Amount to Split' }]
 
 export default function ReservaPage() {
   const {
@@ -44,18 +37,15 @@ export default function ReservaPage() {
     retry,
     isSplitFormOpen,
     splitDate,
-    gleisonSalaryGross,
-    gleisonSalaryNet,
-    arianaSalaryGross,
-    arianaSalaryNet,
-    lottery,
-    dividendoJuros,
+    splitAmount,
     isSubmittingSplit,
     splitError,
+    lastSplitResult,
     showSplitForm,
     cancelSplitForm,
     setSplitField,
     submitIncomeSplit,
+    dismissSplitResult,
     isWithdrawalFormOpen,
     withdrawalBucket,
     withdrawalAmount,
@@ -79,12 +69,7 @@ export default function ReservaPage() {
 
   const splitValues: Record<SplitFormField, string> = {
     splitDate,
-    gleisonSalaryGross,
-    gleisonSalaryNet,
-    arianaSalaryGross,
-    arianaSalaryNet,
-    lottery,
-    dividendoJuros,
+    splitAmount,
   }
 
   const withdrawalValues: Record<WithdrawalFormField, string> = {
@@ -143,6 +128,42 @@ export default function ReservaPage() {
             </button>
           </div>
           {splitError && <p className="reserva-page__error">{splitError}</p>}
+        </div>
+      )}
+
+      {lastSplitResult && (
+        <div className="reserva-page__form-panel">
+          <p className="reserva-page__form-title">Income Split Posted</p>
+          <table className="reserva-page__table reserva-page__split-result-table data-table">
+            <BalanceColumns />
+            <tbody>
+              <tr>
+                <td>Investimento</td>
+                <td className="data-table__col--numeric">{formatN2(lastSplitResult.investimento)}</td>
+              </tr>
+              <tr>
+                <td>HouseTreats</td>
+                <td className="data-table__col--numeric">{formatN2(lastSplitResult.houseTreats)}</td>
+              </tr>
+              <tr>
+                <td>Ariana</td>
+                <td className="data-table__col--numeric">{formatN2(lastSplitResult.ariana)}</td>
+              </tr>
+              <tr>
+                <td>Gleison</td>
+                <td className="data-table__col--numeric">{formatN2(lastSplitResult.gleison)}</td>
+              </tr>
+              <tr className="reserva-page__totals-row">
+                <td>Total</td>
+                <td className="data-table__col--numeric">{formatN2(lastSplitResult.total)}</td>
+              </tr>
+            </tbody>
+          </table>
+          <div className="reserva-page__form-actions">
+            <button type="button" onClick={dismissSplitResult}>
+              Dismiss
+            </button>
+          </div>
         </div>
       )}
 

--- a/Financial.Web/src/pages/ReservaPage.tsx
+++ b/Financial.Web/src/pages/ReservaPage.tsx
@@ -287,7 +287,7 @@ export default function ReservaPage() {
                       </tr>
                       {m.groupTotal !== null && (
                         <tr className="reserva-page__totals-row">
-                          <td colSpan={3}>Total</td>
+                          <td colSpan={3}>Total split for {m.description}</td>
                           <td className="data-table__col--numeric">{formatN2(m.groupTotal)}</td>
                         </tr>
                       )}

--- a/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
@@ -73,7 +73,7 @@ describe('ReservaPage', () => {
     const rows = within(movementSection).getAllByRole('row')
     // header + 4 movement rows + 1 group-total row
     expect(rows).toHaveLength(6)
-    expect(within(rows[5]).getByText('Total')).toBeInTheDocument()
+    expect(within(rows[5]).getByText('Total split for Ramsay')).toBeInTheDocument()
     expect(within(rows[5]).getByText('1,963.00')).toBeInTheDocument()
   })
 

--- a/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
@@ -26,7 +26,10 @@ const BALANCES: ReserveBucketBalanceDto[] = [
 ]
 
 const MOVEMENTS: ReserveMovementDto[] = [
-  { id: 'm1', bucket: 'Investimento', amount: 654.33, date: '2026-07-01', description: 'Monthly income split' },
+  { id: 'm1', bucket: 'Investimento', amount: 654.33, date: '2026-07-17', description: 'Ramsay' },
+  { id: 'm2', bucket: 'HouseTreats', amount: 654.33, date: '2026-07-17', description: 'Ramsay' },
+  { id: 'm3', bucket: 'Ariana', amount: 327.17, date: '2026-07-17', description: 'Ramsay' },
+  { id: 'm4', bucket: 'Gleison', amount: 327.17, date: '2026-07-17', description: 'Ramsay' },
 ]
 
 describe('ReservaPage', () => {
@@ -59,15 +62,28 @@ describe('ReservaPage', () => {
     for (const b of BALANCES) {
       expect(screen.getAllByText(b.bucket).length).toBeGreaterThan(0)
     }
-    expect(screen.getByText('Monthly income split')).toBeInTheDocument()
+    expect(screen.getAllByText('Ramsay').length).toBe(4)
+  })
+
+  it('shows a group total after the last movement of a same date+description split in history', async () => {
+    render(<ReservaPage />)
+
+    await waitFor(() => expect(screen.getByText('Movement History')).toBeInTheDocument())
+    const movementSection = screen.getByText('Movement History').closest('section') as HTMLElement
+    const rows = within(movementSection).getAllByRole('row')
+    // header + 4 movement rows + 1 group-total row
+    expect(rows).toHaveLength(6)
+    expect(within(rows[5]).getByText('Total')).toBeInTheDocument()
+    expect(within(rows[5]).getByText('1,963.00')).toBeInTheDocument()
   })
 
   it('renders the total balance across all buckets, bold and always visible', async () => {
     render(<ReservaPage />)
 
     await waitFor(() => expect(screen.getByText('Bucket Balances')).toBeInTheDocument())
+    const balancesSection = screen.getByText('Bucket Balances').closest('section') as HTMLElement
     // 654.33 + 654.33 + 327.17 + 327.17 = 1963.00
-    expect(screen.getByText('1,963.00')).toBeInTheDocument()
+    expect(within(balancesSection).getByText('1,963.00')).toBeInTheDocument()
   })
 
   it('shows the income-split form only after New Income Split is clicked', async () => {
@@ -97,6 +113,7 @@ describe('ReservaPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'New Income Split' }))
     fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2026-07-01' } })
     fireEvent.change(screen.getByLabelText('Amount to Split'), { target: { value: '1963' } })
+    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Ramsay' } })
     fireEvent.click(screen.getByRole('button', { name: 'Post Income Split' }))
 
     await waitFor(() => expect(screen.getByText('Income Split Posted')).toBeInTheDocument())

--- a/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ReservaPage from '../ReservaPage'
 import type { FinancialApiClient } from '../../api/financialApiClient'
@@ -79,9 +79,33 @@ describe('ReservaPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'New Income Split' }))
 
     expect(screen.getByText('Post Monthly Income Split')).toBeInTheDocument()
-    expect(screen.getByLabelText('Salario Gleison (gross)')).toBeInTheDocument()
-    expect(screen.getByLabelText('Salario Ariana (net)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Amount to Split')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Post Income Split' })).toBeInTheDocument()
+  })
+
+  it('shows the posted split breakdown and total after a successful submission', async () => {
+    postIncomeSplitMock.mockResolvedValue({
+      investimento: 654.33,
+      houseTreats: 654.33,
+      ariana: 327.17,
+      gleison: 327.17,
+      total: 1963,
+    })
+    render(<ReservaPage />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New Income Split' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'New Income Split' }))
+    fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2026-07-01' } })
+    fireEvent.change(screen.getByLabelText('Amount to Split'), { target: { value: '1963' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Post Income Split' }))
+
+    await waitFor(() => expect(screen.getByText('Income Split Posted')).toBeInTheDocument())
+    const resultPanel = screen.getByText('Income Split Posted').closest('.reserva-page__form-panel') as HTMLElement
+    expect(within(resultPanel).getAllByText('654.33')).toHaveLength(2)
+    expect(within(resultPanel).getByText('1,963.00')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(screen.queryByText('Income Split Posted')).not.toBeInTheDocument()
   })
 
   it('shows the withdrawal form only after New Withdrawal is clicked', async () => {

--- a/Tests/Financial.Api.Tests/ReserveEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/ReserveEndpointsTests.cs
@@ -15,12 +15,7 @@ public class ReserveEndpointsTests
         var request = new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            GleisonSalaryGross = 4500m,
-            GleisonSalaryNet = 3600m,
-            ArianaSalaryGross = 3200m,
-            ArianaSalaryNet = 2600m,
-            Lottery = 50m,
-            DividendoJuros = 120m
+            Amount = 1963m
         };
 
         var response = await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", request);
@@ -28,31 +23,26 @@ public class ReserveEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var result = await response.Content.ReadFromJsonAsync<IncomeSplitResultDTO>();
         result.Should().NotBeNull();
-        result!.Dizimo.Should().Be(637m);
-        result.Investimento.Should().Be(654.33m);
+        result!.Investimento.Should().Be(654.33m);
+        result.Total.Should().Be(1963.00m);
     }
 
     [Fact]
-    public async Task PostIncomeSplit_NegativeField_ReturnsBadRequestWithMessage()
+    public async Task PostIncomeSplit_NonPositiveAmount_ReturnsBadRequestWithMessage()
     {
         await using var factory = new ApiTestFactory();
         using var client = factory.CreateClient();
         var request = new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            GleisonSalaryGross = 4500m,
-            GleisonSalaryNet = -100m,
-            ArianaSalaryGross = 3200m,
-            ArianaSalaryNet = 2600m,
-            Lottery = 50m,
-            DividendoJuros = 120m
+            Amount = 0m
         };
 
         var response = await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", request);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("must not be negative");
+        body.Should().Contain("greater than zero");
     }
 
     [Fact]
@@ -63,12 +53,7 @@ public class ReserveEndpointsTests
         await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            GleisonSalaryGross = 4500m,
-            GleisonSalaryNet = 3600m,
-            ArianaSalaryGross = 3200m,
-            ArianaSalaryNet = 2600m,
-            Lottery = 50m,
-            DividendoJuros = 120m
+            Amount = 1963m
         });
 
         var response = await client.GetAsync("/api/v1/financial/reserve/balances");
@@ -87,12 +72,7 @@ public class ReserveEndpointsTests
         await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            GleisonSalaryGross = 4500m,
-            GleisonSalaryNet = 3600m,
-            ArianaSalaryGross = 3200m,
-            ArianaSalaryNet = 2600m,
-            Lottery = 0m,
-            DividendoJuros = 0m
+            Amount = 1963m
         });
 
         var response = await client.PostAsJsonAsync("/api/v1/financial/reserve/withdrawals", new WithdrawalRequestDTO
@@ -117,12 +97,7 @@ public class ReserveEndpointsTests
         await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            GleisonSalaryGross = 4500m,
-            GleisonSalaryNet = 3600m,
-            ArianaSalaryGross = 3200m,
-            ArianaSalaryNet = 2600m,
-            Lottery = 0m,
-            DividendoJuros = 0m
+            Amount = 1963m
         });
 
         var response = await client.PostAsJsonAsync("/api/v1/financial/reserve/withdrawals", new WithdrawalRequestDTO
@@ -147,12 +122,7 @@ public class ReserveEndpointsTests
         await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            GleisonSalaryGross = 4500m,
-            GleisonSalaryNet = 3600m,
-            ArianaSalaryGross = 3200m,
-            ArianaSalaryNet = 2600m,
-            Lottery = 0m,
-            DividendoJuros = 0m
+            Amount = 1963m
         });
         var balancesBefore = await client.GetFromJsonAsync<List<ReserveBucketBalanceDTO>>("/api/v1/financial/reserve/balances");
         var gleisonBefore = balancesBefore!.Single(b => b.Bucket == "Gleison").Balance;
@@ -179,12 +149,7 @@ public class ReserveEndpointsTests
         await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            GleisonSalaryGross = 4500m,
-            GleisonSalaryNet = 3600m,
-            ArianaSalaryGross = 3200m,
-            ArianaSalaryNet = 2600m,
-            Lottery = 0m,
-            DividendoJuros = 0m
+            Amount = 1963m
         });
 
         var response = await client.GetAsync("/api/v1/financial/reserve/movements");

--- a/Tests/Financial.Api.Tests/ReserveEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/ReserveEndpointsTests.cs
@@ -15,7 +15,8 @@ public class ReserveEndpointsTests
         var request = new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            Amount = 1963m
+            Amount = 1963m,
+            Description = "Ramsay"
         };
 
         var response = await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", request);
@@ -35,7 +36,8 @@ public class ReserveEndpointsTests
         var request = new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            Amount = 0m
+            Amount = 0m,
+            Description = "Ramsay"
         };
 
         var response = await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", request);
@@ -46,6 +48,25 @@ public class ReserveEndpointsTests
     }
 
     [Fact]
+    public async Task PostIncomeSplit_MissingDescription_ReturnsBadRequestWithMessage()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new IncomeSplitRequestDTO
+        {
+            Date = new DateOnly(2026, 7, 1),
+            Amount = 1963m,
+            Description = ""
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Description is required");
+    }
+
+    [Fact]
     public async Task GetBucketBalances_ReflectsPostedIncomeSplit()
     {
         await using var factory = new ApiTestFactory();
@@ -53,7 +74,8 @@ public class ReserveEndpointsTests
         await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            Amount = 1963m
+            Amount = 1963m,
+            Description = "Ramsay"
         });
 
         var response = await client.GetAsync("/api/v1/financial/reserve/balances");
@@ -72,7 +94,8 @@ public class ReserveEndpointsTests
         await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            Amount = 1963m
+            Amount = 1963m,
+            Description = "Ramsay"
         });
 
         var response = await client.PostAsJsonAsync("/api/v1/financial/reserve/withdrawals", new WithdrawalRequestDTO
@@ -97,7 +120,8 @@ public class ReserveEndpointsTests
         await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            Amount = 1963m
+            Amount = 1963m,
+            Description = "Ramsay"
         });
 
         var response = await client.PostAsJsonAsync("/api/v1/financial/reserve/withdrawals", new WithdrawalRequestDTO
@@ -122,7 +146,8 @@ public class ReserveEndpointsTests
         await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            Amount = 1963m
+            Amount = 1963m,
+            Description = "Ramsay"
         });
         var balancesBefore = await client.GetFromJsonAsync<List<ReserveBucketBalanceDTO>>("/api/v1/financial/reserve/balances");
         var gleisonBefore = balancesBefore!.Single(b => b.Bucket == "Gleison").Balance;
@@ -149,7 +174,8 @@ public class ReserveEndpointsTests
         await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            Amount = 1963m
+            Amount = 1963m,
+            Description = "Ramsay"
         });
 
         var response = await client.GetAsync("/api/v1/financial/reserve/movements");
@@ -157,5 +183,6 @@ public class ReserveEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var movements = await response.Content.ReadFromJsonAsync<List<ReserveMovementDTO>>();
         movements.Should().HaveCount(4);
+        movements.Should().OnlyContain(m => m.Description == "Ramsay");
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
@@ -26,6 +26,7 @@ public class ReserveServiceTests
         var result = await service.PostIncomeSplitAsync(ValidIncomeSplitRequest());
 
         repository.ReserveMovements.Should().HaveCount(4);
+        repository.ReserveMovements.Should().OnlyContain(m => m.Description == "Ramsay");
         result.Investimento.Should().Be(654.33m);
         result.HouseTreats.Should().Be(654.33m);
         result.Ariana.Should().Be(327.17m);
@@ -44,7 +45,29 @@ public class ReserveServiceTests
         var request = new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            Amount = amount
+            Amount = amount,
+            Description = "Ramsay"
+        };
+
+        var act = async () => await service.PostIncomeSplitAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+        repository.ReserveMovements.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task PostIncomeSplitAsync_WithMissingDescription_ThrowsBeforeTouchingRepository(string? description)
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new ReserveService(repository);
+        var request = new IncomeSplitRequestDTO
+        {
+            Date = new DateOnly(2026, 7, 1),
+            Amount = 1963m,
+            Description = description!
         };
 
         var act = async () => await service.PostIncomeSplitAsync(request);
@@ -198,7 +221,8 @@ public class ReserveServiceTests
     private static IncomeSplitRequestDTO ValidIncomeSplitRequest() => new()
     {
         Date = new DateOnly(2026, 7, 1),
-        Amount = 1963m
+        Amount = 1963m,
+        Description = "Ramsay"
     };
 
     private sealed class StubCashFlowRepository : ICashFlowRepository

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
@@ -26,34 +26,25 @@ public class ReserveServiceTests
         var result = await service.PostIncomeSplitAsync(ValidIncomeSplitRequest());
 
         repository.ReserveMovements.Should().HaveCount(4);
-        result.Dizimo.Should().Be(637m);
         result.Investimento.Should().Be(654.33m);
         result.HouseTreats.Should().Be(654.33m);
         result.Ariana.Should().Be(327.17m);
         result.Gleison.Should().Be(327.17m);
+        result.Total.Should().Be(1963.00m);
         repository.SaveChangesCallCount.Should().Be(1);
     }
 
     [Theory]
-    [InlineData(-1, 3600, 2600, 50, 120)]
-    [InlineData(4500, -1, 2600, 50, 120)]
-    [InlineData(4500, 3600, -1, 50, 120)]
-    [InlineData(4500, 3600, 2600, -1, 120)]
-    [InlineData(4500, 3600, 2600, 50, -1)]
-    public async Task PostIncomeSplitAsync_WithAnyNegativeField_ThrowsBeforeTouchingRepository(
-        decimal gleisonGross, decimal gleisonNet, decimal arianaGross, decimal arianaNet, decimal lottery)
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task PostIncomeSplitAsync_WithNonPositiveAmount_ThrowsBeforeTouchingRepository(decimal amount)
     {
         var repository = new StubCashFlowRepository();
         var service = new ReserveService(repository);
         var request = new IncomeSplitRequestDTO
         {
             Date = new DateOnly(2026, 7, 1),
-            GleisonSalaryGross = gleisonGross,
-            GleisonSalaryNet = gleisonNet,
-            ArianaSalaryGross = arianaGross,
-            ArianaSalaryNet = arianaNet,
-            Lottery = lottery,
-            DividendoJuros = 120m
+            Amount = amount
         };
 
         var act = async () => await service.PostIncomeSplitAsync(request);
@@ -207,12 +198,7 @@ public class ReserveServiceTests
     private static IncomeSplitRequestDTO ValidIncomeSplitRequest() => new()
     {
         Date = new DateOnly(2026, 7, 1),
-        GleisonSalaryGross = 4500m,
-        GleisonSalaryNet = 3600m,
-        ArianaSalaryGross = 3200m,
-        ArianaSalaryNet = 2600m,
-        Lottery = 50m,
-        DividendoJuros = 120m
+        Amount = 1963m
     };
 
     private sealed class StubCashFlowRepository : ICashFlowRepository

--- a/Tests/Financial.CashFlow.Domain.Tests/Rules/ReserveSplitCalculatorTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Rules/ReserveSplitCalculatorTests.cs
@@ -6,28 +6,10 @@ namespace Financial.CashFlow.Domain.Tests;
 public class ReserveSplitCalculatorTests
 {
     [Fact]
-    public void Calculate_ComputesDizimoAsExactly10PercentOfCombinedIncome()
+    public void Calculate_SplitsAmountIntoExactThirdsAndSixths()
     {
-        var result = ReserveSplitCalculator.Calculate(
-            gleisonSalaryNet: 3600m,
-            arianaSalaryNet: 2600m,
-            lottery: 50m,
-            dividendoJuros: 120m);
+        var result = ReserveSplitCalculator.Calculate(1963m);
 
-        // (3600 + 2600 + 50 + 120) * 10% = 637
-        result.Dizimo.Should().Be(637m);
-    }
-
-    [Fact]
-    public void Calculate_SplitsLimpoIntoExactThirdsAndSixths()
-    {
-        var result = ReserveSplitCalculator.Calculate(
-            gleisonSalaryNet: 3600m,
-            arianaSalaryNet: 2600m,
-            lottery: 50m,
-            dividendoJuros: 120m);
-
-        // Limpo = ArianaNet(2600) - Dizimo(637) = 1963
         result.Investimento.Should().Be(654.33m);
         result.HouseTreats.Should().Be(654.33m);
         result.Ariana.Should().Be(327.17m);
@@ -35,33 +17,10 @@ public class ReserveSplitCalculatorTests
     }
 
     [Fact]
-    public void Calculate_LotteryAndDividendoJuros_AreNeverDirectlyAddedToTheSplitPool()
+    public void Calculate_ZeroAmount_ProducesAllZeroOutputs()
     {
-        // Lottery/Dividendo/Juros are not part of the 1/3-1/3-1/6-1/6 split pool itself (Limpo is
-        // Ariana's net wage minus Dizimo, full stop) - but since Dizimo grows with Lottery/Dividendo,
-        // Limpo (and therefore the four splits) shrinks correspondingly. This proves the splits are
-        // always derived from Limpo alone, never from (Ariana net + Lottery + Dividendo) directly.
-        const decimal arianaSalaryNet = 2600m;
+        var result = ReserveSplitCalculator.Calculate(0m);
 
-        var withoutExtraIncome = ReserveSplitCalculator.Calculate(3600m, 2600m, lottery: 0m, dividendoJuros: 0m);
-        var withExtraIncome = ReserveSplitCalculator.Calculate(3600m, 2600m, lottery: 500m, dividendoJuros: 300m);
-
-        withExtraIncome.Dizimo.Should().BeGreaterThan(withoutExtraIncome.Dizimo);
-
-        var limpoWithout = arianaSalaryNet - withoutExtraIncome.Dizimo;
-        var limpoWith = arianaSalaryNet - withExtraIncome.Dizimo;
-        (withoutExtraIncome.Investimento + withoutExtraIncome.HouseTreats + withoutExtraIncome.Ariana + withoutExtraIncome.Gleison)
-            .Should().BeApproximately(limpoWithout, 0.02m);
-        (withExtraIncome.Investimento + withExtraIncome.HouseTreats + withExtraIncome.Ariana + withExtraIncome.Gleison)
-            .Should().BeApproximately(limpoWith, 0.02m);
-    }
-
-    [Fact]
-    public void Calculate_AllZeroInputs_ProducesAllZeroOutputs()
-    {
-        var result = ReserveSplitCalculator.Calculate(0m, 0m, 0m, 0m);
-
-        result.Dizimo.Should().Be(0m);
         result.Investimento.Should().Be(0m);
         result.HouseTreats.Should().Be(0m);
         result.Ariana.Should().Be(0m);


### PR DESCRIPTION
## Summary
- **Simplified input**: "New Income Split" no longer asks for Gleison/Ariana gross+net salary, Lottery, and Dividendo/Juros (6 fields) to derive Dizimo/Limpo server-side. It now takes a single `Amount` — the value to split — since that computation already happens outside the app before the user enters it.
- **Split math unchanged in shape**: the amount is still split 1/3 Investimento, 1/3 HouseTreats, 1/6 Ariana, 1/6 Gleison, each posted as its own `ReserveMovement`, same as before.
- **Total now surfaced**: the API's `IncomeSplitResultDTO` gains a `Total` field (sum of the 4 posted movements), and the frontend — which previously computed but silently discarded this result — now shows an "Income Split Posted" summary with the per-bucket breakdown and total after submitting. Previously the only way to know the total split was to manually sum the 4 ledger movements sharing the same description.

## Architecture
- `Domain`: `ReserveSplitCalculator.Calculate(decimal amount)` — pure split math, no framework/DB code, single responsibility.
- `Application`: `ReserveService.PostIncomeSplitAsync` validates `Amount > 0`, posts 4 movements via `ICashFlowRepository` (unchanged abstraction, no layer violation), returns the breakdown + total.
- `Presentation`: form and result panel just render what the API returns — no business logic moved to the frontend.

## Test plan
- [x] `dotnet test` — full solution, 0 failures (Domain/Application/Api/Infrastructure suites all updated and passing)
- [x] `npx tsc -b --noEmit` — no type errors
- [x] `npx vitest run` — 521 passed, including new coverage for the simplified form, non-positive-amount validation, and the posted-split summary panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)