### PR TITLE
feat(P12-F01): expense payment state model

### DIFF
--- a/Financial.CashFlow.Application/DTOs/ExpenseCreateDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/ExpenseCreateDTO.cs
@@ -17,8 +17,8 @@ public sealed class ExpenseCreateDTO
     /// <summary>Expense category name.</summary>
     public required string Category { get; init; }
 
-    /// <summary>Payment source name.</summary>
-    public required string PaymentSource { get; init; }
+    /// <summary>Payment source name. Omit when charging to a credit card.</summary>
+    public string? PaymentSource { get; init; }
 
     /// <summary>Optional credit-card tag name.</summary>
     public string? CardTag { get; init; }

--- a/Financial.CashFlow.Application/DTOs/ExpenseDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/ExpenseDTO.cs
@@ -20,9 +20,15 @@ public sealed class ExpenseDTO
     /// <summary>Expense category name.</summary>
     public required string Category { get; init; }
 
-    /// <summary>Payment source name.</summary>
-    public required string PaymentSource { get; init; }
+    /// <summary>Payment source name. Null while the expense is an unsettled credit card charge.</summary>
+    public string? PaymentSource { get; init; }
 
     /// <summary>Optional credit-card tag name.</summary>
     public string? CardTag { get; init; }
+
+    /// <summary>Date the expense's card statement was settled. Null unless settled.</summary>
+    public DateOnly? SettledAt { get; init; }
+
+    /// <summary>Computed payment status derived from the payment source and card tag.</summary>
+    public required string PaymentStatus { get; init; }
 }

--- a/Financial.CashFlow.Application/DTOs/ExpenseUpdateDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/ExpenseUpdateDTO.cs
@@ -17,8 +17,8 @@ public sealed class ExpenseUpdateDTO
     /// <summary>Expense category name.</summary>
     public required string Category { get; init; }
 
-    /// <summary>Payment source name.</summary>
-    public required string PaymentSource { get; init; }
+    /// <summary>Payment source name. Omit when charging to a credit card.</summary>
+    public string? PaymentSource { get; init; }
 
     /// <summary>Optional credit-card tag name.</summary>
     public string? CardTag { get; init; }

--- a/Financial.CashFlow.Application/Services/ExpenseService.cs
+++ b/Financial.CashFlow.Application/Services/ExpenseService.cs
@@ -75,8 +75,8 @@ public sealed class ExpenseService : IExpenseService
         _repository.GetExpenses().FirstOrDefault(e => e.Id == id)
             ?? throw new KeyNotFoundException($"Expense '{id}' was not found.");
 
-    private static (Category Category, PaymentSource PaymentSource, CreditCard? CardTag) ValidateFields(
-        string description, decimal value, string category, string paymentSource, string? cardTag)
+    private static (Category Category, PaymentSource? PaymentSource, CreditCard? CardTag) ValidateFields(
+        string description, decimal value, string category, string? paymentSource, string? cardTag)
     {
         if (string.IsNullOrWhiteSpace(description))
         {
@@ -98,9 +98,15 @@ public sealed class ExpenseService : IExpenseService
             throw new ArgumentException($"Category '{category}' is not recognized.");
         }
 
-        if (!PaymentSourceParser.TryParse(paymentSource, out var parsedPaymentSource))
+        PaymentSource? parsedPaymentSource = null;
+        if (!string.IsNullOrWhiteSpace(paymentSource))
         {
-            throw new ArgumentException($"Payment source '{paymentSource}' is not recognized.");
+            if (!PaymentSourceParser.TryParse(paymentSource, out var source))
+            {
+                throw new ArgumentException($"Payment source '{paymentSource}' is not recognized.");
+            }
+
+            parsedPaymentSource = source;
         }
 
         CreditCard? parsedCardTag = null;
@@ -124,7 +130,9 @@ public sealed class ExpenseService : IExpenseService
         Description = expense.Description,
         Value = expense.Value,
         Category = expense.Category.ToString(),
-        PaymentSource = expense.PaymentSource.ToString(),
-        CardTag = expense.CardTag?.ToString()
+        PaymentSource = expense.PaymentSource?.ToString(),
+        CardTag = expense.CardTag?.ToString(),
+        SettledAt = expense.SettledAt,
+        PaymentStatus = expense.PaymentStatus.ToString()
     };
 }

--- a/Financial.CashFlow.Domain/Entities/Expense.cs
+++ b/Financial.CashFlow.Domain/Entities/Expense.cs
@@ -10,8 +10,14 @@ public class Expense
     public string Description { get; private set; } = string.Empty;
     public decimal Value { get; private set; }
     public Category Category { get; private set; }
-    public PaymentSource PaymentSource { get; private set; }
+    public PaymentSource? PaymentSource { get; private set; }
     public CreditCard? CardTag { get; private set; }
+    public DateOnly? SettledAt { get; private set; }
+
+    public ExpensePaymentStatus PaymentStatus =>
+        CardTag is null ? ExpensePaymentStatus.ImmediatePayment
+        : PaymentSource is null ? ExpensePaymentStatus.CreditCardCharge
+        : ExpensePaymentStatus.CreditCardSettled;
 
     private Expense() { }
 
@@ -20,9 +26,12 @@ public class Expense
         string description,
         decimal value,
         Category category,
