### PR TITLE
chore(P11): reorder CashFlow tabs

### DIFF
--- a/Financial.Web/src/components/CashFlowLayout.tsx
+++ b/Financial.Web/src/components/CashFlowLayout.tsx
@@ -6,11 +6,11 @@ function CashFlowLayout() {
     <div className="cashflow-layout">
       <nav className="cashflow-layout__nav" aria-label="CashFlow">
         <NavLink to="/cashflow/monthly">Monthly</NavLink>
+        <NavLink to="/cashflow/investment-snapshots">Investment Snapshots</NavLink>
+        <NavLink to="/cashflow/yearly-summary">Yearly Summary</NavLink>
         <NavLink to="/cashflow/reserva">Reserva</NavLink>
         <NavLink to="/cashflow/mensais">Mensais</NavLink>
         <NavLink to="/cashflow/controle-mae">Controle Mae</NavLink>
-        <NavLink to="/cashflow/investment-snapshots">Investment Snapshots</NavLink>
-        <NavLink to="/cashflow/yearly-summary">Yearly Summary</NavLink>
       </nav>
       <div className="cashflow-layout__content">
         <Outlet />

--- a/Financial.Web/src/components/__tests__/CashFlowLayout.test.tsx
+++ b/Financial.Web/src/components/__tests__/CashFlowLayout.test.tsx
@@ -26,11 +26,11 @@ describe('CashFlowLayout', () => {
     expect(links).toHaveLength(6)
     expect(links.map((link) => link.textContent)).toEqual([
       'Monthly',
+      'Investment Snapshots',
+      'Yearly Summary',
       'Reserva',
       'Mensais',
       'Controle Mae',
-      'Investment Snapshots',
-      'Yearly Summary',
     ])
   })
 


### PR DESCRIPTION
## Summary
- Reorders the CashFlow nav tabs from Monthly, Reserva, Mensais, Controle Mae, Investment Snapshots, Yearly Summary to Monthly, Investment Snapshots, Yearly Summary, Reserva, Mensais, Controle Mae.

## Test plan
- [x] `npx vitest run src/components/__tests__/CashFlowLayout.test.tsx` — updated order assertion passes
- [x] `npx tsc -b --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)