### PR TITLE
feat(P11): Reserva movements can be updated or deleted

### DIFF
--- a/Financial.Api/Controllers/ReserveController.cs
+++ b/Financial.Api/Controllers/ReserveController.cs
@@ -76,4 +76,46 @@ public sealed class ReserveController : ControllerBase
     {
         return Ok(_reserveService.GetMovementHistory());
     }
+
+    [HttpPut("movements/{id:guid}")]
+    [ProducesResponseType(typeof(ReserveMovementDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ReserveMovementDTO>> UpdateMovement(Guid id, [FromBody] UpdateReserveMovementDTO? request)
+    {
+        if (request is null)
+        {
+            return BadRequest();
+        }
+
+        try
+        {
+            var result = await _reserveService.UpdateMovementAsync(id, request);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound);
+        }
+    }
+
+    [HttpDelete("movements/{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteMovement(Guid id)
+    {
+        try
+        {
+            await _reserveService.DeleteMovementAsync(id);
+            return Ok();
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound);
+        }
+    }
 }

--- a/Financial.CashFlow.Application/DTOs/UpdateReserveMovementDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/UpdateReserveMovementDTO.cs
@@ -1,0 +1,12 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Request to edit a single Reserva movement's fields.
+/// </summary>
+public sealed class UpdateReserveMovementDTO
+{
+    public required string Bucket { get; init; }
+    public required decimal Amount { get; init; }
+    public required DateOnly Date { get; init; }
+    public required string Description { get; init; }
+}

--- a/Financial.CashFlow.Application/Interfaces/IReserveService.cs
+++ b/Financial.CashFlow.Application/Interfaces/IReserveService.cs
@@ -8,4 +8,6 @@ public interface IReserveService
     Task<ReserveMovementDTO> PostWithdrawalAsync(WithdrawalRequestDTO request);
     IReadOnlyList<ReserveBucketBalanceDTO> GetBucketBalances();
     IReadOnlyList<ReserveMovementDTO> GetMovementHistory();
+    Task<ReserveMovementDTO> UpdateMovementAsync(Guid id, UpdateReserveMovementDTO request);
+    Task DeleteMovementAsync(Guid id);
 }

--- a/Financial.CashFlow.Application/Services/ReserveService.cs
+++ b/Financial.CashFlow.Application/Services/ReserveService.cs
@@ -127,6 +127,48 @@ public sealed class ReserveService : IReserveService
             .Select(ToDto)
             .ToList();
 
+    public async Task<ReserveMovementDTO> UpdateMovementAsync(Guid id, UpdateReserveMovementDTO request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.Description))
+        {
+            throw new ArgumentException("Description is required.");
+        }
+
+        if (!ReserveBucketParser.TryParse(request.Bucket, out var bucket))
+        {
+            throw new ArgumentException($"Bucket '{request.Bucket}' is not recognized.");
+        }
+
+        var movement = _repository.GetReserveMovements().FirstOrDefault(m => m.Id == id)
+            ?? throw new KeyNotFoundException($"Reserve movement '{id}' was not found.");
+
+        movement.Update(bucket, request.Amount, request.Date, request.Description);
+        await _repository.SaveChangesAsync().ConfigureAwait(false);
+
+        return ToDto(movement);
+    }
+
+    public async Task DeleteMovementAsync(Guid id)
+    {
+        var movement = _repository.GetReserveMovements().FirstOrDefault(m => m.Id == id)
+            ?? throw new KeyNotFoundException($"Reserve movement '{id}' was not found.");
+
+        // Movements from the same income split share Date+Description (see PostIncomeSplitAsync) -
+        // deleting one deletes the whole split, not just this bucket's line.
+        var group = _repository.GetReserveMovements()
+            .Where(m => m.Date == movement.Date && m.Description == movement.Description)
+            .ToList();
+
+        foreach (var groupMovement in group)
+        {
+            _repository.DeleteReserveMovement(groupMovement.Id);
+        }
+
+        await _repository.SaveChangesAsync().ConfigureAwait(false);
+    }
+
     private decimal GetBalance(ReserveBucket bucket) =>
         _repository.GetReserveMovements().Where(m => m.Bucket == bucket).Sum(m => m.Amount);
 

--- a/Financial.CashFlow.Domain/Entities/ReserveMovement.cs
+++ b/Financial.CashFlow.Domain/Entities/ReserveMovement.cs
@@ -22,4 +22,12 @@ public class ReserveMovement
             Date = date,
             Description = description
         };
+
+    public void Update(ReserveBucket bucket, decimal amount, DateOnly date, string description)
+    {
+        Bucket = bucket;
+        Amount = amount;
+        Date = date;
+        Description = description;
+    }
 }

--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -19,6 +19,7 @@ import type {
   UpdateInvestmentSnapshotValueDto,
   UpdateMaeLedgerEntryValuesDto,
   UpdateRecurringBillDto,
+  UpdateReserveMovementDto,
   WithdrawalRequestDto,
   XirrResultDto,
 } from './types'
