### PR TITLE
feat(P12-F02): credit card statement settlement with payment source

### DIFF
--- a/Financial.Api/Controllers/CardStatementsController.cs
+++ b/Financial.Api/Controllers/CardStatementsController.cs
@@ -25,12 +25,33 @@ public sealed class CardStatementsController : ControllerBase
 
     [HttpPost("{id:guid}/mark-paid")]
     [ProducesResponseType(typeof(CardStatementDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<CardStatementDTO>> MarkStatementPaid(Guid id)
+    public async Task<ActionResult<CardStatementDTO>> MarkStatementPaid(Guid id, [FromBody] MarkStatementPaidDTO request)
     {
         try
         {
-            var result = await _cardStatementService.MarkStatementPaidAsync(id);
+            var result = await _cardStatementService.MarkStatementPaidAsync(id, request);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound);
+        }
+    }
+
+    [HttpPost("{id:guid}/unmark-paid")]
+    [ProducesResponseType(typeof(CardStatementDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<CardStatementDTO>> UnmarkStatementPaid(Guid id)
+    {
+        try
+        {
+            var result = await _cardStatementService.UnmarkStatementPaidAsync(id);
             return Ok(result);
         }
         catch (KeyNotFoundException ex)

--- a/Financial.CashFlow.Application/DTOs/MarkStatementPaidDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/MarkStatementPaidDTO.cs
@@ -1,0 +1,10 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Request to mark a card statement paid, naming the bank account that paid it.
+/// </summary>
+public sealed class MarkStatementPaidDTO
+{
+    /// <summary>Payment source name that settled the statement.</summary>
+    public string? PaymentSource { get; init; }
+}

--- a/Financial.CashFlow.Application/Interfaces/ICardStatementService.cs
+++ b/Financial.CashFlow.Application/Interfaces/ICardStatementService.cs
@@ -5,5 +5,6 @@ namespace Financial.CashFlow.Application.Interfaces;
 public interface ICardStatementService
 {
     Task<IReadOnlyList<CardStatementDTO>> GetStatementsForMonthAsync(int year, int month);
-    Task<CardStatementDTO> MarkStatementPaidAsync(Guid id);
+    Task<CardStatementDTO> MarkStatementPaidAsync(Guid id, MarkStatementPaidDTO request);
+    Task<CardStatementDTO> UnmarkStatementPaidAsync(Guid id);
 }

--- a/Financial.CashFlow.Application/Services/CardStatementService.cs
+++ b/Financial.CashFlow.Application/Services/CardStatementService.cs
@@ -1,5 +1,6 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Application.Validation;
 using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Domain.Enums;
 
@@ -41,25 +42,33 @@ public sealed class CardStatementService : ICardStatementService
             await _repository.SaveChangesAsync().ConfigureAwait(false);
         }
 
-        var outstandingByCard = _repository.GetExpenses()
-            .Where(e => e.Date.Year == year && e.Date.Month == month && e.CardTag.HasValue)
-            .GroupBy(e => e.CardTag!.Value)
-            .ToDictionary(g => g.Key, g => g.Sum(e => e.Value));
-
-        return existingStatements.Select(s => ToDto(s, outstandingByCard)).ToList();
+        return existingStatements.Select(ToDto).ToList();
     }
 
-    public async Task<CardStatementDTO> MarkStatementPaidAsync(Guid id)
+    public async Task<CardStatementDTO> MarkStatementPaidAsync(Guid id, MarkStatementPaidDTO request)
     {
-        var statement = _repository.GetCardStatements().FirstOrDefault(s => s.Id == id)
-            ?? throw new KeyNotFoundException($"Card statement '{id}' was not found.");
+        ArgumentNullException.ThrowIfNull(request);
+
+        var statement = FindStatementOrThrow(id);
 
         if (statement.IsPaid)
         {
             return ToDto(statement);
         }
 
+        if (!PaymentSourceParser.TryParse(request.PaymentSource, out var paymentSource))
+        {
+            throw new ArgumentException($"Payment source '{request.PaymentSource}' is not recognized.");
+        }
+
+        var settledAt = DateOnly.FromDateTime(DateTime.Today);
+        var charges = GetStatementExpenses(statement, ExpensePaymentStatus.CreditCardCharge);
+
         statement.MarkPaid();
+        foreach (var charge in charges)
+        {
+            charge.Settle(paymentSource, settledAt);
+        }
 
         try
         {
@@ -68,29 +77,74 @@ public sealed class CardStatementService : ICardStatementService
         catch
         {
             statement.MarkUnpaid();
+            foreach (var charge in charges)
+            {
+                charge.Unsettle();
+            }
+
             throw;
         }
 
-        return ToDto(statement, outstandingByCard: null);
+        return ToDto(statement);
     }
 
-    private CardStatementDTO ToDto(CardStatement statement, IReadOnlyDictionary<CreditCard, decimal>? outstandingByCard = null)
+    public async Task<CardStatementDTO> UnmarkStatementPaidAsync(Guid id)
     {
-        var outstandingTotal = statement.IsPaid
-            ? 0m
-            : outstandingByCard?.GetValueOrDefault(statement.Card)
-                ?? _repository.GetExpenses()
-                    .Where(e => e.CardTag == statement.Card && e.Date.Year == statement.Year && e.Date.Month == statement.Month)
-                    .Sum(e => e.Value);
+        var statement = FindStatementOrThrow(id);
 
-        return new CardStatementDTO
+        if (!statement.IsPaid)
         {
-            Id = statement.Id,
-            Card = statement.Card.ToString(),
-            Year = statement.Year,
-            Month = statement.Month,
-            IsPaid = statement.IsPaid,
-            OutstandingTotal = outstandingTotal
-        };
+            return ToDto(statement);
+        }
+
+        var settledExpenses = GetStatementExpenses(statement, ExpensePaymentStatus.CreditCardSettled);
+        var settlements = settledExpenses
+            .Select(e => (Expense: e, PaymentSource: e.PaymentSource!.Value, SettledAt: e.SettledAt!.Value))
+            .ToList();
+
+        statement.MarkUnpaid();
+        foreach (var expense in settledExpenses)
+        {
+            expense.Unsettle();
+        }
+
+        try
+        {
+            await _repository.SaveChangesAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            statement.MarkPaid();
+            foreach (var (expense, paymentSource, settledAt) in settlements)
+            {
+                expense.Settle(paymentSource, settledAt);
+            }
+
+            throw;
+        }
+
+        return ToDto(statement);
     }
+
+    private CardStatement FindStatementOrThrow(Guid id) =>
+        _repository.GetCardStatements().FirstOrDefault(s => s.Id == id)
+            ?? throw new KeyNotFoundException($"Card statement '{id}' was not found.");
+
+    private List<Expense> GetStatementExpenses(CardStatement statement, ExpensePaymentStatus status) =>
+        _repository.GetExpenses()
+            .Where(e => e.CardTag == statement.Card
+                && e.Date.Year == statement.Year
+                && e.Date.Month == statement.Month
+                && e.PaymentStatus == status)
+            .ToList();
+
+    private CardStatementDTO ToDto(CardStatement statement) => new()
+    {
+        Id = statement.Id,
+        Card = statement.Card.ToString(),
+        Year = statement.Year,
+        Month = statement.Month,
+        IsPaid = statement.IsPaid,
+        OutstandingTotal = GetStatementExpenses(statement, ExpensePaymentStatus.CreditCardCharge).Sum(e => e.Value)
+    };
 }

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -27,6 +27,7 @@ import type {
   InvestmentSnapshotDto,
   MaeLedgerEntryDto,
   MaeLedgerTotalsDto,
+  MarkCardStatementPaidDto,
   PortfolioAssetSummaryItemDto,
   PortfolioBreakdownItemDto,
   PortfolioReferenceDto,
@@ -102,7 +103,8 @@ export interface FinancialApiClient {
   updateExpense: (id: string, request: UpdateExpenseDto) => Promise<ExpenseDto>
   deleteExpense: (id: string) => Promise<void>
   getCardStatementsByMonth: (year: number, month: number) => Promise<CardStatementDto[]>
-  markCardStatementPaid: (id: string) => Promise<CardStatementDto>
+  markCardStatementPaid: (id: string, request: MarkCardStatementPaidDto) => Promise<CardStatementDto>
+  unmarkCardStatementPaid: (id: string) => Promise<CardStatementDto>
   getCategoryTotalsForYear: (year: number) => Promise<CategoryYearlyTotalDto[]>
   getInvestmentDiffsForYear: (year: number) => Promise<InvestmentDiffsYearlyDto>
 }
@@ -332,8 +334,13 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
     deleteExpense: (id) => requestVoid(`/expenses/${encodeURIComponent(id)}`, { method: 'DELETE' }),
     getCardStatementsByMonth: (year, month) =>
       request<CardStatementDto[]>(`/card-statements/${year}/${month}`),
-    markCardStatementPaid: (id) =>
+    markCardStatementPaid: (id, requestBody) =>
       request<CardStatementDto>(`/card-statements/${encodeURIComponent(id)}/mark-paid`, {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      }),
+    unmarkCardStatementPaid: (id) =>
+      request<CardStatementDto>(`/card-statements/${encodeURIComponent(id)}/unmark-paid`, {
         method: 'POST',
       }),
     getCategoryTotalsForYear: (year) =>

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -400,6 +400,10 @@ export interface CardStatementDto {
   outstandingTotal: number
 }
 
+export interface MarkCardStatementPaidDto {
+  paymentSource: string
+}
+
 export interface CategoryYearlyTotalDto {
   category: string
   monthlyTotals: number[]

--- a/Financial.Web/src/hooks/useMonthly.test.ts
+++ b/Financial.Web/src/hooks/useMonthly.test.ts
@@ -19,6 +19,7 @@ const createExpenseMock = vi.fn<FinancialApiClient['createExpense']>()
 const updateExpenseMock = vi.fn<FinancialApiClient['updateExpense']>()
 const deleteExpenseMock = vi.fn<FinancialApiClient['deleteExpense']>()
 const markCardStatementPaidMock = vi.fn<FinancialApiClient['markCardStatementPaid']>()
+const unmarkCardStatementPaidMock = vi.fn<FinancialApiClient['unmarkCardStatementPaid']>()
 
 vi.mock('../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
@@ -29,6 +30,7 @@ vi.mock('../api/financialApiClient', () => ({
     updateExpense: updateExpenseMock,
     deleteExpense: deleteExpenseMock,
     markCardStatementPaid: markCardStatementPaidMock,
+    unmarkCardStatementPaid: unmarkCardStatementPaidMock,
   }),
 }))
 
@@ -176,14 +178,44 @@ describe('useMonthly', () => {
     expect(deleteExpenseMock).not.toHaveBeenCalled()
   })
 
-  it('marks a card statement paid and re-fetches', async () => {
+  it('marks a card statement paid with the selected bank and re-fetches', async () => {
     markCardStatementPaidMock.mockResolvedValue({ ...CARD_STATEMENTS[0], isPaid: true, outstandingTotal: 0 })
     const { result } = renderHook(() => useMonthly())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    act(() => result.current.markStatementPaid('c1'))
+    act(() => result.current.markStatementPaid('c1', 'Trading212'))
 
-    await waitFor(() => expect(markCardStatementPaidMock).toHaveBeenCalledWith('c1'))
+    await waitFor(() => expect(markCardStatementPaidMock).toHaveBeenCalledWith('c1', { paymentSource: 'Trading212' }))
     await waitFor(() => expect(getCardStatementsByMonthMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('tracks the selected paying bank per statement', async () => {
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setMarkPaidSource('c1', 'Chase'))
+
+    expect(result.current.markPaidSources).toEqual({ c1: 'Chase' })
+  })
+
+  it('unmarks a paid statement after confirmation and re-fetches', async () => {
+    unmarkCardStatementPaidMock.mockResolvedValue({ ...CARD_STATEMENTS[1], isPaid: false, outstandingTotal: 45 })
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.unmarkStatementPaid('c2'))
+
+    await waitFor(() => expect(unmarkCardStatementPaidMock).toHaveBeenCalledWith('c2'))
+    await waitFor(() => expect(getCardStatementsByMonthMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('does not unmark when the user cancels the confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.unmarkStatementPaid('c2'))
+
+    expect(unmarkCardStatementPaidMock).not.toHaveBeenCalled()
   })
 })

--- a/Financial.Web/src/hooks/useMonthly.ts
+++ b/Financial.Web/src/hooks/useMonthly.ts
@@ -58,6 +58,7 @@ interface MonthlyState {
   editCardTag: string
   isSaving: boolean
   saveError: string | null
+  markPaidSources: Record<string, string>
 }
 
 type MonthlyAction =
@@ -82,6 +83,7 @@ type MonthlyAction =
   | { type: 'SAVE_SUCCESS' }
   | { type: 'SAVE_ERROR'; payload: string }
   | { type: 'MARK_PAID_ERROR'; payload: string }
+  | { type: 'SET_MARK_PAID_SOURCE'; payload: { id: string; value: string } }
 
 const { year: DEFAULT_YEAR, month: DEFAULT_MONTH } = currentYearMonth()
 
@@ -116,6 +118,7 @@ const INITIAL_STATE: MonthlyState = {
   editCardTag: '',
   isSaving: false,
   saveError: null,
+  markPaidSources: {},
 }
 
 function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
@@ -193,6 +196,8 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
       return { ...state, isSaving: false, saveError: action.payload }
     case 'MARK_PAID_ERROR':
       return { ...state, saveError: action.payload }
+    case 'SET_MARK_PAID_SOURCE':
+      return { ...state, markPaidSources: { ...state.markPaidSources, [action.payload.id]: action.payload.value } }
     default:
       return state
   }
@@ -238,7 +243,10 @@ export interface MonthlyData {
   cancelEdit: () => void
   saveEdit: () => void
   deleteExpense: (id: string) => void
-  markStatementPaid: (id: string) => void
+  markPaidSources: Record<string, string>
+  setMarkPaidSource: (id: string, value: string) => void
+  markStatementPaid: (id: string, paymentSource: string) => void
+  unmarkStatementPaid: (id: string) => void
 }
 
 export function useMonthly(): MonthlyData {
@@ -379,15 +387,37 @@ export function useMonthly(): MonthlyData {
     [apiClient],
   )
 
+  const setMarkPaidSource = useCallback(
+    (id: string, value: string) => dispatch({ type: 'SET_MARK_PAID_SOURCE', payload: { id, value } }),
+    [],
+  )
+
   const markStatementPaid = useCallback(
-    (id: string) => {
+    (id: string, paymentSource: string) => {
       void apiClient
-        .markCardStatementPaid(id)
+        .markCardStatementPaid(id, { paymentSource })
         .then(() => dispatch({ type: 'RETRY' }))
         .catch((err: unknown) => {
           dispatch({
             type: 'MARK_PAID_ERROR',
             payload: err instanceof Error ? err.message : 'Failed to mark statement paid',
+          })
+        })
+    },
+    [apiClient],
+  )
+
+  const unmarkStatementPaid = useCallback(
+    (id: string) => {
+      if (!window.confirm('Unmark this statement as paid? Its settled charges revert to unsettled.')) return
+
+      void apiClient
+        .unmarkCardStatementPaid(id)
+        .then(() => dispatch({ type: 'RETRY' }))
+        .catch((err: unknown) => {
+          dispatch({
+            type: 'MARK_PAID_ERROR',
+            payload: err instanceof Error ? err.message : 'Failed to unmark statement paid',
           })
         })
     },
@@ -446,6 +476,9 @@ export function useMonthly(): MonthlyData {
     cancelEdit,
     saveEdit,
     deleteExpense,
+    markPaidSources: state.markPaidSources,
+    setMarkPaidSource,
     markStatementPaid,
+    unmarkStatementPaid,
   }
 }

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -203,7 +203,10 @@ export default function MonthlyPage() {
     cancelEdit,
     saveEdit,
     deleteExpense,
+    markPaidSources,
+    setMarkPaidSource,
     markStatementPaid,
+    unmarkStatementPaid,
   } = useMonthly()
 
   const isEditing = editingId !== null
@@ -295,10 +298,32 @@ export default function MonthlyPage() {
                         <td className="data-table__col--numeric">{formatN2(s.outstandingTotal)}</td>
                         <td>{s.isPaid ? 'Paid' : 'Unpaid'}</td>
                         <td>
-                          {!s.isPaid && (
-                            <button type="button" onClick={() => markStatementPaid(s.id)}>
-                              Mark Paid
+                          {s.isPaid ? (
+                            <button type="button" onClick={() => unmarkStatementPaid(s.id)}>
+                              Unmark Paid
                             </button>
+                          ) : (
+                            <>
+                              <select
+                                aria-label={`Paying bank for ${s.card}`}
+                                value={markPaidSources[s.id] ?? ''}
+                                onChange={(e) => setMarkPaidSource(s.id, e.target.value)}
+                              >
+                                <option value="">Bank…</option>
+                                {PAYMENT_SOURCES.map((p) => (
+                                  <option key={p} value={p}>
+                                    {p}
+                                  </option>
+                                ))}
+                              </select>{' '}
+                              <button
+                                type="button"
+                                disabled={!markPaidSources[s.id]}
+                                onClick={() => markStatementPaid(s.id, markPaidSources[s.id])}
+                              >
+                                Mark Paid
+                              </button>
+                            </>
                           )}
                         </td>
                       </tr>

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -11,6 +11,7 @@ const createExpenseMock = vi.fn<FinancialApiClient['createExpense']>()
 const updateExpenseMock = vi.fn<FinancialApiClient['updateExpense']>()
 const deleteExpenseMock = vi.fn<FinancialApiClient['deleteExpense']>()
 const markCardStatementPaidMock = vi.fn<FinancialApiClient['markCardStatementPaid']>()
+const unmarkCardStatementPaidMock = vi.fn<FinancialApiClient['unmarkCardStatementPaid']>()
 
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
@@ -21,6 +22,7 @@ vi.mock('../../api/financialApiClient', () => ({
     updateExpense: updateExpenseMock,
     deleteExpense: deleteExpenseMock,
     markCardStatementPaid: markCardStatementPaidMock,
+    unmarkCardStatementPaid: unmarkCardStatementPaidMock,
   }),
 }))
 
@@ -102,21 +104,40 @@ describe('MonthlyPage', () => {
     expect(screen.getByText('Banks').closest('section')).toHaveClass('monthly-page__section--grid')
   })
 
-  it('only shows Mark Paid for unpaid cards', async () => {
+  it('shows Mark Paid with a bank picker for unpaid cards and Unmark Paid for paid ones', async () => {
     render(<MonthlyPage />)
 
     await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
     expect(screen.getAllByRole('button', { name: 'Mark Paid' })).toHaveLength(1)
+    expect(screen.getByLabelText('Paying bank for BaAmex')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Unmark Paid' })).toHaveLength(1)
   })
 
-  it('marks a card statement paid when clicked', async () => {
+  it('disables Mark Paid until a bank is selected, then marks paid with that bank', async () => {
     markCardStatementPaidMock.mockResolvedValue({ ...CARD_STATEMENTS[0], isPaid: true, outstandingTotal: 0 })
     render(<MonthlyPage />)
 
     await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: 'Mark Paid' }))
+    const markPaidButton = screen.getByRole('button', { name: 'Mark Paid' })
+    expect(markPaidButton).toBeDisabled()
 
-    await waitFor(() => expect(markCardStatementPaidMock).toHaveBeenCalledWith('c1'))
+    fireEvent.change(screen.getByLabelText('Paying bank for BaAmex'), { target: { value: 'Trading212' } })
+    expect(markPaidButton).toBeEnabled()
+    fireEvent.click(markPaidButton)
+
+    await waitFor(() =>
+      expect(markCardStatementPaidMock).toHaveBeenCalledWith('c1', { paymentSource: 'Trading212' }),
+    )
+  })
+
+  it('unmarks a paid statement after confirmation', async () => {
+    unmarkCardStatementPaidMock.mockResolvedValue({ ...CARD_STATEMENTS[1], isPaid: false, outstandingTotal: 0 })
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'ChaseMaster4023' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Unmark Paid' }))
+
+    await waitFor(() => expect(unmarkCardStatementPaidMock).toHaveBeenCalledWith('c2'))
   })
 
   it('shows the add-expense form only after New Expense is clicked, and submits a new expense', async () => {

--- a/Tests/Financial.Api.Tests/CardStatementsEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/CardStatementsEndpointsTests.cs
@@ -43,7 +43,7 @@ public class CardStatementsEndpointsTests
     }
 
     [Fact]
-    public async Task MarkStatementPaid_ExistingId_ReturnsOkAndZeroesOutstandingTotal()
+    public async Task MarkStatementPaid_WithPaymentSource_SettlesChargesAndZeroesOutstandingTotal()
     {
         await using var factory = new ApiTestFactory();
         using var client = factory.CreateClient();
@@ -56,16 +56,47 @@ public class CardStatementsEndpointsTests
             PaymentSource = null,
             CardTag = "BarclaysPlatinumVisa8003"
         });
-        var monthResponse = await client.GetAsync("/api/v1/financial/card-statements/2026/7");
-        var statements = await monthResponse.Content.ReadFromJsonAsync<List<CardStatementDTO>>();
-        var target = statements!.First(s => s.Card == "BarclaysPlatinumVisa8003");
+        var target = await GetStatementAsync(client, "BarclaysPlatinumVisa8003");
 
-        var response = await client.PostAsync($"/api/v1/financial/card-statements/{target.Id}/mark-paid", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/financial/card-statements/{target.Id}/mark-paid",
+            new MarkStatementPaidDTO { PaymentSource = "Trading212" });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var updated = await response.Content.ReadFromJsonAsync<CardStatementDTO>();
         updated!.IsPaid.Should().BeTrue();
         updated.OutstandingTotal.Should().Be(0m);
+
+        var expenses = await client.GetFromJsonAsync<List<ExpenseDTO>>("/api/v1/financial/expenses/month/2026/7");
+        var settled = expenses!.Single(e => e.Description == "Card charge");
+        settled.PaymentStatus.Should().Be("CreditCardSettled");
+        settled.PaymentSource.Should().Be("Trading212");
+        settled.SettledAt.Should().Be(DateOnly.FromDateTime(DateTime.Today));
+    }
+
+    [Fact]
+    public async Task MarkStatementPaid_WithoutPaymentSource_ReturnsBadRequestWithoutChangingExpenses()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 10),
+            Description = "Card charge",
+            Value = 45m,
+            Category = "Mercado",
+            PaymentSource = null,
+            CardTag = "BarclaysPlatinumVisa8003"
+        });
+        var target = await GetStatementAsync(client, "BarclaysPlatinumVisa8003");
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/financial/card-statements/{target.Id}/mark-paid",
+            new MarkStatementPaidDTO { PaymentSource = null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var expenses = await client.GetFromJsonAsync<List<ExpenseDTO>>("/api/v1/financial/expenses/month/2026/7");
+        expenses!.Single(e => e.Description == "Card charge").PaymentStatus.Should().Be("CreditCardCharge");
     }
 
     [Fact]
@@ -73,12 +104,12 @@ public class CardStatementsEndpointsTests
     {
         await using var factory = new ApiTestFactory();
         using var client = factory.CreateClient();
-        var monthResponse = await client.GetAsync("/api/v1/financial/card-statements/2026/7");
-        var statements = await monthResponse.Content.ReadFromJsonAsync<List<CardStatementDTO>>();
-        var target = statements!.First();
-        await client.PostAsync($"/api/v1/financial/card-statements/{target.Id}/mark-paid", null);
+        var target = await GetFirstStatementAsync(client);
+        await MarkPaidAsync(client, target.Id, "Barclays");
 
-        var response = await client.PostAsync($"/api/v1/financial/card-statements/{target.Id}/mark-paid", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/financial/card-statements/{target.Id}/mark-paid",
+            new MarkStatementPaidDTO { PaymentSource = "Barclays" });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
@@ -89,8 +120,83 @@ public class CardStatementsEndpointsTests
         await using var factory = new ApiTestFactory();
         using var client = factory.CreateClient();
 
-        var response = await client.PostAsync($"/api/v1/financial/card-statements/{Guid.NewGuid()}/mark-paid", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/financial/card-statements/{Guid.NewGuid()}/mark-paid",
+            new MarkStatementPaidDTO { PaymentSource = "Barclays" });
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+
+    [Fact]
+    public async Task UnmarkStatementPaid_RevertsSettledChargesToUnsettled()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 10),
+            Description = "Card charge",
+            Value = 45m,
+            Category = "Mercado",
+            PaymentSource = null,
+            CardTag = "BarclaysPlatinumVisa8003"
+        });
+        var target = await GetStatementAsync(client, "BarclaysPlatinumVisa8003");
+        await MarkPaidAsync(client, target.Id, "Trading212");
+
+        var response = await client.PostAsync($"/api/v1/financial/card-statements/{target.Id}/unmark-paid", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await response.Content.ReadFromJsonAsync<CardStatementDTO>();
+        updated!.IsPaid.Should().BeFalse();
+        updated.OutstandingTotal.Should().Be(45m);
+
+        var expenses = await client.GetFromJsonAsync<List<ExpenseDTO>>("/api/v1/financial/expenses/month/2026/7");
+        var reverted = expenses!.Single(e => e.Description == "Card charge");
+        reverted.PaymentStatus.Should().Be("CreditCardCharge");
+        reverted.PaymentSource.Should().BeNull();
+        reverted.SettledAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UnmarkStatementPaid_OnUnpaidStatement_StillReturnsOk()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var target = await GetFirstStatementAsync(client);
+
+        var response = await client.PostAsync($"/api/v1/financial/card-statements/{target.Id}/unmark-paid", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await response.Content.ReadFromJsonAsync<CardStatementDTO>();
+        updated!.IsPaid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UnmarkStatementPaid_UnknownId_ReturnsNotFound()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync($"/api/v1/financial/card-statements/{Guid.NewGuid()}/unmark-paid", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private static async Task<CardStatementDTO> GetStatementAsync(HttpClient client, string card)
+    {
+        var statements = await client.GetFromJsonAsync<List<CardStatementDTO>>("/api/v1/financial/card-statements/2026/7");
+        return statements!.First(s => s.Card == card);
+    }
+
+    private static async Task<CardStatementDTO> GetFirstStatementAsync(HttpClient client)
+    {
+        var statements = await client.GetFromJsonAsync<List<CardStatementDTO>>("/api/v1/financial/card-statements/2026/7");
+        return statements!.First();
+    }
+
+    private static Task<HttpResponseMessage> MarkPaidAsync(HttpClient client, Guid id, string paymentSource) =>
+        client.PostAsJsonAsync(
+            $"/api/v1/financial/card-statements/{id}/mark-paid",
+            new MarkStatementPaidDTO { PaymentSource = paymentSource });
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/CardStatementServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/CardStatementServiceTests.cs
@@ -9,6 +9,16 @@ namespace Financial.CashFlow.Application.Tests.Services;
 
 public class CardStatementServiceTests
 {
+    private static MarkStatementPaidDTO PaidBy(string? paymentSource) => new() { PaymentSource = paymentSource };
+
+    private static Expense AddCharge(
+        StubCashFlowRepository repository, DateOnly date, decimal value, CreditCard card)
+    {
+        var expense = Expense.Create(date, "Charge", value, Category.Mercado, null, card);
+        repository.Expenses.Add(expense);
+        return expense;
+    }
+
     [Fact]
     public void Constructor_WithNullRepository_Throws()
     {
@@ -44,13 +54,13 @@ public class CardStatementServiceTests
     }
 
     [Fact]
-    public async Task GetStatementsForMonthAsync_OutstandingTotalSumsThatMonthsTaggedExpensesForTheCard()
+    public async Task GetStatementsForMonthAsync_OutstandingTotalSumsThatMonthsChargesForTheCard()
     {
         var repository = new StubCashFlowRepository();
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 10), "Charge 1", 30m, Category.Mercado, null, CreditCard.BarclaysPlatinumVisa8003));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 15), "Charge 2", 20m, Category.Mercado, null, CreditCard.BarclaysPlatinumVisa8003));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 8, 1), "Other month", 100m, Category.Mercado, null, CreditCard.BarclaysPlatinumVisa8003));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 12), "Other card", 999m, Category.Mercado, null, CreditCard.BaAmex));
+        AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
+        AddCharge(repository, new DateOnly(2026, 7, 15), 20m, CreditCard.BarclaysPlatinumVisa8003);
+        AddCharge(repository, new DateOnly(2026, 8, 1), 100m, CreditCard.BarclaysPlatinumVisa8003);
+        AddCharge(repository, new DateOnly(2026, 7, 12), 999m, CreditCard.BaAmex);
         var service = new CardStatementService(repository);
 
         var result = await service.GetStatementsForMonthAsync(2026, 7);
