### PR TITLE
feat(P12-F03): legacy data migration for expense payment states

### DIFF
--- a/Financial.slnx
+++ b/Financial.slnx
@@ -14,6 +14,7 @@
 		<Project Path="Financial.Shared.Infrastructure/Financial.Shared.Infrastructure.csproj" />
 	</Folder>
 	<Folder Name="/Integrations/">
+		<Project Path="Integrations/CashFlowPaymentStateMigration/CashFlowPaymentStateMigration.csproj" />
 		<Project Path="Integrations/CashFlowSpreadsheetImport/CashFlowSpreadsheetImport.csproj" />
 		<Project Path="Integrations/GoogleFinancialSupport/GoogleFinancialSupport.csproj" />
 		<Project Path="Integrations/ImportGoogleSpreadSheets/ImportGoogleSpreadSheets.csproj" />
@@ -30,6 +31,7 @@
 		<Project Path="Tests/Financial.CashFlow.Application.Tests/Financial.CashFlow.Application.Tests.csproj" />
 		<Project Path="Tests/Financial.CashFlow.Infrastructure.Tests/Financial.CashFlow.Infrastructure.Tests.csproj" />
 		<Project Path="Tests/Financial.CashFlowSpreadsheetImport.Tests/Financial.CashFlowSpreadsheetImport.Tests.csproj" />
+		<Project Path="Tests/Financial.CashFlowPaymentStateMigration.Tests/Financial.CashFlowPaymentStateMigration.Tests.csproj" />
 	</Folder>
 	<Folder Name="/Presentation/">
 		<Project Path="Financial.App/Financial.App.csproj" />

--- a/Integrations/CashFlowPaymentStateMigration/CashFlowPaymentStateMigration.csproj
+++ b/Integrations/CashFlowPaymentStateMigration/CashFlowPaymentStateMigration.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Financial.CashFlow.Infrastructure.Integrations.CashFlowPaymentStateMigration</RootNamespace>
+    <AssemblyName>Financial.CashFlow.Infrastructure.Integrations.CashFlowPaymentStateMigration</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Financial.CashFlow.Domain\Financial.CashFlow.Domain.csproj" />
+    <ProjectReference Include="..\..\Financial.CashFlow.Infrastructure\Financial.CashFlow.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\Financial.Shared.Infrastructure\Financial.Shared.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Integrations/CashFlowPaymentStateMigration/ExpensePaymentStateMigrator.cs
+++ b/Integrations/CashFlowPaymentStateMigration/ExpensePaymentStateMigrator.cs
@@ -1,0 +1,98 @@
+using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Domain.Enums;
+
+namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowPaymentStateMigration;
+
+/// <summary>
+/// Reclassifies every stored <see cref="Expense"/> into the F01 payment-state model using only
+/// the entity's own Settle/Unsettle transitions, so the result can never violate the domain
+/// invariant. Re-runnable: records already in a conforming shape are left untouched, including
+/// settled expenses whose real settlement date was recorded by the statement settlement flow.
+/// </summary>
+public static class ExpensePaymentStateMigrator
+{
+    public static MigrationSummary Migrate(CashFlowData data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        var summary = new MigrationSummary();
+        var paidStatements = data.CardStatements
+            .Where(s => s.IsPaid)
+            .ToDictionary(s => (s.Card, s.Year, s.Month));
+        var allStatements = data.CardStatements
+            .Select(s => (s.Card, s.Year, s.Month))
+            .ToHashSet();
+
+        foreach (var expense in data.Expenses)
+        {
+            MigrateExpense(expense, paidStatements, allStatements, summary);
+        }
+
+        return summary;
+    }
+
+    private static void MigrateExpense(
+        Expense expense,
+        IReadOnlyDictionary<(CreditCard, int, int), CardStatement> paidStatements,
+        IReadOnlySet<(CreditCard, int, int)> allStatements,
+        MigrationSummary summary)
+    {
+        if (expense.CardTag is null)
+        {
+            summary.CountImmediatePayment();
+            return;
+        }
+
+        var statementKey = (expense.CardTag.Value, expense.Date.Year, expense.Date.Month);
+        if (!allStatements.Contains(statementKey))
+        {
+            summary.FlagMissingStatement(expense);
+            ReclassifyAsCharge(expense, summary);
+            return;
+        }
+
+        if (paidStatements.ContainsKey(statementKey))
+        {
+            ReclassifyAsSettled(expense, summary);
+            return;
+        }
+
+        ReclassifyAsCharge(expense, summary);
+    }
+
+    private static void ReclassifyAsSettled(Expense expense, MigrationSummary summary)
+    {
+        if (expense.PaymentSource is null)
+        {
+            // Already a charge; the settling bank was never recorded, so there is nothing to infer.
+            summary.CountAlreadyCharge();
+            return;
+        }
+
+        if (expense.SettledAt is not null)
+        {
+            summary.CountAlreadySettled();
+            return;
+        }
+
+        var settlingBank = expense.PaymentSource.Value;
+        expense.Unsettle();
+        expense.Settle(settlingBank, LastDayOfMonth(expense.Date));
+        summary.CountNewlySettled();
+    }
+
+    private static void ReclassifyAsCharge(Expense expense, MigrationSummary summary)
+    {
+        if (expense.PaymentSource is null)
+        {
+            summary.CountAlreadyCharge();
+            return;
+        }
+
+        expense.Unsettle();
+        summary.CountNewlyCharge();
+    }
+
+    private static DateOnly LastDayOfMonth(DateOnly date) =>
+        new(date.Year, date.Month, DateTime.DaysInMonth(date.Year, date.Month));
+}

