### PR TITLE
chore(P11): Mensais Brasil/UK grids side by side

### DIFF
--- a/Financial.Web/src/pages/MensaisPage.css
+++ b/Financial.Web/src/pages/MensaisPage.css
@@ -15,6 +15,21 @@
   flex-shrink: 0;
 }
 
+.mensais-page__new-btn {
+  font: inherit;
+  font-weight: 600;
+  padding: 8px 16px;
+  cursor: pointer;
+  background: #007acc;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+}
+
+.mensais-page__new-btn:hover {
+  background: #005fa3;
+}
+
 .mensais-page__form-panel {
   flex-shrink: 0;
   padding: 12px 16px;

--- a/Financial.Web/src/pages/MensaisPage.css
+++ b/Financial.Web/src/pages/MensaisPage.css
@@ -51,11 +51,19 @@
 .mensais-page__content {
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
+  overflow: hidden;
+  display: flex;
+  gap: 24px;
+  align-items: stretch;
+  padding-bottom: 24px;
+}
+
+.mensais-page__section {
+  flex: 1 1 0;
+  min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 32px;
-  padding-bottom: 24px;
+  min-height: 0;
 }
 
 .mensais-page__section h2 {
@@ -63,9 +71,15 @@
   margin-bottom: 12px;
 }
 
+.mensais-page__table-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
 .mensais-page__table {
   width: 100%;
-  max-width: 720px;
+  max-width: none;
 }
 
 .mensais-page__error {

--- a/Financial.Web/src/pages/MensaisPage.tsx
+++ b/Financial.Web/src/pages/MensaisPage.tsx
@@ -21,6 +21,7 @@ function BillRow({ bill, showBrasilFields, isDeleting, onEdit, onDelete }: BillR
     <tr>
       <td>{bill.dueDay}</td>
       <td>{bill.description}</td>
+      <td>{bill.note}</td>
       {showBrasilFields && <td>{bill.nitNumber ?? ''}</td>}
       {showBrasilFields && <td className="data-table__col--numeric">{bill.minimumWageValue !== null ? formatN2(bill.minimumWageValue) : ''}</td>}
       <td className="data-table__col--numeric">{formatN2(bill.value)}</td>
@@ -64,6 +65,7 @@ function BillTable({ title, bills, showBrasilFields, deletingBillId, onEdit, onD
             <tr>
               <th>Due Day</th>
               <th>Description</th>
+              <th>Note</th>
               {showBrasilFields && <th>NIT</th>}
               {showBrasilFields && <th className="data-table__col--numeric">Min. Wage</th>}
               <th className="data-table__col--numeric">Value</th>
@@ -140,11 +142,12 @@ export default function MensaisPage() {
           onChange={(e) => setMonthInputValue(e.target.value)}
         />
         {!isAddFormOpen && (
-          <button type="button" onClick={showAddForm}>
+          <button className="mensais-page__new-btn" type="button" onClick={showAddForm}>
             Add Bill
           </button>
         )}
         <button
+          className="mensais-page__new-btn"
           type="button"
           disabled={isResetting}
           onClick={() => {

--- a/Financial.Web/src/pages/MensaisPage.tsx
+++ b/Financial.Web/src/pages/MensaisPage.tsx
@@ -58,31 +58,33 @@ function BillTable({ title, bills, showBrasilFields, deletingBillId, onEdit, onD
   return (
     <section className="mensais-page__section">
       <h2>{title}</h2>
-      <table className="mensais-page__table data-table">
-        <thead>
-          <tr>
-            <th>Due Day</th>
-            <th>Description</th>
-            {showBrasilFields && <th>NIT</th>}
-            {showBrasilFields && <th className="data-table__col--numeric">Min. Wage</th>}
-            <th className="data-table__col--numeric">Value</th>
-            <th>Status</th>
-            <th />
-          </tr>
-        </thead>
-        <tbody>
-          {bills.map((bill) => (
-            <BillRow
-              key={bill.id}
-              bill={bill}
-              showBrasilFields={showBrasilFields}
-              isDeleting={deletingBillId === bill.id}
-              onEdit={onEdit}
-              onDelete={onDelete}
-            />
-          ))}
-        </tbody>
-      </table>
+      <div className="mensais-page__table-scroll">
+        <table className="mensais-page__table data-table">
+          <thead>
+            <tr>
+              <th>Due Day</th>
+              <th>Description</th>
+              {showBrasilFields && <th>NIT</th>}
+              {showBrasilFields && <th className="data-table__col--numeric">Min. Wage</th>}
+              <th className="data-table__col--numeric">Value</th>
+              <th>Status</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {bills.map((bill) => (
+              <BillRow
+                key={bill.id}
+                bill={bill}
+                showBrasilFields={showBrasilFields}
+                isDeleting={deletingBillId === bill.id}
+                onEdit={onEdit}
+                onDelete={onDelete}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
     </section>
   )
 }

--- a/Financial.Web/src/pages/__tests__/MensaisPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MensaisPage.test.tsx
@@ -26,7 +26,7 @@ const BILLS: RecurringBillDto[] = [
     dueDay: 10,
     description: 'INSS',
     area: 'Brasil',
-    note: '',
+    note: 'Paga via boleto',
     nitNumber: null,
     minimumWageValue: null,
     value: 850,
@@ -37,7 +37,7 @@ const BILLS: RecurringBillDto[] = [
     dueDay: 15,
     description: 'Council Tax',
     area: 'UK',
-    note: '',
+    note: 'Direct debit',
     nitNumber: null,
     minimumWageValue: null,
     value: 120,
@@ -97,6 +97,15 @@ describe('MensaisPage', () => {
       expect(updateMensaisBillMock).toHaveBeenCalledWith('b1', { status: 'Paid', value: 900 }),
     )
     await waitFor(() => expect(screen.getByText('Paid')).toBeInTheDocument())
+  })
+
+  it('shows each bill\'s Note in both the Brasil and UK grids', async () => {
+    render(<MensaisPage />)
+
+    await waitFor(() => expect(screen.getByText('INSS')).toBeInTheDocument())
+    expect(screen.getAllByText('Note')).toHaveLength(2)
+    expect(screen.getByText('Paga via boleto')).toBeInTheDocument()
+    expect(screen.getByText('Direct debit')).toBeInTheDocument()
   })
 
   it('shows NIT and Min. Wage columns only in the Brasil section', async () => {


### PR DESCRIPTION
## Summary
- Brasil and UK bill tables on the Mensais tab are now laid out side by side instead of stacked, each with its own independent vertical scrollbar when its list is longer than the available height.

## Note on implementation
First attempt used `flex-wrap: wrap` (matching the pattern used on Monthly/Reserva's grid rows), but that breaks height-constraint propagation for a container with exactly two items on one line: flex-line height sizes to content instead of the container's bounded height, so `min-height: 0` never reaches the inner scroll div and nothing clips — the whole page grows instead of showing per-grid scrollbars. Since Mensais always has exactly two columns (never needs to wrap), dropping `flex-wrap` fixes it: the row is forced onto one line, cross-axis stretch works normally, and each grid's own `overflow: auto` kicks in independently.

## Test plan
- [x] `npx vitest run` — 525 passed
- [x] `npx tsc -b --noEmit` — no type errors
- [x] Live check: ran the app + API, screenshotted at a short viewport — Brasil (4 rows, fits) and UK (15 rows, scrolls) sit side by side at the same height, UK's internal scrollbar activates independently, no page-level or horizontal scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)