@@ -395,6 +396,43 @@ describe('financialApiClient', () => {
     expect(url).toBe(`${API_BASE_URL}/reserve/withdrawals`)
     expect(init?.method).toBe('POST')
     expect(JSON.parse(init?.body as string)).toEqual(requestBody)
+  })
+
+  it('puts a reserve movement update', async () => {
+    const requestBody: UpdateReserveMovementDto = {
+      bucket: 'Ariana',
+      amount: -45,
+      date: '2026-07-03',
+      description: 'Groceries (corrected)',
+    }
+    const responseBody: ReserveMovementDto = {
+      id: 'm2',
+      bucket: 'Ariana',
+      amount: -45,
+      date: '2026-07-03',
+      description: 'Groceries (corrected)',
+    }
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.updateReserveMovement('m2', requestBody)
+
+    expect(result).toEqual(responseBody)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/reserve/movements/m2`)
+    expect(init?.method).toBe('PUT')
+    expect(JSON.parse(init?.body as string)).toEqual(requestBody)
+  })
+
+  it('deletes a reserve movement', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(undefined))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    await client.deleteReserveMovement('m2')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/reserve/movements/m2`)
+    expect(init?.method).toBe('DELETE')
   })
 
   it('calls the mensais bills endpoint', async () => {

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -42,6 +42,7 @@ import type {
   UpdateInvestmentSnapshotValueDto,
   UpdateMaeLedgerEntryValuesDto,
   UpdateRecurringBillDto,
+  UpdateReserveMovementDto,
   WatchlistItemDto,
   WithdrawalRequestDto,
   XirrResultDto,
@@ -81,6 +82,8 @@ export interface FinancialApiClient {
   getReserveMovements: () => Promise<ReserveMovementDto[]>
   postIncomeSplit: (request: IncomeSplitRequestDto) => Promise<IncomeSplitResultDto>
   postWithdrawal: (request: WithdrawalRequestDto) => Promise<ReserveMovementDto>
+  updateReserveMovement: (id: string, request: UpdateReserveMovementDto) => Promise<ReserveMovementDto>
+  deleteReserveMovement: (id: string) => Promise<void>
   getMensaisBills: () => Promise<RecurringBillDto[]>
   createMensaisBill: (request: CreateRecurringBillDto) => Promise<RecurringBillDto>
   updateMensaisBill: (id: string, request: UpdateRecurringBillDto) => Promise<RecurringBillDto>
@@ -273,6 +276,12 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
         method: 'POST',
         body: JSON.stringify(requestBody),
       }),
+    updateReserveMovement: (id, requestBody) =>
+      request<ReserveMovementDto>(`/reserve/movements/${encodeURIComponent(id)}`, {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+      }),
+    deleteReserveMovement: (id) => requestVoid(`/reserve/movements/${encodeURIComponent(id)}`, { method: 'DELETE' }),
     getMensaisBills: () => request<RecurringBillDto[]>('/mensais'),
     createMensaisBill: (requestBody) =>
       request<RecurringBillDto>('/mensais', {

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -296,6 +296,13 @@ export interface WithdrawalRequestDto {
   confirmed: boolean
 }
 
+export interface UpdateReserveMovementDto {
+  bucket: string
+  amount: number
+  date: string
+  description: string
+}
+
 export interface RecurringBillDto {
   id: string
   dueDay: number

--- a/Financial.Web/src/hooks/useReserva.test.ts
+++ b/Financial.Web/src/hooks/useReserva.test.ts
@@ -9,6 +9,8 @@ const getReserveBalancesMock = vi.fn<FinancialApiClient['getReserveBalances']>()
 const getReserveMovementsMock = vi.fn<FinancialApiClient['getReserveMovements']>()
 const postIncomeSplitMock = vi.fn<FinancialApiClient['postIncomeSplit']>()
 const postWithdrawalMock = vi.fn<FinancialApiClient['postWithdrawal']>()
+const updateReserveMovementMock = vi.fn<FinancialApiClient['updateReserveMovement']>()
+const deleteReserveMovementMock = vi.fn<FinancialApiClient['deleteReserveMovement']>()
 
 vi.mock('../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
@@ -16,6 +18,8 @@ vi.mock('../api/financialApiClient', () => ({
     getReserveMovements: getReserveMovementsMock,
     postIncomeSplit: postIncomeSplitMock,
     postWithdrawal: postWithdrawalMock,
+    updateReserveMovement: updateReserveMovementMock,
+    deleteReserveMovement: deleteReserveMovementMock,
   }),
 }))
 
@@ -69,6 +73,14 @@ describe('useReserva', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.movementRows[0].groupTotal).toBeNull()
+    expect(result.current.movementRows[0].isPartOfGroup).toBe(false)
+  })
+
+  it('marks every movement of a split group as part of a group, not just the last', async () => {
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.movementRows.map((m) => m.isPartOfGroup)).toEqual([true, true, true, true])
   })
 
   it('computes the total balance across all buckets', async () => {
@@ -214,5 +226,60 @@ describe('useReserva', () => {
 
     await waitFor(() => expect(result.current.withdrawalError).toBe('This withdrawal exceeds the balance.'))
     expect(postWithdrawalMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('saves a movement edit and re-fetches on success', async () => {
+    updateReserveMovementMock.mockResolvedValue({ ...MOVEMENTS[0], amount: 700 })
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditMovementForm(MOVEMENTS[0]))
+    act(() => result.current.setEditMovementField('editMovementAmount', '700'))
+    act(() => result.current.saveMovementEdit())
+
+    await waitFor(() =>
+      expect(updateReserveMovementMock).toHaveBeenCalledWith('m1', {
+        bucket: 'Investimento',
+        amount: 700,
+        date: '2026-07-17',
+        description: 'Ramsay',
+      }),
+    )
+    await waitFor(() => expect(getReserveBalancesMock).toHaveBeenCalledTimes(2))
+    expect(result.current.editingMovementId).toBeNull()
+  })
+
+  it('surfaces a movement-edit error without crashing', async () => {
+    updateReserveMovementMock.mockRejectedValue(new Error('Description is required.'))
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditMovementForm(MOVEMENTS[0]))
+    act(() => result.current.setEditMovementField('editMovementDescription', ''))
+    act(() => result.current.saveMovementEdit())
+
+    await waitFor(() => expect(result.current.saveMovementError).toBe('Description is required'))
+    expect(updateReserveMovementMock).not.toHaveBeenCalled()
+  })
+
+  it('deletes a movement and re-fetches on success', async () => {
+    deleteReserveMovementMock.mockResolvedValue(undefined)
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.deleteMovement('m1'))
+
+    await waitFor(() => expect(deleteReserveMovementMock).toHaveBeenCalledWith('m1'))
+    await waitFor(() => expect(getReserveBalancesMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('surfaces a delete error without crashing', async () => {
+    deleteReserveMovementMock.mockRejectedValue(new Error('Reserve movement not found.'))
+    const { result } = renderHook(() => useReserva())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.deleteMovement('unknown'))
+
+    await waitFor(() => expect(result.current.deleteMovementError).toBe('Reserve movement not found.'))
   })
 })

--- a/Financial.Web/src/hooks/useReserva.ts
+++ b/Financial.Web/src/hooks/useReserva.ts
@@ -9,12 +9,17 @@ export type SplitFormField = 'splitDate' | 'splitAmount' | 'splitDescription'
 
 export type WithdrawalFormField = 'withdrawalBucket' | 'withdrawalAmount' | 'withdrawalDate' | 'withdrawalDescription'
 
+export type EditMovementField = 'editMovementBucket' | 'editMovementAmount' | 'editMovementDate' | 'editMovementDescription'
+
 /**
- * A movement row for display, with `groupTotal` set on the last movement of a same
+ * A movement row for display. `groupTotal` is set only on the last movement of a same
  * date+description group (2+ movements) — how a split's total is found when browsing history.
+ * `isPartOfGroup` is set on every movement in such a group (used to warn before a cascading
+ * delete, since removing any one line of a split removes all of them).
  */
 export interface ReserveMovementRow extends ReserveMovementDto {
   groupTotal: number | null
+  isPartOfGroup: boolean
 }
 
 interface ReservaState {
@@ -37,6 +42,15 @@ interface ReservaState {
   withdrawalDescription: string
   isSubmittingWithdrawal: boolean
   withdrawalError: string | null
+  editingMovementId: string | null
+  editMovementBucket: string
+  editMovementAmount: string
+  editMovementDate: string
+  editMovementDescription: string
+  isSavingMovement: boolean
+  saveMovementError: string | null
+  deletingMovementId: string | null
+  deleteMovementError: string | null
 }
 
 type ReservaAction =
@@ -57,6 +71,15 @@ type ReservaAction =
   | { type: 'WITHDRAWAL_START' }
   | { type: 'WITHDRAWAL_SUCCESS' }
   | { type: 'WITHDRAWAL_ERROR'; payload: string }
+  | { type: 'SHOW_EDIT_MOVEMENT_FORM'; payload: ReserveMovementDto }
+  | { type: 'CANCEL_EDIT_MOVEMENT' }
+  | { type: 'SET_EDIT_MOVEMENT_FIELD'; payload: { field: EditMovementField; value: string } }
+  | { type: 'SAVE_MOVEMENT_START' }
+  | { type: 'SAVE_MOVEMENT_SUCCESS' }
+  | { type: 'SAVE_MOVEMENT_ERROR'; payload: string }
+  | { type: 'DELETE_MOVEMENT_START'; payload: string }
+  | { type: 'DELETE_MOVEMENT_SUCCESS' }
+  | { type: 'DELETE_MOVEMENT_ERROR'; payload: string }
 
 const BLANK_SPLIT_FORM = {
   splitDate: '',
@@ -86,6 +109,15 @@ const INITIAL_STATE: ReservaState = {
   ...BLANK_WITHDRAWAL_FORM,
   isSubmittingWithdrawal: false,
   withdrawalError: null,
+  editingMovementId: null,
+  editMovementBucket: RESERVE_BUCKETS[0],
+  editMovementAmount: '',
+  editMovementDate: '',
+  editMovementDescription: '',
+  isSavingMovement: false,
+  saveMovementError: null,
+  deletingMovementId: null,
+  deleteMovementError: null,
 }
 
 function reducer(state: ReservaState, action: ReservaAction): ReservaState {
@@ -130,6 +162,46 @@ function reducer(state: ReservaState, action: ReservaAction): ReservaState {
       return { ...state, ...BLANK_WITHDRAWAL_FORM, isWithdrawalFormOpen: false, isSubmittingWithdrawal: false }
     case 'WITHDRAWAL_ERROR':
       return { ...state, isSubmittingWithdrawal: false, withdrawalError: action.payload }
+    case 'SHOW_EDIT_MOVEMENT_FORM':
+      return {
+        ...state,
+        editingMovementId: action.payload.id,
+        editMovementBucket: action.payload.bucket,
+        editMovementAmount: String(action.payload.amount),
+        editMovementDate: action.payload.date,
+        editMovementDescription: action.payload.description,
+        saveMovementError: null,
+      }
+    case 'CANCEL_EDIT_MOVEMENT':
+      return {
+        ...state,
+        editingMovementId: null,
+        editMovementAmount: '',
+        editMovementDate: '',
+        editMovementDescription: '',
+        saveMovementError: null,
+      }
+    case 'SET_EDIT_MOVEMENT_FIELD':
+      return { ...state, [action.payload.field]: action.payload.value }
+    case 'SAVE_MOVEMENT_START':
+      return { ...state, isSavingMovement: true, saveMovementError: null }
+    case 'SAVE_MOVEMENT_SUCCESS':
+      return {
+        ...state,
+        isSavingMovement: false,
+        editingMovementId: null,
+        editMovementAmount: '',
+        editMovementDate: '',
+        editMovementDescription: '',
+      }
+    case 'SAVE_MOVEMENT_ERROR':
+      return { ...state, isSavingMovement: false, saveMovementError: action.payload }
+    case 'DELETE_MOVEMENT_START':
+      return { ...state, deletingMovementId: action.payload, deleteMovementError: null }
+    case 'DELETE_MOVEMENT_SUCCESS':
+      return { ...state, deletingMovementId: null }
+    case 'DELETE_MOVEMENT_ERROR':
+      return { ...state, deletingMovementId: null, deleteMovementError: action.payload }
     default:
       return state
   }
@@ -166,6 +238,20 @@ export interface ReservaData {
   cancelWithdrawalForm: () => void
   setWithdrawalField: (field: WithdrawalFormField, value: string) => void
   submitWithdrawal: () => void
+  editingMovementId: string | null
+  editMovementBucket: string
+  editMovementAmount: string
+  editMovementDate: string
+  editMovementDescription: string
+  isSavingMovement: boolean
+  saveMovementError: string | null
+  showEditMovementForm: (movement: ReserveMovementDto) => void
+  cancelEditMovement: () => void
+  setEditMovementField: (field: EditMovementField, value: string) => void
+  saveMovementEdit: () => void
+  deletingMovementId: string | null
+  deleteMovementError: string | null
+  deleteMovement: (id: string) => void
 }
 
 function buildMovementRows(movements: ReserveMovementDto[]): ReserveMovementRow[] {
@@ -181,7 +267,11 @@ function buildMovementRows(movements: ReserveMovementDto[]): ReserveMovementRow[
 
   return movements.map((m, index) => {
     const group = groups.get(`${m.date}|${m.description}`)!
-    return { ...m, groupTotal: group.count > 1 && group.lastIndex === index ? group.total : null }
+    return {
+      ...m,
+      groupTotal: group.count > 1 && group.lastIndex === index ? group.total : null,
+      isPartOfGroup: group.count > 1,
+    }
   })
 }
 
@@ -228,6 +318,18 @@ export function useReserva(): ReservaData {
 
   const setWithdrawalField = useCallback(
     (field: WithdrawalFormField, value: string) => dispatch({ type: 'SET_WITHDRAWAL_FIELD', payload: { field, value } }),
+    [],
+  )
+
+  const showEditMovementForm = useCallback(
+    (movement: ReserveMovementDto) => dispatch({ type: 'SHOW_EDIT_MOVEMENT_FORM', payload: movement }),
+    [],
+  )
+
+  const cancelEditMovement = useCallback(() => dispatch({ type: 'CANCEL_EDIT_MOVEMENT' }), [])
+
+  const setEditMovementField = useCallback(
+    (field: EditMovementField, value: string) => dispatch({ type: 'SET_EDIT_MOVEMENT_FIELD', payload: { field, value } }),
     [],
   )
 
@@ -321,6 +423,64 @@ export function useReserva(): ReservaData {
     performWithdrawal(false)
   }
 
+  function saveMovementEdit() {
+    const { editingMovementId, editMovementBucket, editMovementAmount, editMovementDate, editMovementDescription } = state
+    if (!editingMovementId) return
+
+    const amount = Number(editMovementAmount)
+    if (!editMovementAmount.trim() || !isFinite(amount)) {
+      dispatch({ type: 'SAVE_MOVEMENT_ERROR', payload: 'Amount must be a number' })
+      return
+    }
+
+    if (!editMovementDate.trim()) {
+      dispatch({ type: 'SAVE_MOVEMENT_ERROR', payload: 'Date is required' })
+      return
+    }
+
+    if (!editMovementDescription.trim()) {
+      dispatch({ type: 'SAVE_MOVEMENT_ERROR', payload: 'Description is required' })
+      return
+    }
+
+    dispatch({ type: 'SAVE_MOVEMENT_START' })
+
+    void apiClient
+      .updateReserveMovement(editingMovementId, {
+        bucket: editMovementBucket,
+        amount,
+        date: editMovementDate,
+        description: editMovementDescription,
+      })
+      .then(() => {
+        dispatch({ type: 'SAVE_MOVEMENT_SUCCESS' })
+        fetchReservaData()
+      })
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'SAVE_MOVEMENT_ERROR',
+          payload: err instanceof Error ? err.message : 'Failed to update movement',
+        })
+      })
+  }
+
+  function deleteMovement(id: string) {
+    dispatch({ type: 'DELETE_MOVEMENT_START', payload: id })
+
+    void apiClient
+      .deleteReserveMovement(id)
+      .then(() => {
+        dispatch({ type: 'DELETE_MOVEMENT_SUCCESS' })
+        fetchReservaData()
+      })
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'DELETE_MOVEMENT_ERROR',
+          payload: err instanceof Error ? err.message : 'Failed to delete movement',
+        })
+      })
+  }
+
   return {
     balances: state.balances,
     totalBalance,
@@ -352,5 +512,19 @@ export function useReserva(): ReservaData {
     cancelWithdrawalForm,
     setWithdrawalField,
     submitWithdrawal,
+    editingMovementId: state.editingMovementId,
+    editMovementBucket: state.editMovementBucket,
+    editMovementAmount: state.editMovementAmount,
+    editMovementDate: state.editMovementDate,
+    editMovementDescription: state.editMovementDescription,
+    isSavingMovement: state.isSavingMovement,
+    saveMovementError: state.saveMovementError,
+    showEditMovementForm,
+    cancelEditMovement,
+    setEditMovementField,
+    saveMovementEdit,
+    deletingMovementId: state.deletingMovementId,
+    deleteMovementError: state.deleteMovementError,
+    deleteMovement,
   }
 }

--- a/Financial.Web/src/pages/ReservaPage.css
+++ b/Financial.Web/src/pages/ReservaPage.css
@@ -126,6 +126,10 @@
   width: 120px;
 }
 