--- a/Integrations/CashFlowPaymentStateMigration/MigrationBackup.cs
+++ b/Integrations/CashFlowPaymentStateMigration/MigrationBackup.cs
@@ -1,0 +1,34 @@
+namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowPaymentStateMigration;
+
+/// <summary>
+/// Copies the data file to a timestamped sibling before the migration touches it,
+/// so a failed or interrupted run can always be recovered from.
+/// </summary>
+public static class MigrationBackup
+{
+    private const string BackupTimestampFormat = "yyyyMMdd-HHmmss";
+
+    public static string Create(string dataPath)
+    {
+        if (!File.Exists(dataPath))
+        {
+            throw new FileNotFoundException($"Data file not found at '{dataPath}'.", dataPath);
+        }
+
+        var directory = Path.GetDirectoryName(Path.GetFullPath(dataPath))!;
+        var name = Path.GetFileNameWithoutExtension(dataPath);
+        var extension = Path.GetExtension(dataPath);
+        var timestamp = DateTime.Now.ToString(BackupTimestampFormat);
+        var backupPath = Path.Combine(directory, $"{name}.backup-payment-state-{timestamp}{extension}");
+
+        var suffix = 1;
+        while (File.Exists(backupPath))
+        {
+            backupPath = Path.Combine(directory, $"{name}.backup-payment-state-{timestamp}-{suffix}{extension}");
+            suffix++;
+        }
+
+        File.Copy(dataPath, backupPath);
+        return backupPath;
+    }
+}