@@ -59,33 +69,67 @@ public class CardStatementServiceTests
     }
 
     [Fact]
-    public async Task GetStatementsForMonthAsync_WhenStatementIsPaid_OutstandingTotalIsZeroDespiteTaggedExpenses()
+    public async Task GetStatementsForMonthAsync_ExcludesSettledAndImmediateExpensesFromOutstandingTotal()
     {
         var repository = new StubCashFlowRepository();
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 10), "Charge", 30m, Category.Mercado, null, CreditCard.BarclaysPlatinumVisa8003));
+        var settled = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
+        settled.Settle(PaymentSource.Barclays, new DateOnly(2026, 7, 20));
+        AddCharge(repository, new DateOnly(2026, 7, 11), 20m, CreditCard.BarclaysPlatinumVisa8003);
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 12), "Immediate", 5m, Category.Casa, PaymentSource.Barclays, null));
         var service = new CardStatementService(repository);
-        await service.GetStatementsForMonthAsync(2026, 7);
-        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
-        await service.MarkStatementPaidAsync(statement.Id);
 
         var result = await service.GetStatementsForMonthAsync(2026, 7);
 
-        result.Should().ContainSingle(s => s.Card == "BarclaysPlatinumVisa8003" && s.OutstandingTotal == 0m && s.IsPaid);
+        result.Should().ContainSingle(s => s.Card == "BarclaysPlatinumVisa8003" && s.OutstandingTotal == 20m);
     }
 
     [Fact]