-        PaymentSource paymentSource,
-        CreditCard? cardTag) =>
-        new()
+        PaymentSource? paymentSource,
+        CreditCard? cardTag)
+    {
+        ValidatePaymentShape(paymentSource, cardTag);
+
+        return new()
         {
             Id = Guid.NewGuid(),
             Date = date,
@@ -32,20 +41,70 @@ public class Expense
             PaymentSource = paymentSource,
             CardTag = cardTag
         };
+    }
 
     public void UpdateDetails(
         DateOnly date,
         string description,
         decimal value,
         Category category,
-        PaymentSource paymentSource,
+        PaymentSource? paymentSource,
         CreditCard? cardTag)
     {
+        if (PaymentStatus == ExpensePaymentStatus.CreditCardSettled)
+        {
+            if (paymentSource != PaymentSource || cardTag != CardTag)
+            {
+                throw new ArgumentException(
+                    "A settled expense's payment fields cannot be changed; unmark its card statement paid first.");
+            }
+        }
+        else
+        {
+            ValidatePaymentShape(paymentSource, cardTag);
+            PaymentSource = paymentSource;
+            CardTag = cardTag;
+        }
+
         Date = date;
         Description = description;
         Value = value;
         Category = category;
+    }
+
+    public void Settle(PaymentSource paymentSource, DateOnly settledAt)
+    {
+        if (PaymentStatus != ExpensePaymentStatus.CreditCardCharge)
+        {
+            throw new ArgumentException("Only an unsettled credit card charge can be settled.");
+        }
+
         PaymentSource = paymentSource;
-        CardTag = cardTag;
+        SettledAt = settledAt;
+    }
+
+    public void Unsettle()
+    {
+        if (PaymentStatus != ExpensePaymentStatus.CreditCardSettled)
+        {
+            throw new ArgumentException("Only a settled credit card expense can be unsettled.");
+        }
+
+        PaymentSource = null;
+        SettledAt = null;
+    }
+
+    private static void ValidatePaymentShape(PaymentSource? paymentSource, CreditCard? cardTag)
+    {
+        if (paymentSource is null && cardTag is null)
+        {
+            throw new ArgumentException("An expense requires either a payment source or a card tag.");
+        }
+
+        if (paymentSource is not null && cardTag is not null)
+        {
+            throw new ArgumentException(
+                "An expense cannot have both a payment source and a card tag; a settled expense is only produced by marking its card statement paid.");
+        }
     }
 }

--- a/Financial.CashFlow.Domain/Enums/ExpensePaymentStatus.cs
+++ b/Financial.CashFlow.Domain/Enums/ExpensePaymentStatus.cs
@@ -1,0 +1,8 @@
+namespace Financial.CashFlow.Domain.Enums;
+
+public enum ExpensePaymentStatus
+{
+    ImmediatePayment,
+    CreditCardCharge,
+    CreditCardSettled
+}

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -362,8 +362,10 @@ export interface ExpenseDto {
   description: string
   value: number
   category: string
-  paymentSource: string
+  paymentSource: string | null
   cardTag: string | null
+  settledAt: string | null
+  paymentStatus: string
 }
 
 export interface CreateExpenseDto {
@@ -371,7 +373,7 @@ export interface CreateExpenseDto {
   description: string
   value: number
   category: string
-  paymentSource: string
+  paymentSource: string | null
   cardTag: string | null
 }
 
@@ -380,7 +382,7 @@ export interface UpdateExpenseDto {
   description: string
   value: number
   category: string
-  paymentSource: string
+  paymentSource: string | null
   cardTag: string | null
 }
 

--- a/Financial.Web/src/components/__tests__/ExpensesSection.test.tsx
+++ b/Financial.Web/src/components/__tests__/ExpensesSection.test.tsx
@@ -12,6 +12,8 @@ const EXPENSES: ExpenseDto[] = [
     category: 'Mercado',
     paymentSource: 'Barclays',
     cardTag: null,
+    settledAt: null,
+    paymentStatus: 'ImmediatePayment',
   },
   {
     id: 'e2',
@@ -19,8 +21,10 @@ const EXPENSES: ExpenseDto[] = [
     description: 'Amazon',
     value: 9.99,
     category: 'Extras',
-    paymentSource: 'Trading212',
+    paymentSource: null,
     cardTag: 'BarclaysPlatinumVisa8003',
+    settledAt: null,
+    paymentStatus: 'CreditCardCharge',
   },
 ]
 

--- a/Financial.Web/src/hooks/useMonthly.test.ts
+++ b/Financial.Web/src/hooks/useMonthly.test.ts
@@ -41,6 +41,8 @@ const EXPENSES: ExpenseDto[] = [
     category: 'Mercado',
     paymentSource: 'Barclays',
     cardTag: null,
+    settledAt: null,
+    paymentStatus: 'ImmediatePayment',
   },
 ]
 

--- a/Financial.Web/src/hooks/useMonthly.ts
+++ b/Financial.Web/src/hooks/useMonthly.ts
@@ -5,6 +5,12 @@ import { currentYearMonth, formatMonthInputValue, parseMonthInputValue } from '.
 
 export const PAYMENT_SOURCES = ['Barclays', 'Trading212', 'Chase'] as const
 
+// A card-tagged expense is an unsettled credit card charge and must carry no bank tag.
+function toPaymentSourcePayload(paymentSource: string, cardTag: string): string | null {
+  if (cardTag.trim() !== '') return null
+  return paymentSource.trim() === '' ? null : paymentSource
+}
+
 export interface BankTotal {
   bank: string
   totalValue: number
@@ -151,7 +157,7 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
         editDescription: action.payload.description,
         editValue: String(action.payload.value),
         editCategory: action.payload.category,
-        editPaymentSource: action.payload.paymentSource,
+        editPaymentSource: action.payload.paymentSource ?? '',
         editCardTag: action.payload.cardTag ?? '',
         saveError: null,
       }
@@ -300,7 +306,7 @@ export function useMonthly(): MonthlyData {
         description: createDescription,
         value,
         category: createCategory,
-        paymentSource: createPaymentSource,
+        paymentSource: toPaymentSourcePayload(createPaymentSource, createCardTag),
         cardTag: createCardTag.trim() === '' ? null : createCardTag,
       })
       .then(() => {
@@ -341,7 +347,7 @@ export function useMonthly(): MonthlyData {
         description: state.editDescription,
         value,
         category: state.editCategory,
-        paymentSource: state.editPaymentSource,
+        paymentSource: toPaymentSourcePayload(state.editPaymentSource, state.editCardTag),
         cardTag: state.editCardTag.trim() === '' ? null : state.editCardTag,
       })
       .then(() => {

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -33,6 +33,8 @@ const EXPENSES: ExpenseDto[] = [
     category: 'Mercado',
     paymentSource: 'Barclays',
     cardTag: null,
+    settledAt: null,
+    paymentStatus: 'ImmediatePayment',
   },
 ]
 

--- a/Integrations/CashFlowSpreadsheetImport/SheetImporters/MonthlyExpenseSheetImporter.cs
+++ b/Integrations/CashFlowSpreadsheetImport/SheetImporters/MonthlyExpenseSheetImporter.cs
@@ -94,8 +94,8 @@ public static class MonthlyExpenseSheetImporter
 
             var description = sheet.Cell(row, descriptionColumn).GetString();
             var rawPaymentSourceTag = sheet.Cell(row, PaymentSourceColumn).GetString();
-            var paymentSource = ResolvePaymentSource(rawPaymentSourceTag);
             var cardTag = ResolveCardTag(row, year, month, rawPaymentSourceTag);
+            PaymentSource? paymentSource = cardTag is null ? ResolvePaymentSource(rawPaymentSourceTag) : null;
 
             expenses.Add(Expense.Create(date, description, value.Value, category, paymentSource, cardTag));
         }

--- a/Tests/Financial.Api.Tests/CardStatementsEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/CardStatementsEndpointsTests.cs
@@ -32,7 +32,7 @@ public class CardStatementsEndpointsTests
             Description = "Card charge",
             Value = 45m,
             Category = "Mercado",
-            PaymentSource = "Barclays",
+            PaymentSource = null,
             CardTag = "BarclaysPlatinumVisa8003"
         });
 
