### PR TITLE
feat(P13-F02): expense round-up capture

### DIFF
--- a/Financial.CashFlow.Application/DTOs/ExpenseCreateDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/ExpenseCreateDTO.cs
@@ -22,4 +22,7 @@ public sealed class ExpenseCreateDTO
 
     /// <summary>Optional credit-card tag name.</summary>
     public string? CardTag { get; init; }
+
+    /// <summary>Round-up amount to save immediately. Omit/null to leave "not yet decided".</summary>
+    public decimal? RoundUpAmount { get; init; }
 }

--- a/Financial.CashFlow.Application/DTOs/ExpenseDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/ExpenseDTO.cs
@@ -31,4 +31,10 @@ public sealed class ExpenseDTO
 
     /// <summary>Computed payment status derived from the payment source and card tag.</summary>
     public required string PaymentStatus { get; init; }
+
+    /// <summary>Saved round-up amount, or null if not yet decided.</summary>
+    public decimal? RoundUpAmount { get; init; }
+
+    /// <summary>Suggested round-up amount (difference to the next whole £1), present only when eligible and not yet saved.</summary>
+    public decimal? SuggestedRoundUpAmount { get; init; }
 }

--- a/Financial.CashFlow.Application/DTOs/ExpenseUpdateDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/ExpenseUpdateDTO.cs
@@ -22,4 +22,7 @@ public sealed class ExpenseUpdateDTO
 
     /// <summary>Optional credit-card tag name.</summary>
     public string? CardTag { get; init; }
+
+    /// <summary>Round-up amount. Full-replace: whatever is sent (including null) becomes the new stored value.</summary>
+    public decimal? RoundUpAmount { get; init; }
 }

--- a/Financial.CashFlow.Application/Services/ExpenseService.cs
+++ b/Financial.CashFlow.Application/Services/ExpenseService.cs
@@ -23,8 +23,10 @@ public sealed class ExpenseService : IExpenseService
 
         var (category, paymentSource, cardTag) = ValidateFields(
             request.Description, request.Value, request.Category, request.PaymentSource, request.CardTag);
+        ValidateRoundUpEligibility(request.RoundUpAmount, paymentSource);
 
         var expense = Expense.Create(request.Date, request.Description, request.Value, category, paymentSource, cardTag);
+        expense.SetRoundUpAmount(request.RoundUpAmount);
         _repository.AddExpense(expense);
         await _repository.SaveChangesAsync().ConfigureAwait(false);
 
@@ -39,9 +41,10 @@ public sealed class ExpenseService : IExpenseService
 
         var (category, paymentSource, cardTag) = ValidateFields(
             request.Description, request.Value, request.Category, request.PaymentSource, request.CardTag);
-
+        ValidateRoundUpEligibility(request.RoundUpAmount, paymentSource);
 
         expense.UpdateDetails(request.Date, request.Description, request.Value, category, paymentSource, cardTag);
+        expense.SetRoundUpAmount(request.RoundUpAmount);
         await _repository.SaveChangesAsync().ConfigureAwait(false);
 
         return ToDto(expense);
@@ -124,7 +127,20 @@ public sealed class ExpenseService : IExpenseService
         return (parsedCategory, parsedPaymentSource, parsedCardTag);
     }
 
-    private static ExpenseDTO ToDto(Expense expense) => new()
+    private void ValidateRoundUpEligibility(decimal? roundUpAmount, string? paymentSource)
+    {
+        if (roundUpAmount is null || paymentSource is null)
+        {
+            return;
+        }
+
+        if (BankNameResolver.TryResolve(paymentSource, _repository.GetBanks(), out var bank) && !bank!.RoundUpEnabled)
+        {
+            throw new ArgumentException($"Bank '{bank.Name}' does not support round-up.");
+        }
+    }
+
+    private ExpenseDTO ToDto(Expense expense) => new()
     {
         Id = expense.Id,
         Date = expense.Date,
@@ -134,6 +150,20 @@ public sealed class ExpenseService : IExpenseService
         PaymentSource = expense.PaymentSource,
         CardTag = expense.CardTag?.ToString(),
         SettledAt = expense.SettledAt,
-        PaymentStatus = expense.PaymentStatus.ToString()
+        PaymentStatus = expense.PaymentStatus.ToString(),
+        RoundUpAmount = expense.RoundUpAmount,
+        SuggestedRoundUpAmount = GetSuggestedRoundUpAmount(expense)
     };
+
+    private decimal? GetSuggestedRoundUpAmount(Expense expense)
+    {
+        if (expense.RoundUpAmount is not null || expense.PaymentStatus != ExpensePaymentStatus.ImmediatePayment)
+        {
+            return null;
+        }
+
+        return BankNameResolver.TryResolve(expense.PaymentSource, _repository.GetBanks(), out var bank) && bank!.RoundUpEnabled
+            ? expense.RoundUpSuggestion
+            : null;
+    }
 }

