### PR TITLE
feat(P12-F05): two-mode expense form and payment-state panel contracts

### DIFF
--- a/Financial.Web/src/hooks/useMonthly.test.ts
+++ b/Financial.Web/src/hooks/useMonthly.test.ts
@@ -218,4 +218,146 @@ describe('useMonthly', () => {
 
     expect(unmarkCardStatementPaidMock).not.toHaveBeenCalled()
   })
+
+  it('creates in bank mode with a null card tag by default', async () => {
+    createExpenseMock.mockResolvedValue({ ...EXPENSES[0], id: 'e2' })
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreateField('createDate', '2026-07-16'))
+    act(() => result.current.setCreateField('createDescription', 'Waitrose'))
+    act(() => result.current.setCreateField('createValue', '15.5'))
+    act(() => result.current.submitCreate())
+
+    expect(result.current.createPaymentMode).toBe('bank')
+    await waitFor(() =>
+      expect(createExpenseMock).toHaveBeenCalledWith(
+        expect.objectContaining({ paymentSource: 'Barclays', cardTag: null }),
+      ),
+    )
+  })
+
+  it('creates in card mode with a null payment source', async () => {
+    createExpenseMock.mockResolvedValue({ ...EXPENSES[0], id: 'e2' })
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreateField('createDate', '2026-07-16'))
+    act(() => result.current.setCreateField('createDescription', 'Amazon'))
+    act(() => result.current.setCreateField('createValue', '9.99'))
+    act(() => result.current.setCreatePaymentMode('card'))
+    act(() => result.current.setCreateField('createCardTag', 'ChaseMaster4023'))
+    act(() => result.current.submitCreate())
+
+    await waitFor(() =>
+      expect(createExpenseMock).toHaveBeenCalledWith(
+        expect.objectContaining({ paymentSource: null, cardTag: 'ChaseMaster4023' }),
+      ),
+    )
+  })
+
+  it('rejects card-mode create without a card before calling the API', async () => {
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreateField('createDate', '2026-07-16'))
+    act(() => result.current.setCreateField('createDescription', 'Amazon'))
+    act(() => result.current.setCreateField('createValue', '9.99'))
+    act(() => result.current.setCreatePaymentMode('card'))
+    act(() => result.current.submitCreate())
+
+    expect(result.current.createError).toBe('Card is required')
+    expect(createExpenseMock).not.toHaveBeenCalled()
+  })
+
+  it('switching create mode clears the field made irrelevant by the switch', async () => {
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreatePaymentMode('card'))
+    act(() => result.current.setCreateField('createCardTag', 'BaAmex'))
+    act(() => result.current.setCreatePaymentMode('bank'))
+
+    expect(result.current.createCardTag).toBe('')
+    expect(result.current.createPaymentSource).toBe('Barclays')
+
+    act(() => result.current.setCreatePaymentMode('card'))
+    expect(result.current.createPaymentSource).toBe('')
+  })
+
+  it('opens edit in card mode for a credit card charge', async () => {
+    const charge: ExpenseDto = {
+      ...EXPENSES[0],
+      id: 'e3',
+      paymentSource: null,
+      cardTag: 'BaAmex',
+      paymentStatus: 'CreditCardCharge',
+    }
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditForm(charge))
+
+    expect(result.current.editPaymentMode).toBe('card')
+    expect(result.current.editIsSettled).toBe(false)
+  })
+
+  it('saves a settled expense with its payment fields unchanged', async () => {
+    const settled: ExpenseDto = {
+      ...EXPENSES[0],
+      id: 'e4',
+      paymentSource: 'Trading212',
+      cardTag: 'BaAmex',
+      settledAt: '2026-07-20',
+      paymentStatus: 'CreditCardSettled',
+    }
+    updateExpenseMock.mockResolvedValue(settled)
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditForm(settled))
+    expect(result.current.editIsSettled).toBe(true)
+
+    act(() => result.current.setEditField('editDescription', 'Renamed'))
+    act(() => result.current.saveEdit())
+
+    await waitFor(() =>
+      expect(updateExpenseMock).toHaveBeenCalledWith(
+        'e4',
+        expect.objectContaining({ description: 'Renamed', paymentSource: 'Trading212', cardTag: 'BaAmex' }),
+      ),
+    )
+  })
+
+  it('bank totals count immediate and settled expenses per bank and exclude charges', async () => {
+    getExpensesByMonthMock.mockResolvedValue([
+      EXPENSES[0],
+      {
+        ...EXPENSES[0],
+        id: 'e5',
+        value: 20,
+        paymentSource: 'Barclays',
+        cardTag: 'BaAmex',
+        settledAt: '2026-07-20',
+        paymentStatus: 'CreditCardSettled',
+      },
+      {
+        ...EXPENSES[0],
+        id: 'e6',
+        value: 99,
+        paymentSource: null,
+        cardTag: 'ChaseMaster4023',
+        paymentStatus: 'CreditCardCharge',
+      },
+    ])
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.bankTotals).toEqual([
+      { bank: 'Barclays', totalValue: 62.5 },
+      { bank: 'Trading212', totalValue: 0 },
+      { bank: 'Chase', totalValue: 0 },
+    ])
+    expect(result.current.bankTotalsSum).toBe(62.5)
+  })
 })