-    public async Task MarkStatementPaidAsync_SetsIsPaidAndZeroesOutstandingTotal()
+    public async Task MarkStatementPaidAsync_SettlesEveryChargeForTheCardMonthWithBankAndToday()
     {
         var repository = new StubCashFlowRepository();
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 10), "Charge", 30m, Category.Mercado, null, CreditCard.BarclaysPlatinumVisa8003));
+        var first = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
+        var second = AddCharge(repository, new DateOnly(2026, 7, 15), 20m, CreditCard.BarclaysPlatinumVisa8003);
+        var otherMonth = AddCharge(repository, new DateOnly(2026, 8, 1), 100m, CreditCard.BarclaysPlatinumVisa8003);
+        var otherCard = AddCharge(repository, new DateOnly(2026, 7, 12), 999m, CreditCard.BaAmex);
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
-        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
+        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003 && s.Month == 7);
 
-        var result = await service.MarkStatementPaidAsync(statement.Id);
+        var result = await service.MarkStatementPaidAsync(statement.Id, PaidBy("Trading212"));
 
         result.IsPaid.Should().BeTrue();
         result.OutstandingTotal.Should().Be(0m);
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        foreach (var expense in new[] { first, second })
+        {
+            expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardSettled);
+            expense.PaymentSource.Should().Be(PaymentSource.Trading212);
+            expense.SettledAt.Should().Be(today);
+        }
+
+        otherMonth.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+        otherCard.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("NotABank")]
+    public async Task MarkStatementPaidAsync_WithMissingOrUnknownPaymentSource_ThrowsWithoutChangingState(string? paymentSource)
+    {
+        var repository = new StubCashFlowRepository();
+        var charge = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
+        var service = new CardStatementService(repository);
+        await service.GetStatementsForMonthAsync(2026, 7);
+        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
+        var savesBefore = repository.SaveChangesCallCount;
+
+        var act = async () => await service.MarkStatementPaidAsync(statement.Id, PaidBy(paymentSource));
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Payment source*not recognized*");
+        statement.IsPaid.Should().BeFalse();
+        charge.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+        repository.SaveChangesCallCount.Should().Be(savesBefore);
     }
 
     [Fact]