@@ -53,7 +53,7 @@ public class CardStatementsEndpointsTests
             Description = "Card charge",
             Value = 45m,
             Category = "Mercado",
-            PaymentSource = "Barclays",
+            PaymentSource = null,
             CardTag = "BarclaysPlatinumVisa8003"
         });
         var monthResponse = await client.GetAsync("/api/v1/financial/card-statements/2026/7");

--- a/Tests/Financial.Api.Tests/ExpenseEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/ExpenseEndpointsTests.cs
@@ -29,6 +29,77 @@ public class ExpenseEndpointsTests
         expense.Should().NotBeNull();
         expense!.Description.Should().Be("Weekly groceries");
         expense.Category.Should().Be("Mercado");
+        expense.PaymentStatus.Should().Be("ImmediatePayment");
+        expense.SettledAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddExpense_CardTagWithoutPaymentSource_ReturnsCreditCardCharge()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 15),
+            Description = "Card charge",
+            Value = 30m,
+            Category = "Extras",
+            PaymentSource = null,
+            CardTag = "ChaseMaster4023"
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/expenses", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var expense = await response.Content.ReadFromJsonAsync<ExpenseDTO>();
+        expense!.PaymentSource.Should().BeNull();
+        expense.CardTag.Should().Be("ChaseMaster4023");
+        expense.SettledAt.Should().BeNull();
+        expense.PaymentStatus.Should().Be("CreditCardCharge");
+    }
+
+    [Fact]
+    public async Task AddExpense_NeitherPaymentSourceNorCardTag_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 15),
+            Description = "No payment shape",
+            Value = 30m,
+            Category = "Extras",
+            PaymentSource = null,
+            CardTag = null
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/expenses", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("payment source or a card tag");
+    }
+
+    [Fact]
+    public async Task AddExpense_BothPaymentSourceAndCardTag_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 15),
+            Description = "Both payment fields",
+            Value = 30m,
+            Category = "Extras",
+            PaymentSource = "Barclays",
+            CardTag = "ChaseMaster4023"
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/expenses", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("marking its card statement paid");
     }
 
     [Fact]

--- a/Tests/Financial.CashFlow.Application.Tests/Services/CardStatementServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/CardStatementServiceTests.cs
@@ -47,10 +47,10 @@ public class CardStatementServiceTests
     public async Task GetStatementsForMonthAsync_OutstandingTotalSumsThatMonthsTaggedExpensesForTheCard()
     {
         var repository = new StubCashFlowRepository();
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 10), "Charge 1", 30m, Category.Mercado, PaymentSource.Barclays, CreditCard.BarclaysPlatinumVisa8003));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 15), "Charge 2", 20m, Category.Mercado, PaymentSource.Barclays, CreditCard.BarclaysPlatinumVisa8003));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 8, 1), "Other month", 100m, Category.Mercado, PaymentSource.Barclays, CreditCard.BarclaysPlatinumVisa8003));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 12), "Other card", 999m, Category.Mercado, PaymentSource.Barclays, CreditCard.BaAmex));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 10), "Charge 1", 30m, Category.Mercado, null, CreditCard.BarclaysPlatinumVisa8003));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 15), "Charge 2", 20m, Category.Mercado, null, CreditCard.BarclaysPlatinumVisa8003));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 8, 1), "Other month", 100m, Category.Mercado, null, CreditCard.BarclaysPlatinumVisa8003));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 12), "Other card", 999m, Category.Mercado, null, CreditCard.BaAmex));
         var service = new CardStatementService(repository);
 
         var result = await service.GetStatementsForMonthAsync(2026, 7);
@@ -62,7 +62,7 @@ public class CardStatementServiceTests
     public async Task GetStatementsForMonthAsync_WhenStatementIsPaid_OutstandingTotalIsZeroDespiteTaggedExpenses()
     {
         var repository = new StubCashFlowRepository();
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 10), "Charge", 30m, Category.Mercado, PaymentSource.Barclays, CreditCard.BarclaysPlatinumVisa8003));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 10), "Charge", 30m, Category.Mercado, null, CreditCard.BarclaysPlatinumVisa8003));
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
         var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
@@ -77,7 +77,7 @@ public class CardStatementServiceTests
     public async Task MarkStatementPaidAsync_SetsIsPaidAndZeroesOutstandingTotal()
     {
         var repository = new StubCashFlowRepository();
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 10), "Charge", 30m, Category.Mercado, PaymentSource.Barclays, CreditCard.BarclaysPlatinumVisa8003));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 10), "Charge", 30m, Category.Mercado, null, CreditCard.BarclaysPlatinumVisa8003));
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
         var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
@@ -29,20 +29,60 @@ public class ExpenseServiceTests
         result.Category.Should().Be("Mercado");
         result.PaymentSource.Should().Be("Barclays");
         result.CardTag.Should().BeNull();
+        result.SettledAt.Should().BeNull();
+        result.PaymentStatus.Should().Be("ImmediatePayment");
         repository.Expenses.Should().ContainSingle();
         repository.SaveChangesCallCount.Should().Be(1);
     }
 
     [Fact]
