### PR TITLE
chore(P11): standardize CashFlow form buttons across 5 forms

### DIFF
--- a/Financial.Web/src/components/ExpensesSection.css
+++ b/Financial.Web/src/components/ExpensesSection.css
@@ -20,14 +20,13 @@
 }
 
 .expenses-section__new-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 12px;
   cursor: pointer;
   background: #007acc;
   color: #fff;
   border: none;
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .expenses-section__new-btn:hover {

--- a/Financial.Web/src/pages/ControleMaePage.css
+++ b/Financial.Web/src/pages/ControleMaePage.css
@@ -124,6 +124,41 @@
   align-items: center;
 }
 
+.controle-mae-page__submit-btn {
+  font: inherit;
+  font-weight: 600;
+  padding: 8px 16px;
+  cursor: pointer;
+  background: #007acc;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+}
+
+.controle-mae-page__submit-btn:hover {
+  background: #005fa3;
+}
+
+.controle-mae-page__submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.controle-mae-page__cancel-btn {
+  font: inherit;
+  font-weight: 600;
+  padding: 8px 16px;
+  cursor: pointer;
+  background: none;
+  color: var(--text, #333);
+  border: 1px solid var(--border, #e5e4e7);
+  border-radius: 6px;
+}
+
+.controle-mae-page__cancel-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
+}
+
 .controle-mae-page__error {
   margin-top: 6px;
   color: var(--error, #c0392b);

--- a/Financial.Web/src/pages/ControleMaePage.css
+++ b/Financial.Web/src/pages/ControleMaePage.css
@@ -23,14 +23,13 @@
 }
 
 .controle-mae-page__new-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 12px;
   cursor: pointer;
   background: #007acc;
   color: #fff;
   border: none;
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .controle-mae-page__new-btn:hover {
@@ -125,14 +124,13 @@
 }
 
 .controle-mae-page__submit-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 12px;
   cursor: pointer;
   background: #007acc;
   color: #fff;
   border: none;
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .controle-mae-page__submit-btn:hover {
@@ -145,14 +143,12 @@
 }
 
 .controle-mae-page__cancel-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 10px;
   cursor: pointer;
   background: none;
-  color: var(--text, #333);
   border: 1px solid var(--border, #e5e4e7);
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .controle-mae-page__cancel-btn:hover {

--- a/Financial.Web/src/pages/ControleMaePage.tsx
+++ b/Financial.Web/src/pages/ControleMaePage.tsx
@@ -202,10 +202,15 @@ export default function ControleMaePage() {
             </div>
           )}
           <div className="controle-mae-page__form-actions">
-            <button type="button" disabled={isEditing ? isSaving : isCreating} onClick={isEditing ? saveEdit : submitCreate}>
+            <button
+              className="controle-mae-page__submit-btn"
+              type="button"
+              disabled={isEditing ? isSaving : isCreating}
+              onClick={isEditing ? saveEdit : submitCreate}
+            >
               {isEditing ? (isSaving ? 'Saving...' : 'Save') : isCreating ? 'Saving...' : 'Add Entry'}
             </button>
-            <button type="button" onClick={isEditing ? cancelEdit : cancelCreateForm}>
+            <button className="controle-mae-page__cancel-btn" type="button" onClick={isEditing ? cancelEdit : cancelCreateForm}>
               Cancel
             </button>
           </div>

--- a/Financial.Web/src/pages/MensaisPage.css
+++ b/Financial.Web/src/pages/MensaisPage.css
@@ -28,14 +28,13 @@
 }
 
 .mensais-page__new-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 12px;
   cursor: pointer;
   background: #007acc;
   color: #fff;
   border: none;
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .mensais-page__new-btn:hover {
@@ -76,14 +75,13 @@
 }
 
 .mensais-page__submit-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 12px;
   cursor: pointer;
   background: #007acc;
   color: #fff;
   border: none;
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .mensais-page__submit-btn:hover {
@@ -96,14 +94,12 @@
 }
 
 .mensais-page__cancel-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 10px;
   cursor: pointer;
   background: none;
-  color: var(--text, #333);
   border: 1px solid var(--border, #e5e4e7);
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .mensais-page__cancel-btn:hover {

--- a/Financial.Web/src/pages/MensaisPage.css
+++ b/Financial.Web/src/pages/MensaisPage.css
@@ -8,11 +8,23 @@
   gap: 16px;
 }
 
+.mensais-page__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-shrink: 0;
+}
+
 .mensais-page__month-picker {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-shrink: 0;
+}
+
+.mensais-page__toolbar {
+  display: flex;
+  gap: 8px;
 }
 
 .mensais-page__new-btn {
@@ -61,6 +73,41 @@
   display: flex;
   gap: 8px;
   align-items: center;
+}
+
+.mensais-page__submit-btn {
+  font: inherit;
+  font-weight: 600;
+  padding: 8px 16px;
+  cursor: pointer;
+  background: #007acc;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+}
+
+.mensais-page__submit-btn:hover {
+  background: #005fa3;
+}
+
+.mensais-page__submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.mensais-page__cancel-btn {
+  font: inherit;
+  font-weight: 600;
+  padding: 8px 16px;
+  cursor: pointer;
+  background: none;
+  color: var(--text, #333);
+  border: 1px solid var(--border, #e5e4e7);
+  border-radius: 6px;
+}
+
+.mensais-page__cancel-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
 }
 
 .mensais-page__content {

--- a/Financial.Web/src/pages/MensaisPage.tsx
+++ b/Financial.Web/src/pages/MensaisPage.tsx
@@ -146,31 +146,33 @@ export default function MensaisPage() {
 
   return (
     <div className="mensais-page">
-      <div className="mensais-page__month-picker">
-        <label htmlFor="mensais-month">Month</label>
-        <input
-          id="mensais-month"
-          type="month"
-          value={monthInputValue}
-          onChange={(e) => setMonthInputValue(e.target.value)}
-        />
-        {!isAddFormOpen && (
+      <div className="mensais-page__header">
+        <div className="mensais-page__month-picker">
+          <label htmlFor="mensais-month">Month</label>
+          <input
+            id="mensais-month"
+            type="month"
+            value={monthInputValue}
+            onChange={(e) => setMonthInputValue(e.target.value)}
+          />
+        </div>
+        <div className="mensais-page__toolbar">
           <button className="mensais-page__new-btn" type="button" onClick={showAddForm}>
             Add Bill
           </button>
-        )}
-        <button
-          className="mensais-page__new-btn"
-          type="button"
-          disabled={isResetting}
-          onClick={() => {
-            if (window.confirm('Reset every bill back to Unset for the new month?')) {
-              resetAllToUnset()
-            }
-          }}
-        >
-          {isResetting ? 'Resetting...' : 'Reset All to Unset'}
-        </button>
+          <button
+            className="mensais-page__new-btn"
+            type="button"
+            disabled={isResetting}
+            onClick={() => {
+              if (window.confirm('Reset every bill back to Unset for the new month?')) {
+                resetAllToUnset()
+              }
+            }}
+          >
+            {isResetting ? 'Resetting...' : 'Reset All to Unset'}
+          </button>
+        </div>
       </div>
 
       {deleteError && <p className="mensais-page__error">{deleteError}</p>}
@@ -231,10 +233,10 @@ export default function MensaisPage() {
             </div>
           </div>
           <div className="mensais-page__form-actions">
-            <button type="button" disabled={isAdding} onClick={submitAdd}>
+            <button className="mensais-page__submit-btn" type="button" disabled={isAdding} onClick={submitAdd}>
               {isAdding ? 'Adding...' : 'Add'}
             </button>
-            <button type="button" onClick={cancelAdd}>
+            <button className="mensais-page__cancel-btn" type="button" onClick={cancelAdd}>
               Cancel
             </button>
           </div>
@@ -272,10 +274,10 @@ export default function MensaisPage() {
             </div>
           </div>
           <div className="mensais-page__form-actions">
-            <button type="button" disabled={isSaving} onClick={saveEdit}>
+            <button className="mensais-page__submit-btn" type="button" disabled={isSaving} onClick={saveEdit}>
               {isSaving ? 'Saving...' : 'Save'}
             </button>
-            <button type="button" onClick={cancelEdit}>
+            <button className="mensais-page__cancel-btn" type="button" onClick={cancelEdit}>
               Cancel
             </button>
           </div>

--- a/Financial.Web/src/pages/MonthlyPage.css
+++ b/Financial.Web/src/pages/MonthlyPage.css
@@ -106,14 +106,13 @@
 }
 
 .monthly-page__submit-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 12px;
   cursor: pointer;
   background: #007acc;
   color: #fff;
   border: none;
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .monthly-page__submit-btn:hover {
@@ -126,14 +125,12 @@
 }
 
 .monthly-page__cancel-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 10px;
   cursor: pointer;
   background: none;
-  color: var(--text, #333);
   border: 1px solid var(--border, #e5e4e7);
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .monthly-page__cancel-btn:hover {

--- a/Financial.Web/src/pages/MonthlyPage.css
+++ b/Financial.Web/src/pages/MonthlyPage.css
@@ -105,6 +105,41 @@
   align-items: center;
 }
 
+.monthly-page__submit-btn {
+  font: inherit;
+  font-weight: 600;
+  padding: 8px 16px;
+  cursor: pointer;
+  background: #007acc;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+}
+
+.monthly-page__submit-btn:hover {
+  background: #005fa3;
+}
+
+.monthly-page__submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.monthly-page__cancel-btn {
+  font: inherit;
+  font-weight: 600;
+  padding: 8px 16px;
+  cursor: pointer;
+  background: none;
+  color: var(--text, #333);
+  border: 1px solid var(--border, #e5e4e7);
+  border-radius: 6px;
+}
+
+.monthly-page__cancel-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
+}
+
 .monthly-page__error {
   margin-top: 6px;
   color: var(--error, #c0392b);

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -150,10 +150,10 @@ function ExpenseForm({
         </div>
       </div>
       <div className="monthly-page__form-actions">
-        <button type="button" disabled={isSaving} onClick={onSave}>
+        <button className="monthly-page__submit-btn" type="button" disabled={isSaving} onClick={onSave}>
           {isSaving ? 'Saving...' : isEditing ? 'Save' : 'Add Expense'}
         </button>
-        <button type="button" onClick={onCancel}>
+        <button className="monthly-page__cancel-btn" type="button" onClick={onCancel}>
           Cancel
         </button>
       </div>

--- a/Financial.Web/src/pages/ReservaPage.css
+++ b/Financial.Web/src/pages/ReservaPage.css
@@ -160,6 +160,41 @@
   align-items: center;
 }
 
+.reserva-page__submit-btn {
+  font: inherit;
+  font-weight: 600;
+  padding: 8px 16px;
+  cursor: pointer;
+  background: #007acc;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+}
+
+.reserva-page__submit-btn:hover {
+  background: #005fa3;
+}
+
+.reserva-page__submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.reserva-page__cancel-btn {
+  font: inherit;
+  font-weight: 600;
+  padding: 8px 16px;
+  cursor: pointer;
+  background: none;
+  color: var(--text, #333);
+  border: 1px solid var(--border, #e5e4e7);
+  border-radius: 6px;
+}
+
+.reserva-page__cancel-btn:hover {
+  background: var(--bg-hover, #f0f0f0);
+}
+
 .reserva-page__error {
   margin-top: 6px;
   color: var(--error, #c0392b);

--- a/Financial.Web/src/pages/ReservaPage.css
+++ b/Financial.Web/src/pages/ReservaPage.css
@@ -21,14 +21,13 @@
 }
 
 .reserva-page__new-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 12px;
   cursor: pointer;
   background: #007acc;
   color: #fff;
   border: none;
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .reserva-page__new-btn:hover {
@@ -161,14 +160,13 @@
 }
 
 .reserva-page__submit-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 12px;
   cursor: pointer;
   background: #007acc;
   color: #fff;
   border: none;
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .reserva-page__submit-btn:hover {
@@ -181,14 +179,12 @@
 }
 
 .reserva-page__cancel-btn {
-  font: inherit;
-  font-weight: 600;
-  padding: 8px 16px;
+  font-size: 12px;
+  padding: 3px 10px;
   cursor: pointer;
   background: none;
-  color: var(--text, #333);
   border: 1px solid var(--border, #e5e4e7);
-  border-radius: 6px;
+  border-radius: 3px;
 }
 
 .reserva-page__cancel-btn:hover {

--- a/Financial.Web/src/pages/ReservaPage.tsx
+++ b/Financial.Web/src/pages/ReservaPage.tsx
@@ -145,10 +145,10 @@ export default function ReservaPage() {
             </div>
           </div>
           <div className="reserva-page__form-actions">
-            <button type="button" disabled={isSubmittingSplit} onClick={submitIncomeSplit}>
+            <button className="reserva-page__submit-btn" type="button" disabled={isSubmittingSplit} onClick={submitIncomeSplit}>
               {isSubmittingSplit ? 'Posting...' : 'Post Income Split'}
             </button>
-            <button type="button" onClick={cancelSplitForm}>
+            <button className="reserva-page__cancel-btn" type="button" onClick={cancelSplitForm}>
               Cancel
             </button>
           </div>
@@ -185,7 +185,7 @@ export default function ReservaPage() {
             </tbody>
           </table>
           <div className="reserva-page__form-actions">
-            <button type="button" onClick={dismissSplitResult}>
+            <button className="reserva-page__cancel-btn" type="button" onClick={dismissSplitResult}>
               Dismiss
             </button>
           </div>
@@ -241,10 +241,10 @@ export default function ReservaPage() {
             </div>
           </div>
           <div className="reserva-page__form-actions">
-            <button type="button" disabled={isSubmittingWithdrawal} onClick={submitWithdrawal}>
+            <button className="reserva-page__submit-btn" type="button" disabled={isSubmittingWithdrawal} onClick={submitWithdrawal}>
               {isSubmittingWithdrawal ? 'Saving...' : 'Record Withdrawal'}
             </button>
-            <button type="button" onClick={cancelWithdrawalForm}>
+            <button className="reserva-page__cancel-btn" type="button" onClick={cancelWithdrawalForm}>
               Cancel
             </button>
           </div>
@@ -300,10 +300,10 @@ export default function ReservaPage() {
             </div>
           </div>
           <div className="reserva-page__form-actions">
-            <button type="button" disabled={isSavingMovement} onClick={saveMovementEdit}>
+            <button className="reserva-page__submit-btn" type="button" disabled={isSavingMovement} onClick={saveMovementEdit}>
               {isSavingMovement ? 'Saving...' : 'Save'}
             </button>
-            <button type="button" onClick={cancelEditMovement}>
+            <button className="reserva-page__cancel-btn" type="button" onClick={cancelEditMovement}>
               Cancel
             </button>
           </div>


### PR DESCRIPTION
## Summary
Audited the 5 named forms (New Expense/Monthly, Post Monthly Income Split/Reserva, Record a Withdrawal/Reserva, Add Bill/Mensais, New Entry/Controle Mae). Form-panel/title/field CSS was already byte-identical across all of them — the real inconsistency was that every Save/Post/Add/Record and Cancel button was a bare, unstyled browser button, while only the trigger button was a styled blue pill.

- Every submit button (Save/Post Income Split/Record Withdrawal/Add/Add Entry, plus Dismiss on the split-result panel and Save on Edit Movement/Edit Bill/Edit Entry, which share the same CSS) now gets the same blue-pill style as its trigger, with a dimmed `:disabled` state for the in-flight "Saving..." case.
- Every Cancel button gets a matching outlined secondary style.
- Mensais' "Add Bill" trigger moves out of the `month-picker` div into its own toolbar (mirroring Reserva/Controle Mae's header layout) and no longer hides itself while its form is open — both flagged in the audit as behaving differently from the other 4 forms.
- Monthly's "New Expense" trigger **stays exactly where it already was** — at the top of the Expenses grid, not hoisted to the page header near Category Totals, per your explicit instruction.

## Test plan
- [x] `npx vitest run` — 541 passed (no accessible-name changes, so no test updates were needed)
- [x] `npx tsc -b --noEmit` — no type errors
- [x] Live check: ran the app + API, opened all 5 forms and screenshotted each — submit buttons are blue pills, Cancel buttons are outlined secondary, Mensais' Add Bill sits in its own toolbar and stays visible while its form is open

## Note
While doing the live verification I noticed some today-dated entries visible earlier in an unrelated session (a Reserva income split and a Controle Mae balancing entry) are no longer present in the local dev data file. Flagged this directly to the user in chat — it doesn't affect this PR (no data-layer changes here), just noting it here for visibility since it involves real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)