--- a/Financial.CashFlow.Domain/Entities/Expense.cs
+++ b/Financial.CashFlow.Domain/Entities/Expense.cs
@@ -5,6 +5,9 @@ namespace Financial.CashFlow.Domain.Entities;
 
 public class Expense
 {
+    private const decimal MinRoundUpAmount = 0.00m;
+    private const decimal MaxRoundUpAmount = 0.99m;
+
     public Guid Id { get; private set; }
     public DateOnly Date { get; private set; }
     public string Description { get; private set; } = string.Empty;
@@ -13,11 +16,14 @@ public class Expense
     public string? PaymentSource { get; private set; }
     public CreditCard? CardTag { get; private set; }
     public DateOnly? SettledAt { get; private set; }
+    public decimal? RoundUpAmount { get; private set; }
 
     public ExpensePaymentStatus PaymentStatus =>
         CardTag is null ? ExpensePaymentStatus.ImmediatePayment
         : PaymentSource is null ? ExpensePaymentStatus.CreditCardCharge
         : ExpensePaymentStatus.CreditCardSettled;
+
+    public decimal RoundUpSuggestion => Math.Ceiling(Value) - Value;
 
     private Expense() { }
 
@@ -92,6 +98,29 @@ public class Expense
 
         PaymentSource = null;
         SettledAt = null;
+    }
+
+    public void SetRoundUpAmount(decimal? amount)
+    {
+        if (amount is null)
+        {
+            RoundUpAmount = null;
+            return;
+        }
+
+        if (PaymentStatus != ExpensePaymentStatus.ImmediatePayment)
+        {
+            throw new ArgumentException(
+                "Round-up only applies to an expense paid directly from a bank, not a credit-card charge.");
+        }
+
+        if (amount < MinRoundUpAmount || amount > MaxRoundUpAmount)
+        {
+            throw new ArgumentException(
+                $"Round-up amount must be between £{MinRoundUpAmount:F2} and £{MaxRoundUpAmount:F2}.");
+        }
+
+        RoundUpAmount = amount;
     }
 
     private static void ValidatePaymentShape(string? paymentSource, CreditCard? cardTag)

--- a/Tests/Financial.Api.Tests/ExpenseEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/ExpenseEndpointsTests.cs
@@ -293,4 +293,96 @@ public class ExpenseEndpointsTests
         var totals = await response.Content.ReadFromJsonAsync<List<CategoryTotalDTO>>();
         totals.Should().ContainSingle(t => t.Category == "Mercado" && t.TotalValue == 15m);
     }
+
+    [Fact]
+    public async Task AddExpense_RoundUpAmountOnRoundUpEnabledBank_ReturnsOkWithAmountSaved()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 15),
+            Description = "TfL",
+            Value = 9.40m,
+            Category = "Extras",
+            PaymentSource = "Trading212",
+            CardTag = null,
+            RoundUpAmount = 0.60m
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/expenses", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var expense = await response.Content.ReadFromJsonAsync<ExpenseDTO>();
+        expense!.RoundUpAmount.Should().Be(0.60m);
+        expense.SuggestedRoundUpAmount.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddExpense_RoundUpAmountOnNonRoundUpBank_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 15),
+            Description = "Groceries",
+            Value = 9.40m,
+            Category = "Mercado",
+            PaymentSource = "Barclays",
+            CardTag = null,
+            RoundUpAmount = 0.60m
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/expenses", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Barclays").And.Contain("does not support round-up");
+    }
+
+    [Fact]
+    public async Task AddExpense_RoundUpAmountWithCardTag_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 15),
+            Description = "Card charge",
+            Value = 9.40m,
+            Category = "Extras",
+            PaymentSource = null,
+            CardTag = "ChaseMaster4023",
+            RoundUpAmount = 0.60m
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/expenses", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("not a credit-card charge");
+    }
+
+    [Fact]
+    public async Task GetExpensesByMonth_EligibleExpenseWithNoSavedRoundUp_IncludesSuggestion()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 15),
+            Description = "TfL",
+            Value = 9.40m,
+            Category = "Extras",
+            PaymentSource = "Trading212",
+            CardTag = null
+        });
+
+        var response = await client.GetAsync("/api/v1/financial/expenses/month/2026/7");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await response.Content.ReadFromJsonAsync<List<ExpenseDTO>>();
+        items.Should().ContainSingle(e => e.Description == "TfL" && e.SuggestedRoundUpAmount == 0.60m);
+    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
@@ -252,6 +252,141 @@ public class ExpenseServiceTests
         result.Should().ContainSingle(t => t.Category == "Reserva" && t.TotalValue == 70m);
     }
 
