### PR TITLE
feat(P12-F04): historical import emits expense payment-state shape

### DIFF
--- a/Integrations/CashFlowSpreadsheetImport/SheetImporters/MonthlyExpenseSheetImporter.cs
+++ b/Integrations/CashFlowSpreadsheetImport/SheetImporters/MonthlyExpenseSheetImporter.cs
@@ -15,7 +15,10 @@ namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowSpreadsheetImpo
 /// card charges into sections that each start at a known row number (see
 /// <see cref="CardSectionStartRows"/>), so rows in those months are tagged by row position - but
 /// only when column E has no explicit "T"/"C" payment-source tag, which still takes precedence
-/// when present.
+/// when present (column E never identifies a card; an explicit tag means the row was paid
+/// directly from that bank). A row that does resolve a card tag imports as an unsettled
+/// credit card charge - <see cref="Expense.PaymentSource"/> stays null - and settlement is
+/// applied afterward in-app by marking the card statement paid, never inferred by the import.
 /// </summary>
 public static class MonthlyExpenseSheetImporter
 {

--- a/Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/MonthlyExpenseSheetImporterTests.cs
+++ b/Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/MonthlyExpenseSheetImporterTests.cs
@@ -221,6 +221,31 @@ public class MonthlyExpenseSheetImporterTests
         expense.CardTag.Should().BeNull();
     }
 
+    [Fact]
+    public void Import_MixedSheet_NoExpenseEverCarriesBothPaymentSourceAndCardTag()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Jul2026");
+        WriteExpenseRow(sheet, row: 10, paymentSourceTag: null);
+        WriteExpenseRow(sheet, row: 11, paymentSourceTag: "T");
+        WriteExpenseRow(sheet, row: 130, paymentSourceTag: null);
+        WriteExpenseRow(sheet, row: 150, paymentSourceTag: "C");
+        WriteExpenseRow(sheet, row: 210, paymentSourceTag: null);
+        WriteExpenseRow(sheet, row: 230, paymentSourceTag: null);
+
+        var report = new ImportReport();
+
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, report);
+
+        expenses.Should().HaveCount(6);
+        expenses.Should().NotContain(e => e.PaymentSource != null && e.CardTag != null);
+        expenses.Should().OnlyContain(e => e.SettledAt == null);
+        expenses.Should().OnlyContain(e =>
+            e.PaymentStatus == ExpensePaymentStatus.ImmediatePayment
+            || e.PaymentStatus == ExpensePaymentStatus.CreditCardCharge);
+        expenses.Count(e => e.PaymentStatus == ExpensePaymentStatus.CreditCardCharge).Should().Be(3);
+    }
+
     [Theory]
     [InlineData(2017, 10)]
     [InlineData(2026, 9)]

--- a/docs/P12-F04-historical-import-update/plan.md
+++ b/docs/P12-F04-historical-import-update/plan.md
@@ -1,0 +1,13 @@
+# Implementation Plan: F04. Historical Import Update
+
+**Prerequisites:**
+- F01 merged (importer already emits the new shape; entity invariant active)
+- .NET SDK; no new packages
+
+### Stage 1: Verification and Documentation
+
+**1. Importer documentation** - Update the importer's documentation comment to describe the payment-state output shape (card rows import as unsettled charges; settlement is applied in-app afterward). See spec Section 4.
+
+**2. Acceptance-criteria tests** - Add the importer-level tests covering the column-E precedence case and the whole-sheet guarantee that no imported expense carries both a bank and a card tag. See spec Section 7.
+
+**3. Full-solution verification** - Run the complete .NET test suite to confirm everything stays green.