--- a/Financial.Web/src/hooks/useMonthly.ts
+++ b/Financial.Web/src/hooks/useMonthly.ts
@@ -5,11 +5,10 @@ import { currentYearMonth, formatMonthInputValue, parseMonthInputValue } from '.
 
 export const PAYMENT_SOURCES = ['Barclays', 'Trading212', 'Chase'] as const
 
-// A card-tagged expense is an unsettled credit card charge and must carry no bank tag.
-function toPaymentSourcePayload(paymentSource: string, cardTag: string): string | null {
-  if (cardTag.trim() !== '') return null
-  return paymentSource.trim() === '' ? null : paymentSource
-}
+export type PaymentMode = 'bank' | 'card'
+
+const SETTLED_STATUS = 'CreditCardSettled'
+const CHARGE_STATUS = 'CreditCardCharge'
 
 export interface BankTotal {
   bank: string
@@ -56,6 +55,9 @@ interface MonthlyState {
   editCategory: string
   editPaymentSource: string
   editCardTag: string
+  createPaymentMode: PaymentMode
+  editPaymentMode: PaymentMode
+  editIsSettled: boolean
   isSaving: boolean
   saveError: string | null
   markPaidSources: Record<string, string>
@@ -84,6 +86,8 @@ type MonthlyAction =
   | { type: 'SAVE_ERROR'; payload: string }
   | { type: 'MARK_PAID_ERROR'; payload: string }
   | { type: 'SET_MARK_PAID_SOURCE'; payload: { id: string; value: string } }
+  | { type: 'SET_CREATE_MODE'; payload: PaymentMode }
+  | { type: 'SET_EDIT_MODE'; payload: PaymentMode }
 
 const { year: DEFAULT_YEAR, month: DEFAULT_MONTH } = currentYearMonth()
 
@@ -94,6 +98,7 @@ const BLANK_CREATE_FORM = {
   createCategory: 'Mercado',
   createPaymentSource: 'Barclays',
   createCardTag: '',
+  createPaymentMode: 'bank',
 } as const
 
 const INITIAL_STATE: MonthlyState = {
@@ -116,6 +121,8 @@ const INITIAL_STATE: MonthlyState = {
   editCategory: '',
   editPaymentSource: '',
   editCardTag: '',
+  editPaymentMode: 'bank',
+  editIsSettled: false,
   isSaving: false,
   saveError: null,
   markPaidSources: {},
@@ -162,6 +169,8 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
         editCategory: action.payload.category,
         editPaymentSource: action.payload.paymentSource ?? '',
         editCardTag: action.payload.cardTag ?? '',
+        editPaymentMode: action.payload.paymentStatus === CHARGE_STATUS ? 'card' : 'bank',
+        editIsSettled: action.payload.paymentStatus === SETTLED_STATUS,
         saveError: null,
       }
     case 'CANCEL_EDIT':
@@ -174,6 +183,8 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
         editCategory: '',
         editPaymentSource: '',
         editCardTag: '',
+        editPaymentMode: 'bank',
+        editIsSettled: false,
         saveError: null,
       }
     case 'SET_EDIT_FIELD':
@@ -191,6 +202,8 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
         editCategory: '',
         editPaymentSource: '',
         editCardTag: '',
+        editPaymentMode: 'bank',
+        editIsSettled: false,
       }
     case 'SAVE_ERROR':
       return { ...state, isSaving: false, saveError: action.payload }
@@ -198,6 +211,20 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
       return { ...state, saveError: action.payload }
     case 'SET_MARK_PAID_SOURCE':
       return { ...state, markPaidSources: { ...state.markPaidSources, [action.payload.id]: action.payload.value } }
+    case 'SET_CREATE_MODE':
+      return {
+        ...state,
+        createPaymentMode: action.payload,
+        createPaymentSource: action.payload === 'bank' ? 'Barclays' : '',
+        createCardTag: '',
+      }
+    case 'SET_EDIT_MODE':
+      return {
+        ...state,
+        editPaymentMode: action.payload,
+        editPaymentSource: action.payload === 'bank' ? 'Barclays' : '',
+        editCardTag: '',
+      }
     default:
       return state
   }