+    [Fact]
+    public async Task AddExpenseAsync_WithRoundUpAmountOnRoundUpEnabledBank_SavesAmount()
+    {
+        var service = new ExpenseService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Trading212", Value = 9.40m, RoundUpAmount = 0.60m });
+
+        var result = await service.AddExpenseAsync(request);
+
+        result.RoundUpAmount.Should().Be(0.60m);
+    }
+
+    [Fact]
+    public async Task AddExpenseAsync_WithRoundUpAmountOnNonRoundUpBank_ThrowsNamingTheBank()
+    {
+        var service = new ExpenseService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Barclays", RoundUpAmount = 0.50m });
+
+        var act = async () => await service.AddExpenseAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Barclays*does not support round-up*");
+    }
+
+    [Fact]
+    public async Task AddExpenseAsync_WithRoundUpAmountOnCreditCardTaggedExpense_Throws()
+    {
+        var service = new ExpenseService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = null, CardTag = "ChaseMaster4023", RoundUpAmount = 0.50m });
+
+        var act = async () => await service.AddExpenseAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*not a credit-card charge*");
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(1.00)]
+    public async Task AddExpenseAsync_WithRoundUpAmountOutsideRange_Throws(decimal roundUpAmount)
+    {
+        var service = new ExpenseService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Chase", RoundUpAmount = roundUpAmount });
+
+        var act = async () => await service.AddExpenseAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*between £0.00 and £0.99*");
+    }
+
+    [Fact]
+    public async Task AddExpenseAsync_EligibleWithNoRoundUpAmount_ReturnsSuggestedAmount()
+    {
+        var service = new ExpenseService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Trading212", Value = 9.40m });
+
+        var result = await service.AddExpenseAsync(request);
+
+        result.RoundUpAmount.Should().BeNull();
+        result.SuggestedRoundUpAmount.Should().Be(0.60m);
+    }
+
+    [Fact]
+    public async Task AddExpenseAsync_EligibleWithRoundUpAmountAlreadySaved_ReturnsNoSuggestion()
+    {
+        var service = new ExpenseService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Trading212", Value = 9.40m, RoundUpAmount = 0.60m });
+
+        var result = await service.AddExpenseAsync(request);
+
+        result.SuggestedRoundUpAmount.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddExpenseAsync_OnNonRoundUpBank_ReturnsNoSuggestion()
+    {
+        var service = new ExpenseService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Barclays", Value = 9.40m });
+
+        var result = await service.AddExpenseAsync(request);
+
+        result.SuggestedRoundUpAmount.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddExpenseAsync_CreditCardCharge_ReturnsNoSuggestion()
+    {
+        var service = new ExpenseService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = null, CardTag = "ChaseMaster4023", Value = 9.40m });
+
+        var result = await service.AddExpenseAsync(request);
+
+        result.SuggestedRoundUpAmount.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateExpenseAsync_ChangingValueOnly_LeavesRoundUpAmountUnchanged()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new ExpenseService(repository);
+        var added = await service.AddExpenseAsync(ToCreateDto(
+            ValidCreateRequest() with { PaymentSource = "Trading212", Value = 9.40m, RoundUpAmount = 0.60m }));
+
+        var updateRequest = ToUpdateDto(
+            ValidCreateRequest() with { PaymentSource = "Trading212", Value = 20m, RoundUpAmount = 0.60m });
+        var result = await service.UpdateExpenseAsync(added.Id, updateRequest);
+
+        result.Value.Should().Be(20m);
+        result.RoundUpAmount.Should().Be(0.60m);
+    }
+
+    [Fact]
+    public async Task UpdateExpenseAsync_WithNewRoundUpAmount_ChangesIt()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new ExpenseService(repository);
+        var added = await service.AddExpenseAsync(ToCreateDto(
+            ValidCreateRequest() with { PaymentSource = "Trading212", RoundUpAmount = 0.60m }));
+
+        var updateRequest = ToUpdateDto(ValidCreateRequest() with { PaymentSource = "Trading212", RoundUpAmount = 0.10m });
+        var result = await service.UpdateExpenseAsync(added.Id, updateRequest);
+
+        result.RoundUpAmount.Should().Be(0.10m);
+    }
+
+    [Fact]
+    public async Task UpdateExpenseAsync_WithNullRoundUpAmount_ClearsAPreviouslySavedAmount()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new ExpenseService(repository);
+        var added = await service.AddExpenseAsync(ToCreateDto(
+            ValidCreateRequest() with { PaymentSource = "Trading212", RoundUpAmount = 0.60m }));
+
+        var updateRequest = ToUpdateDto(ValidCreateRequest() with { PaymentSource = "Trading212", RoundUpAmount = null });
+        var result = await service.UpdateExpenseAsync(added.Id, updateRequest);
+
+        result.RoundUpAmount.Should().BeNull();
+    }
+
     private static ExpenseCreateRequest ValidCreateRequest() => new(
         new DateOnly(2026, 7, 15),
         "Weekly groceries",
@@ -267,7 +402,8 @@ public class ExpenseServiceTests
         Value = r.Value,
         Category = r.Category,
         PaymentSource = r.PaymentSource,
-        CardTag = r.CardTag
+        CardTag = r.CardTag,
+        RoundUpAmount = r.RoundUpAmount
     };
 
     private static ExpenseUpdateDTO ToUpdateDto(ExpenseCreateRequest r) => new()
@@ -277,11 +413,13 @@ public class ExpenseServiceTests
         Value = r.Value,
         Category = r.Category,
         PaymentSource = r.PaymentSource,
-        CardTag = r.CardTag
+        CardTag = r.CardTag,
+        RoundUpAmount = r.RoundUpAmount
     };
 
     private sealed record ExpenseCreateRequest(
-        DateOnly Date, string Description, decimal Value, string Category, string? PaymentSource, string? CardTag);
+        DateOnly Date, string Description, decimal Value, string Category, string? PaymentSource, string? CardTag,
+        decimal? RoundUpAmount = null);
 
     private sealed class StubCashFlowRepository : ICashFlowRepository
     {

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
@@ -264,6 +264,17 @@ public class ExpenseServiceTests
     }
 
     [Fact]