--- a/Integrations/CashFlowPaymentStateMigration/MigrationSummary.cs
+++ b/Integrations/CashFlowPaymentStateMigration/MigrationSummary.cs
@@ -1,0 +1,50 @@
+using System.Text;
+using Financial.CashFlow.Domain.Entities;
+
+namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowPaymentStateMigration;
+
+/// <summary>
+/// Outcome of one migration run: how many expenses ended in each payment state,
+/// plus the card-tagged expenses that had no matching statement and need manual review.
+/// </summary>
+public sealed class MigrationSummary
+{
+    private readonly List<Expense> _missingStatementExpenses = new();
+
+    public int ImmediatePaymentCount { get; private set; }
+    public int NewlySettledCount { get; private set; }
+    public int AlreadySettledCount { get; private set; }
+    public int NewlyChargeCount { get; private set; }
+    public int AlreadyChargeCount { get; private set; }
+
+    public IReadOnlyList<Expense> MissingStatementExpenses => _missingStatementExpenses;
+
+    public void CountImmediatePayment() => ImmediatePaymentCount++;
+    public void CountNewlySettled() => NewlySettledCount++;
+    public void CountAlreadySettled() => AlreadySettledCount++;
+    public void CountNewlyCharge() => NewlyChargeCount++;
+    public void CountAlreadyCharge() => AlreadyChargeCount++;
+
+    public void FlagMissingStatement(Expense expense) => _missingStatementExpenses.Add(expense);
+
+    public string Render()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Payment state migration summary");
+        builder.AppendLine($"  ImmediatePayment (untouched): {ImmediatePaymentCount}");
+        builder.AppendLine($"  CreditCardSettled: {NewlySettledCount} reclassified, {AlreadySettledCount} already conforming");
+        builder.AppendLine($"  CreditCardCharge: {NewlyChargeCount} reclassified, {AlreadyChargeCount} already conforming");
+
+        if (_missingStatementExpenses.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("Card-tagged expenses with no matching statement (treated as unpaid, review manually):");
+            foreach (var expense in _missingStatementExpenses)
+            {
+                builder.AppendLine($"  {expense.Id} {expense.Date:yyyy-MM-dd} '{expense.Description}' [{expense.CardTag}]");
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/Integrations/CashFlowPaymentStateMigration/Program.cs
+++ b/Integrations/CashFlowPaymentStateMigration/Program.cs
@@ -1,0 +1,31 @@
+using Financial.CashFlow.Infrastructure.Integrations.CashFlowPaymentStateMigration;
+using Financial.CashFlow.Infrastructure.Persistence;
+using Financial.CashFlow.Infrastructure.Repositories;
+using Financial.Shared.Infrastructure.Persistence;
+
+var dataPath = args.Length > 0
+    ? args[0]
+    : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "data", "data-cashflow.json"));
+
+if (!File.Exists(dataPath))
+{
+    Console.Error.WriteLine($"Data file not found at '{dataPath}'.");
+    return 1;
+}
+
+var backupPath = MigrationBackup.Create(dataPath);
+Console.WriteLine($"Backed up data file to '{backupPath}'.");
+
+var serializer = new CashFlowSerializerAdapter();
+var storage = new LocalJsonStorage(dataPath);
+var data = CashFlowLoader.LoadSync(storage, serializer);
+
+var summary = ExpensePaymentStateMigrator.Migrate(data);
+
+var repository = new CashFlowJsonRepository(data, storage, serializer);
+await repository.SaveChangesAsync();
+
+Console.WriteLine($"Wrote migrated data to '{dataPath}'.");
+Console.WriteLine();
+Console.WriteLine(summary.Render());
+return 0;

--- a/Tests/Financial.CashFlowPaymentStateMigration.Tests/ExpensePaymentStateMigratorTests.cs
+++ b/Tests/Financial.CashFlowPaymentStateMigration.Tests/ExpensePaymentStateMigratorTests.cs
@@ -1,0 +1,155 @@
+using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Domain.Enums;
+using Financial.CashFlow.Infrastructure.Integrations.CashFlowPaymentStateMigration;
+using FluentAssertions;
+
+namespace Financial.CashFlowPaymentStateMigration.Tests;
+
+public class ExpensePaymentStateMigratorTests
+{
+    private static CashFlowData DataWithStatement(CreditCard card, int year, int month, bool isPaid)
+    {
+        var data = CashFlowData.Create();
+        var statement = CardStatement.Create(card, year, month);
+        if (isPaid)
+        {
+            statement.MarkPaid();
+        }
+
+        data.AddCardStatement(statement);
+        return data;
+    }
+
+    private static Expense LegacyCardExpense(CashFlowData data, PaymentSource bank, CreditCard card, DateOnly date)
+    {
+        // Legacy records carry both a bank and a card tag; that shape can no longer be produced
+        // through Expense.Create, so build it the way deserialization does: charge + settle.
+        var expense = Expense.Create(date, "Legacy", 30m, Category.Mercado, null, card);
+        expense.Settle(bank, date);
+        typeof(Expense).GetProperty(nameof(Expense.SettledAt))!
+            .SetMethod!.Invoke(expense, new object?[] { null });
+        return AddExpense(data, expense);
+    }
+
+    private static Expense AddExpense(CashFlowData data, Expense expense)
+    {
+        data.AddExpense(expense);
+        return expense;
+    }
+
+    [Fact]
+    public void Migrate_ExpenseWithoutCardTag_IsLeftUntouched()
+    {
+        var data = CashFlowData.Create();
+        var expense = AddExpense(data, Expense.Create(new DateOnly(2026, 5, 10), "Groceries", 20m, Category.Mercado, PaymentSource.Barclays, null));
+
+        var summary = ExpensePaymentStateMigrator.Migrate(data);
+
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.ImmediatePayment);
+        expense.PaymentSource.Should().Be(PaymentSource.Barclays);
+        expense.SettledAt.Should().BeNull();
+        summary.ImmediatePaymentCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Migrate_LegacyCardExpenseWithPaidStatement_BecomesSettledWithMonthEndDate()
+    {
+        var data = DataWithStatement(CreditCard.ChaseMaster4023, 2026, 2, isPaid: true);
+        var expense = LegacyCardExpense(data, PaymentSource.Chase, CreditCard.ChaseMaster4023, new DateOnly(2026, 2, 10));
+
+        var summary = ExpensePaymentStateMigrator.Migrate(data);
+
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardSettled);
+        expense.PaymentSource.Should().Be(PaymentSource.Chase);
+        expense.SettledAt.Should().Be(new DateOnly(2026, 2, 28));
+        expense.CardTag.Should().Be(CreditCard.ChaseMaster4023);
+        summary.NewlySettledCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Migrate_SettledExpenseWithRealSettlementDate_IsLeftUntouched()
+    {
+        var data = DataWithStatement(CreditCard.BaAmex, 2026, 7, isPaid: true);
+        var expense = AddExpense(data, Expense.Create(new DateOnly(2026, 7, 5), "Settled via F02", 10m, Category.Extras, null, CreditCard.BaAmex));
+        expense.Settle(PaymentSource.Trading212, new DateOnly(2026, 7, 24));
+
+        var summary = ExpensePaymentStateMigrator.Migrate(data);
+
+        expense.SettledAt.Should().Be(new DateOnly(2026, 7, 24));
+        expense.PaymentSource.Should().Be(PaymentSource.Trading212);
+        summary.AlreadySettledCount.Should().Be(1);
+        summary.NewlySettledCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Migrate_LegacyCardExpenseWithUnpaidStatement_BecomesChargeWithClearedBank()
+    {
+        var data = DataWithStatement(CreditCard.BarclaysPlatinumVisa8003, 2026, 3, isPaid: false);
+        var expense = LegacyCardExpense(data, PaymentSource.Barclays, CreditCard.BarclaysPlatinumVisa8003, new DateOnly(2026, 3, 15));
+
+        var summary = ExpensePaymentStateMigrator.Migrate(data);
+
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+        expense.PaymentSource.Should().BeNull();
+        expense.SettledAt.Should().BeNull();
+        expense.CardTag.Should().Be(CreditCard.BarclaysPlatinumVisa8003);
+        summary.NewlyChargeCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Migrate_LegacyCardExpenseWithNoMatchingStatement_BecomesChargeAndIsFlaggedForReview()
+    {
+        var data = CashFlowData.Create();
+        var expense = LegacyCardExpense(data, PaymentSource.Barclays, CreditCard.PaypalCredit, new DateOnly(2026, 4, 15));
+
+        var summary = ExpensePaymentStateMigrator.Migrate(data);
+
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+        expense.PaymentSource.Should().BeNull();
+        summary.NewlyChargeCount.Should().Be(1);
+        summary.MissingStatementExpenses.Should().ContainSingle().Which.Id.Should().Be(expense.Id);
+    }
+
+    [Fact]
+    public void Migrate_ChargeWithNullBankAndPaidStatement_IsLeftAsChargeSinceNoBankIsKnown()
+    {
+        var data = DataWithStatement(CreditCard.BaAmex, 2026, 6, isPaid: true);
+        var expense = AddExpense(data, Expense.Create(new DateOnly(2026, 6, 5), "Charge", 10m, Category.Extras, null, CreditCard.BaAmex));
+
+        var summary = ExpensePaymentStateMigrator.Migrate(data);
+
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+        expense.PaymentSource.Should().BeNull();
+        summary.AlreadyChargeCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Migrate_SecondRunOverFirstRunsOutput_ChangesNothing()
+    {
+        var data = DataWithStatement(CreditCard.ChaseMaster4023, 2026, 2, isPaid: true);
+        var paidExpense = LegacyCardExpense(data, PaymentSource.Chase, CreditCard.ChaseMaster4023, new DateOnly(2026, 2, 10));
+        var unpaidData = CardStatement.Create(CreditCard.BaAmex, 2026, 2);
+        data.AddCardStatement(unpaidData);
+        var unpaidExpense = LegacyCardExpense(data, PaymentSource.Barclays, CreditCard.BaAmex, new DateOnly(2026, 2, 12));
+        var immediate = AddExpense(data, Expense.Create(new DateOnly(2026, 2, 14), "Immediate", 5m, Category.Casa, PaymentSource.Trading212, null));
+
+        ExpensePaymentStateMigrator.Migrate(data);
+        var afterFirst = data.Expenses
+            .Select(e => (e.Id, e.PaymentSource, e.CardTag, e.SettledAt, e.PaymentStatus))
+            .ToList();
+
+        var secondSummary = ExpensePaymentStateMigrator.Migrate(data);
+
+        data.Expenses
+            .Select(e => (e.Id, e.PaymentSource, e.CardTag, e.SettledAt, e.PaymentStatus))
+            .Should().Equal(afterFirst);
+        secondSummary.NewlySettledCount.Should().Be(0);
+        secondSummary.NewlyChargeCount.Should().Be(0);
+        secondSummary.AlreadySettledCount.Should().Be(1);
+        secondSummary.AlreadyChargeCount.Should().Be(1);
+        secondSummary.ImmediatePaymentCount.Should().Be(1);
+        immediate.PaymentStatus.Should().Be(ExpensePaymentStatus.ImmediatePayment);
+        paidExpense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardSettled);
+        unpaidExpense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+    }
+}

--- a/Tests/Financial.CashFlowPaymentStateMigration.Tests/Financial.CashFlowPaymentStateMigration.Tests.csproj
+++ b/Tests/Financial.CashFlowPaymentStateMigration.Tests/Financial.CashFlowPaymentStateMigration.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Integrations\CashFlowPaymentStateMigration\CashFlowPaymentStateMigration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Financial.CashFlowPaymentStateMigration.Tests/MigrationBackupTests.cs
+++ b/Tests/Financial.CashFlowPaymentStateMigration.Tests/MigrationBackupTests.cs
@@ -1,0 +1,61 @@
+using Financial.CashFlow.Infrastructure.Integrations.CashFlowPaymentStateMigration;
+using FluentAssertions;
+
+namespace Financial.CashFlowPaymentStateMigration.Tests;
+
+public class MigrationBackupTests
+{
+    [Fact]
+    public void Create_CopiesTheDataFileToATimestampedSibling()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dataPath = Path.Combine(directory.FullName, "data-cashflow.json");
+            File.WriteAllText(dataPath, "{\"Expenses\":[]}");
+
+            var backupPath = MigrationBackup.Create(dataPath);
+
+            File.Exists(backupPath).Should().BeTrue();
+            Path.GetDirectoryName(backupPath).Should().Be(directory.FullName);
+            Path.GetFileName(backupPath).Should().StartWith("data-cashflow.backup-payment-state-").And.EndWith(".json");
+            File.ReadAllText(backupPath).Should().Be("{\"Expenses\":[]}");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Create_CalledTwice_ProducesDistinctBackups()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dataPath = Path.Combine(directory.FullName, "data-cashflow.json");
+            File.WriteAllText(dataPath, "{}");
+
+            var first = MigrationBackup.Create(dataPath);
+            var second = MigrationBackup.Create(dataPath);
+
+            second.Should().NotBe(first);
+            File.Exists(first).Should().BeTrue();
+            File.Exists(second).Should().BeTrue();
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Create_WhenSourceMissing_Throws()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.json");
+
+        var act = () => MigrationBackup.Create(missingPath);
+
+        act.Should().Throw<FileNotFoundException>();
+    }
+}

--- a/docs/P12-F03-legacy-data-migration/plan.md
+++ b/docs/P12-F03-legacy-data-migration/plan.md
@@ -1,0 +1,17 @@
+# Implementation Plan: F03. Legacy Data Migration
+
+**Prerequisites:**
+- F01 merged (`Settle`/`Unsettle` transitions available); F02 merged (real settlement dates may exist and must be preserved)
+- .NET SDK; no new packages
+
+### Stage 1: Migration Core
+
+**1. Console project scaffold** - Create the migration console project under Integrations mirroring the spreadsheet importer's project shape, and register it plus its test project in the solution file. See spec Section 4.
+
+**2. Migrator and summary** - Implement the classification rules over the loaded data aggregate using only the domain's settle/unsettle transitions, producing the per-state summary with the manual-review list. See spec Section 3 for the rule decisions.
+
+### Stage 2: Console Entry Point
+
+**3. Backup helper and program flow** - Implement the timestamped backup helper and the entry point: resolve the data path, back up, load, migrate, save, and print the summary. See spec Sections 3 (Backup discipline) and 4.
+
+**4. Full-solution verification** - Run the complete .NET test suite and exercise the tool end-to-end against a copy of the live data file, confirming the summary and the resulting file shape.

--- a/docs/P12-F03-legacy-data-migration/spec.md
+++ b/docs/P12-F03-legacy-data-migration/spec.md
@@ -1,0 +1,85 @@
+# F03. Legacy Data Migration
+
+## 1. Technical Overview
+
+**What:** A one-time console tool that reclassifies every `Expense` in the live `data-cashflow.json` into F01's payment-state model: expenses with no card tag are left alone; card-tagged expenses whose statement is paid become `CreditCardSettled` (keeping their stored bank, defaulting `SettledAt` to the statement month's last day); card-tagged expenses whose statement is unpaid (or missing) become `CreditCardCharge` (bank cleared). The tool backs up the data file before writing and prints a per-state summary.
+
+**Why:** Every record stored before F01 carries the old conflated shape (card-tagged expenses also have a bank tag), which violates F01's invariant and — until reclassified — is excluded from F02's outstanding totals and double-counted by the Banks panel. A file-level backfill (not a re-import) preserves expenses entered directly in the app since go-live.
+
+**Scope:**
+- Included: new console project `Integrations/CashFlowPaymentStateMigration` mirroring the spreadsheet importer's structure; a pure, testable `ExpensePaymentStateMigrator` operating on `CashFlowData`; a timestamped file backup before any write; a run summary with per-state counts and a manual-review list for card-tagged expenses lacking a matching statement; a new test project registered in `Financial.slnx`.
+- Excluded: any API/UI surface; importer changes (F04); automatic or scheduled execution — this is a manual, one-time run (re-runnable safely).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Integrations/CashFlowPaymentStateMigration/CashFlowPaymentStateMigration.csproj` — new console project (references CashFlow Domain/Infrastructure + Shared Infrastructure)
+- `Integrations/CashFlowPaymentStateMigration/Program.cs` — CLI entry point: resolve path, backup, load, migrate, save, print summary
+- `Integrations/CashFlowPaymentStateMigration/ExpensePaymentStateMigrator.cs` — the 3 classification rules over `CashFlowData`, returning a `MigrationSummary`
+- `Integrations/CashFlowPaymentStateMigration/MigrationSummary.cs` — per-state counts + review list + `Render()`
+- `Tests/Financial.CashFlowPaymentStateMigration.Tests/` — new xUnit project
+- `Financial.slnx` — registers both new projects
+
+```mermaid
+graph TD
+  A["Program.cs (console)"] --> B["File backup (timestamped copy)"]
+  A --> C["CashFlowLoader.LoadSync + LocalJsonStorage"]
+  A --> D[ExpensePaymentStateMigrator]
+  D --> E["CashFlowData.Expenses + CardStatements"]
+  D --> F["Expense.Settle / Unsettle (F01 transitions)"]
+  A --> G["CashFlowJsonRepository.SaveChangesAsync"]
+  A --> H["MigrationSummary.Render()"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Tool location | Separate console project under `Integrations/`, exactly mirroring `CashFlowSpreadsheetImport` (Program.cs + logic classes + sibling test project) | A `--migrate-payment-state` flag on the existing import tool | The importer rebuilds data from the spreadsheet; the migrator must never touch the spreadsheet. Separate tools keep one responsibility each and the existing precedent makes the layout obvious. |
+| Mutation mechanism | Only F01's public entity transitions: rule "paid statement, `SettledAt` null" runs `Unsettle()` then `Settle(storedBank, lastDayOfMonth)`; rule "unpaid/missing statement" runs `Unsettle()`; everything else is untouched | Reflection or a resolver-style private-setter write | Going through `Settle`/`Unsettle` makes it impossible for the migration to produce a shape violating F01's invariant (the PRD's cross-feature criterion), at zero extra code. |
+| Idempotency vs. real settlement dates | A card-tagged expense whose statement is paid and whose `SettledAt` is **already set** is left untouched (counted as already-settled) | Always re-default `SettledAt` to the month's last day | Re-running after F02 has recorded real settlement dates must not overwrite them with the artificial month-end default; skipping when `SettledAt` is present keeps runs idempotent *and* preserves genuine dates. |
+| Card-tagged, bank already null | Already `CreditCardCharge` — left untouched regardless of statement state (counted as already-charge); no bank exists to infer a settlement from | Flag as error | This is exactly the shape a second run (or a post-F01 app entry) produces; treating it as already-migrated is what makes the run idempotent. |
+| Missing statement record | Defensive: treated as unpaid → `CreditCardCharge`, and the expense (id, date, description, card) is listed in the summary for manual review | Failing the run | PRD prescribes this handling; `CardStatementService` lazily creates statements so the case should not occur, but the file is hand-editable. |
+| Backup discipline | `Program.cs` copies the data file to `<name>.backup-payment-state-<yyyyMMdd-HHmmss>.json` beside it before loading; backup failure aborts the run before any write | Reuse `LocalJsonStorage` (no backup support) | Matches the ad-hoc backup naming already present in `/data`; the backup exists even if the migration then fails partway (PRD AC). Backup creation is a small static helper (`MigrationBackup.Create`) so it is unit-testable with temp files. |
+
+## 4. Component Overview
+
+**Backend (all new):**
+
+| File Path | Purpose | Key Responsibilities |
+|-----------|---------|-----------------------|
+| `Integrations/CashFlowPaymentStateMigration/CashFlowPaymentStateMigration.csproj` | Console project | `net10.0` exe; RootNamespace `Financial.CashFlow.Infrastructure.Integrations.CashFlowPaymentStateMigration`; references CashFlow Domain, CashFlow Infrastructure, Shared Infrastructure |
+| `.../Program.cs` | Entry point | Args: `[dataPath]` (default = the importer's relative `data/data-cashflow.json` resolution); abort with error if file missing; `MigrationBackup.Create`; `CashFlowLoader.LoadSync`; run migrator; `CashFlowJsonRepository.SaveChangesAsync`; print `MigrationSummary.Render()`; exit 0/1 |
+| `.../MigrationBackup.cs` | Backup helper | Static `Create(dataPath)` → copies to timestamped sibling, returns backup path |
+| `.../ExpensePaymentStateMigrator.cs` | Classification rules | Static `Migrate(CashFlowData data)` → `MigrationSummary`; statement lookup by (card, year, month); applies the decisions in Section 3 via `Settle`/`Unsettle` only; never touches `CardTag` or non-payment fields |
+| `.../MigrationSummary.cs` | Run report | Counts: immediate (untouched), settled (newly + already), charges (newly cleared + already), missing-statement review list; `Render()` string |
+| `Tests/Financial.CashFlowPaymentStateMigration.Tests/Financial.CashFlowPaymentStateMigration.Tests.csproj` | Test project | Same package set as the importer tests; references the console project |
+| `Tests/.../ExpensePaymentStateMigratorTests.cs`, `MigrationBackupTests.cs` | Unit tests | See Section 7 |
+| `Financial.slnx` | Solution | Registers console + test projects in the existing Integrations/Tests folders |
+
+## 5. API Contracts
+
+None — console tool only. Invocation: `dotnet run --project Integrations/CashFlowPaymentStateMigration [path\to\data-cashflow.json]`.
+
+## 6. Data Model
+
+No shape change. Only `PaymentSource` and `SettledAt` values on existing expense records are modified (per Section 3); `CardTag`, ids, dates, descriptions, values, categories, and every other collection in `data-cashflow.json` are byte-for-byte preserved except for serializer formatting. The backup file `data-cashflow.backup-payment-state-<timestamp>.json` is created beside the data file.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Tests/Financial.CashFlowPaymentStateMigration.Tests/ExpensePaymentStateMigratorTests.cs` | Unit | Migrator | No-card expense untouched (fields + count); card + paid statement + bank → settled with month-end `SettledAt`, bank kept; card + paid statement + `SettledAt` already set → untouched (real date preserved); card + unpaid statement → bank and `SettledAt` cleared to charge; card + no matching statement → charge + listed in review list; card + bank already null → untouched, counted as charge; second run over first run's output changes nothing (idempotency, asserted field-by-field); `CardTag` never modified; summary counts match each scenario |
+| `Tests/Financial.CashFlowPaymentStateMigration.Tests/MigrationBackupTests.cs` | Unit | Backup helper | Creates a timestamped copy with identical content beside the source; distinct name per call; throws when source missing |
+
+**Acceptance tests (PRD Section 9, F03):**
+- No-`CardTag` expenses unchanged → migrator tests
+- Card + `IsPaid == true` keeps bank, `SettledAt` = month's last day → migrator tests
+- Card + `IsPaid == false` clears bank → migrator tests
+- Second run idempotent → migrator tests
+- Backup exists independent of run outcome → backup helper test + Program order (backup before load/write); the failure-path half is by construction (backup is the first side effect)
+- No status field written; only `PaymentSource`/`SettledAt` change; `CardTag` untouched → migrator tests + F01's serializer (status is a computed property, never serialized — covered by existing `CashFlowSerializerAdapterTests`)
+
+**Cross-Feature Integration criteria touching F03 (PRD Section 9):**
+- "F03's backfill writes expenses into F01's shape with zero violations" → structurally guaranteed (only `Settle`/`Unsettle` are used); asserted via resulting `PaymentStatus` in every migrator test
+- "The computed payment status is derived identically everywhere" → the migrator has no derivation of its own; it reads `Expense.PaymentStatus`

--- a/docs/prd/P12-prd-expense-credit-card-settlement/prd-expense-credit-card-settlement.md
+++ b/docs/prd/P12-prd-expense-credit-card-settlement/prd-expense-credit-card-settlement.md
@@ -244,12 +244,12 @@ graph TD
 - [x] Marking an already-paid statement paid again, or unmarking an already-unpaid statement, is a no-op with a confirmation message, not an error
 
 ### F03. Legacy Data Migration
-- [ ] Running the backfill script against `data-cashflow.json` leaves every expense with no `CardTag` unchanged (computing to `ImmediatePayment` with its existing `PaymentSource`)
-- [ ] Every expense with a `CardTag` whose matching statement is `IsPaid == true` keeps its existing `PaymentSource` and gets `SettledAt` defaulted to that statement month's last day, computing to `CreditCardSettled`
-- [ ] Every expense with a `CardTag` whose matching statement is `IsPaid == false` has `PaymentSource` cleared to null, computing to `CreditCardCharge`
-- [ ] Running the script a second time against its own output produces the same result as the first run (idempotent)
-- [ ] A backup of the pre-migration file exists after the run, independent of whether the run succeeded or failed partway through
-- [ ] No status field is added to `data-cashflow.json`'s expense records — only `PaymentSource` and `SettledAt` values change; `CardTag` is untouched
+- [x] Running the backfill script against `data-cashflow.json` leaves every expense with no `CardTag` unchanged (computing to `ImmediatePayment` with its existing `PaymentSource`)
+- [x] Every expense with a `CardTag` whose matching statement is `IsPaid == true` keeps its existing `PaymentSource` and gets `SettledAt` defaulted to that statement month's last day, computing to `CreditCardSettled`
+- [x] Every expense with a `CardTag` whose matching statement is `IsPaid == false` has `PaymentSource` cleared to null, computing to `CreditCardCharge`
+- [x] Running the script a second time against its own output produces the same result as the first run (idempotent)
+- [x] A backup of the pre-migration file exists after the run, independent of whether the run succeeded or failed partway through
+- [x] No status field is added to `data-cashflow.json`'s expense records — only `PaymentSource` and `SettledAt` values change; `CardTag` is untouched
 
 ### F04. Historical Import Update
 - [ ] A row that resolves a `CreditCard` tag during import produces an expense with that `CardTag` set and `PaymentSource = null`, regardless of its column-E value
@@ -266,7 +266,7 @@ graph TD
 
 ### Cross-Feature Integration
 - [x] F02's mark-paid/unmark-paid cascades correctly read and write the `PaymentSource` and `SettledAt` fields defined by F01, and reject the action if the resulting `PaymentSource`/`CardTag`/`SettledAt` combination would violate F01's validation rule
-- [ ] F03's backfill correctly writes expenses into the `PaymentSource`/`CardTag`/`SettledAt` shape defined by F01, with zero resulting records violating F01's validation rule
+- [x] F03's backfill correctly writes expenses into the `PaymentSource`/`CardTag`/`SettledAt` shape defined by F01, with zero resulting records violating F01's validation rule
 - [ ] F04's updated importer produces expenses in the `PaymentSource`/`CardTag` shape defined by F01, with zero imported card-tagged rows carrying a non-null `PaymentSource`
 - [ ] F05's Cards and Banks panels correctly reflect the field changes produced by F02's mark-paid/unmark-paid cascade immediately after each action
 - [ ] F05's expense form correctly enforces F01's validation rule for both create and edit, with no path in the UI that can produce a rejected combination


### PR DESCRIPTION
## Summary

Implements **F03 – Legacy Data Migration** from the P12 PRD, per the committed spec/plan in `docs/P12-F03-legacy-data-migration/`.

- New console tool `Integrations/CashFlowPaymentStateMigration` (mirrors the spreadsheet importer's layout) that reclassifies every stored expense into F01's payment-state model, mutating **only** through `Expense.Settle`/`Unsettle` — so the output cannot violate the domain invariant
- Rules: no card tag → untouched; card + paid statement → keeps its stored bank, `SettledAt` defaults to the statement month's last day; card + unpaid or missing statement → bank cleared to a `CreditCardCharge` (missing-statement cases are listed in the summary for manual review)
- Idempotent: already-conforming records (including F02-settled expenses with real settlement dates) are never touched; a second run reports zero reclassifications
- A timestamped backup (`data-cashflow.backup-payment-state-<ts>.json`) is written beside the data file before anything is loaded

**Note:** this PR only ships the tool. The actual one-time run against the live `data/data-cashflow.json` is yours to trigger after merge:
`dotnet run --project Integrations/CashFlowPaymentStateMigration` (then restart the container — data.json loads once at startup). Smoke-tested here against a copy of the live file: 13,704 immediate expenses untouched, card rows reclassified, re-run idempotent.

## Acceptance Criteria (PRD Section 9 — F03)

- [x] Running the backfill script against `data-cashflow.json` leaves every expense with no `CardTag` unchanged (computing to `ImmediatePayment` with its existing `PaymentSource`)
- [x] Every expense with a `CardTag` whose matching statement is `IsPaid == true` keeps its existing `PaymentSource` and gets `SettledAt` defaulted to that statement month's last day, computing to `CreditCardSettled`
- [x] Every expense with a `CardTag` whose matching statement is `IsPaid == false` has `PaymentSource` cleared to null, computing to `CreditCardCharge`
- [x] Running the script a second time against its own output produces the same result as the first run (idempotent)
- [x] A backup of the pre-migration file exists after the run, independent of whether the run succeeded or failed partway through
- [x] No status field is added to `data-cashflow.json`'s expense records — only `PaymentSource` and `SettledAt` values change; `CardTag` is untouched

Cross-feature: the F01↔F03 integration criterion is checked in the PRD (migrator writes only via F01's invariant-enforcing transitions).

## Test plan

- New `Financial.CashFlowPaymentStateMigration.Tests`: 10 tests covering all 3 rules, idempotency, missing-statement review flagging, real-settlement-date preservation, and the backup helper
- Full .NET suite: all 11 test projects green
- End-to-end smoke run (twice) against a copy of the live data file

🤖 Generated with [Claude Code](https://claude.com/claude-code)