@@ -223,11 +250,13 @@ export interface MonthlyData {
   createCategory: string
   createPaymentSource: string
   createCardTag: string
+  createPaymentMode: PaymentMode
   isCreating: boolean
   createError: string | null
   showCreateForm: () => void
   cancelCreateForm: () => void
   setCreateField: (field: CreateFormField, value: string) => void
+  setCreatePaymentMode: (mode: PaymentMode) => void
   submitCreate: () => void
   editingId: string | null
   editDate: string
@@ -236,9 +265,12 @@ export interface MonthlyData {
   editCategory: string
   editPaymentSource: string
   editCardTag: string
+  editPaymentMode: PaymentMode
+  editIsSettled: boolean
   isSaving: boolean
   saveError: string | null
   setEditField: (field: EditField, value: string) => void
+  setEditPaymentMode: (mode: PaymentMode) => void
   showEditForm: (expense: ExpenseDto) => void
   cancelEdit: () => void
   saveEdit: () => void
@@ -287,8 +319,18 @@ export function useMonthly(): MonthlyData {
     [],
   )
 
+  const setCreatePaymentMode = useCallback(
+    (mode: PaymentMode) => dispatch({ type: 'SET_CREATE_MODE', payload: mode }),
+    [],
+  )
+
+  const setEditPaymentMode = useCallback(
+    (mode: PaymentMode) => dispatch({ type: 'SET_EDIT_MODE', payload: mode }),
+    [],
+  )
+
   function submitCreate() {
-    const { createDate, createDescription, createValue, createCategory, createPaymentSource, createCardTag } = state
+    const { createDate, createDescription, createValue, createCategory, createPaymentMode, createPaymentSource, createCardTag } = state
 
     if (!createDate.trim()) {
       dispatch({ type: 'CREATE_ERROR', payload: 'Date is required' })
@@ -306,6 +348,11 @@ export function useMonthly(): MonthlyData {
       return
     }
 
+    if (createPaymentMode === 'card' && createCardTag.trim() === '') {
+      dispatch({ type: 'CREATE_ERROR', payload: 'Card is required' })
+      return
+    }
+
     dispatch({ type: 'CREATE_START' })
 
     void apiClient
@@ -314,8 +361,8 @@ export function useMonthly(): MonthlyData {
         description: createDescription,
         value,
         category: createCategory,
-        paymentSource: toPaymentSourcePayload(createPaymentSource, createCardTag),
-        cardTag: createCardTag.trim() === '' ? null : createCardTag,
+        paymentSource: createPaymentMode === 'bank' ? createPaymentSource : null,
+        cardTag: createPaymentMode === 'card' ? createCardTag : null,
       })
       .then(() => {
         dispatch({ type: 'CREATE_SUCCESS' })
@@ -347,6 +394,24 @@ export function useMonthly(): MonthlyData {
       return
     }
 
+    if (!state.editIsSettled && state.editPaymentMode === 'card' && state.editCardTag.trim() === '') {
+      dispatch({ type: 'SAVE_ERROR', payload: 'Card is required' })
+      return
+    }
+
+    // A settled expense's payment fields are frozen: send them back unchanged so only
+    // the editable fields move; the server rejects any payment-field change until the
+    // statement is unmarked paid.
+    const paymentFields = state.editIsSettled
+      ? {
+          paymentSource: state.editPaymentSource.trim() === '' ? null : state.editPaymentSource,
+          cardTag: state.editCardTag.trim() === '' ? null : state.editCardTag,
+        }
+      : {
+          paymentSource: state.editPaymentMode === 'bank' ? state.editPaymentSource : null,
+          cardTag: state.editPaymentMode === 'card' ? state.editCardTag : null,
+        }
+
     dispatch({ type: 'SAVE_START' })
 
     void apiClient
@@ -355,8 +420,7 @@ export function useMonthly(): MonthlyData {
         description: state.editDescription,
         value,
         category: state.editCategory,
-        paymentSource: toPaymentSourcePayload(state.editPaymentSource, state.editCardTag),
-        cardTag: state.editCardTag.trim() === '' ? null : state.editCardTag,
+        ...paymentFields,
       })
       .then(() => {
         dispatch({ type: 'SAVE_SUCCESS' })
@@ -456,6 +520,8 @@ export function useMonthly(): MonthlyData {
     createCategory: state.createCategory,
     createPaymentSource: state.createPaymentSource,
     createCardTag: state.createCardTag,
+    createPaymentMode: state.createPaymentMode,
+    setCreatePaymentMode,
     isCreating: state.isCreating,
     createError: state.createError,
     showCreateForm,
@@ -469,6 +535,9 @@ export function useMonthly(): MonthlyData {
     editCategory: state.editCategory,
     editPaymentSource: state.editPaymentSource,
     editCardTag: state.editCardTag,
+    editPaymentMode: state.editPaymentMode,
+    editIsSettled: state.editIsSettled,
+    setEditPaymentMode,
     isSaving: state.isSaving,
     saveError: state.saveError,
     setEditField,

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -1,7 +1,7 @@
 import ErrorState from '../components/ErrorState'
 import ExpensesSection from '../components/ExpensesSection'
 import LoadingState from '../components/LoadingState'
-import { PAYMENT_SOURCES, useMonthly, type CreateFormField, type EditField } from '../hooks/useMonthly'
+import { PAYMENT_SOURCES, useMonthly, type CreateFormField, type EditField, type PaymentMode } from '../hooks/useMonthly'
 import { formatN2 } from '../utils/formatters'
 import './MonthlyPage.css'
 
@@ -52,9 +52,12 @@ interface ExpenseFormProps {
   category: string
   paymentSource: string
   cardTag: string
+  paymentMode: PaymentMode
+  isSettled: boolean
   isSaving: boolean
   saveError: string | null
   onFieldChange: (field: ExpenseFormField, value: string) => void
+  onModeChange: (mode: PaymentMode) => void
   onSave: () => void
   onCancel: () => void
 }
@@ -67,9 +70,12 @@ function ExpenseForm({
   category,
   paymentSource,
   cardTag,
+  paymentMode,
+  isSettled,
   isSaving,
   saveError,
   onFieldChange,
+  onModeChange,
   onSave,
   onCancel,
 }: ExpenseFormProps) {
@@ -119,35 +125,71 @@ function ExpenseForm({
             onChange={(e) => onFieldChange('value', e.target.value)}
           />
         </div>
-        <div className="monthly-page__form-field">
-          <label htmlFor="expense-payment-source">Payment Source</label>
-          <select
-            id="expense-payment-source"
-            value={paymentSource}
-            onChange={(e) => onFieldChange('paymentSource', e.target.value)}
-          >
-            {PAYMENT_SOURCES.map((p) => (
-              <option key={p} value={p}>
-                {p}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="monthly-page__form-field">
-          <label htmlFor="expense-card-tag">Card</label>
-          <select
-            id="expense-card-tag"
-            value={cardTag}
-            onChange={(e) => onFieldChange('cardTag', e.target.value)}
-          >
-            <option value="">—</option>
-            {CARDS.map((c) => (
-              <option key={c} value={c}>
-                {c}
-              </option>
-            ))}
-          </select>
-        </div>
+        {isSettled ? (
+          <div className="monthly-page__form-field">
+            <label>Payment</label>
+            <p className="monthly-page__settled-note">
+              Paid by {paymentSource} via card {cardTag}. Settled via its card statement — unmark the
+              statement paid to change these fields.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="monthly-page__form-field">
+              <span>Payment</span>
+              <label>
+                <input
+                  type="radio"
+                  name="expense-payment-mode"
+                  checked={paymentMode === 'bank'}
+                  onChange={() => onModeChange('bank')}
+                />
+                Pay immediately
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="expense-payment-mode"
+                  checked={paymentMode === 'card'}
+                  onChange={() => onModeChange('card')}
+                />
+                Charge to card
+              </label>
+            </div>
+            {paymentMode === 'bank' ? (
+              <div className="monthly-page__form-field">
+                <label htmlFor="expense-payment-source">Payment Source</label>
+                <select
+                  id="expense-payment-source"
+                  value={paymentSource}
+                  onChange={(e) => onFieldChange('paymentSource', e.target.value)}
+                >
+                  {PAYMENT_SOURCES.map((p) => (
+                    <option key={p} value={p}>
+                      {p}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : (
+              <div className="monthly-page__form-field">
+                <label htmlFor="expense-card-tag">Card</label>
+                <select
+                  id="expense-card-tag"
+                  value={cardTag}
+                  onChange={(e) => onFieldChange('cardTag', e.target.value)}
+                >
+                  <option value="">Select card…</option>
+                  {CARDS.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </>
+        )}
       </div>
       <div className="monthly-page__form-actions">
         <button className="monthly-page__submit-btn" type="button" disabled={isSaving} onClick={onSave}>
@@ -183,6 +225,8 @@ export default function MonthlyPage() {
     createCategory,
     createPaymentSource,
     createCardTag,
+    createPaymentMode,
+    setCreatePaymentMode,
     isCreating,
     createError,
     showCreateForm,
@@ -196,6 +240,9 @@ export default function MonthlyPage() {
     editCategory,
     editPaymentSource,
     editCardTag,
+    editPaymentMode,
+    editIsSettled,
+    setEditPaymentMode,
     isSaving,
     saveError,
     setEditField,
@@ -235,6 +282,8 @@ export default function MonthlyPage() {
           category={isEditing ? editCategory : createCategory}
           paymentSource={isEditing ? editPaymentSource : createPaymentSource}
           cardTag={isEditing ? editCardTag : createCardTag}
+          paymentMode={isEditing ? editPaymentMode : createPaymentMode}
+          isSettled={isEditing && editIsSettled}
           isSaving={isEditing ? isSaving : isCreating}
           saveError={isEditing ? saveError : createError}
           onFieldChange={(field, value) =>
@@ -242,6 +291,7 @@ export default function MonthlyPage() {
               ? setEditField(EDIT_FIELD_BY_FORM_FIELD[field], value)
               : setCreateField(CREATE_FIELD_BY_FORM_FIELD[field], value)
           }
+          onModeChange={isEditing ? setEditPaymentMode : setCreatePaymentMode}
           onSave={isEditing ? saveEdit : submitCreate}
           onCancel={isEditing ? cancelEdit : cancelCreateForm}
         />

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -140,6 +140,62 @@ describe('MonthlyPage', () => {
     await waitFor(() => expect(unmarkCardStatementPaidMock).toHaveBeenCalledWith('c2'))
   })
 
+  it('bank mode shows only the bank picker and card mode only the card picker', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
+
+    expect(screen.getByLabelText('Payment Source')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Card')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Charge to card' }))
+
+    expect(screen.queryByLabelText('Payment Source')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Card')).toBeInTheDocument()
+  })
+
+  it('submits a card-mode expense with a null payment source', async () => {
+    createExpenseMock.mockResolvedValue({ ...EXPENSES[0], id: 'e2' })
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
+    fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2026-07-16' } })
+    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Amazon' } })
+    fireEvent.change(screen.getByLabelText('Value'), { target: { value: '9.99' } })
+    fireEvent.click(screen.getByRole('radio', { name: 'Charge to card' }))
+    fireEvent.change(screen.getByLabelText('Card'), { target: { value: 'BaAmex' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add Expense' }))
+
+    await waitFor(() =>
+      expect(createExpenseMock).toHaveBeenCalledWith(
+        expect.objectContaining({ paymentSource: null, cardTag: 'BaAmex' }),
+      ),
+    )
+  })
+
+  it('shows read-only payment fields with a settlement note when editing a settled expense', async () => {
+    getExpensesByMonthMock.mockResolvedValue([
+      {
+        ...EXPENSES[0],
+        paymentSource: 'Trading212',
+        cardTag: 'BaAmex',
+        settledAt: '2026-07-20',
+        paymentStatus: 'CreditCardSettled',
+      },
+    ])
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByText('Lidl UK')).toBeInTheDocument())
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit expense' })[0])
+
+    expect(screen.getByText(/Settled via its card statement/)).toBeInTheDocument()
+    expect(screen.queryByLabelText('Payment Source')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Card')).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+  })
+
   it('shows the add-expense form only after New Expense is clicked, and submits a new expense', async () => {
     createExpenseMock.mockResolvedValue({ ...EXPENSES[0], id: 'e2' })
     render(<MonthlyPage />)

--- a/docs/P12-F05-expense-form-panels-ux-update/plan.md
+++ b/docs/P12-F05-expense-form-panels-ux-update/plan.md
@@ -1,0 +1,17 @@
+# Implementation Plan: F05. Expense Form & Panels UX Update
+
+**Prerequisites:**
+- F01 and F02 merged (expense payment-state contract and statement settlement endpoints live)
+- Node/npm for `Financial.Web`; no new packages
+
+### Stage 1: Form Mode State
+
+**1. Hook mode state and payloads** - Add the per-form payment-mode state to the monthly hook, with mode-switch actions that clear the irrelevant field, mode-shaped create/edit payloads, the card-required check, and settled-expense read-only handling derived from the server-computed status. See spec Section 3.
+
+### Stage 2: Form UI and Panel Contracts
+
+**2. Form UI** - Render the mode radio control and conditionally show exactly one picker per mode, with the read-only payment display and explanatory note for settled expenses. See spec Section 4.
+
+**3. Panel acceptance tests** - Add the bank-totals and form-mode tests that pin the panels and form to the PRD's acceptance criteria. See spec Section 7.
+
+**4. Full verification** - Run the web test suite and TypeScript build check, plus the .NET suite to confirm nothing regressed.

--- a/docs/P12-F05-expense-form-panels-ux-update/spec.md
+++ b/docs/P12-F05-expense-form-panels-ux-update/spec.md
@@ -1,0 +1,80 @@
+# F05. Expense Form & Panels UX Update
+
+## 1. Technical Overview
+
+**What:** Rework the Monthly expense create/edit form into two mutually exclusive modes — "Pay immediately" (bank picker only) and "Charge to card" (card picker only) — with mode switching clearing the irrelevant field, and a read-only payment display (with an explanatory note) when editing a `CreditCardSettled` expense. Add the Banks-panel and Cards-panel acceptance tests that pin the panel totals to the payment-state model.
+
+**Why:** The form still renders both pickers side by side, so the UI can produce the both-set combination the server now rejects, and a settled expense's payment fields look editable when they aren't. The panels' computations are already correct after F01/F02 (bank totals key off `paymentSource`, which is null exactly for unsettled charges; outstanding totals sum only charges; the Cards panel controls shipped with F02) — F05 makes that behavior contractual with tests.
+
+**Scope:**
+- Included: form mode state in `useMonthly` (create + edit), mode-driven payloads (bank mode → `cardTag: null`; card mode → `paymentSource: null`, card required), settled-expense read-only handling, `MonthlyPage` form/UI changes, panel AC tests, removal of the now-redundant F01 transitional payload helper.
+- Excluded: backend changes (none needed — F01/F02 contracts are final); Cards panel controls and totals (shipped in F02, kept as-is); WPF (the Monthly view is web-only).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/hooks/useMonthly.ts` — mode fields/actions, payload logic, card-required validation, settled-edit handling
+- `Financial.Web/src/pages/MonthlyPage.tsx` — mode radio control, conditional pickers, settled read-only display + note
+- `Financial.Web/src/hooks/useMonthly.test.ts`, `src/pages/__tests__/MonthlyPage.test.tsx` — mode/panel tests
+
+```mermaid
+graph TD
+  A[User] --> B["ExpenseForm (mode radio: Pay immediately / Charge to card)"]
+  B -->|bank mode| C["payload: paymentSource set, cardTag null"]
+  B -->|card mode| D["payload: cardTag set, paymentSource null"]
+  B -->|settled expense| E["read-only payment fields + statement note"]
+  C --> F["POST/PUT /expenses (F01 validation)"]
+  D --> F
+  G["Banks panel"] -.->|"paymentSource === bank (null excluded)"| H["month expenses"]
+  I["Cards panel (F02 controls)"] -.->|outstandingTotal from API| J["card statements"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Mode representation | Explicit `'bank' \| 'card'` state per form (create and edit), rendered as two radio buttons; switching dispatches one action that sets the mode and clears the other field | Infer mode from which field is filled | An explicit mode is what makes the pickers mutually exclusive by construction (PRD AC: no UI path to a rejected combination); inference breaks on the blank-card default. |
+| Edit-mode derivation | `SHOW_EDIT_FORM` derives the mode from the expense's server-computed `paymentStatus` (`CreditCardCharge` → card, otherwise bank); `CreditCardSettled` puts the form in a read-only payment display instead of either mode | Re-derive from field presence client-side | Uses the single server-side derivation (PRD cross-feature criterion) instead of a second client-side rule. |
+| Settled expense editing | Date/description/value/category stay editable; payment fields render as plain text with the note "Settled via its card statement — unmark the statement paid to change"; save sends the unchanged `paymentSource`/`cardTag` (the F01 entity requires them unchanged and preserves `SettledAt`) | Block editing settled expenses entirely | The PRD only freezes the payment fields; blocking the rest would regress F01's `UpdateDetails` capability. |
+| Card-required validation | Card mode with no card selected is rejected client-side ("Card is required") before the API call; bank mode always has a bank (existing Barclays default) | Let the server's both-null rejection surface | The server message ("payment source or a card tag") is phrased for the API shape, not the mode UI; a mode-aware message is clearer. Server validation remains the backstop. |
+| Banks panel computation | Unchanged: filter `expense.paymentSource === bank` — under the state model this equals immediate-plus-settled-by-bank and excludes charges (null bank) by construction; F05 adds the AC test making it contractual | Re-filter via `paymentStatus` | The existing filter is already exactly the PRD formula with fewer moving parts; a status-based re-derivation would duplicate what `paymentSource`'s nullability already encodes. |
+| Transitional helper removal | `toPaymentSourcePayload` (F01's bridge for the old two-picker form) is removed; payloads are built explicitly per mode | Keep routing through it | The helper's card-overrides-bank rule exists only because both pickers used to be visible; with modes, it is dead indirection. |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/hooks/useMonthly.ts` | Modified | Form mode state | `createPaymentMode`/`editPaymentMode` (`'bank' \| 'card'`); `SET_CREATE_MODE`/`SET_EDIT_MODE` actions clearing the irrelevant field; `SHOW_EDIT_FORM` derives mode + `editIsSettled` from `paymentStatus`; `submitCreate`/`saveEdit` build mode-shaped payloads; card-required check; settled edit sends unchanged payment fields |
+| `Financial.Web/src/pages/MonthlyPage.tsx` | Modified | Form UI | Mode radio group; bank select only in bank mode; card select (no blank option, required) only in card mode; settled: read-only payment text + note; Banks/Cards panels untouched |
+| `Financial.Web/src/hooks/useMonthly.test.ts` | Modified | Hook tests | Mode switching clears the other field; payload shapes per mode; card-required error; settled edit payload unchanged; bank-totals AC (immediate + settled counted per bank, charges excluded) |
+| `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` | Modified | UI tests | Only one picker visible per mode; mode switch swaps pickers; settled expense shows read-only note; create-in-card-mode submits `paymentSource: null` |
+
+## 5. API Contracts
+
+None changed — the form consumes F01's expense endpoints and F02's statement endpoints exactly as already shipped.
+
+## 6. Data Model
+
+No change.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `src/hooks/useMonthly.test.ts` | Unit (vitest) | Hook | Default create mode is bank and sends `{ paymentSource, cardTag: null }`; card mode sends `{ paymentSource: null, cardTag }`; switching to bank clears the card and vice versa; card mode without a card → validation error, no API call; editing a charge opens card mode; editing a settled expense flags read-only and saves with unchanged payment fields; bank totals count immediate + settled per bank and exclude charges (AC formula) |
+| `src/pages/__tests__/MonthlyPage.test.tsx` | Unit (vitest) | Form + panels | Bank mode shows only the bank picker; card mode shows only the card picker; radio switch swaps them; settled expense's edit panel shows the read-only note and no payment pickers; submitting a card-mode expense calls the client with `paymentSource: null`; Banks panel renders the per-bank totals from the hook |
+
+**Acceptance tests (PRD Section 9, F05):**
+- "Pay immediately" mode shows only the bank picker, saves as `ImmediatePayment` → page + hook tests (payload shape; status is server-computed from that shape per F01)
+- "Charge to card" mode shows only the card picker, saves as `CreditCardCharge` → page + hook tests
+- Settled expense's payment fields read-only with no direct edit path → page + hook tests
+- Cards panel outstanding = sum of that card's charges → shipped and tested in F02 (`CardStatementServiceTests`, endpoint tests); UI reads `outstandingTotal` from the API unchanged
+- Banks panel total = immediate + settled-by-bank, excluding charges → hook bank-totals AC test
+- Mark Paid requires bank selection; paid statement shows Unmark Paid → shipped and tested in F02 (`MonthlyPage` tests)
+
+**Cross-Feature Integration criteria touching F05 (PRD Section 9):**
+- Panels reflect F02 cascade changes immediately after each action → existing F02 tests (mark/unmark re-fetch month data); bank-totals test covers the settled-expense contribution
+- Form enforces F01's rule with no UI path to a rejected combination → mode tests (mutual exclusivity + card-required + settled read-only)
+- Payment status derived identically everywhere → form uses server `paymentStatus` only; asserted in edit-mode derivation tests

--- a/docs/prd/P12-prd-expense-credit-card-settlement/prd-expense-credit-card-settlement.md
+++ b/docs/prd/P12-prd-expense-credit-card-settlement/prd-expense-credit-card-settlement.md
@@ -257,17 +257,17 @@ graph TD
 - [x] No row is imported with both `PaymentSource` and `CardTag` set
 
 ### F05. Expense Form & Panels UX Update
-- [ ] The expense form's "Pay immediately" mode shows only the bank picker and saves the expense as `ImmediatePayment`
-- [ ] The expense form's "Charge to card" mode shows only the card picker and saves the expense as `CreditCardCharge`
-- [ ] A `CreditCardSettled` expense's payment fields are shown read-only on the form, with no way to edit them directly
-- [ ] The Cards panel's outstanding total for a card equals the sum of that card's `CreditCardCharge` expenses for the selected month
-- [ ] The Banks panel's total for a bank equals the sum of that bank's `ImmediatePayment` expenses plus `CreditCardSettled` expenses settled by that bank for the selected month, excluding all `CreditCardCharge` expenses
-- [ ] The Cards panel's "Mark Paid" control requires a bank selection before it can be confirmed, and a paid statement shows an "Unmark Paid" control
+- [x] The expense form's "Pay immediately" mode shows only the bank picker and saves the expense as `ImmediatePayment`
+- [x] The expense form's "Charge to card" mode shows only the card picker and saves the expense as `CreditCardCharge`
+- [x] A `CreditCardSettled` expense's payment fields are shown read-only on the form, with no way to edit them directly
+- [x] The Cards panel's outstanding total for a card equals the sum of that card's `CreditCardCharge` expenses for the selected month
+- [x] The Banks panel's total for a bank equals the sum of that bank's `ImmediatePayment` expenses plus `CreditCardSettled` expenses settled by that bank for the selected month, excluding all `CreditCardCharge` expenses
+- [x] The Cards panel's "Mark Paid" control requires a bank selection before it can be confirmed, and a paid statement shows an "Unmark Paid" control
 
 ### Cross-Feature Integration
 - [x] F02's mark-paid/unmark-paid cascades correctly read and write the `PaymentSource` and `SettledAt` fields defined by F01, and reject the action if the resulting `PaymentSource`/`CardTag`/`SettledAt` combination would violate F01's validation rule
 - [x] F03's backfill correctly writes expenses into the `PaymentSource`/`CardTag`/`SettledAt` shape defined by F01, with zero resulting records violating F01's validation rule
 - [x] F04's updated importer produces expenses in the `PaymentSource`/`CardTag` shape defined by F01, with zero imported card-tagged rows carrying a non-null `PaymentSource`
-- [ ] F05's Cards and Banks panels correctly reflect the field changes produced by F02's mark-paid/unmark-paid cascade immediately after each action
-- [ ] F05's expense form correctly enforces F01's validation rule for both create and edit, with no path in the UI that can produce a rejected combination
-- [ ] The computed payment status is derived identically everywhere it's exposed (API responses consumed by F05, the F03 migration's own classification logic) — there is no second, independently-maintained derivation that could disagree with F01's rule
+- [x] F05's Cards and Banks panels correctly reflect the field changes produced by F02's mark-paid/unmark-paid cascade immediately after each action
+- [x] F05's expense form correctly enforces F01's validation rule for both create and edit, with no path in the UI that can produce a rejected combination
+- [x] The computed payment status is derived identically everywhere it's exposed (API responses consumed by F05, the F03 migration's own classification logic) — there is no second, independently-maintained derivation that could disagree with F01's rule


### PR DESCRIPTION
## Summary

Implements **F05 – Expense Form & Panels UX Update** from the P12 PRD, per the committed spec/plan in `docs/P12-F05-expense-form-panels-ux-update/` — the final P12 feature.

- The expense form now has two mutually exclusive modes via radio buttons: **Pay immediately** (bank picker only) and **Charge to card** (card picker only, card required); switching modes clears the field made irrelevant, so no UI path can produce the both-set combination F01 rejects
- Editing derives the mode from the server-computed `paymentStatus`; a **`CreditCardSettled` expense shows its payment fields read-only** with a note directing to the statement unmark action, while date/description/value/category stay editable (payment fields are sent back unchanged)
- Bank totals are now contractual: an AC test pins the per-bank total to immediate + settled-by-that-bank, excluding unsettled charges (the F01 data shape already made the existing `paymentSource === bank` filter compute exactly this)
- Cards panel controls/totals were shipped in F02 and are unchanged; F01's transitional payload helper is removed

## Acceptance Criteria (PRD Section 9 — F05)

- [x] The expense form's "Pay immediately" mode shows only the bank picker and saves the expense as `ImmediatePayment`
- [x] The expense form's "Charge to card" mode shows only the card picker and saves the expense as `CreditCardCharge`
- [x] A `CreditCardSettled` expense's payment fields are shown read-only on the form, with no way to edit them directly
- [x] The Cards panel's outstanding total for a card equals the sum of that card's `CreditCardCharge` expenses for the selected month *(shipped + tested in F02)*
- [x] The Banks panel's total for a bank equals the sum of that bank's `ImmediatePayment` expenses plus `CreditCardSettled` expenses settled by that bank, excluding all `CreditCardCharge` expenses
- [x] The Cards panel's "Mark Paid" control requires a bank selection before it can be confirmed, and a paid statement shows an "Unmark Paid" control *(shipped + tested in F02)*

This PR also checks off the three remaining Cross-Feature Integration boxes — every feature they reference (F01–F05) is now implemented.

## Test plan

- Web: `tsc -b --noEmit` clean; vitest **555 passed** (10 new AC tests: mode payloads, mode switching clears fields, card-required, settled read-only + unchanged save, bank-totals formula, page-level picker visibility)
- Full .NET suite: all 11 test projects green (no backend changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)