+    public async Task AddExpenseAsync_WithRoundUpAmountOfZero_SavesExplicitZero()
+    {
+        var service = new ExpenseService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Trading212", Value = 10.00m, RoundUpAmount = 0.00m });
+
+        var result = await service.AddExpenseAsync(request);
+
+        result.RoundUpAmount.Should().Be(0.00m);
+    }
+
+    [Fact]
     public async Task AddExpenseAsync_WithRoundUpAmountOnNonRoundUpBank_ThrowsNamingTheBank()
     {
         var service = new ExpenseService(new StubCashFlowRepository());

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/ExpenseTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/ExpenseTests.cs
@@ -204,4 +204,104 @@ public class ExpenseTests
 
         act.Should().Throw<ArgumentException>().WithMessage("*settled credit card expense*");
     }
+
+    [Theory]
+    [InlineData(9.40, 0.60)]
+    [InlineData(10.00, 0.00)]
+    [InlineData(0.01, 0.99)]
+    public void RoundUpSuggestion_ComputesDifferenceToNextWholePound(decimal value, decimal expected)
+    {
+        var expense = Expense.Create(new DateOnly(2026, 7, 1), "Test", value, Category.Mercado, "Chase", null);
+
+        expense.RoundUpSuggestion.Should().Be(expected);
+    }
+
+    [Fact]
+    public void SetRoundUpAmount_OnImmediatePaymentWithinRange_Succeeds()
+    {
+        var expense = CreateImmediateExpense();
+
+        expense.SetRoundUpAmount(0.60m);
+
+        expense.RoundUpAmount.Should().Be(0.60m);
+    }
+
+    [Theory]
+    [InlineData(0.00)]
+    [InlineData(0.99)]
+    public void SetRoundUpAmount_AtRangeBoundaries_Succeeds(decimal amount)
+    {
+        var expense = CreateImmediateExpense();
+
+        expense.SetRoundUpAmount(amount);
+
+        expense.RoundUpAmount.Should().Be(amount);
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(1.00)]
+    public void SetRoundUpAmount_OutsideRange_Throws(decimal amount)
+    {
+        var expense = CreateImmediateExpense();
+
+        var act = () => expense.SetRoundUpAmount(amount);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*between £0.00 and £0.99*");
+    }
+
+    [Fact]
+    public void SetRoundUpAmount_OnCreditCardCharge_Throws()
+    {
+        var expense = CreateCardCharge();
+
+        var act = () => expense.SetRoundUpAmount(0.50m);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*not a credit-card charge*");
+    }
+
+    [Fact]
+    public void SetRoundUpAmount_OnSettledExpense_Throws()
+    {
+        var expense = CreateSettledExpense();
+
+        var act = () => expense.SetRoundUpAmount(0.50m);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*not a credit-card charge*");
+    }
+
+    [Fact]
+    public void SetRoundUpAmount_Null_AlwaysSucceedsRegardlessOfShape()
+    {
+        var immediate = CreateImmediateExpense();
+        var charge = CreateCardCharge();
+
+        immediate.SetRoundUpAmount(null);
+        charge.SetRoundUpAmount(null);
+
+        immediate.RoundUpAmount.Should().BeNull();
+        charge.RoundUpAmount.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetRoundUpAmount_Null_ClearsAPreviouslySetAmount()
+    {
+        var expense = CreateImmediateExpense();
+        expense.SetRoundUpAmount(0.60m);
+
+        expense.SetRoundUpAmount(null);
+
+        expense.RoundUpAmount.Should().BeNull();
+    }
+
+    [Fact]
+    public void UpdateDetails_ChangingValue_LeavesRoundUpAmountUnchanged()
+    {
+        var expense = CreateImmediateExpense();
+        expense.SetRoundUpAmount(0.60m);
+
+        expense.UpdateDetails(expense.Date, expense.Description, 20m, expense.Category, expense.PaymentSource, expense.CardTag);
+
+        expense.RoundUpAmount.Should().Be(0.60m);
+    }
 }

--- a/docs/P13-F02-expense-round-up-capture/plan.md
+++ b/docs/P13-F02-expense-round-up-capture/plan.md
@@ -1,0 +1,19 @@
+# Implementation Plan: F02. Expense Round-Up Capture
+
+**Prerequisites:**
+- F01 merged (`Bank` entity, `ICashFlowRepository.GetBanks()`, `BankNameResolver` available)
+- .NET SDK; no new packages
+
+### Stage 1: Domain Model
+
+**1. `Expense` round-up field and invariant** - Add the stored round-up amount and the computed suggestion to the entity, along with the transition method that enforces the payment-shape and range invariants described in the spec, while leaving every other transition (`Create`, `UpdateDetails`, `Settle`, `Unsettle`) free of any round-up-recalculation side effect. See spec Sections 3 and 4.
+
+### Stage 2: Application Layer
+
+**2. Expense DTOs** - Add the round-up amount field to the create/update request DTOs and both the stored amount and the computed suggestion to the read DTO. See spec Sections 4 and 5.
+
+**3. Expense service validation and suggestion** - Wire `ExpenseService` to validate a submitted round-up amount against the live bank list before applying it to the entity, and to compute the exposed suggestion under the eligibility rule. See spec Sections 3 and 4.
+
+### Stage 3: Verification
+
+**4. Full-solution verification** - Run the complete .NET test suite and exercise the create/update expense endpoints end-to-end to confirm the suggestion, validation errors, and update semantics behave as specified.