-    public async Task AddExpenseAsync_WithCardTag_SavesCardTag()
+    public async Task AddExpenseAsync_WithCardTagAndNoPaymentSource_SavesAsCreditCardCharge()
     {
         var repository = new StubCashFlowRepository();
         var service = new ExpenseService(repository);
-        var request = ValidCreateRequest() with { CardTag = "BarclaysPlatinumVisa8003" };
+        var request = ValidCreateRequest() with { PaymentSource = null, CardTag = "BarclaysPlatinumVisa8003" };
 
         var result = await service.AddExpenseAsync(ToCreateDto(request));
 
         result.CardTag.Should().Be("BarclaysPlatinumVisa8003");
+        result.PaymentSource.Should().BeNull();
+        result.SettledAt.Should().BeNull();
+        result.PaymentStatus.Should().Be("CreditCardCharge");
+    }
+
+    [Fact]
+    public async Task AddExpenseAsync_WithNeitherPaymentSourceNorCardTag_ThrowsArgumentException()
+    {
+        var service = new ExpenseService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = null, CardTag = null });
+
+        var act = async () => await service.AddExpenseAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*payment source or a card tag*");
+    }
+
+    [Fact]
+    public async Task AddExpenseAsync_WithBothPaymentSourceAndCardTag_ThrowsArgumentException()
+    {
+        var service = new ExpenseService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { CardTag = "BarclaysPlatinumVisa8003" });
+
+        var act = async () => await service.AddExpenseAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*marking its card statement paid*");
+    }
+
+    [Fact]
+    public async Task UpdateExpenseAsync_WithBothPaymentSourceAndCardTag_ThrowsArgumentException()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new ExpenseService(repository);
+        var added = await service.AddExpenseAsync(ToCreateDto(ValidCreateRequest()));
+        var updateRequest = ToUpdateDto(ValidCreateRequest() with { CardTag = "BaAmex" });
+
+        var act = async () => await service.UpdateExpenseAsync(added.Id, updateRequest);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*marking its card statement paid*");
     }
 
     [Fact]
@@ -241,7 +281,7 @@ public class ExpenseServiceTests
     };
 
     private sealed record ExpenseCreateRequest(
-        DateOnly Date, string Description, decimal Value, string Category, string PaymentSource, string? CardTag);
+        DateOnly Date, string Description, decimal Value, string Category, string? PaymentSource, string? CardTag);
 
     private sealed class StubCashFlowRepository : ICashFlowRepository
     {

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/ExpenseTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/ExpenseTests.cs
@@ -6,6 +6,19 @@ namespace Financial.CashFlow.Domain.Tests;
 
 public class ExpenseTests
 {
+    private static Expense CreateImmediateExpense() =>
+        Expense.Create(new DateOnly(2026, 7, 1), "Immediate", 10m, Category.Casa, PaymentSource.Chase, null);
+
+    private static Expense CreateCardCharge() =>
+        Expense.Create(new DateOnly(2026, 7, 1), "Charge", 10m, Category.Extras, null, CreditCard.ChaseMaster4023);
+
+    private static Expense CreateSettledExpense()
+    {
+        var expense = CreateCardCharge();
+        expense.Settle(PaymentSource.Barclays, new DateOnly(2026, 7, 31));
+        return expense;
+    }
+
     [Fact]
     public void Create_AssignsAllFieldsAndANewId()
     {
@@ -20,6 +33,7 @@ public class ExpenseTests
         expense.Category.Should().Be(Category.Mercado);
         expense.PaymentSource.Should().Be(PaymentSource.Barclays);
         expense.CardTag.Should().BeNull();
+        expense.SettledAt.Should().BeNull();
     }
 
     [Fact]
@@ -32,34 +46,162 @@ public class ExpenseTests
     }
 
     [Fact]
-    public void Create_WithCardTag_SetsCardTag()
+    public void Create_WithPaymentSourceOnly_ComputesImmediatePayment()
     {
-        var expense = Expense.Create(
+        var expense = CreateImmediateExpense();
+
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.ImmediatePayment);
+    }
+
+    [Fact]
+    public void Create_WithCardTagOnly_ComputesCreditCardCharge()
+    {
+        var expense = CreateCardCharge();
+
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+        expense.PaymentSource.Should().BeNull();
+        expense.SettledAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithNeitherPaymentSourceNorCardTag_Throws()
+    {
+        var act = () => Expense.Create(new DateOnly(2026, 7, 1), "Invalid", 10m, Category.Casa, null, null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*payment source or a card tag*");
+    }
+
+    [Fact]
+    public void Create_WithBothPaymentSourceAndCardTag_Throws()
+    {
+        var act = () => Expense.Create(
             new DateOnly(2026, 7, 1),
-            "Amazon",
+            "Invalid",
             10m,
             Category.Extras,
             PaymentSource.Barclays,
             CreditCard.BarclaysPlatinumVisa8003);
 
-        expense.CardTag.Should().Be(CreditCard.BarclaysPlatinumVisa8003);
+        act.Should().Throw<ArgumentException>().WithMessage("*marking its card statement paid*");
     }
 
     [Fact]
     public void UpdateDetails_MutatesEveryFieldWithoutChangingId()
     {
-        var expense = Expense.Create(new DateOnly(2026, 7, 1), "Original", 10m, Category.Casa, PaymentSource.Chase, null);
+        var expense = CreateImmediateExpense();
         var originalId = expense.Id;
         var newDate = new DateOnly(2026, 8, 1);
 
-        expense.UpdateDetails(newDate, "Updated", 20m, Category.Mercado, PaymentSource.Barclays, CreditCard.ChaseMaster4023);
+        expense.UpdateDetails(newDate, "Updated", 20m, Category.Mercado, null, CreditCard.ChaseMaster4023);
 
         expense.Id.Should().Be(originalId);
         expense.Date.Should().Be(newDate);
         expense.Description.Should().Be("Updated");
         expense.Value.Should().Be(20m);
         expense.Category.Should().Be(Category.Mercado);
+        expense.PaymentSource.Should().BeNull();
+        expense.CardTag.Should().Be(CreditCard.ChaseMaster4023);
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+    }
+
+    [Fact]
+    public void UpdateDetails_WithNeitherPaymentSourceNorCardTag_Throws()
+    {
+        var expense = CreateImmediateExpense();
+
+        var act = () => expense.UpdateDetails(expense.Date, "Updated", 20m, Category.Casa, null, null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*payment source or a card tag*");
+    }
+
+    [Fact]
+    public void UpdateDetails_WithBothPaymentSourceAndCardTag_Throws()
+    {
+        var expense = CreateImmediateExpense();
+
+        var act = () => expense.UpdateDetails(
+            expense.Date, "Updated", 20m, Category.Casa, PaymentSource.Chase, CreditCard.BaAmex);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*marking its card statement paid*");
+    }
+
+    [Fact]
+    public void UpdateDetails_OnSettledExpense_WithUnchangedPaymentFields_KeepsSettlement()
+    {
+        var expense = CreateSettledExpense();
+
+        expense.UpdateDetails(new DateOnly(2026, 7, 2), "Renamed", 25m, Category.Mercado, expense.PaymentSource, expense.CardTag);
+
+        expense.Description.Should().Be("Renamed");
+        expense.Value.Should().Be(25m);
         expense.PaymentSource.Should().Be(PaymentSource.Barclays);
         expense.CardTag.Should().Be(CreditCard.ChaseMaster4023);
+        expense.SettledAt.Should().Be(new DateOnly(2026, 7, 31));
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardSettled);
+    }
+
+    [Fact]
+    public void UpdateDetails_OnSettledExpense_ChangingPaymentFields_Throws()
+    {
+        var expense = CreateSettledExpense();
+
+        var act = () => expense.UpdateDetails(expense.Date, "Renamed", 25m, Category.Mercado, PaymentSource.Chase, expense.CardTag);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*unmark its card statement paid*");
+    }
+
+    [Fact]
+    public void Settle_OnCardCharge_SetsPaymentSourceAndSettledAt()
+    {
+        var expense = CreateCardCharge();
+        var settledAt = new DateOnly(2026, 7, 24);
+
+        expense.Settle(PaymentSource.Trading212, settledAt);
+
+        expense.PaymentSource.Should().Be(PaymentSource.Trading212);
+        expense.SettledAt.Should().Be(settledAt);
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardSettled);
+    }
+
+    [Fact]
+    public void Settle_OnImmediatePayment_Throws()
+    {
+        var expense = CreateImmediateExpense();
+
+        var act = () => expense.Settle(PaymentSource.Barclays, new DateOnly(2026, 7, 24));
+
+        act.Should().Throw<ArgumentException>().WithMessage("*unsettled credit card charge*");
+    }
+
+    [Fact]
+    public void Settle_OnAlreadySettledExpense_Throws()
+    {
+        var expense = CreateSettledExpense();
+
+        var act = () => expense.Settle(PaymentSource.Barclays, new DateOnly(2026, 7, 24));
+
+        act.Should().Throw<ArgumentException>().WithMessage("*unsettled credit card charge*");
+    }
+
+    [Fact]
+    public void Unsettle_OnSettledExpense_ClearsPaymentSourceAndSettledAt()
+    {
+        var expense = CreateSettledExpense();
+
+        expense.Unsettle();
+
+        expense.PaymentSource.Should().BeNull();
+        expense.SettledAt.Should().BeNull();
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+    }
+
+    [Fact]
+    public void Unsettle_OnUnsettledExpense_Throws()
+    {
+        var expense = CreateCardCharge();
+
+        var act = () => expense.Unsettle();
+
+        act.Should().Throw<ArgumentException>().WithMessage("*settled credit card expense*");
     }
 }

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs
@@ -17,8 +17,9 @@ public class CashFlowSerializerAdapterTests
             "Weekly groceries",
             54.32m,
             Category.Mercado,
-            PaymentSource.Barclays,
+            null,
             CreditCard.BarclaysPlatinumVisa8003);
