### PR TITLE
chore(P11): Controle Mae grid fills available width

### DIFF
--- a/Financial.Web/src/pages/ControleMaePage.css
+++ b/Financial.Web/src/pages/ControleMaePage.css
@@ -64,7 +64,6 @@
 
 .controle-mae-page__table {
   width: 100%;
-  max-width: 840px;
   table-layout: fixed;
   border-collapse: separate;
   border-spacing: 0;
@@ -74,8 +73,18 @@
   width: 110px;
 }
 
+/*
+ * Description/Note are the only percentage-width columns (all others are fixed px), and
+ * their percentages sum to 100% - a fixed-layout table allocates the space left over after
+ * the px columns to percentage columns in that ratio, so this splits it 80/20 without
+ * overflowing regardless of viewport width.
+ */
+.controle-mae-page__col-description {
+  width: 80%;
+}
+
 .controle-mae-page__col-note {
-  width: 160px;
+  width: 20%;
 }
 
 .controle-mae-page__col-value {

--- a/Financial.Web/src/pages/ControleMaePage.tsx
+++ b/Financial.Web/src/pages/ControleMaePage.tsx
@@ -9,7 +9,7 @@ function LedgerColumns() {
   return (
     <colgroup>
       <col className="controle-mae-page__col-date" />
-      <col />
+      <col className="controle-mae-page__col-description" />
       <col className="controle-mae-page__col-note" />
       <col className="controle-mae-page__col-value" />
       <col className="controle-mae-page__col-value" />


### PR DESCRIPTION
## Summary
- Removes the `max-width: 840px` cap on the Controle Mae ledger table so it fills the available horizontal space on wide viewports.
- Description column now takes ~80% and Note ~20% of the leftover space (after the fixed-width Date/BRL/GBP/Actions columns), instead of Note's old fixed 160px.
- No horizontal scrollbar — verified live in a headless-Chromium screenshot at a 1600px viewport (`scrollWidth === clientWidth`).

## Note on implementation
`calc()` on `<col>`/cell widths is silently ignored by Chromium's fixed-table-layout algorithm (confirmed with an isolated repro) — both flexible columns fell back to an even 50/50 split regardless of the calc() ratio. Plain percentages on Description/Note work correctly instead: when a fixed-layout table's percentage-width columns sum to 100%, the browser allocates the space left over after the pixel columns in that ratio, rather than as a percentage of the whole table (which would have overflowed). This is why the CSS uses plain `80%`/`20%`, not a calc() expression.

## Test plan
- [x] `npx vitest run` — 525 passed
- [x] `npx tsc -b --noEmit` — no type errors
- [x] Live check: ran the app + API locally, screenshotted Controle Mae at 1600px viewport — table fills the width, Description ≈ 937px vs Note ≈ 234px (80/20 of the 1172px leftover), `scrollWidth === clientWidth` (no horizontal scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)