--- a/docs/P13-F02-expense-round-up-capture/spec.md
+++ b/docs/P13-F02-expense-round-up-capture/spec.md
@@ -1,0 +1,152 @@
+# F02. Expense Round-Up Capture
+
+## 1. Technical Overview
+
+**What:** `Expense` gains an optional stored round-up amount (`decimal? RoundUpAmount`) and a computed suggestion (`decimal RoundUpSuggestion`, the difference to the next whole £1). A round-up amount is settable only on an `ImmediatePayment` expense (bank-paid, not a credit-card charge), restricted to £0.00–£0.99, and — critically — is never recalculated when the expense's `Value` is edited afterward; only an explicit new value in the request changes it. `ExpenseService` additionally validates, when a non-null amount is supplied, that the expense's resolved bank has `RoundUpEnabled = true` (via F01's `BankNameResolver`/`ICashFlowRepository.GetBanks()`), and exposes a `SuggestedRoundUpAmount` in the read DTO whenever the expense is eligible and no amount has been saved yet.
+
+**Why:** The suggestion and the saved amount need to travel together everywhere an expense is read or written (F03's form, F04's balance totals), so both are added to the existing `Expense`/`ExpenseDTO`/create-update DTO surface rather than as a separate concept — consistent with how `PaymentStatus` is already a derived, always-present field alongside the stored payment fields.
+
+**Scope:**
+- Included: `Expense.RoundUpAmount` (stored) and `Expense.RoundUpSuggestion` (computed, pure math over `Value`); a domain-level eligibility guard (`ImmediatePayment`-only) and range check (£0.00–£0.99); `ExpenseService` eligibility check against the live `Bank` list; `RoundUpAmount`/`SuggestedRoundUpAmount` on the DTOs; full-replace update semantics identical to every other expense field (whatever the request carries — including `null` — becomes the new stored value).
+- Excluded: any UI (F03); balance/round-up total calculations (F04); credit-card charge/settled expenses (round-up never applies, per PRD Out of Scope); a Bank management screen (F01's scope, already shipped).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.CashFlow.Domain/Entities/Expense.cs` — `RoundUpAmount` field, `RoundUpSuggestion` computed property, `SetRoundUpAmount(decimal?)` method
+- `Financial.CashFlow.Application/DTOs/ExpenseDTO.cs` — `RoundUpAmount`, `SuggestedRoundUpAmount`
+- `Financial.CashFlow.Application/DTOs/ExpenseCreateDTO.cs`, `ExpenseUpdateDTO.cs` — `RoundUpAmount` (request input)
+- `Financial.CashFlow.Application/Services/ExpenseService.cs` — bank round-up-eligibility check, suggestion computation in `ToDto`
+
+```mermaid
+graph TD
+  A["ExpenseCreateDTO / ExpenseUpdateDTO"] --> B[ExpenseService]
+  B --> C["BankNameResolver.TryResolve (RoundUpEnabled check)"]
+  C --> D["ICashFlowRepository.GetBanks()"]
+  B --> E["Expense.SetRoundUpAmount"]
+  E --> F["Expense.RoundUpAmount (stored)"]
+  B --> G["Expense.RoundUpSuggestion (computed)"]
+  G --> H["ExpenseDTO.SuggestedRoundUpAmount"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Where eligibility is enforced | Split across layers: `Expense.SetRoundUpAmount` rejects any non-null amount unless `PaymentStatus == ImmediatePayment` (pure, no external data needed); `ExpenseService` separately rejects a non-null amount when the resolved bank's `RoundUpEnabled` is `false` (needs the live `Bank` list, which only Application can reach via the repository) | Push both checks into Application, keeping `Expense` naive | `Expense` already knows its own payment shape (it derives `PaymentStatus` from its own fields), so the shape check belongs with the entity per Clean Architecture (Domain owns its own invariants); only the cross-entity `RoundUpEnabled` lookup needs Application/repository access. |
+| Setting `null` is always allowed, unconditionally | `SetRoundUpAmount(null)` short-circuits before any eligibility/range check and simply clears the field | Still validating eligibility even when clearing | Clearing removes data — it can never violate an invariant, regardless of the expense's current shape (e.g., clearing after switching an expense from bank-paid to card-charged must succeed, not throw). The AC "it can be cleared back to 'not yet decided'" needs this to work unconditionally. |
+| Update semantics | Full-replace, exactly like every other `ExpenseUpdateDTO` field: `ExpenseService.UpdateExpenseAsync` always calls `expense.SetRoundUpAmount(request.RoundUpAmount)` once after `UpdateDetails`, regardless of whether the value looks unchanged | A dedicated `PATCH`-style "only touch round-up if provided" endpoint | The PRD requires that editing `Value` never recalculates a saved `RoundUpAmount` — that guarantee lives entirely in the client (F03) always resending the *current* stored amount, never a freshly recomputed suggestion, exactly mirroring how `Date`/`Description`/`Category` are already resent unchanged on every edit. No new endpoint or partial-update machinery is needed. |
+| Suggestion computation ownership | `Expense.RoundUpSuggestion` is a plain computed property (`Math.Ceiling(Value) - Value`), always present with no eligibility gating of its own — mirrors the existing `PaymentStatus` computed-property pattern (harmless to compute even when not applicable) | Compute the suggestion inline in `ExpenseService` only | Keeping the arithmetic on the entity (pure function of `Value`) is testable in isolation exactly like `PaymentStatus`, and matches this codebase's established convention of computed properties serializing harmlessly alongside stored fields (see F01/P12-F03 precedent: `PaymentStatus` already round-trips into `data-cashflow.json` even though it's derived). |
+| Suggestion exposure gating | `ExpenseService.ToDto` sets `ExpenseDTO.SuggestedRoundUpAmount` to `expense.RoundUpSuggestion` only when `RoundUpAmount is null && PaymentStatus == ImmediatePayment && ` the resolved bank's `RoundUpEnabled == true`; otherwise `null` | Always expose the raw suggestion, let the frontend decide whether to show it | The PRD's eligibility rule ("no suggestion... for a non-round-up bank or credit-card-tagged expenses") is a business rule, not a display concern — it belongs in the Application layer, which is the only layer that can resolve the bank's `RoundUpEnabled` flag. |
+| Bank resolution reuse | Reuse F01's `BankNameResolver.TryResolve` against `_repository.GetBanks()` — the exact same call `ExpenseService.ValidateFields` already makes to validate `PaymentSource` | A dedicated round-up-specific bank lookup | No new abstraction needed; the resolver is already a pure, stateless, reusable lookup. |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Domain/Entities/Expense.cs` | Modified | Round-up storage + invariant | `RoundUpAmount` (`decimal?`, private set); `RoundUpSuggestion` (`decimal`, computed `Math.Ceiling(Value) - Value`); `SetRoundUpAmount(decimal? amount)`: `null` always clears; non-null requires `PaymentStatus == ImmediatePayment` (else throws) and `0m <= amount <= 0.99m` (else throws) |
+| `Financial.CashFlow.Application/DTOs/ExpenseDTO.cs` | Modified | Read model | `decimal? RoundUpAmount` (stored value); `decimal? SuggestedRoundUpAmount` (eligibility-gated, null when not applicable or already saved) |
+| `Financial.CashFlow.Application/DTOs/ExpenseCreateDTO.cs` | Modified | Create request | `decimal? RoundUpAmount` (optional, defaults to "not yet decided") |
+| `Financial.CashFlow.Application/DTOs/ExpenseUpdateDTO.cs` | Modified | Update request | `decimal? RoundUpAmount` (full-replace, same as every other field) |
+| `Financial.CashFlow.Application/Services/ExpenseService.cs` | Modified | Business rules | `AddExpenseAsync`/`UpdateExpenseAsync` call a new private `ValidateRoundUpEligibility(decimal? amount, string? paymentSource)` (resolves the bank via `BankNameResolver` + `_repository.GetBanks()`, throws `ArgumentException` naming the bank when `RoundUpEnabled` is `false`) before calling `expense.SetRoundUpAmount(amount)`; `ToDto` computes `SuggestedRoundUpAmount` per the gating rule in Section 3 |
+
+## 5. API Contracts
+
+**Endpoint: Create Expense** (existing, extended)
+- **Method:** POST
+- **Path:** `/api/v1/financial/expenses`
+
+**Request (added field):**
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|--------------|
+| `roundUpAmount` | `decimal?` | No | `0.00`–`0.99` inclusive; only settable when `paymentSource` resolves to a `RoundUpEnabled` bank and `cardTag` is absent | Round-up amount to save immediately; omit/`null` to leave "not yet decided" |
+
+**Request Example:**
+```json
+{
+  "date": "2026-07-15",
+  "description": "Weekly groceries",
+  "value": 9.40,
+  "category": "Mercado",
+  "paymentSource": "Trading212",
+  "cardTag": null,
+  "roundUpAmount": 0.60
+}
+```
+
+**Response (added fields):**
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `roundUpAmount` | `decimal?` | Currently saved round-up amount, or `null` if not yet decided |
+| `suggestedRoundUpAmount` | `decimal?` | `ceil(value) - value`, present only when eligible and `roundUpAmount` is `null` |
+
+**Response Example:**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "date": "2026-07-15",
+  "description": "Weekly groceries",
+  "value": 9.40,
+  "category": "Mercado",
+  "paymentSource": "Trading212",
+  "cardTag": null,
+  "settledAt": null,
+  "paymentStatus": "ImmediatePayment",
+  "roundUpAmount": 0.60,
+  "suggestedRoundUpAmount": null
+}
+```
+
+**Endpoint: Update Expense** (existing, extended) — same `roundUpAmount` field added to the request body, full-replace semantics (see Section 3).
+
+**Error Codes (added):**
+
+| Code | HTTP Status | Description |
+|------|-------------|--------------|
+| N/A (existing `ArgumentException` → 400 pattern) | 400 | Round-up amount on a credit-card-tagged expense: "Round-up only applies to an expense paid directly from a bank, not a credit-card charge." |
+| N/A | 400 | Round-up amount on a non-round-up bank: "Bank '{name}' does not support round-up." |
+| N/A | 400 | Round-up amount outside £0.00–£0.99: "Round-up amount must be between £0.00 and £0.99." |
+
+## 6. Data Model
+
+`Expense` records in `data-cashflow.json` gain one new field, `RoundUpAmount` (nullable decimal), defaulting to absent/`null` on every pre-existing record (no migration needed — matches PRD's "Historical round-up backfill" Out-of-Scope item). The computed `RoundUpSuggestion` is **not** persisted as a new top-level concept exposed via the API contract, but — mirroring the existing `PaymentStatus` computed property — it does serialize onto the `Expense` JSON object as a harmless derived field, ignored on deserialization (no setter, same mechanism as `PaymentStatus`).
+
+```json
+{
+  "Id": "...",
+  "Date": "2026-07-15",
+  "Description": "Weekly groceries",
+  "Value": 9.40,
+  "Category": "Mercado",
+  "PaymentSource": "Trading212",
+  "CardTag": null,
+  "SettledAt": null,
+  "RoundUpAmount": 0.60,
+  "PaymentStatus": "ImmediatePayment",
+  "RoundUpSuggestion": 0.60
+}
+```
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Tests/Financial.CashFlow.Domain.Tests/Entities/ExpenseTests.cs` | Unit | `Expense` | `RoundUpSuggestion` computes `ceil(value) - value` for various values (including an already-whole £ value → `0.00`); `SetRoundUpAmount` on an `ImmediatePayment` expense within range succeeds; on a `CreditCardCharge`/`CreditCardSettled` expense throws; outside £0.00–£0.99 throws (both bounds, above and below); exactly `0.00` and exactly `0.99` succeed; `SetRoundUpAmount(null)` always succeeds regardless of shape, including clearing a previously-set amount; `UpdateDetails` never touches `RoundUpAmount` |
+| `Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs` | Unit | `ExpenseService` | `AddExpenseAsync`/`UpdateExpenseAsync` with a valid `RoundUpAmount` against a `RoundUpEnabled` bank saves it; against a non-round-up bank (e.g. Barclays) throws naming the bank; on a credit-card-tagged request throws; outside range throws; `ToDto` returns `SuggestedRoundUpAmount = 0.60` for a £9.40 expense on a round-up-enabled bank with no saved amount; returns `null` suggestion once an amount is saved; returns `null` suggestion for a non-round-up bank; returns `null` suggestion for a credit-card charge; editing only `Value` (resending the same `RoundUpAmount`) leaves it unchanged; explicitly submitting a new `RoundUpAmount` on update changes it; submitting `null` on update clears a previously-saved amount |
+| `Tests/Financial.Api.Tests/ExpenseEndpointsTests.cs` | Integration | Expense endpoints | POST with a valid round-up amount against a round-up-enabled bank returns 200 with `roundUpAmount` set; POST against Barclays (round-up disabled) with a round-up amount returns 400; POST with a round-up amount and a `cardTag` returns 400; GET-by-month response includes `suggestedRoundUpAmount` for an eligible, unsaved expense |
+
+**Acceptance tests (PRD Section 9, F02):**
+- £9.40 on a `RoundUpEnabled` bank suggests £0.60 → `ExpenseServiceTests` + `ExpenseEndpointsTests`
+- Round-up on a credit-card-tagged expense rejected → `ExpenseTests` (`SetRoundUpAmount` shape guard) + `ExpenseServiceTests`/`ExpenseEndpointsTests`
+- Round-up on a `RoundUpEnabled = false` bank rejected → `ExpenseServiceTests`/`ExpenseEndpointsTests`
+- Outside £0.00–£0.99 rejected → `ExpenseTests` + `ExpenseServiceTests`
+- Exactly £0.00 can be saved → `ExpenseTests` + `ExpenseServiceTests`
+- Editing `Value` after saving leaves `RoundUpAmount` unchanged → `ExpenseServiceTests`
+- A saved amount can be directly edited later → `ExpenseServiceTests`
+
+**Cross-Feature Integration criteria touching F02 (PRD Section 9):**
+- "F02's round-up suggestion and eligibility check correctly read each bank's `RoundUpEnabled` flag as defined by F01" → `ExpenseServiceTests` (suggestion/rejection tests directly exercise `BankNameResolver` + `ICashFlowRepository.GetBanks()` from F01)

--- a/docs/prd/P13-prd-bank-round-up/prd-bank-round-up.md
+++ b/docs/prd/P13-prd-bank-round-up/prd-bank-round-up.md
@@ -215,13 +215,13 @@ graph TD
 - [x] Card statement settlement (mark paid / unmark paid) continues to function exactly as it did before this change, now referencing a bank instead of the old enum
 
 ### F02. Expense Round-Up Capture
-- [ ] An eligible expense (paid directly from a `RoundUpEnabled` bank) with value £9.40 is offered a suggested round-up of £0.60
-- [ ] Saving a round-up amount on a credit-card-tagged expense is rejected with a validation message
-- [ ] Saving a round-up amount on an expense whose bank has `RoundUpEnabled = false` is rejected with a validation message
-- [ ] Saving a round-up amount outside the £0.00–£0.99 range is rejected with a validation message
-- [ ] A round-up amount can be explicitly saved as £0.00
-- [ ] Editing an expense's value after its round-up amount is saved leaves that round-up amount unchanged
-- [ ] A previously saved round-up amount can be directly edited to a new value at any time after the expense was created
+- [x] An eligible expense (paid directly from a `RoundUpEnabled` bank) with value £9.40 is offered a suggested round-up of £0.60
+- [x] Saving a round-up amount on a credit-card-tagged expense is rejected with a validation message
+- [x] Saving a round-up amount on an expense whose bank has `RoundUpEnabled = false` is rejected with a validation message
+- [x] Saving a round-up amount outside the £0.00–£0.99 range is rejected with a validation message
+- [x] A round-up amount can be explicitly saved as £0.00
+- [x] Editing an expense's value after its round-up amount is saved leaves that round-up amount unchanged
+- [x] A previously saved round-up amount can be directly edited to a new value at any time after the expense was created
 
 ### F03. Expense Form Bank Picker & Round-Up UX
 - [ ] The expense form's bank picker lists the banks resolved from F01 rather than a fixed set of options
@@ -237,6 +237,6 @@ graph TD
 - [ ] The Banks panel's balance and round-up total both update immediately after an expense is saved
 
 ### Cross-Feature Integration
-- [ ] F02's round-up suggestion and eligibility check correctly read each bank's `RoundUpEnabled` flag as defined by F01, offering a suggestion only for banks where it is `true`
+- [x] F02's round-up suggestion and eligibility check correctly read each bank's `RoundUpEnabled` flag as defined by F01, offering a suggestion only for banks where it is `true`
 - [ ] F03's bank picker and round-up field correctly reflect the bank list and `RoundUpEnabled` flags from F01, and correctly read and write the round-up amount contract defined by F02
 - [ ] F04's balance and round-up total calculations correctly group expenses by the bank identity defined by F01 and correctly sum the round-up amounts defined by F02


### PR DESCRIPTION
## Summary

Implements **F02 – Expense Round-Up Capture** from the P13 PRD, per the committed spec/plan in `docs/P13-F02-expense-round-up-capture/`.

- `Expense` gains a stored `RoundUpAmount` (`decimal?`) and a computed `RoundUpSuggestion` (`ceil(Value) − Value`), mirroring the existing `PaymentStatus` computed-property pattern
- `Expense.SetRoundUpAmount`: setting `null` always succeeds (clearing is never invalid); setting a value requires the expense to be `ImmediatePayment` (not a credit-card charge) and within £0.00–£0.99
- `ExpenseService` additionally validates, before applying a non-null amount, that the expense's resolved bank has `RoundUpEnabled = true` (reusing F01's `BankNameResolver`/`ICashFlowRepository.GetBanks()`), rejecting with a message naming the bank otherwise
- `ExpenseDTO.SuggestedRoundUpAmount` is populated only when eligible and nothing is saved yet; `RoundUpAmount` always round-trips through create/update as a full-replace field, exactly like every other expense field — so editing `Value` alone never touches a saved round-up amount, and an explicit new value (including `null`) always takes effect
- No UI or balance-calculation changes — those are F03/F04