+        expense.Settle(PaymentSource.Barclays, new DateOnly(2026, 7, 31));
         var reserveMovement = ReserveMovement.Create(ReserveBucket.Investimento, 866.67m, new DateOnly(2026, 7, 1), "Monthly income split");
         var cardStatement = CardStatement.Create(CreditCard.BarclaysPlatinumVisa8003, 2026, 7);
         var recurringBill = RecurringBill.Create(10, "INSS", 850m, Area.Brasil, "Direct debit", "12345678901", 1621m);
@@ -43,6 +44,7 @@ public class CashFlowSerializerAdapterTests
         resultExpense.Category.Should().Be(expense.Category);
         resultExpense.PaymentSource.Should().Be(expense.PaymentSource);
         resultExpense.CardTag.Should().Be(expense.CardTag);
+        resultExpense.SettledAt.Should().Be(expense.SettledAt);
         var resultMovement = result.ReserveMovements.Should().ContainSingle().Which;
         resultMovement.Id.Should().Be(reserveMovement.Id);
         resultMovement.Bucket.Should().Be(reserveMovement.Bucket);

--- a/Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/MonthlyExpenseSheetImporterTests.cs
+++ b/Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/MonthlyExpenseSheetImporterTests.cs
@@ -193,7 +193,16 @@ public class MonthlyExpenseSheetImporterTests
 
         var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, report);
 
-        expenses.Should().ContainSingle().Which.CardTag.Should().Be(expectedCardTag);
+        var expense = expenses.Should().ContainSingle().Which;
+        expense.CardTag.Should().Be(expectedCardTag);
+        if (expectedCardTag is null)
+        {
+            expense.PaymentSource.Should().Be(PaymentSource.Barclays);
+        }
+        else
+        {
+            expense.PaymentSource.Should().BeNull();
+        }
     }
 
     [Fact]

--- a/docs/P12-F01-expense-payment-state-model/plan.md
+++ b/docs/P12-F01-expense-payment-state-model/plan.md
@@ -1,0 +1,28 @@
+# Implementation Plan: F01. Expense Payment State Model
+
+**Prerequisites:**
+- .NET SDK (solution builds via `Financial.slnx`)
+- Node/npm for `Financial.Web` (vitest, `tsc -b --noEmit`)
+- No new packages, configuration, or environment variables
+
+### Stage 1: Domain Model
+
+**1. Payment status enum** - Add the `ExpensePaymentStatus` enum to the CashFlow domain enums, holding the three computed states. See spec Section 4.
+
+**2. Expense entity state model** - Make the bank tag nullable, add the settlement date field, and expose the computed payment status on the `Expense` entity. See spec Sections 3 and 6 for the derivation rule and persistence expectations.
+
+**3. Entity invariant and transitions** - Enforce the three valid field shapes in the entity's factory and update paths, and add the settle/unsettle transitions as the only operations that produce or clear the settled shape. See spec Section 3 (Decisions 1 and 4).
+
+### Stage 2: Application and API Surface
+
+**4. Expense validation relaxation** - Update the expense service so the bank tag is parsed only when provided, delegating shape rules to the entity while keeping existing field checks and error translation. See spec Section 5 for the resulting error behavior.
+
+**5. DTO and mapping updates** - Make the bank tag nullable across the expense DTOs and expose the settlement date and computed payment status on the read model and its mapping. See spec Sections 4 and 5.
+
+### Stage 3: Downstream Contract Alignment
+
+**6. Importer accommodation** - Adjust the spreadsheet importer so rows that resolve a card tag construct expenses without a bank tag, keeping the importer valid under the new invariant. See spec Section 3 (Decision 5).
+
+**7. Web contract types** - Update the web app's API types and monthly hook payloads to match the new expense shape without changing UI behavior. See spec Section 4 (Frontend).
+
+**8. Full-solution verification** - Run the .NET test suite, the web test suite, and the TypeScript build check to confirm the solution is green end to end.