@@ -95,27 +139,32 @@ public class CardStatementServiceTests
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
         var statement = repository.Statements.First();
-        await service.MarkStatementPaidAsync(statement.Id);
+        await service.MarkStatementPaidAsync(statement.Id, PaidBy("Barclays"));
+        var savesBefore = repository.SaveChangesCallCount;
 
-        var result = await service.MarkStatementPaidAsync(statement.Id);
+        var result = await service.MarkStatementPaidAsync(statement.Id, PaidBy("Chase"));
 
         result.IsPaid.Should().BeTrue();
-        repository.SaveChangesCallCount.Should().Be(2);
+        repository.SaveChangesCallCount.Should().Be(savesBefore);
     }
 
     [Fact]
-    public async Task MarkStatementPaidAsync_WhenSaveFails_RollsBackIsPaid()
+    public async Task MarkStatementPaidAsync_WhenSaveFails_RollsBackStatementAndCascadedExpenses()
     {
         var repository = new StubCashFlowRepository();
+        var charge = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
-        var statement = repository.Statements.First();
+        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
         repository.ThrowOnNextSave = true;
 
-        var act = async () => await service.MarkStatementPaidAsync(statement.Id);
+        var act = async () => await service.MarkStatementPaidAsync(statement.Id, PaidBy("Barclays"));
 
         await act.Should().ThrowAsync<InvalidOperationException>();
         statement.IsPaid.Should().BeFalse();
+        charge.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+        charge.PaymentSource.Should().BeNull();
+        charge.SettledAt.Should().BeNull();
     }
 
     [Fact]