--- a/docs/P12-F04-historical-import-update/spec.md
+++ b/docs/P12-F04-historical-import-update/spec.md
@@ -1,0 +1,65 @@
+# F04. Historical Import Update
+
+## 1. Technical Overview
+
+**What:** Lock in the importer's payment-state rule: a row that resolves a `CreditCard` tag (the fixed-row-section heuristic, active only when its column E is blank) imports as a `CreditCardCharge` — card tag set, `PaymentSource = null`; every other row keeps resolving `PaymentSource` from column E exactly as before (blank → Barclays, "T" → Trading212, "C" → Chase). No row can import with both fields set. Settlement of imported months is applied afterward in-app via F02, never guessed by the importer.
+
+**Why:** F01's wave already applied the minimal code change to `MonthlyExpenseSheetImporter` (a resolved card tag forces a null bank) because the new entity invariant would otherwise have thrown mid-wave. F04 is where the PRD houses this behavior, so this feature verifies it against the PRD's acceptance criteria with explicit importer-level tests, and updates the importer's documentation comment (which still describes the pre-P12 conflated shape via its F10 reference).
+
+**Scope:**
+- Included: importer doc-comment update; explicit AC tests — card-section rows import with null `PaymentSource` regardless of column E's content for the row (blank → card tag by position + null bank; non-blank T/C → no card tag, bank from the tag, unchanged precedence per the cashflow context: column E never identifies a card, an explicit tag means the row was paid directly); a whole-sheet assertion that no imported expense ever carries both fields.
+- Excluded: any change to the precedence rule itself, to `MonthsWithFixedCardSections`, or to the section row map — the source spreadsheet is unchanged; the F03 migration (already shipped); UI (F05).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Integrations/CashFlowSpreadsheetImport/SheetImporters/MonthlyExpenseSheetImporter.cs` — doc comment only (logic landed with F01)
+- `Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/MonthlyExpenseSheetImporterTests.cs` — AC-level tests
+
+```mermaid
+graph TD
+  A["Despesas.xlsx monthly sheet"] --> B[MonthlyExpenseSheetImporter]
+  B --> C{"card tag resolved? (blank column E + fixed-section row)"}
+  C -->|yes| D["Expense: CardTag set, PaymentSource null (CreditCardCharge)"]
+  C -->|no| E["Expense: PaymentSource from column E (ImmediatePayment)"]
+  D -.-> F["F02 mark-paid in-app, when confirmed"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Column-E precedence | Unchanged: an explicit "T"/"C" in a card-section row still suppresses the card tag and resolves that bank | Let the fixed-row section override column E | The cashflow context is explicit that column E never identifies a card and blank/T/C is the only transaction-level payment detail; an explicit tag inside a card section means the row was actually paid directly from that bank. The PRD's "regardless of column-E value" governs the resolved-card case (no defaulted Barclays leaking in), which is what the code does. |
+| Where the logic lives | Already in `MonthlyExpenseSheetImporter` since F01 (accommodation); F04 adds the AC-level tests and corrects the stale doc comment | Re-implement/move the rule | The rule is one expression; duplicating or relocating it would add nothing. The PRD's per-feature traceability is preserved through the tests added here. |
+| "No both-fields row" guarantee | Asserted by a sheet-level test and enforced structurally — `Expense.Create` throws on the both-set shape, so a violating importer build cannot pass any import test | Post-import scan in the importer | The F01 invariant already makes the state unrepresentable; a runtime scan would be dead code. |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `.../SheetImporters/MonthlyExpenseSheetImporter.cs` | Modified (comment) | Document the payment-state output shape | Doc comment states card rows import as unsettled charges with no bank, settlement applied in-app via F02 |
+| `Tests/.../MonthlyExpenseSheetImporterTests.cs` | Modified | AC coverage | Card-section row with blank column E → card tag + null `PaymentSource`; card-section row with "T"/"C" → no card tag + that bank (precedence unchanged); non-section months unchanged; mixed sheet → zero expenses with both fields set |
+
+## 5. API Contracts
+
+None — console import tool only.
+
+## 6. Data Model
+
+No change; the importer emits F01's expense shape (`PaymentSource` null on card-tagged rows, `SettledAt` never set by import).
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/MonthlyExpenseSheetImporterTests.cs` | Unit | Importer | (Existing, from F01) card-section rows → null bank; (new) explicit T/C in a card-section row still yields bank + no card; (new) whole-sheet mixed fixture — card rows, T/C rows, blank rows — imports with zero both-fields expenses and every row computing to `ImmediatePayment` or `CreditCardCharge` only |
+
+**Acceptance tests (PRD Section 9, F04):**
+- Row resolving a card tag → `CardTag` set + `PaymentSource = null` regardless of column E → existing F01 theory (card rows) + new precedence test documenting the non-blank case
+- Row with no resolved card tag → `PaymentSource` from column E exactly as before → existing resolution tests + new precedence test
+- No row imported with both fields set → new mixed-sheet test (+ structural guarantee via F01's invariant)
+
+**Cross-Feature Integration criteria touching F04 (PRD Section 9):**
+- "F04's updated importer produces expenses in the F01 shape with zero card-tagged rows carrying a non-null `PaymentSource`" → the mixed-sheet test asserts exactly this

--- a/docs/prd/P12-prd-expense-credit-card-settlement/prd-expense-credit-card-settlement.md
+++ b/docs/prd/P12-prd-expense-credit-card-settlement/prd-expense-credit-card-settlement.md
@@ -252,9 +252,9 @@ graph TD
 - [x] No status field is added to `data-cashflow.json`'s expense records — only `PaymentSource` and `SettledAt` values change; `CardTag` is untouched
 
 ### F04. Historical Import Update
-- [ ] A row that resolves a `CreditCard` tag during import produces an expense with that `CardTag` set and `PaymentSource = null`, regardless of its column-E value
-- [ ] A row with no resolved `CreditCard` tag continues to import with `PaymentSource` resolved from column E exactly as before this change
-- [ ] No row is imported with both `PaymentSource` and `CardTag` set
+- [x] A row that resolves a `CreditCard` tag during import produces an expense with that `CardTag` set and `PaymentSource = null`, regardless of its column-E value
+- [x] A row with no resolved `CreditCard` tag continues to import with `PaymentSource` resolved from column E exactly as before this change
+- [x] No row is imported with both `PaymentSource` and `CardTag` set
 
 ### F05. Expense Form & Panels UX Update
 - [ ] The expense form's "Pay immediately" mode shows only the bank picker and saves the expense as `ImmediatePayment`
@@ -267,7 +267,7 @@ graph TD
 ### Cross-Feature Integration
 - [x] F02's mark-paid/unmark-paid cascades correctly read and write the `PaymentSource` and `SettledAt` fields defined by F01, and reject the action if the resulting `PaymentSource`/`CardTag`/`SettledAt` combination would violate F01's validation rule
 - [x] F03's backfill correctly writes expenses into the `PaymentSource`/`CardTag`/`SettledAt` shape defined by F01, with zero resulting records violating F01's validation rule
-- [ ] F04's updated importer produces expenses in the `PaymentSource`/`CardTag` shape defined by F01, with zero imported card-tagged rows carrying a non-null `PaymentSource`
+- [x] F04's updated importer produces expenses in the `PaymentSource`/`CardTag` shape defined by F01, with zero imported card-tagged rows carrying a non-null `PaymentSource`
 - [ ] F05's Cards and Banks panels correctly reflect the field changes produced by F02's mark-paid/unmark-paid cascade immediately after each action
 - [ ] F05's expense form correctly enforces F01's validation rule for both create and edit, with no path in the UI that can produce a rejected combination
 - [ ] The computed payment status is derived identically everywhere it's exposed (API responses consumed by F05, the F03 migration's own classification logic) — there is no second, independently-maintained derivation that could disagree with F01's rule


### PR DESCRIPTION
## Summary

Implements **F04 – Historical Import Update** from the P12 PRD, per the committed spec/plan in `docs/P12-F04-historical-import-update/`.

The functional rule (a row resolving a card tag imports with `PaymentSource = null`) shipped inside F01 as the minimal accommodation the new entity invariant required. F04 formalizes it:

- Importer doc comment now states the payment-state contract: card rows import as unsettled `CreditCardCharge` (no bank, no `SettledAt`); settlement is applied in-app via F02, never inferred by the import
- Column-E precedence is deliberately unchanged: per `cashflow-context.md`, column E never identifies a card — an explicit "T"/"C" in a card-section row means the row was paid directly from that bank, so it still suppresses the card tag
- New mixed-sheet test: blank rows, T/C rows, and card-section rows import with **zero** expenses carrying both fields, all computing to `ImmediatePayment` or `CreditCardCharge` only, `SettledAt` always null

## Acceptance Criteria (PRD Section 9 — F04)

- [x] A row that resolves a `CreditCard` tag during import produces an expense with that `CardTag` set and `PaymentSource = null`, regardless of its column-E value
- [x] A row with no resolved `CreditCard` tag continues to import with `PaymentSource` resolved from column E exactly as before this change
- [x] No row is imported with both `PaymentSource` and `CardTag` set

Cross-feature: the F01↔F04 integration criterion is checked in the PRD (the mixed-sheet test asserts zero card-tagged rows with a non-null bank; F01's invariant makes the violating shape unconstructible).

## Test plan

- Importer suite: 78 tests green (new mixed-sheet AC test + existing per-row/precedence theories from F01)
- Full .NET suite: all 11 test projects green

🤖 Generated with [Claude Code](https://claude.com/claude-code)