--- a/docs/P12-F01-expense-payment-state-model/spec.md
+++ b/docs/P12-F01-expense-payment-state-model/spec.md
@@ -1,0 +1,148 @@
+# F01. Expense Payment State Model
+
+## 1. Technical Overview
+
+**What:** Make `Expense.PaymentSource` nullable, add a nullable `SettledAt` date, and introduce a computed `ExpensePaymentStatus` (`ImmediatePayment` / `CreditCardCharge` / `CreditCardSettled`) derived entirely from `PaymentSource` and `CardTag` — never stored. The three valid `PaymentSource`/`CardTag`/`SettledAt` shapes become a domain invariant enforced by the `Expense` entity itself, and two new domain transitions — `Settle(paymentSource, settledAt)` and `Unsettle()` — become the only way to produce or clear the `CreditCardSettled` shape (F02's statement cascade will call them).
+
+**Why:** Today `PaymentSource` is required even on card-tagged expenses, so a card charge reduces a bank total the moment it is entered. Making the bank tag nullable and constraining the valid combinations makes an expense's bank-balance impact computable and unambiguous. The status is derived on read rather than persisted, mirroring the codebase's existing "derive, don't store" convention (`CardStatement` outstanding total).
+
+**Scope:**
+- Included: `Expense` entity changes (nullable `PaymentSource`, new `SettledAt`, invariant, `PaymentStatus` computed property, `Settle`/`Unsettle`); new `ExpensePaymentStatus` enum; `ExpenseService` validation relaxation; DTO shape changes (`PaymentSource` nullable, `SettledAt` + `PaymentStatus` exposed on reads); web API contract types updated to match; a minimal `MonthlyExpenseSheetImporter` accommodation so the solution stays green (card-tagged rows pass a null `PaymentSource`).
+- Excluded: the settlement cascade and mark/unmark-paid endpoints (F02); the one-time data backfill (F03) — until it runs, legacy records may violate the invariant, which is tolerated on read (see Decision 6); the importer's full column-E precedence rule and its acceptance tests (F04); all UI changes — form modes, panels (F05).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.CashFlow.Domain/Enums/ExpensePaymentStatus.cs` — new enum
+- `Financial.CashFlow.Domain/Entities/Expense.cs` — nullable `PaymentSource`, new `SettledAt`, invariant, `PaymentStatus`, `Settle`/`Unsettle`
+- `Financial.CashFlow.Application/Services/ExpenseService.cs` — `PaymentSource` becomes optional in validation; `ToDto` gains `SettledAt`/`PaymentStatus` and null-safe `PaymentSource`
+- `Financial.CashFlow.Application/DTOs/ExpenseDTO.cs`, `ExpenseCreateDTO.cs`, `ExpenseUpdateDTO.cs` — nullable `PaymentSource`; `ExpenseDTO` gains `SettledAt`, `PaymentStatus`
+- `Financial.CashFlow.Infrastructure/Integrations/CashFlowSpreadsheetImport/SheetImporters/MonthlyExpenseSheetImporter.cs` — minimal accommodation (card tag resolved → null `PaymentSource`)
+- `Financial.Web/src/api/types.ts`, `src/hooks/useMonthly.ts` — contract types follow the DTO changes
+
+```mermaid
+graph TD
+  A["ExpensesController (unchanged routes)"] --> B["ExpenseService"]
+  B --> C["Expense entity (invariant + PaymentStatus)"]
+  C --> D["ExpensePaymentStatus enum"]
+  B --> E["ICashFlowRepository"]
+  F["MonthlyExpenseSheetImporter"] --> C
+  G["Financial.Web types.ts / useMonthly"] -.->|reads paymentStatus, settledAt| A
+  H["F02 settlement cascade (future)"] -.->|"Settle() / Unsettle()"| C
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Invariant location | Enforced inside `Expense` (`Create`, `UpdateDetails`, `Settle`, `Unsettle` throw `ArgumentException` on an invalid shape); `ExpenseService` keeps only parsing and pre-existing field checks | Keep all rules in `ExpenseService.ValidateFields` (current pattern) | The entity can no longer be constructed in an invalid shape by any caller (importer, F03 migration, F02 cascade) — "correct by construction" per the PRD. Accepts introducing entity-level validation where none exists today; `ArgumentException` still maps to 400 via the existing controller handling. **(User-confirmed decision.)** |
+| Payment status representation | Computed property `Expense.PaymentStatus` — both set → `CreditCardSettled`; `CardTag` only → `CreditCardCharge`; otherwise `ImmediatePayment`. Serialized into `ExpenseDTO` so the web reads the server-derived value instead of re-deriving | Store a status field, or derive independently client-side | Single derivation lives in one place (PRD cross-feature criterion: no second, independently-maintained derivation). Derivation is total — defined even for legacy pre-F03 records whose `SettledAt` is still null. |
+| `SettledAt` type | `DateOnly?` | `DateTime?` | Matches `Expense.Date`'s existing type; settlement granularity per the PRD is a calendar date. |
+| Producing the settled shape | Only `Settle(paymentSource, settledAt)` creates it; only `Unsettle()` clears it. `Create` never accepts both fields set. `UpdateDetails` on a settled expense allows changing date/description/value/category but rejects any change to `PaymentSource`/`CardTag` (message directs to the statement settlement action), preserving `SettledAt` | Allow `UpdateDetails` to round-trip the settled fields freely | Matches the PRD rule that the settled combination is only ever produced by F02's cascade, and directly supports F05's "payment fields read-only when settled". Accepts a slightly more involved `UpdateDetails` guard. |
+| Importer accommodation | When `MonthlyExpenseSheetImporter` resolves a card tag, it now passes `PaymentSource = null` to `Expense.Create` — the minimal change keeping the importer functional under the new invariant | Leave the importer throwing until F04 lands | Card-tag rows with both fields set would throw under the new invariant, breaking the importer and its tests inside this same wave. F04 still owns the full column-E precedence behavior and its acceptance tests. |
+| Legacy data tolerance | The invariant runs only on the entity's factory/mutation paths. JSON deserialization goes through `CashFlowTypeInfoResolver`'s private-ctor/private-setter binding, bypassing `Create`, so pre-F03 records (both fields set, `SettledAt` null) still load and read | Validate on load and reject non-conforming files | The app must keep working between F01 merging and F03's backfill running. Reads are total; writes are strict. |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Domain/Enums/ExpensePaymentStatus.cs` | New | Computed payment status values | `ImmediatePayment`, `CreditCardCharge`, `CreditCardSettled` |
+| `Financial.CashFlow.Domain/Entities/Expense.cs` | Modified | Payment-state invariant + transitions | `PaymentSource` → `PaymentSource?`; new `DateOnly? SettledAt` (private set — auto-participates in `CashFlowTypeInfoResolver` round-tripping); `PaymentStatus` computed property; `Create`/`UpdateDetails` enforce the valid shapes (both null rejected; both set rejected/guarded per Decision 4); `Settle(paymentSource, settledAt)` valid only from `CreditCardCharge`; `Unsettle()` valid only from `CreditCardSettled` |
+| `Financial.CashFlow.Application/Services/ExpenseService.cs` | Modified | Validation + mapping | `ValidateFields` parses `PaymentSource` only when non-blank (no longer required); shape rules delegated to the entity; `ToDto` maps `PaymentSource?.ToString()`, `SettledAt`, `PaymentStatus.ToString()` |
+| `Financial.CashFlow.Application/DTOs/ExpenseDTO.cs` | Modified | Read model | `PaymentSource` → `string?`; new `SettledAt` (`DateOnly?`), `PaymentStatus` (`string`) |
+| `Financial.CashFlow.Application/DTOs/ExpenseCreateDTO.cs`, `ExpenseUpdateDTO.cs` | Modified | Write models | `PaymentSource` → `string?` (optional); no `SettledAt` — never settable via the expense API |
+| `.../SheetImporters/MonthlyExpenseSheetImporter.cs` | Modified | Keep importer valid under invariant | When a card tag is resolved for a row, pass `PaymentSource = null` to `Expense.Create` |
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/api/types.ts` | Modified | API contract types | `ExpenseDto.paymentSource` → `string \| null`, add `settledAt: string \| null`, `paymentStatus: string`; `CreateExpenseDto`/`UpdateExpenseDto.paymentSource` → `string \| null` |
+| `Financial.Web/src/hooks/useMonthly.ts` | Modified | Keep type-correct | Create/edit payloads send `paymentSource: null` when blank (mirroring the existing `cardTag` convention); no behavioral UI change (F05 owns that) |
+
+## 5. API Contracts
+
+No new endpoints; existing `expenses` routes change shape.
+
+**`POST /api/v1/financial/expenses`** and **`PUT /api/v1/financial/expenses/{id}`**
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|-------------|
+| `date` | `date` | Yes | valid date | Unchanged |
+| `description` | `string` | Yes | ≤ 200 chars | Unchanged |
+| `value` | `decimal` | Yes | non-zero | Unchanged |
+| `category` | `string` | Yes | valid `Category` | Unchanged |
+| `paymentSource` | `string?` | No | valid `PaymentSource` when present; required absent when `cardTag` present; required present when `cardTag` absent | Bank tag — now optional |
+| `cardTag` | `string?` | No | valid `CreditCard` when present | Unchanged field, new rules |
+
+Request example (Credit Card Charge):
+```json
+{ "date": "2026-07-24", "description": "Groceries", "value": 42.10, "category": "Mercado", "paymentSource": null, "cardTag": "ChaseMaster4023" }
+```
+
+**Response (200) — `ExpenseDTO`, also returned by `GET /expenses/month/{year}/{month}`:**
+```json
+{
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "date": "2026-07-24",
+  "description": "Groceries",
+  "value": 42.10,
+  "category": "Mercado",
+  "paymentSource": null,
+  "cardTag": "ChaseMaster4023",
+  "settledAt": null,
+  "paymentStatus": "CreditCardCharge"
+}
+```
+
+**Error responses (400, ProblemDetails `detail`):**
+
+| Condition | Message intent |
+|-----------|----------------|
+| Neither `paymentSource` nor `cardTag` set | Expense must have a payment source or a card tag |
+| Both `paymentSource` and `cardTag` set (create, or edit changing them) | Settled state is only produced by marking a card statement paid — directs user to the statement settlement action |
+| Unparseable `paymentSource`/`cardTag`/`category` | Existing parser messages, unchanged |
+
+## 6. Data Model
+
+**`data-cashflow.json` — `Expenses` item shape (PascalCase, via `CashFlowSerializerAdapter`):**
+
+```json
+{
+  "Id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "Date": "2026-07-24",
+  "Description": "Groceries",
+  "Value": 42.10,
+  "Category": "Mercado",
+  "PaymentSource": null,
+  "CardTag": "ChaseMaster4023",
+  "SettledAt": null
+}
+```
+
+- `PaymentStatus` is never persisted — computed on read.
+- Existing records without `SettledAt` deserialize with `SettledAt = null` (missing property → default); no file migration is needed for F01 itself (F03 owns reclassification).
+- `CashFlowTypeInfoResolver` picks up `SettledAt` automatically (public property with private setter).
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Tests/Financial.CashFlow.Domain.Tests/Entities/ExpenseTests.cs` | Unit | `Expense` | `Create` with bank only → `ImmediatePayment`; card only → `CreditCardCharge`; both null → throws; both set → throws; `Settle` from charge sets fields → `CreditCardSettled`; `Settle` from non-charge throws; `Unsettle` clears both → `CreditCardCharge`; `Unsettle` from non-settled throws; `UpdateDetails` on settled expense keeps `SettledAt` when payment fields unchanged and throws when they change; `UpdateDetails` both-null/both-set rejections |
+| `Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs` | Unit | `ExpenseService` | Create/update with null `paymentSource` + card → succeeds, DTO has `paymentStatus = "CreditCardCharge"`, `paymentSource = null`; bank only → `"ImmediatePayment"`; neither → `ArgumentException`; both → `ArgumentException` with settlement-directing message; DTO carries `settledAt` |
+| `Tests/Financial.Api.Tests/ExpenseEndpointsTests.cs` | Integration | expenses endpoints | POST card-only charge → 200 with `paymentStatus`/`settledAt` in body; POST neither → 400; POST both → 400; GET month returns new fields |
+| `Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/MonthlyExpenseSheetImporterTests.cs` | Unit | Importer accommodation | Card-section rows now import with null `PaymentSource` (assert existing card-tag tests updated accordingly) |
+| `Financial.Web/src/hooks/useMonthly.test.ts`, `src/api/financialApiClient.test.ts` | Unit (vitest) | Contract types | Payloads/fixtures updated for nullable `paymentSource`, `settledAt`, `paymentStatus`; `tsc -b --noEmit` passes |
+
+**Acceptance tests (PRD Section 9, F01):**
+- Bank set + no card saves and computes `ImmediatePayment` → `ExpenseTests` + `ExpenseServiceTests` + endpoint test
+- Card set + no bank saves and computes `CreditCardCharge` → same trio
+- Neither set rejected with validation message → same trio
+- Both set outside F02's cascade rejected with validation message → same trio (`Settle` is the only both-set path, covered in `ExpenseTests`)
+- Inconsistent `SettledAt` rejected → `ExpenseTests` (`Settle`/`Unsettle`/`UpdateDetails` guards make an inconsistent combination unconstructible through any public path)
+
+**Cross-Feature Integration criteria touching F01 (PRD Section 9):**
+- "The computed payment status is derived identically everywhere it's exposed" — guaranteed structurally: the only derivation is `Expense.PaymentStatus`; API serializes it; the web reads the serialized value. Covered by `ExpenseServiceTests` + endpoint tests asserting the serialized value matches the entity rule.
+- F02/F03/F04 cascade/backfill/importer shape criteria — deferred to those features; F01 provides the invariant they are tested against.

--- a/docs/prd/P12-prd-expense-credit-card-settlement/prd-expense-credit-card-settlement.md
+++ b/docs/prd/P12-prd-expense-credit-card-settlement/prd-expense-credit-card-settlement.md
@@ -230,11 +230,11 @@ graph TD
 ## 9. Acceptance Criteria
 
 ### F01. Expense Payment State Model
-- [ ] An expense saved with a `PaymentSource` set and no `CardTag` saves successfully and computes to `ImmediatePayment`
-- [ ] An expense saved with a `CardTag` set and no `PaymentSource` saves successfully and computes to `CreditCardCharge`
-- [ ] Saving an expense with neither `PaymentSource` nor `CardTag` set is rejected with a validation message
-- [ ] Saving an expense with both `PaymentSource` and `CardTag` set outside of F02's settlement cascade is rejected with a validation message
-- [ ] Saving an expense whose `SettledAt` is inconsistent with its `PaymentSource`/`CardTag` combination is rejected with a validation message
+- [x] An expense saved with a `PaymentSource` set and no `CardTag` saves successfully and computes to `ImmediatePayment`
+- [x] An expense saved with a `CardTag` set and no `PaymentSource` saves successfully and computes to `CreditCardCharge`
+- [x] Saving an expense with neither `PaymentSource` nor `CardTag` set is rejected with a validation message
+- [x] Saving an expense with both `PaymentSource` and `CardTag` set outside of F02's settlement cascade is rejected with a validation message
+- [x] Saving an expense whose `SettledAt` is inconsistent with its `PaymentSource`/`CardTag` combination is rejected with a validation message
 
 ### F02. Credit Card Statement Settlement with Payment Source
 - [ ] Marking a statement paid without a `PaymentSource` selected is rejected before any expense changes


### PR DESCRIPTION
## Summary

Implements **F01 – Expense Payment State Model** from the P12 PRD (`docs/prd/P12-prd-expense-credit-card-settlement`), per the committed spec/plan in `docs/P12-F01-expense-payment-state-model/`.

- `Expense.PaymentSource` is now nullable and a nullable `SettledAt` date was added; the payment status (`ImmediatePayment` / `CreditCardCharge` / `CreditCardSettled`) is **computed on read** from `PaymentSource`/`CardTag` — never stored (derive, don't store)
- The three valid field shapes are enforced as a domain invariant in `Expense` (`Create`/`UpdateDetails`); new `Settle(bank, date)`/`Unsettle()` transitions are the only way to produce/clear the settled shape (F02 will consume them)
- `ExpenseService`/DTOs accept an optional `paymentSource`; `ExpenseDTO` exposes `settledAt` + `paymentStatus`; API error messages direct both-set attempts to the statement settlement action
- `MonthlyExpenseSheetImporter` minimally accommodated: rows resolving a card tag import with a null bank tag (full importer rule lands in F04)
- Web contract types (`types.ts`, `useMonthly.ts`) aligned; card-tagged saves from the current form now send a null bank tag (F05 owns the full form UX)

## Acceptance Criteria (PRD Section 9 — F01)

- [x] An expense saved with a `PaymentSource` set and no `CardTag` saves successfully and computes to `ImmediatePayment`
- [x] An expense saved with a `CardTag` set and no `PaymentSource` saves successfully and computes to `CreditCardCharge`
- [x] Saving an expense with neither `PaymentSource` nor `CardTag` set is rejected with a validation message
- [x] Saving an expense with both `PaymentSource` and `CardTag` set outside of F02's settlement cascade is rejected with a validation message
- [x] Saving an expense whose `SettledAt` is inconsistent with its `PaymentSource`/`CardTag` combination is rejected with a validation message

## Test plan

- Full .NET suite: 1,182 passed, 0 failed (domain, application, infrastructure, importer, API integration)
- Web: `tsc -b --noEmit` clean; vitest 541 passed (44 files)
- Legacy data note: pre-migration records (both fields set) still deserialize — invariant applies to write paths only; F03's backfill reclassifies stored data

🤖 Generated with [Claude Code](https://claude.com/claude-code)