@@ -123,7 +172,91 @@ public class CardStatementServiceTests
     {
         var service = new CardStatementService(new StubCashFlowRepository());
 
-        var act = async () => await service.MarkStatementPaidAsync(Guid.NewGuid());
+        var act = async () => await service.MarkStatementPaidAsync(Guid.NewGuid(), PaidBy("Barclays"));
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task UnmarkStatementPaidAsync_RevertsEverySettledExpenseForTheCardMonth()
+    {
+        var repository = new StubCashFlowRepository();
+        var first = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
+        var second = AddCharge(repository, new DateOnly(2026, 7, 15), 20m, CreditCard.BarclaysPlatinumVisa8003);
+        var service = new CardStatementService(repository);
+        await service.GetStatementsForMonthAsync(2026, 7);
+        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
+        await service.MarkStatementPaidAsync(statement.Id, PaidBy("Barclays"));
+
+        var result = await service.UnmarkStatementPaidAsync(statement.Id);
+
+        result.IsPaid.Should().BeFalse();
+        result.OutstandingTotal.Should().Be(50m);
+        foreach (var expense in new[] { first, second })
+        {
+            expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+            expense.PaymentSource.Should().BeNull();
+            expense.SettledAt.Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public async Task UnmarkStatementPaidAsync_OnAlreadyUnpaidStatement_IsANoOpThatStillSucceeds()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new CardStatementService(repository);
+        await service.GetStatementsForMonthAsync(2026, 7);
+        var statement = repository.Statements.First();
+        var savesBefore = repository.SaveChangesCallCount;
+
+        var result = await service.UnmarkStatementPaidAsync(statement.Id);
+
+        result.IsPaid.Should().BeFalse();
+        repository.SaveChangesCallCount.Should().Be(savesBefore);
+    }
+
+    [Fact]
+    public async Task UnmarkStatementPaidAsync_WithNoSettledExpenses_StillFlipsStatementToUnpaid()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new CardStatementService(repository);
+        await service.GetStatementsForMonthAsync(2026, 7);
+        var statement = repository.Statements.First();
+        await service.MarkStatementPaidAsync(statement.Id, PaidBy("Barclays"));
+
+        var result = await service.UnmarkStatementPaidAsync(statement.Id);
+
+        result.IsPaid.Should().BeFalse();
+        statement.IsPaid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UnmarkStatementPaidAsync_WhenSaveFails_RollsBackStatementAndCascadedExpenses()
+    {
+        var repository = new StubCashFlowRepository();
+        var charge = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
+        var service = new CardStatementService(repository);
+        await service.GetStatementsForMonthAsync(2026, 7);
+        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
+        await service.MarkStatementPaidAsync(statement.Id, PaidBy("Trading212"));
+        var settledAt = charge.SettledAt;
+        repository.ThrowOnNextSave = true;
+
+        var act = async () => await service.UnmarkStatementPaidAsync(statement.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        statement.IsPaid.Should().BeTrue();
+        charge.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardSettled);
+        charge.PaymentSource.Should().Be(PaymentSource.Trading212);
+        charge.SettledAt.Should().Be(settledAt);
+    }
+
+    [Fact]
+    public async Task UnmarkStatementPaidAsync_WithUnknownId_ThrowsKeyNotFoundException()
+    {
+        var service = new CardStatementService(new StubCashFlowRepository());
+
+        var act = async () => await service.UnmarkStatementPaidAsync(Guid.NewGuid());
 
         await act.Should().ThrowAsync<KeyNotFoundException>();
     }

--- a/docs/P12-F02-credit-card-statement-settlement-with-payment-source/plan.md
+++ b/docs/P12-F02-credit-card-statement-settlement-with-payment-source/plan.md
@@ -1,0 +1,26 @@
+# Implementation Plan: F02. Credit Card Statement Settlement with Payment Source
+
+**Prerequisites:**
+- F01 (Expense Payment State Model) merged — `Settle`/`Unsettle` transitions and nullable payment fields available
+- .NET SDK and Node/npm for the two test stacks
+- No new packages, configuration, or environment variables
+
+### Stage 1: Application Settlement Cascades
+
+**1. Mark-paid request contract** - Add the request DTO carrying the paying bank and extend the card statement service interface with the new mark/unmark operations. See spec Sections 4 and 5.
+
+**2. Settle and unsettle cascades** - Implement the mark-paid cascade (validate the bank first, settle every eligible charge, flip the statement, save once) and the unmark-paid reverse cascade, both with full rollback on save failure. See spec Section 3 for cascade membership, date, and no-op rules.
+
+**3. Outstanding-total rule** - Change the statement DTO's outstanding-total derivation to sum only unsettled charges. See spec Section 3 (Outstanding total).
+
+### Stage 2: API Surface
+
+**4. Controller endpoints** - Update the mark-paid endpoint to accept the request body and translate validation failures, and add the unmark-paid endpoint with the same error conventions. See spec Section 5 for status codes and side effects.
+
+### Stage 3: Web Cards Panel
+
+**5. Client contract** - Update the web API client and types for the mark-paid body and the new unmark operation. See spec Section 4 (Frontend).
+
+**6. Cards panel controls** - Add per-row bank selection and the confirmation-guarded unmark control to the Cards panel, wiring both through the monthly hook with the existing re-fetch pattern. See spec Section 3 (Cards panel controls).
+
+**7. Full-solution verification** - Run the .NET suite, web suite, and TypeScript build check to confirm everything is green end to end.

--- a/docs/P12-F02-credit-card-statement-settlement-with-payment-source/spec.md
+++ b/docs/P12-F02-credit-card-statement-settlement-with-payment-source/spec.md
@@ -1,0 +1,112 @@
+# F02. Credit Card Statement Settlement with Payment Source
+
+## 1. Technical Overview
+
+**What:** Make "mark statement paid" require a `PaymentSource` and cascade settlement onto the statement's charges — every `CreditCardCharge` expense for that card/month gets `Settle(bank, today)` — and add the missing "unmark statement paid" action that reverses the cascade via `Unsettle()`. The outstanding-total derivation changes to sum only `CreditCardCharge` expenses. The Cards panel gains the bank picker on Mark Paid and an Unmark Paid control (per this feature's PRD Experience; F05 keeps them and reworks the panels' totals and the expense form).
+
+**Why:** `CardStatement.IsPaid` today records nothing about which bank paid or when, and expenses never change state on settlement. F01 provides the `Settle`/`Unsettle` transitions and the settled shape; F02 is the only producer/consumer of those transitions, making settlement explicit, auditable (bank + date on each expense), and reversible.
+
+**Scope:**
+- Included: `MarkStatementPaidAsync` gains a required payment source and the settle cascade; new `UnmarkStatementPaidAsync` with the reverse cascade; all-or-nothing rollback on save failure for both; outstanding total = sum of that card/month's `CreditCardCharge` expenses; API contract changes (`mark-paid` body, new `unmark-paid` endpoint); web client + Cards panel controls (bank select before Mark Paid, Unmark Paid with confirmation).
+- Excluded: Banks panel and expense-form changes (F05); data backfill (F03) — until it runs, legacy both-set expenses compute `CreditCardSettled` and are excluded from outstanding totals, which is the accepted transitional state; any per-expense settlement action (PRD out of scope).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.CashFlow.Application/Interfaces/ICardStatementService.cs`, `Services/CardStatementService.cs` — settle/unsettle cascades, outstanding-total rule
+- `Financial.CashFlow.Application/DTOs/MarkStatementPaidDTO.cs` — new request DTO
+- `Financial.Api/Controllers/CardStatementsController.cs` — `mark-paid` takes a body, new `unmark-paid` endpoint, `ArgumentException` → 400
+- `Financial.Web/src/api/types.ts`, `financialApiClient.ts` — mark-paid request shape, unmark method
+- `Financial.Web/src/hooks/useMonthly.ts`, `src/pages/MonthlyPage.tsx` — per-row bank selection state, `markStatementPaid(id, bank)`, `unmarkStatementPaid(id)` with confirm
+
+```mermaid
+graph TD
+  A["Cards panel (MonthlyPage)"] --> B["financialApiClient"]
+  B --> C["CardStatementsController"]
+  C --> D["CardStatementService"]
+  D --> E["CardStatement.MarkPaid / MarkUnpaid"]
+  D --> F["Expense.Settle / Unsettle (F01)"]
+  D --> G["ICashFlowRepository.SaveChangesAsync"]
+  G -.->|save failure| H["rollback statement + cascaded expenses"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Cascade location | `CardStatementService` orchestrates: flips the statement, calls `Expense.Settle`/`Unsettle` on each affected expense, saves once; on save failure reverts every mutated entity before rethrowing (extends the existing `MarkPaid`/`MarkUnpaid` rollback pattern) | A domain service owning the cascade | The repository is an in-memory aggregate with a single full-document save, so one save covers the whole cascade atomically-enough; a domain service would add a layer this codebase doesn't use elsewhere. |
+| "Settled by this statement" on unmark | All `CreditCardSettled` expenses for that card/month | Track which expense ids each settlement touched | F01 makes the settled shape producible only via the cascade, so card/month membership fully identifies them; an id list would be stored state the PRD explicitly excludes (no settlement history). Legacy pre-F03 both-set records also revert, which is the desired cleanup. |
+| Settlement date | `DateOnly.FromDateTime(DateTime.Today)` taken once per cascade in the service | Injected clock abstraction | No clock abstraction exists in the codebase; introducing one for a personal app violates the no-over-engineering rule. Tests assert the settled date equals today's date at assertion time. |
+| Outstanding total | Sum of the card/month's `CreditCardCharge` expenses (`PaymentStatus` filter); the `IsPaid → 0` short-circuit is removed | Keep the `IsPaid` short-circuit | Under the state model, settling zeroes the sum naturally (charges become settled); a charge added after settlement correctly shows as outstanding again. Matches PRD F02/F05 wording. Pre-F03 legacy both-set expenses are excluded (compute settled) — transitional until F03. |
+| Mark-paid contract | `POST .../mark-paid` gains a JSON body `{ "paymentSource": "..." }`, parsed via `PaymentSourceParser`; missing/blank/unknown → `ArgumentException` → 400 before any state change | Query-string parameter | Body matches every other write endpoint's convention; parser reuse keeps one enum-parsing path. Breaking API change is acceptable — the web app in this repo is the only client and is updated in the same feature. |
+| Idempotent no-ops | Mark-paid on an already-paid statement returns its DTO unchanged (no cascade, no save) even if the body's bank differs from the original settlement; unmark on an already-unpaid statement likewise | Rejecting repeats as 409 | PRD mandates no-op-with-confirmation semantics; the returned DTO is the confirmation. |
+| Cards panel controls | Each unpaid row gets a bank `<select>` (the 3 `PAYMENT_SOURCES`, empty default) next to Mark Paid, disabled until a bank is chosen; each paid row gets Unmark Paid guarded by `window.confirm` (multi-expense revert), matching the existing delete-confirmation convention | Defer all UI to F05 | The PRD puts this control UX in F02's own Experience section; without it the only client can't call the new contract. F05 consumes and keeps these controls. |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Application/DTOs/MarkStatementPaidDTO.cs` | New | Mark-paid request | `PaymentSource` (`string?`) — validated present + parseable in the service |
+| `Financial.CashFlow.Application/Interfaces/ICardStatementService.cs` | Modified | Contract | `MarkStatementPaidAsync(Guid id, MarkStatementPaidDTO request)`; new `UnmarkStatementPaidAsync(Guid id)` |
+| `Financial.CashFlow.Application/Services/CardStatementService.cs` | Modified | Cascades + totals | Validate bank before touching state; settle cascade (each card/month `CreditCardCharge` → `Settle(bank, today)`); unsettle cascade (each card/month `CreditCardSettled` → `Unsettle()`); single save with full rollback of statement + expenses on failure; `ToDto` outstanding = Σ `CreditCardCharge` for card/month |
+| `Financial.Api/Controllers/CardStatementsController.cs` | Modified | HTTP surface | `mark-paid` accepts body, catches `ArgumentException` → 400 (alongside existing 404); new `POST {id:guid}/unmark-paid` → 200 / 404 |
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/api/types.ts` | Modified | Contracts | `MarkCardStatementPaidDto { paymentSource: string }` |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | Client | `markCardStatementPaid(id, request)` posts the body; new `unmarkCardStatementPaid(id)` |
+| `Financial.Web/src/hooks/useMonthly.ts` | Modified | State | Per-statement selected-bank state (`markPaidSource` map or single pending selection keyed by statement id); `markStatementPaid(id, bank)`; `unmarkStatementPaid(id)` with `window.confirm`; both re-fetch month data on success (existing `RETRY` pattern) |
+| `Financial.Web/src/pages/MonthlyPage.tsx` | Modified | Cards panel | Unpaid row: bank `<select>` + Mark Paid disabled until selected; paid row: Unmark Paid button |
+
+## 5. API Contracts
+
+**`POST /api/v1/financial/card-statements/{id}/mark-paid`** (changed)
+
+Request body:
+```json
+{ "paymentSource": "Barclays" }
+```
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| `paymentSource` | `string` | Yes | one of `Barclays`/`Trading212`/`Chase` |
+
+- **200**: `CardStatementDTO` (`isPaid: true`, `outstandingTotal: 0` once charges settle). Already-paid → same 200, no changes (bank in body ignored).
+- **400**: missing/blank/unknown `paymentSource` — rejected before any expense or statement changes.
+- **404**: unknown statement id.
+- Side effect: every `CreditCardCharge` expense for that card/year/month becomes `CreditCardSettled` with that bank and today's date; expense reads then show `paymentSource`, `settledAt`, `paymentStatus: "CreditCardSettled"`.
+
+**`POST /api/v1/financial/card-statements/{id}/unmark-paid`** (new)
+
+- No body. **200**: `CardStatementDTO` (`isPaid: false`, outstanding reflecting reverted charges). Already-unpaid → same 200 no-op. **404**: unknown id.
+- Side effect: every `CreditCardSettled` expense for that card/year/month reverts to `CreditCardCharge` (`paymentSource`/`settledAt` null). No settled expenses → statement still flips to unpaid.
+
+Failure atomicity (both endpoints): a save failure leaves the statement flag and every expense exactly as before the request.
+
+## 6. Data Model
+
+No shape changes — F01's `Expense` fields (`PaymentSource`, `SettledAt`) and `CardStatement` are reused as-is. This feature only changes when those fields transition.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Tests/Financial.CashFlow.Application.Tests/Services/CardStatementServiceTests.cs` | Unit | `CardStatementService` | Mark-paid: missing/blank/unknown bank throws `ArgumentException` with no state change; valid bank settles every `CreditCardCharge` for card/month (bank + today's `SettledAt`, status `CreditCardSettled`) and leaves other cards/months untouched; already-paid → no-op DTO, no save call; save failure reverts statement and every cascaded expense; statement with no charges settles nothing but flips. Unmark: reverts every settled expense (fields null, status `CreditCardCharge`); already-unpaid → no-op; no settled expenses → still flips to unpaid; save failure reverts statement + expenses. Outstanding: sums only `CreditCardCharge` (settled and immediate excluded); charge added after settlement counts again |
+| `Tests/Financial.Api.Tests/CardStatementsEndpointsTests.cs` | Integration | endpoints | mark-paid without body/bank → 400; with bank → 200 and the month's expenses now read settled (`paymentStatus`, `settledAt`, `paymentSource`); unmark-paid → 200 and expenses read as charges again; unmark unknown id → 404; repeat mark/unmark → 200 no-ops |
+| `Financial.Web/src/hooks/useMonthly.test.ts` | Unit (vitest) | hook | `markStatementPaid(id, bank)` posts the body and re-fetches; `unmarkStatementPaid` asks for confirmation, posts, re-fetches; cancel skips the call; API error surfaces via existing error state |
+| `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` | Unit (vitest) | Cards panel | Unpaid row shows bank select + disabled Mark Paid until a bank is chosen; choosing a bank and clicking calls the client with `{ paymentSource }`; paid row shows Unmark Paid; clicking it (confirm accepted) calls unmark |
+
+**Acceptance tests (PRD Section 9, F02):**
+- Mark paid without `PaymentSource` rejected before any expense changes → service + endpoint tests
+- Mark paid with `PaymentSource` settles every charge with bank + today's date → service + endpoint tests
+- Unmark clears `PaymentSource`/`SettledAt` on every settled expense → service + endpoint tests
+- Save failure partway leaves statement + cascade unchanged → service tests (throwing stub repository)
+- Repeat mark/unmark are no-ops with confirmation, not errors → service + endpoint tests
+
+**Cross-Feature Integration criteria touching F02 (PRD Section 9):**
+- "F02's cascades correctly read/write F01's fields and reject actions violating F01's rule" → the cascades use only `Expense.Settle`/`Unsettle`, which enforce F01's invariant; covered by the service tests asserting resulting shapes and by `ExpenseTests` transition guards
+- Panel-refresh and F05-related boxes remain for F05

--- a/docs/prd/P12-prd-expense-credit-card-settlement/prd-expense-credit-card-settlement.md
+++ b/docs/prd/P12-prd-expense-credit-card-settlement/prd-expense-credit-card-settlement.md
@@ -237,11 +237,11 @@ graph TD
 - [x] Saving an expense whose `SettledAt` is inconsistent with its `PaymentSource`/`CardTag` combination is rejected with a validation message
 
 ### F02. Credit Card Statement Settlement with Payment Source
-- [ ] Marking a statement paid without a `PaymentSource` selected is rejected before any expense changes
-- [ ] Marking a statement paid with a `PaymentSource` selected sets that `PaymentSource` and today's date as `SettledAt` on every `CreditCardCharge` expense on that card/month, computing each to `CreditCardSettled`
-- [ ] Unmarking a paid statement clears `PaymentSource` and `SettledAt` on every `CreditCardSettled` expense on that card/month, computing each back to `CreditCardCharge`
-- [ ] A save failure partway through either cascade leaves the statement's paid/unpaid flag and every expense in that cascade unchanged from before the action
-- [ ] Marking an already-paid statement paid again, or unmarking an already-unpaid statement, is a no-op with a confirmation message, not an error
+- [x] Marking a statement paid without a `PaymentSource` selected is rejected before any expense changes
+- [x] Marking a statement paid with a `PaymentSource` selected sets that `PaymentSource` and today's date as `SettledAt` on every `CreditCardCharge` expense on that card/month, computing each to `CreditCardSettled`
+- [x] Unmarking a paid statement clears `PaymentSource` and `SettledAt` on every `CreditCardSettled` expense on that card/month, computing each back to `CreditCardCharge`
+- [x] A save failure partway through either cascade leaves the statement's paid/unpaid flag and every expense in that cascade unchanged from before the action
+- [x] Marking an already-paid statement paid again, or unmarking an already-unpaid statement, is a no-op with a confirmation message, not an error
 
 ### F03. Legacy Data Migration
 - [ ] Running the backfill script against `data-cashflow.json` leaves every expense with no `CardTag` unchanged (computing to `ImmediatePayment` with its existing `PaymentSource`)
@@ -265,7 +265,7 @@ graph TD
 - [ ] The Cards panel's "Mark Paid" control requires a bank selection before it can be confirmed, and a paid statement shows an "Unmark Paid" control
 
 ### Cross-Feature Integration
-- [ ] F02's mark-paid/unmark-paid cascades correctly read and write the `PaymentSource` and `SettledAt` fields defined by F01, and reject the action if the resulting `PaymentSource`/`CardTag`/`SettledAt` combination would violate F01's validation rule
+- [x] F02's mark-paid/unmark-paid cascades correctly read and write the `PaymentSource` and `SettledAt` fields defined by F01, and reject the action if the resulting `PaymentSource`/`CardTag`/`SettledAt` combination would violate F01's validation rule
 - [ ] F03's backfill correctly writes expenses into the `PaymentSource`/`CardTag`/`SettledAt` shape defined by F01, with zero resulting records violating F01's validation rule
 - [ ] F04's updated importer produces expenses in the `PaymentSource`/`CardTag` shape defined by F01, with zero imported card-tagged rows carrying a non-null `PaymentSource`
 - [ ] F05's Cards and Banks panels correctly reflect the field changes produced by F02's mark-paid/unmark-paid cascade immediately after each action


### PR DESCRIPTION
## Summary

Implements **F02 – Credit Card Statement Settlement with Payment Source** from the P12 PRD, per the committed spec/plan in `docs/P12-F02-credit-card-statement-settlement-with-payment-source/`.

- `POST /card-statements/{id}/mark-paid` now requires a body `{ "paymentSource": "Barclays|Trading212|Chase" }`; on success every `CreditCardCharge` expense for that card/month is settled via F01's `Expense.Settle(bank, today)` — stamping the paying bank and settlement date
- New `POST /card-statements/{id}/unmark-paid` endpoint reverses the cascade via `Expense.Unsettle()` (fields cleared back to null); works even when no settled expenses remain
- Both cascades are all-or-nothing: a save failure rolls back the statement flag and every touched expense; repeat mark/unmark calls are 200 no-ops
- Outstanding total now sums only `CreditCardCharge` expenses (the `IsPaid → 0` short-circuit is gone — settlement zeroes it naturally, and a charge added after settlement correctly counts again)
- Cards panel: unpaid rows get a bank picker with Mark Paid disabled until a bank is chosen; paid rows get an Unmark Paid button behind a confirmation

## Acceptance Criteria (PRD Section 9 — F02)

- [x] Marking a statement paid without a `PaymentSource` selected is rejected before any expense changes
- [x] Marking a statement paid with a `PaymentSource` selected sets that `PaymentSource` and today's date as `SettledAt` on every `CreditCardCharge` expense on that card/month, computing each to `CreditCardSettled`
- [x] Unmarking a paid statement clears `PaymentSource` and `SettledAt` on every `CreditCardSettled` expense on that card/month, computing each back to `CreditCardCharge`
- [x] A save failure partway through either cascade leaves the statement's paid/unpaid flag and every expense in that cascade unchanged from before the action
- [x] Marking an already-paid statement paid again, or unmarking an already-unpaid statement, is a no-op with a confirmation message, not an error

Cross-feature: the F01↔F02 integration criterion is checked in the PRD (cascades go exclusively through F01's `Settle`/`Unsettle` invariant-enforcing transitions).

## Test plan

- Full .NET suite: all 10 test projects green (application cascade tests incl. rollback via throwing stub; API round-trips asserting expense `paymentStatus`/`settledAt` through mark → unmark)
- Web: `tsc -b --noEmit` clean; vitest 545 passed (hook + Cards panel control tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)