+.reserva-page__col-actions {
+  width: 32px;
+}
+
 .reserva-page__totals-table {
   flex-shrink: 0;
   margin-top: 8px;

--- a/Financial.Web/src/pages/ReservaPage.tsx
+++ b/Financial.Web/src/pages/ReservaPage.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react'
 import ErrorState from '../components/ErrorState'
 import LoadingState from '../components/LoadingState'
 import { RESERVE_BUCKETS, useReserva } from '../hooks/useReserva'
-import type { WithdrawalFormField } from '../hooks/useReserva'
+import type { EditMovementField, WithdrawalFormField } from '../hooks/useReserva'
 import { formatN2, formatShortDate } from '../utils/formatters'
 import './ReservaPage.css'
 
@@ -18,6 +18,8 @@ function BalanceColumns() {
 function MovementColumns() {
   return (
     <colgroup>
+      <col className="reserva-page__col-actions" />
+      <col className="reserva-page__col-actions" />
       <col className="reserva-page__col-date" />
       <col className="reserva-page__col-bucket" />
       <col />
@@ -57,6 +59,20 @@ export default function ReservaPage() {
     cancelWithdrawalForm,
     setWithdrawalField,
     submitWithdrawal,
+    editingMovementId,
+    editMovementBucket,
+    editMovementAmount,
+    editMovementDate,
+    editMovementDescription,
+    isSavingMovement,
+    saveMovementError,
+    showEditMovementForm,
+    cancelEditMovement,
+    setEditMovementField,
+    saveMovementEdit,
+    deletingMovementId,
+    deleteMovementError,
+    deleteMovement,
   } = useReserva()
 
   if (isLoading) {
@@ -72,6 +88,13 @@ export default function ReservaPage() {
     withdrawalAmount,
     withdrawalDate,
     withdrawalDescription,
+  }
+
+  const editMovementValues: Record<EditMovementField, string> = {
+    editMovementBucket,
+    editMovementAmount,
+    editMovementDate,
+    editMovementDescription,
   }
 
   return (
@@ -229,6 +252,67 @@ export default function ReservaPage() {
         </div>
       )}
 
+      {editingMovementId && (
+        <div className="reserva-page__form-panel">
+          <p className="reserva-page__form-title">Edit Movement</p>
+          <div className="reserva-page__form">
+            <div className="reserva-page__form-field">
+              <label htmlFor="edit-movement-bucket">Bucket</label>
+              <select
+                id="edit-movement-bucket"
+                value={editMovementValues.editMovementBucket}
+                onChange={(e) => setEditMovementField('editMovementBucket', e.target.value)}
+              >
+                {RESERVE_BUCKETS.map((bucket) => (
+                  <option key={bucket} value={bucket}>
+                    {bucket}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="reserva-page__form-field">
+              <label htmlFor="edit-movement-amount">Amount</label>
+              <input
+                id="edit-movement-amount"
+                type="number"
+                step="0.01"
+                value={editMovementValues.editMovementAmount}
+                onChange={(e) => setEditMovementField('editMovementAmount', e.target.value)}
+              />
+            </div>
+            <div className="reserva-page__form-field">
+              <label htmlFor="edit-movement-date">Date</label>
+              <input
+                id="edit-movement-date"
+                type="date"
+                value={editMovementValues.editMovementDate}
+                onChange={(e) => setEditMovementField('editMovementDate', e.target.value)}
+              />
+            </div>
+            <div className="reserva-page__form-field">
+              <label htmlFor="edit-movement-description">Description</label>
+              <input
+                id="edit-movement-description"
+                type="text"
+                value={editMovementValues.editMovementDescription}
+                onChange={(e) => setEditMovementField('editMovementDescription', e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="reserva-page__form-actions">
+            <button type="button" disabled={isSavingMovement} onClick={saveMovementEdit}>
+              {isSavingMovement ? 'Saving...' : 'Save'}
+            </button>
+            <button type="button" onClick={cancelEditMovement}>
+              Cancel
+            </button>
+          </div>
+          {saveMovementError && <p className="reserva-page__error">{saveMovementError}</p>}
+        </div>
+      )}
+
+      {deleteMovementError && <p className="reserva-page__error">{deleteMovementError}</p>}
+
       <div className="reserva-page__content">
         <div className="reserva-page__grids-row">
           <section className="reserva-page__section reserva-page__section--grid reserva-page__section--balances">
@@ -270,6 +354,8 @@ export default function ReservaPage() {
                 <MovementColumns />
                 <thead>
                   <tr>
+                    <th />
+                    <th />
                     <th>Date</th>
                     <th>Bucket</th>
                     <th>Description</th>
@@ -280,6 +366,37 @@ export default function ReservaPage() {
                   {movementRows.map((m) => (
                     <Fragment key={m.id}>
                       <tr>
+                        <td>
+                          <button
+                            className="data-table__action-btn"
+                            type="button"
+                            aria-label="Edit movement"
+                            onClick={() => showEditMovementForm(m)}
+                          >
+                            ✏
+                          </button>
+                        </td>
+                        <td>
+                          <button
+                            className="data-table__action-btn"
+                            type="button"
+                            aria-label={deletingMovementId === m.id ? 'Deleting movement' : 'Delete movement'}
+                            disabled={deletingMovementId === m.id}
+                            onClick={() => {
+                              const warning = m.isPartOfGroup
+                                ? `Delete "${m.description}"? This is part of a split and will delete all 4 lines.`
+                                : `Delete "${m.description}"? This removes it for good.`
+                              if (window.confirm(warning)) {
+                                deleteMovement(m.id)
+                              }
+                            }}
+                          >
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                              <path d="M20 20H7L3 16a2 2 0 0 1 0-2.83L14.59 1.58a2 2 0 0 1 2.83 0l4 4a2 2 0 0 1 0 2.83L8 20" />
+                              <path d="M6.5 15.5 15 7" />
+                            </svg>
+                          </button>
+                        </td>
                         <td>{formatShortDate(m.date)}</td>
                         <td>{m.bucket}</td>
                         <td>{m.description}</td>
@@ -287,6 +404,8 @@ export default function ReservaPage() {
                       </tr>
                       {m.groupTotal !== null && (
                         <tr className="reserva-page__totals-row">
+                          <td />
+                          <td />
                           <td colSpan={3}>Total split for {m.description}</td>
                           <td className="data-table__col--numeric">{formatN2(m.groupTotal)}</td>
                         </tr>

--- a/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
@@ -8,6 +8,8 @@ const getReserveBalancesMock = vi.fn<FinancialApiClient['getReserveBalances']>()
 const getReserveMovementsMock = vi.fn<FinancialApiClient['getReserveMovements']>()
 const postIncomeSplitMock = vi.fn<FinancialApiClient['postIncomeSplit']>()
 const postWithdrawalMock = vi.fn<FinancialApiClient['postWithdrawal']>()
+const updateReserveMovementMock = vi.fn<FinancialApiClient['updateReserveMovement']>()
+const deleteReserveMovementMock = vi.fn<FinancialApiClient['deleteReserveMovement']>()
 
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
@@ -15,6 +17,8 @@ vi.mock('../../api/financialApiClient', () => ({
     getReserveMovements: getReserveMovementsMock,
     postIncomeSplit: postIncomeSplitMock,
     postWithdrawal: postWithdrawalMock,
+    updateReserveMovement: updateReserveMovementMock,
+    deleteReserveMovement: deleteReserveMovementMock,
   }),
 }))
 
@@ -137,5 +141,58 @@ describe('ReservaPage', () => {
     expect(screen.getByLabelText('Bucket')).toBeInTheDocument()
     expect(screen.getByLabelText('Amount')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Record Withdrawal' })).toBeInTheDocument()
+  })
+
+  it('edits a movement via the toggled panel and saves, updating the displayed row', async () => {
+    updateReserveMovementMock.mockResolvedValue({ ...MOVEMENTS[0], amount: 700 })
+    render(<ReservaPage />)
+
+    await waitFor(() => expect(screen.getAllByText('Ramsay').length).toBe(4))
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit movement' })[0])
+    expect(screen.getByText('Edit Movement')).toBeInTheDocument()
+    const amountInput = screen.getByDisplayValue('654.33')
+    fireEvent.change(amountInput, { target: { value: '700' } })
+
+    getReserveMovementsMock.mockResolvedValue([{ ...MOVEMENTS[0], amount: 700 }, ...MOVEMENTS.slice(1)])
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(updateReserveMovementMock).toHaveBeenCalledWith('m1', {
+        bucket: 'Investimento',
+        amount: 700,
+        date: '2026-07-17',
+        description: 'Ramsay',
+      }),
+    )
+    await waitFor(() => expect(screen.getByText('700.00')).toBeInTheDocument())
+  })
+
+  it('warns that deleting a split movement removes all 4 lines, and deletes on confirm', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    deleteReserveMovementMock.mockResolvedValue(undefined)
+    render(<ReservaPage />)
+
+    await waitFor(() => expect(screen.getAllByText('Ramsay').length).toBe(4))
+
+    getReserveMovementsMock.mockResolvedValue([])
+    fireEvent.click(screen.getAllByRole('button', { name: 'Delete movement' })[0])
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      expect.stringContaining('part of a split and will delete all 4 lines'),
+    )
+    await waitFor(() => expect(deleteReserveMovementMock).toHaveBeenCalledWith('m1'))
+    await waitFor(() => expect(screen.queryAllByText('Ramsay').length).toBe(0))
+  })
+
+  it('does not delete a movement when the confirmation prompt is declined', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    render(<ReservaPage />)
+
+    await waitFor(() => expect(screen.getAllByText('Ramsay').length).toBe(4))
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Delete movement' })[0])
+
+    expect(deleteReserveMovementMock).not.toHaveBeenCalled()
   })
 })

--- a/Tests/Financial.Api.Tests/ReserveEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/ReserveEndpointsTests.cs
@@ -185,4 +185,82 @@ public class ReserveEndpointsTests
         movements.Should().HaveCount(4);
         movements.Should().OnlyContain(m => m.Description == "Ramsay");
     }
+
+    [Fact]
+    public async Task UpdateMovement_ExistingId_ReturnsOkAndUpdatesFields()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var withdrawal = await client.PostAsJsonAsync("/api/v1/financial/reserve/withdrawals", new WithdrawalRequestDTO
+        {
+            Bucket = "Ariana",
+            Amount = 30m,
+            Date = new DateOnly(2026, 7, 2),
+            Description = "Groceries",
+            Confirmed = true
+        });
+        var movement = await withdrawal.Content.ReadFromJsonAsync<ReserveMovementDTO>();
+
+        var response = await client.PutAsJsonAsync($"/api/v1/financial/reserve/movements/{movement!.Id}", new UpdateReserveMovementDTO
+        {
+            Bucket = "Ariana",
+            Amount = -45m,
+            Date = new DateOnly(2026, 7, 3),
+            Description = "Groceries (corrected)"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await response.Content.ReadFromJsonAsync<ReserveMovementDTO>();
+        updated!.Amount.Should().Be(-45m);
+        updated.Description.Should().Be("Groceries (corrected)");
+    }
+
+    [Fact]
+    public async Task UpdateMovement_UnknownId_ReturnsNotFound()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PutAsJsonAsync($"/api/v1/financial/reserve/movements/{Guid.NewGuid()}", new UpdateReserveMovementDTO
+        {
+            Bucket = "Ariana",
+            Amount = 10m,
+            Date = new DateOnly(2026, 7, 1),
+            Description = "Test"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteMovement_MovementFromASplit_DeletesAllFourLines()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/financial/reserve/income-split", new IncomeSplitRequestDTO
+        {
+            Date = new DateOnly(2026, 7, 1),
+            Amount = 1963m,
+            Description = "Ramsay"
+        });
+        var movements = await client.GetFromJsonAsync<List<ReserveMovementDTO>>("/api/v1/financial/reserve/movements");
+        var oneLineOfTheSplit = movements!.First();
+
+        var response = await client.DeleteAsync($"/api/v1/financial/reserve/movements/{oneLineOfTheSplit.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var remaining = await client.GetFromJsonAsync<List<ReserveMovementDTO>>("/api/v1/financial/reserve/movements");
+        remaining.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteMovement_UnknownId_ReturnsNotFound()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.DeleteAsync($"/api/v1/financial/reserve/movements/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
@@ -218,6 +218,101 @@ public class ReserveServiceTests
         history.Select(m => m.Date).Should().BeInDescendingOrder();
     }
 
+    [Fact]
+    public async Task UpdateMovementAsync_ExistingId_UpdatesFieldsAndSaves()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Seed(ReserveBucket.Investimento, 100m, new DateOnly(2026, 7, 1));
+        var movement = repository.ReserveMovements[0];
+        var service = new ReserveService(repository);
+
+        var result = await service.UpdateMovementAsync(movement.Id, new UpdateReserveMovementDTO
+        {
+            Bucket = "HouseTreats",
+            Amount = 150m,
+            Date = new DateOnly(2026, 7, 5),
+            Description = "Corrected"
+        });
+
+        result.Bucket.Should().Be("HouseTreats");
+        result.Amount.Should().Be(150m);
+        result.Date.Should().Be(new DateOnly(2026, 7, 5));
+        result.Description.Should().Be("Corrected");
+        repository.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UpdateMovementAsync_WithUnknownId_ThrowsKeyNotFoundException()
+    {
+        var service = new ReserveService(new StubCashFlowRepository());
+
+        var act = async () => await service.UpdateMovementAsync(Guid.NewGuid(), new UpdateReserveMovementDTO
+        {
+            Bucket = "Investimento",
+            Amount = 10m,
+            Date = new DateOnly(2026, 7, 1),
+            Description = "Test"
+        });
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task UpdateMovementAsync_WithUnknownBucket_ThrowsArgumentException()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Seed(ReserveBucket.Investimento, 100m);
+        var service = new ReserveService(repository);
+
+        var act = async () => await service.UpdateMovementAsync(repository.ReserveMovements[0].Id, new UpdateReserveMovementDTO
+        {
+            Bucket = "NotABucket",
+            Amount = 10m,
+            Date = new DateOnly(2026, 7, 1),
+            Description = "Test"
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*not recognized*");
+    }
+
+    [Fact]
+    public async Task DeleteMovementAsync_SoloMovement_DeletesOnlyThatOne()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Seed(ReserveBucket.Investimento, -30m, new DateOnly(2026, 7, 1));
+        var toDelete = repository.ReserveMovements[0];
+        repository.Seed(ReserveBucket.Ariana, -20m, new DateOnly(2026, 7, 2));
+        var service = new ReserveService(repository);
+
+        await service.DeleteMovementAsync(toDelete.Id);
+
+        repository.ReserveMovements.Should().ContainSingle();
+        repository.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DeleteMovementAsync_MovementFromASplit_DeletesAllFourSiblingMovements()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new ReserveService(repository);
+        await service.PostIncomeSplitAsync(ValidIncomeSplitRequest());
+        var oneLineOfTheSplit = repository.ReserveMovements[0];
+
+        await service.DeleteMovementAsync(oneLineOfTheSplit.Id);
+
+        repository.ReserveMovements.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteMovementAsync_WithUnknownId_ThrowsKeyNotFoundException()
+    {
+        var service = new ReserveService(new StubCashFlowRepository());
+
+        var act = async () => await service.DeleteMovementAsync(Guid.NewGuid());
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
     private static IncomeSplitRequestDTO ValidIncomeSplitRequest() => new()
     {
         Date = new DateOnly(2026, 7, 1),


### PR DESCRIPTION
## Summary
Movement History was append-only — no way to correct a mistyped amount/date/description, or remove an entry. Adds Update and Delete for Reserva movements, with one key behavior the user specifically asked for: **deleting one line of an income split deletes all 4 lines**, since a split's 4 movements share the same Date+Description (the same grouping key already used for the history's "Total split for X" row). A solo withdrawal still deletes just itself.

- **Domain**: `ReserveMovement.Update(bucket, amount, date, description)`
- **Application**: `ReserveService.UpdateMovementAsync` / `DeleteMovementAsync` — delete groups all movements sharing the target's Date+Description before removing any of them
- **Api**: `PUT`/`DELETE /reserve/movements/{id}`
- **Web**: `updateReserveMovement`/`deleteReserveMovement` client methods; edit-movement form state in `useReserva` (mirrors the existing withdrawal form); pencil/trash icon buttons on every Movement History row (matching the CashFlow icon-button standard); the delete confirm prompt explicitly says "this is part of a split and will delete all 4 lines" vs. the generic wording for a solo movement

## Architecture
- Presentation owns the confirm dialog and calls the hook; the hook owns API/form state; the service validates existence, resolves the group, and delegates to the repository abstraction (`DeleteReserveMovement`, already existed for rollback-on-save-failure) — consistent with how Mensais/Expense/Controle Mae delete are structured, no layer violations.

## Test plan
- [x] `dotnet test` — full solution, 0 failures. New coverage: `UpdateMovementAsync_*`, `DeleteMovementAsync_SoloMovement_DeletesOnlyThatOne`, `DeleteMovementAsync_MovementFromASplit_DeletesAllFourSiblingMovements`, plus API-level `UpdateMovement_*`/`DeleteMovement_*` including the 4-line cascade
- [x] `npx tsc -b --noEmit` — no type errors
- [x] `npx vitest run` — 541 passed. New coverage: movement edit/delete success+error, `isPartOfGroup` exposed on every split line (not just the last), and a page-level test asserting the confirm-prompt wording differs for a split line vs. a solo movement
- [x] Live check: ran the app + API, screenshotted Reserva — edit/delete icons render on every row, opened the Edit Movement form and confirmed it pre-fills the movement's current values; did not confirm an actual delete against the real local data store

🤖 Generated with [Claude Code](https://claude.com/claude-code)