## Acceptance Criteria (PRD Section 9 — F02)

- [x] An eligible expense (paid directly from a `RoundUpEnabled` bank) with value £9.40 is offered a suggested round-up of £0.60
- [x] Saving a round-up amount on a credit-card-tagged expense is rejected with a validation message
- [x] Saving a round-up amount on an expense whose bank has `RoundUpEnabled = false` is rejected with a validation message
- [x] Saving a round-up amount outside the £0.00–£0.99 range is rejected with a validation message
- [x] A round-up amount can be explicitly saved as £0.00
- [x] Editing an expense's value after its round-up amount is saved leaves that round-up amount unchanged
- [x] A previously saved round-up amount can be directly edited to a new value at any time after the expense was created

Cross-feature: "F02's round-up suggestion and eligibility check correctly read each bank's `RoundUpEnabled` flag as defined by F01" is also checked in the PRD (only names F01+F02, both now shipped). The F03/F04 cross-feature bullets stay unchecked until those features land.

## Test plan

- New/updated `ExpenseTests` (Domain): suggestion math, range boundaries, credit-card/settled rejection, unconditional `null` clearing, `UpdateDetails` never touching the saved amount
- New `ExpenseServiceTests` cases: round-up-enabled vs. non-round-up bank, credit-card rejection, out-of-range rejection, explicit £0.00, suggestion gating (saved amount / non-round-up bank / credit-card charge all suppress it), full-replace update semantics (value-only edit leaves amount unchanged, explicit edit changes it, `null` clears it)
- New `ExpenseEndpointsTests` integration cases covering the same scenarios end-to-end through the API
- Full .NET solution: all 12 test projects green (1,243 passed, 5 pre-existing skips unrelated to this change, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)