### PR TITLE
feat(P13-F03): expense form bank picker and round-up UX

### DIFF
--- a/Financial.Api/Controllers/BanksController.cs
+++ b/Financial.Api/Controllers/BanksController.cs
@@ -1,0 +1,25 @@
+using Financial.CashFlow.Application.DTOs;
+using Financial.CashFlow.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Financial.Api.Controllers;
+
+[ApiController]
+[Route("banks")]
+public sealed class BanksController : ControllerBase
+{
+    private readonly IBankService _bankService;
+
+    public BanksController(IBankService bankService)
+    {
+        _bankService = bankService ?? throw new ArgumentNullException(nameof(bankService));
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(IReadOnlyList<BankDTO>), StatusCodes.Status200OK)]
+    public ActionResult<IReadOnlyList<BankDTO>> GetBanks()
+    {
+        var result = _bankService.GetBanks();
+        return Ok(result);
+    }
+}

--- a/Financial.CashFlow.Application/DTOs/BankDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/BankDTO.cs
@@ -1,0 +1,13 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Read model for a tracked bank.
+/// </summary>
+public sealed class BankDTO
+{
+    /// <summary>Bank name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Whether this bank rounds up card payments.</summary>
+    public required bool RoundUpEnabled { get; init; }
+}

--- a/Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs
+++ b/Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class CashFlowApplicationServiceCollectionExtensions
         services.AddSingleton<IInvestmentSnapshotService, InvestmentSnapshotService>();
         services.AddSingleton<ICardStatementService, CardStatementService>();
         services.AddSingleton<IYearlySummaryService, YearlySummaryService>();
+        services.AddSingleton<IBankService, BankService>();
 
         return services;
     }

--- a/Financial.CashFlow.Application/Interfaces/IBankService.cs
+++ b/Financial.CashFlow.Application/Interfaces/IBankService.cs
@@ -1,0 +1,8 @@
+using Financial.CashFlow.Application.DTOs;
+
+namespace Financial.CashFlow.Application.Interfaces;
+
+public interface IBankService
+{
+    IReadOnlyList<BankDTO> GetBanks();
+}

--- a/Financial.CashFlow.Application/Services/BankService.cs
+++ b/Financial.CashFlow.Application/Services/BankService.cs
@@ -1,0 +1,19 @@
+using Financial.CashFlow.Application.DTOs;
+using Financial.CashFlow.Application.Interfaces;
+
+namespace Financial.CashFlow.Application.Services;
+
+public sealed class BankService : IBankService
+{
+    private readonly ICashFlowRepository _repository;
+
+    public BankService(ICashFlowRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public IReadOnlyList<BankDTO> GetBanks() =>
+        _repository.GetBanks()
+            .Select(bank => new BankDTO { Name = bank.Name, RoundUpEnabled = bank.RoundUpEnabled })
+            .ToList();
+}

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -5,6 +5,7 @@ import type {
   AssetCashFlowDto,
   AssetDetailsDto,
   AssetPriceDto,
+  BankDto,
   BrokerNodeDto,
   CalculateXirrRequestDto,
   CardStatementDto,
@@ -99,6 +100,7 @@ export interface FinancialApiClient {
   updateInvestmentSnapshotValue: (id: string, request: UpdateInvestmentSnapshotValueDto) => Promise<InvestmentSnapshotDto>
   getExpensesByMonth: (year: number, month: number) => Promise<ExpenseDto[]>
   getCategoryTotalsByMonth: (year: number, month: number) => Promise<CategoryTotalDto[]>
+  getBanks: () => Promise<BankDto[]>
   createExpense: (request: CreateExpenseDto) => Promise<ExpenseDto>
   updateExpense: (id: string, request: UpdateExpenseDto) => Promise<ExpenseDto>
   deleteExpense: (id: string) => Promise<void>
@@ -321,6 +323,7 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
     getExpensesByMonth: (year, month) => request<ExpenseDto[]>(`/expenses/month/${year}/${month}`),
     getCategoryTotalsByMonth: (year, month) =>
       request<CategoryTotalDto[]>(`/expenses/month/${year}/${month}/category-totals`),
+    getBanks: () => request<BankDto[]>('/banks'),
     createExpense: (requestBody) =>
       request<ExpenseDto>('/expenses', {
         method: 'POST',

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -366,6 +366,8 @@ export interface ExpenseDto {
   cardTag: string | null
   settledAt: string | null
   paymentStatus: string
+  roundUpAmount: number | null
+  suggestedRoundUpAmount: number | null
 }
 
 export interface CreateExpenseDto {
@@ -375,6 +377,7 @@ export interface CreateExpenseDto {
   category: string
   paymentSource: string | null
   cardTag: string | null
+  roundUpAmount: number | null
 }
 
 export interface UpdateExpenseDto {
@@ -384,6 +387,12 @@ export interface UpdateExpenseDto {
   category: string
   paymentSource: string | null
   cardTag: string | null
+  roundUpAmount: number | null
+}
+
+export interface BankDto {
+  name: string
+  roundUpEnabled: boolean
 }
 
 export interface CategoryTotalDto {

--- a/Financial.Web/src/components/__tests__/ExpensesSection.test.tsx
+++ b/Financial.Web/src/components/__tests__/ExpensesSection.test.tsx
@@ -14,6 +14,8 @@ const EXPENSES: ExpenseDto[] = [
     cardTag: null,
     settledAt: null,
     paymentStatus: 'ImmediatePayment',
+    roundUpAmount: null,
+    suggestedRoundUpAmount: null,
   },
   {
     id: 'e2',
@@ -25,6 +27,8 @@ const EXPENSES: ExpenseDto[] = [
     cardTag: 'BarclaysPlatinumVisa8003',
     settledAt: null,
     paymentStatus: 'CreditCardCharge',
+    roundUpAmount: null,
+    suggestedRoundUpAmount: null,
   },
 ]
 

--- a/Financial.Web/src/hooks/useMonthly.test.ts
+++ b/Financial.Web/src/hooks/useMonthly.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FinancialApiClient } from '../api/financialApiClient'
-import type { CardStatementDto, CategoryTotalDto, ExpenseDto } from '../api/types'
+import type { BankDto, CardStatementDto, CategoryTotalDto, ExpenseDto } from '../api/types'
 import { useMonthly } from './useMonthly'
 
 const NOW = new Date()
@@ -15,6 +15,7 @@ const NEXT_MONTH_INPUT = `${NEXT_MONTH_YEAR}-${String(NEXT_MONTH).padStart(2, '0
 const getExpensesByMonthMock = vi.fn<FinancialApiClient['getExpensesByMonth']>()
 const getCategoryTotalsByMonthMock = vi.fn<FinancialApiClient['getCategoryTotalsByMonth']>()
 const getCardStatementsByMonthMock = vi.fn<FinancialApiClient['getCardStatementsByMonth']>()
+const getBanksMock = vi.fn<FinancialApiClient['getBanks']>()
 const createExpenseMock = vi.fn<FinancialApiClient['createExpense']>()
 const updateExpenseMock = vi.fn<FinancialApiClient['updateExpense']>()
 const deleteExpenseMock = vi.fn<FinancialApiClient['deleteExpense']>()
@@ -26,6 +27,7 @@ vi.mock('../api/financialApiClient', () => ({
     getExpensesByMonth: getExpensesByMonthMock,
     getCategoryTotalsByMonth: getCategoryTotalsByMonthMock,
     getCardStatementsByMonth: getCardStatementsByMonthMock,
+    getBanks: getBanksMock,
     createExpense: createExpenseMock,
     updateExpense: updateExpenseMock,
     deleteExpense: deleteExpenseMock,
@@ -33,6 +35,12 @@ vi.mock('../api/financialApiClient', () => ({
     unmarkCardStatementPaid: unmarkCardStatementPaidMock,
   }),
 }))
+
+const BANKS: BankDto[] = [
+  { name: 'Barclays', roundUpEnabled: false },
+  { name: 'Trading212', roundUpEnabled: true },
+  { name: 'Chase', roundUpEnabled: true },
+]
 
 const EXPENSES: ExpenseDto[] = [
   {
@@ -45,6 +53,8 @@ const EXPENSES: ExpenseDto[] = [
     cardTag: null,
     settledAt: null,
     paymentStatus: 'ImmediatePayment',
+    roundUpAmount: null,
+    suggestedRoundUpAmount: null,
   },
 ]
 
@@ -61,10 +71,11 @@ describe('useMonthly', () => {
     getExpensesByMonthMock.mockResolvedValue(EXPENSES)
     getCategoryTotalsByMonthMock.mockResolvedValue(CATEGORY_TOTALS)
     getCardStatementsByMonthMock.mockResolvedValue(CARD_STATEMENTS)
+    getBanksMock.mockResolvedValue(BANKS)
     vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
 
-  it('fetches expenses, category totals, and card statements for the current month on mount', async () => {
+  it('fetches expenses, category totals, card statements, and banks for the current month on mount', async () => {
     const { result } = renderHook(() => useMonthly())
 
     expect(result.current.isLoading).toBe(true)
@@ -73,10 +84,12 @@ describe('useMonthly', () => {
     expect(getExpensesByMonthMock).toHaveBeenCalledWith(CURRENT_YEAR, CURRENT_MONTH)
     expect(getCategoryTotalsByMonthMock).toHaveBeenCalledWith(CURRENT_YEAR, CURRENT_MONTH)
     expect(getCardStatementsByMonthMock).toHaveBeenCalledWith(CURRENT_YEAR, CURRENT_MONTH)
+    expect(getBanksMock).toHaveBeenCalledOnce()
     expect(result.current.monthInputValue).toBe(CURRENT_MONTH_INPUT)
     expect(result.current.expenses).toEqual(EXPENSES)
     expect(result.current.categoryTotals).toEqual(CATEGORY_TOTALS)
     expect(result.current.cardStatements).toEqual(CARD_STATEMENTS)
+    expect(result.current.banks).toEqual(BANKS)
   })
 
   it('computes the combined adjustment figure as the sum of outstanding totals', async () => {
@@ -86,7 +99,7 @@ describe('useMonthly', () => {
     expect(result.current.adjustmentTotal).toBe(100)
   })
 
-  it('computes category totals sum and per-bank totals from the fetched expenses', async () => {
+  it('computes category totals sum and per-bank totals from the fetched banks and expenses', async () => {
     const { result } = renderHook(() => useMonthly())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
@@ -359,5 +372,144 @@ describe('useMonthly', () => {
       { bank: 'Chase', totalValue: 0 },
     ])
     expect(result.current.bankTotalsSum).toBe(62.5)
+  })
+
+  it('picking a round-up-enabled bank auto-suggests when the field is blank', async () => {
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreateField('createValue', '9.40'))
+    act(() => result.current.setCreateField('createPaymentSource', 'Trading212'))
+
+    expect(result.current.createRoundUpAmount).toBe('0.60')
+  })
+
+  it('picking a round-up-enabled bank does not overwrite an amount the user already typed', async () => {
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreateField('createValue', '9.40'))
+    act(() => result.current.setCreateField('createRoundUpAmount', '0.10'))
+    act(() => result.current.setCreateField('createPaymentSource', 'Chase'))
+
+    expect(result.current.createRoundUpAmount).toBe('0.10')
+  })
+
+  it('picking a non-round-up bank does not fill a suggestion', async () => {
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreateField('createValue', '9.40'))
+    act(() => result.current.setCreateField('createPaymentSource', 'Barclays'))
+
+    expect(result.current.createRoundUpAmount).toBe('')
+  })
+
+  it('sends the round-up amount on create for a round-up-enabled bank', async () => {
+    createExpenseMock.mockResolvedValue({ ...EXPENSES[0], id: 'e2' })
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreateField('createDate', '2026-07-16'))
+    act(() => result.current.setCreateField('createDescription', 'TfL'))
+    act(() => result.current.setCreateField('createValue', '9.40'))
+    act(() => result.current.setCreateField('createPaymentSource', 'Trading212'))
+    act(() => result.current.submitCreate())
+
+    await waitFor(() =>
+      expect(createExpenseMock).toHaveBeenCalledWith(expect.objectContaining({ roundUpAmount: 0.6 })),
+    )
+  })
+
+  it('sends a null round-up amount when charging to card', async () => {
+    createExpenseMock.mockResolvedValue({ ...EXPENSES[0], id: 'e2' })
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreateField('createDate', '2026-07-16'))
+    act(() => result.current.setCreateField('createDescription', 'Amazon'))
+    act(() => result.current.setCreateField('createValue', '9.99'))
+    act(() => result.current.setCreatePaymentMode('card'))
+    act(() => result.current.setCreateField('createCardTag', 'ChaseMaster4023'))
+    act(() => result.current.submitCreate())
+
+    await waitFor(() =>
+      expect(createExpenseMock).toHaveBeenCalledWith(expect.objectContaining({ roundUpAmount: null })),
+    )
+  })
+
+  it('rejects a round-up amount outside £0.00-£0.99 before calling the API', async () => {
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.setCreateField('createDate', '2026-07-16'))
+    act(() => result.current.setCreateField('createDescription', 'TfL'))
+    act(() => result.current.setCreateField('createValue', '9.40'))
+    act(() => result.current.setCreateField('createPaymentSource', 'Trading212'))
+    act(() => result.current.setCreateField('createRoundUpAmount', '1.50'))
+    act(() => result.current.submitCreate())
+
+    expect(result.current.createError).toContain('between £0.00 and £0.99')
+    expect(createExpenseMock).not.toHaveBeenCalled()
+  })
+
+  it('pre-fills the edit round-up field from the saved amount, not the suggestion', async () => {
+    const expense: ExpenseDto = {
+      ...EXPENSES[0],
+      id: 'e7',
+      value: 9.4,
+      paymentSource: 'Trading212',
+      roundUpAmount: 0.1,
+      suggestedRoundUpAmount: null,
+    }
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditForm(expense))
+
+    expect(result.current.editRoundUpAmount).toBe('0.1')
+  })
+
+  it('leaves a saved round-up amount unchanged when only Value is edited', async () => {
+    const expense: ExpenseDto = {
+      ...EXPENSES[0],
+      id: 'e8',
+      value: 9.4,
+      paymentSource: 'Trading212',
+      roundUpAmount: 0.1,
+      suggestedRoundUpAmount: null,
+    }
+    updateExpenseMock.mockResolvedValue(expense)
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditForm(expense))
+    act(() => result.current.setEditField('editValue', '20'))
+    act(() => result.current.saveEdit())
+
+    await waitFor(() =>
+      expect(updateExpenseMock).toHaveBeenCalledWith('e8', expect.objectContaining({ value: 20, roundUpAmount: 0.1 })),
+    )
+  })
+
+  it('clears a saved round-up amount when the edit field is emptied', async () => {
+    const expense: ExpenseDto = {
+      ...EXPENSES[0],
+      id: 'e9',
+      paymentSource: 'Trading212',
+      roundUpAmount: 0.1,
+      suggestedRoundUpAmount: null,
+    }
+    updateExpenseMock.mockResolvedValue(expense)
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => result.current.showEditForm(expense))
+    act(() => result.current.setEditField('editRoundUpAmount', ''))
+    act(() => result.current.saveEdit())
+
+    await waitFor(() =>
+      expect(updateExpenseMock).toHaveBeenCalledWith('e9', expect.objectContaining({ roundUpAmount: null })),
+    )
   })
 })

--- a/Financial.Web/src/hooks/useMonthly.ts
+++ b/Financial.Web/src/hooks/useMonthly.ts
@@ -163,7 +163,8 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
       return { ...state, year: action.payload.year, month: action.payload.month }
     case 'FETCH_START':
       return { ...state, isLoading: true, error: null }
-    case 'FETCH_SUCCESS':
+    case 'FETCH_SUCCESS': {
+      const defaultBankStillUnset = state.createPaymentMode === 'bank' && state.createPaymentSource === ''
       return {
         ...state,
         isLoading: false,
@@ -171,7 +172,11 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
         categoryTotals: action.payload.categoryTotals,
         cardStatements: action.payload.cardStatements,
         banks: action.payload.banks,
+        createPaymentSource: defaultBankStillUnset
+          ? (action.payload.banks[0]?.name ?? '')
+          : state.createPaymentSource,
       }
+    }
     case 'FETCH_ERROR':
       return { ...state, isLoading: false, error: action.payload }
     case 'RETRY':

--- a/Financial.Web/src/hooks/useMonthly.ts
+++ b/Financial.Web/src/hooks/useMonthly.ts
@@ -1,14 +1,30 @@
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { createFinancialApiClient } from '../api/financialApiClient'
-import type { CardStatementDto, CategoryTotalDto, ExpenseDto } from '../api/types'
+import type { BankDto, CardStatementDto, CategoryTotalDto, ExpenseDto } from '../api/types'
 import { currentYearMonth, formatMonthInputValue, parseMonthInputValue } from '../utils/formatters'
-
-export const PAYMENT_SOURCES = ['Barclays', 'Trading212', 'Chase'] as const
 
 export type PaymentMode = 'bank' | 'card'
 
 const SETTLED_STATUS = 'CreditCardSettled'
 const CHARGE_STATUS = 'CreditCardCharge'
+
+const MIN_ROUND_UP_AMOUNT = 0
+const MAX_ROUND_UP_AMOUNT = 0.99
+
+function computeRoundUpSuggestion(value: number): number {
+  return Math.round((Math.ceil(value) - value) * 100) / 100
+}
+
+/** Suggests a round-up amount for the given bank/value, or null if not eligible or no value yet. */
+function suggestRoundUpAmount(banks: BankDto[], bankName: string, value: string): string | null {
+  const bank = banks.find((b) => b.name === bankName)
+  if (!bank?.roundUpEnabled) return null
+
+  const parsedValue = Number(value)
+  if (!value.trim() || !isFinite(parsedValue)) return null
+
+  return computeRoundUpSuggestion(parsedValue).toFixed(2)
+}
 
 export interface BankTotal {
   bank: string
@@ -22,6 +38,7 @@ export type CreateFormField =
   | 'createCategory'
   | 'createPaymentSource'
   | 'createCardTag'
+  | 'createRoundUpAmount'
 export type EditField =
   | 'editDate'
   | 'editDescription'
@@ -29,6 +46,7 @@ export type EditField =
   | 'editCategory'
   | 'editPaymentSource'
   | 'editCardTag'
+  | 'editRoundUpAmount'
 
 interface MonthlyState {
   year: number
@@ -36,6 +54,7 @@ interface MonthlyState {
   expenses: ExpenseDto[]
   categoryTotals: CategoryTotalDto[]
   cardStatements: CardStatementDto[]
+  banks: BankDto[]
   isLoading: boolean
   error: string | null
   retryCount: number
@@ -46,6 +65,7 @@ interface MonthlyState {
   createCategory: string
   createPaymentSource: string
   createCardTag: string
+  createRoundUpAmount: string
   isCreating: boolean
   createError: string | null
   editingId: string | null
@@ -55,6 +75,7 @@ interface MonthlyState {
   editCategory: string
   editPaymentSource: string
   editCardTag: string
+  editRoundUpAmount: string
   createPaymentMode: PaymentMode
   editPaymentMode: PaymentMode
   editIsSettled: boolean
@@ -68,7 +89,12 @@ type MonthlyAction =
   | { type: 'FETCH_START' }
   | {
       type: 'FETCH_SUCCESS'
-      payload: { expenses: ExpenseDto[]; categoryTotals: CategoryTotalDto[]; cardStatements: CardStatementDto[] }
+      payload: {
+        expenses: ExpenseDto[]
+        categoryTotals: CategoryTotalDto[]
+        cardStatements: CardStatementDto[]
+        banks: BankDto[]
+      }
     }
   | { type: 'FETCH_ERROR'; payload: string }
   | { type: 'RETRY' }
@@ -96,8 +122,9 @@ const BLANK_CREATE_FORM = {
   createDescription: '',
   createValue: '',
   createCategory: 'Mercado',
-  createPaymentSource: 'Barclays',
+  createPaymentSource: '',
   createCardTag: '',
+  createRoundUpAmount: '',
   createPaymentMode: 'bank',
 } as const
 
@@ -107,6 +134,7 @@ const INITIAL_STATE: MonthlyState = {
   expenses: [],
   categoryTotals: [],
   cardStatements: [],
+  banks: [],
   isLoading: true,
   error: null,
   retryCount: 0,
@@ -121,6 +149,7 @@ const INITIAL_STATE: MonthlyState = {
   editCategory: '',
   editPaymentSource: '',
   editCardTag: '',
+  editRoundUpAmount: '',
   editPaymentMode: 'bank',
   editIsSettled: false,
   isSaving: false,
@@ -141,6 +170,7 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
         expenses: action.payload.expenses,
         categoryTotals: action.payload.categoryTotals,
         cardStatements: action.payload.cardStatements,
+        banks: action.payload.banks,
       }
     case 'FETCH_ERROR':
       return { ...state, isLoading: false, error: action.payload }
@@ -150,8 +180,16 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
       return { ...state, isCreateFormOpen: true, editingId: null, saveError: null }
     case 'CANCEL_CREATE_FORM':
       return { ...state, ...BLANK_CREATE_FORM, isCreateFormOpen: false, createError: null }
-    case 'SET_CREATE_FIELD':
-      return { ...state, [action.payload.field]: action.payload.value }
+    case 'SET_CREATE_FIELD': {
+      const next = { ...state, [action.payload.field]: action.payload.value }
+      if (action.payload.field === 'createPaymentSource' && state.createRoundUpAmount.trim() === '') {
+        const suggestion = suggestRoundUpAmount(state.banks, action.payload.value, state.createValue)
+        if (suggestion !== null) {
+          next.createRoundUpAmount = suggestion
+        }
+      }
+      return next
+    }
     case 'CREATE_START':
       return { ...state, isCreating: true, createError: null }
     case 'CREATE_SUCCESS':
@@ -169,6 +207,7 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
         editCategory: action.payload.category,
         editPaymentSource: action.payload.paymentSource ?? '',
         editCardTag: action.payload.cardTag ?? '',
+        editRoundUpAmount: action.payload.roundUpAmount != null ? String(action.payload.roundUpAmount) : '',
         editPaymentMode: action.payload.paymentStatus === CHARGE_STATUS ? 'card' : 'bank',
         editIsSettled: action.payload.paymentStatus === SETTLED_STATUS,
         saveError: null,
@@ -183,12 +222,21 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
         editCategory: '',
         editPaymentSource: '',
         editCardTag: '',
+        editRoundUpAmount: '',
         editPaymentMode: 'bank',
         editIsSettled: false,
         saveError: null,
       }
-    case 'SET_EDIT_FIELD':
-      return { ...state, [action.payload.field]: action.payload.value }
+    case 'SET_EDIT_FIELD': {
+      const next = { ...state, [action.payload.field]: action.payload.value }
+      if (action.payload.field === 'editPaymentSource' && state.editRoundUpAmount.trim() === '') {
+        const suggestion = suggestRoundUpAmount(state.banks, action.payload.value, state.editValue)
+        if (suggestion !== null) {
+          next.editRoundUpAmount = suggestion
+        }
+      }
+      return next
+    }
     case 'SAVE_START':
       return { ...state, isSaving: true, saveError: null }
     case 'SAVE_SUCCESS':
@@ -202,6 +250,7 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
         editCategory: '',
         editPaymentSource: '',
         editCardTag: '',
+        editRoundUpAmount: '',
         editPaymentMode: 'bank',
         editIsSettled: false,
       }
@@ -211,20 +260,30 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
       return { ...state, saveError: action.payload }
     case 'SET_MARK_PAID_SOURCE':
       return { ...state, markPaidSources: { ...state.markPaidSources, [action.payload.id]: action.payload.value } }
-    case 'SET_CREATE_MODE':
+    case 'SET_CREATE_MODE': {
+      const nextPaymentSource = action.payload === 'bank' ? (state.banks[0]?.name ?? '') : ''
+      const suggestion =
+        action.payload === 'bank' ? suggestRoundUpAmount(state.banks, nextPaymentSource, state.createValue) : null
       return {
         ...state,
         createPaymentMode: action.payload,
-        createPaymentSource: action.payload === 'bank' ? 'Barclays' : '',
+        createPaymentSource: nextPaymentSource,
         createCardTag: '',
+        createRoundUpAmount: suggestion ?? '',
       }
-    case 'SET_EDIT_MODE':
+    }
+    case 'SET_EDIT_MODE': {
+      const nextPaymentSource = action.payload === 'bank' ? (state.banks[0]?.name ?? '') : ''
+      const suggestion =
+        action.payload === 'bank' ? suggestRoundUpAmount(state.banks, nextPaymentSource, state.editValue) : null
       return {
         ...state,
         editPaymentMode: action.payload,
-        editPaymentSource: action.payload === 'bank' ? 'Barclays' : '',
+        editPaymentSource: nextPaymentSource,
         editCardTag: '',
+        editRoundUpAmount: suggestion ?? '',
       }
+    }
     default:
       return state
   }
@@ -237,6 +296,7 @@ export interface MonthlyData {
   categoryTotals: CategoryTotalDto[]
   categoryTotalsSum: number
   cardStatements: CardStatementDto[]
+  banks: BankDto[]
   adjustmentTotal: number
   bankTotals: BankTotal[]
   bankTotalsSum: number
@@ -250,6 +310,7 @@ export interface MonthlyData {
   createCategory: string
   createPaymentSource: string
   createCardTag: string
+  createRoundUpAmount: string
   createPaymentMode: PaymentMode
   isCreating: boolean
   createError: string | null
@@ -265,6 +326,7 @@ export interface MonthlyData {
   editCategory: string
   editPaymentSource: string
   editCardTag: string
+  editRoundUpAmount: string
   editPaymentMode: PaymentMode
   editIsSettled: boolean
   isSaving: boolean
@@ -291,9 +353,10 @@ export function useMonthly(): MonthlyData {
       apiClient.getExpensesByMonth(state.year, state.month),
       apiClient.getCategoryTotalsByMonth(state.year, state.month),
       apiClient.getCardStatementsByMonth(state.year, state.month),
+      apiClient.getBanks(),
     ])
-      .then(([expenses, categoryTotals, cardStatements]) =>
-        dispatch({ type: 'FETCH_SUCCESS', payload: { expenses, categoryTotals, cardStatements } }),
+      .then(([expenses, categoryTotals, cardStatements, banks]) =>
+        dispatch({ type: 'FETCH_SUCCESS', payload: { expenses, categoryTotals, cardStatements, banks } }),
       )
       .catch((err: unknown) => {
         dispatch({ type: 'FETCH_ERROR', payload: err instanceof Error ? err.message : 'Unable to load Monthly data' })
@@ -330,7 +393,17 @@ export function useMonthly(): MonthlyData {
   )
 
   function submitCreate() {
-    const { createDate, createDescription, createValue, createCategory, createPaymentMode, createPaymentSource, createCardTag } = state
+    const {
+      createDate,
+      createDescription,
+      createValue,
+      createCategory,
+      createPaymentMode,
+      createPaymentSource,
+      createCardTag,
+      createRoundUpAmount,
+      banks,
+    } = state
 
     if (!createDate.trim()) {
       dispatch({ type: 'CREATE_ERROR', payload: 'Date is required' })
@@ -353,6 +426,22 @@ export function useMonthly(): MonthlyData {
       return
     }
 
+    const selectedBank = banks.find((b) => b.name === createPaymentSource)
+    const roundUpEligible = createPaymentMode === 'bank' && selectedBank?.roundUpEnabled === true
+
+    let roundUpAmount: number | null = null
+    if (roundUpEligible && createRoundUpAmount.trim() !== '') {
+      const parsedRoundUp = Number(createRoundUpAmount)
+      if (!isFinite(parsedRoundUp) || parsedRoundUp < MIN_ROUND_UP_AMOUNT || parsedRoundUp > MAX_ROUND_UP_AMOUNT) {
+        dispatch({
+          type: 'CREATE_ERROR',
+          payload: `Round-up amount must be between £${MIN_ROUND_UP_AMOUNT.toFixed(2)} and £${MAX_ROUND_UP_AMOUNT.toFixed(2)}`,
+        })
+        return
+      }
+      roundUpAmount = parsedRoundUp
+    }
+
     dispatch({ type: 'CREATE_START' })
 
     void apiClient
@@ -363,6 +452,7 @@ export function useMonthly(): MonthlyData {
         category: createCategory,
         paymentSource: createPaymentMode === 'bank' ? createPaymentSource : null,
         cardTag: createPaymentMode === 'card' ? createCardTag : null,
+        roundUpAmount,
       })
       .then(() => {
         dispatch({ type: 'CREATE_SUCCESS' })
@@ -412,6 +502,23 @@ export function useMonthly(): MonthlyData {
           cardTag: state.editPaymentMode === 'card' ? state.editCardTag : null,
         }
 
+    const selectedBank = state.banks.find((b) => b.name === state.editPaymentSource)
+    const roundUpEligible =
+      !state.editIsSettled && state.editPaymentMode === 'bank' && selectedBank?.roundUpEnabled === true
+
+    let roundUpAmount: number | null = null
+    if (roundUpEligible && state.editRoundUpAmount.trim() !== '') {
+      const parsedRoundUp = Number(state.editRoundUpAmount)
+      if (!isFinite(parsedRoundUp) || parsedRoundUp < MIN_ROUND_UP_AMOUNT || parsedRoundUp > MAX_ROUND_UP_AMOUNT) {
+        dispatch({
+          type: 'SAVE_ERROR',
+          payload: `Round-up amount must be between £${MIN_ROUND_UP_AMOUNT.toFixed(2)} and £${MAX_ROUND_UP_AMOUNT.toFixed(2)}`,
+        })
+        return
+      }
+      roundUpAmount = parsedRoundUp
+    }
+
     dispatch({ type: 'SAVE_START' })
 
     void apiClient
@@ -421,6 +528,7 @@ export function useMonthly(): MonthlyData {
         value,
         category: state.editCategory,
         ...paymentFields,
+        roundUpAmount,
       })
       .then(() => {
         dispatch({ type: 'SAVE_SUCCESS' })
@@ -492,10 +600,10 @@ export function useMonthly(): MonthlyData {
 
   const categoryTotalsSum = state.categoryTotals.reduce((sum, c) => sum + c.totalValue, 0)
 
-  const bankTotals: BankTotal[] = PAYMENT_SOURCES.map((bank) => ({
-    bank,
+  const bankTotals: BankTotal[] = state.banks.map((bank) => ({
+    bank: bank.name,
     totalValue: state.expenses
-      .filter((expense) => expense.paymentSource === bank)
+      .filter((expense) => expense.paymentSource === bank.name)
       .reduce((sum, expense) => sum + expense.value, 0),
   }))
   const bankTotalsSum = bankTotals.reduce((sum, b) => sum + b.totalValue, 0)
@@ -507,6 +615,7 @@ export function useMonthly(): MonthlyData {
     categoryTotals: state.categoryTotals,
     categoryTotalsSum,
     cardStatements: state.cardStatements,
+    banks: state.banks,
     adjustmentTotal,
     bankTotals,
     bankTotalsSum,
@@ -520,6 +629,7 @@ export function useMonthly(): MonthlyData {
     createCategory: state.createCategory,
     createPaymentSource: state.createPaymentSource,
     createCardTag: state.createCardTag,
+    createRoundUpAmount: state.createRoundUpAmount,
     createPaymentMode: state.createPaymentMode,
     setCreatePaymentMode,
     isCreating: state.isCreating,
@@ -535,6 +645,7 @@ export function useMonthly(): MonthlyData {
     editCategory: state.editCategory,
     editPaymentSource: state.editPaymentSource,
     editCardTag: state.editCardTag,
+    editRoundUpAmount: state.editRoundUpAmount,
     editPaymentMode: state.editPaymentMode,
     editIsSettled: state.editIsSettled,
     setEditPaymentMode,

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -1,11 +1,12 @@
 import ErrorState from '../components/ErrorState'
 import ExpensesSection from '../components/ExpensesSection'
 import LoadingState from '../components/LoadingState'
-import { PAYMENT_SOURCES, useMonthly, type CreateFormField, type EditField, type PaymentMode } from '../hooks/useMonthly'
+import { useMonthly, type CreateFormField, type EditField, type PaymentMode } from '../hooks/useMonthly'
+import type { BankDto } from '../api/types'
 import { formatN2 } from '../utils/formatters'
 import './MonthlyPage.css'
 
-type ExpenseFormField = 'date' | 'description' | 'value' | 'category' | 'paymentSource' | 'cardTag'
+type ExpenseFormField = 'date' | 'description' | 'value' | 'category' | 'paymentSource' | 'cardTag' | 'roundUpAmount'
 
 const CREATE_FIELD_BY_FORM_FIELD: Record<ExpenseFormField, CreateFormField> = {
   date: 'createDate',
@@ -14,6 +15,7 @@ const CREATE_FIELD_BY_FORM_FIELD: Record<ExpenseFormField, CreateFormField> = {
   category: 'createCategory',
   paymentSource: 'createPaymentSource',
   cardTag: 'createCardTag',
+  roundUpAmount: 'createRoundUpAmount',
 }
 
 const EDIT_FIELD_BY_FORM_FIELD: Record<ExpenseFormField, EditField> = {
@@ -23,6 +25,7 @@ const EDIT_FIELD_BY_FORM_FIELD: Record<ExpenseFormField, EditField> = {
   category: 'editCategory',
   paymentSource: 'editPaymentSource',
   cardTag: 'editCardTag',
+  roundUpAmount: 'editRoundUpAmount',
 }
 
 const CATEGORIES = [
@@ -52,7 +55,9 @@ interface ExpenseFormProps {
   category: string
   paymentSource: string
   cardTag: string
+  roundUpAmount: string
   paymentMode: PaymentMode
+  banks: BankDto[]
   isSettled: boolean
   isSaving: boolean
   saveError: string | null
@@ -70,7 +75,9 @@ function ExpenseForm({
   category,
   paymentSource,
   cardTag,
+  roundUpAmount,
   paymentMode,
+  banks,
   isSettled,
   isSaving,
   saveError,
@@ -79,6 +86,8 @@ function ExpenseForm({
   onSave,
   onCancel,
 }: ExpenseFormProps) {
+  const selectedBank = banks.find((b) => b.name === paymentSource)
+  const showRoundUpField = paymentMode === 'bank' && selectedBank?.roundUpEnabled === true
   return (
     <div className="monthly-page__form-panel">
       <p className="monthly-page__form-title">{isEditing ? 'Edit Expense' : 'New Expense'}</p>
@@ -157,20 +166,34 @@ function ExpenseForm({
               </label>
             </div>
             {paymentMode === 'bank' ? (
-              <div className="monthly-page__form-field">
-                <label htmlFor="expense-payment-source">Payment Source</label>
-                <select
-                  id="expense-payment-source"
-                  value={paymentSource}
-                  onChange={(e) => onFieldChange('paymentSource', e.target.value)}
-                >
-                  {PAYMENT_SOURCES.map((p) => (
-                    <option key={p} value={p}>
-                      {p}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <>
+                <div className="monthly-page__form-field">
+                  <label htmlFor="expense-payment-source">Payment Source</label>
+                  <select
+                    id="expense-payment-source"
+                    value={paymentSource}
+                    onChange={(e) => onFieldChange('paymentSource', e.target.value)}
+                  >
+                    {banks.map((b) => (
+                      <option key={b.name} value={b.name}>
+                        {b.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                {showRoundUpField && (
+                  <div className="monthly-page__form-field">
+                    <label htmlFor="expense-round-up-amount">Round-Up</label>
+                    <input
+                      id="expense-round-up-amount"
+                      type="number"
+                      step="0.01"
+                      value={roundUpAmount}
+                      onChange={(e) => onFieldChange('roundUpAmount', e.target.value)}
+                    />
+                  </div>
+                )}
+              </>
             ) : (
               <div className="monthly-page__form-field">
                 <label htmlFor="expense-card-tag">Card</label>
@@ -212,6 +235,7 @@ export default function MonthlyPage() {
     categoryTotals,
     categoryTotalsSum,
     cardStatements,
+    banks,
     adjustmentTotal,
     bankTotals,
     bankTotalsSum,
@@ -225,6 +249,7 @@ export default function MonthlyPage() {
     createCategory,
     createPaymentSource,
     createCardTag,
+    createRoundUpAmount,
     createPaymentMode,
     setCreatePaymentMode,
     isCreating,
@@ -240,6 +265,7 @@ export default function MonthlyPage() {
     editCategory,
     editPaymentSource,
     editCardTag,
+    editRoundUpAmount,
     editPaymentMode,
     editIsSettled,
     setEditPaymentMode,
@@ -282,7 +308,9 @@ export default function MonthlyPage() {
           category={isEditing ? editCategory : createCategory}
           paymentSource={isEditing ? editPaymentSource : createPaymentSource}
           cardTag={isEditing ? editCardTag : createCardTag}
+          roundUpAmount={isEditing ? editRoundUpAmount : createRoundUpAmount}
           paymentMode={isEditing ? editPaymentMode : createPaymentMode}
+          banks={banks}
           isSettled={isEditing && editIsSettled}
           isSaving={isEditing ? isSaving : isCreating}
           saveError={isEditing ? saveError : createError}
@@ -360,9 +388,9 @@ export default function MonthlyPage() {
                                 onChange={(e) => setMarkPaidSource(s.id, e.target.value)}
                               >
                                 <option value="">Bank…</option>
-                                {PAYMENT_SOURCES.map((p) => (
-                                  <option key={p} value={p}>
-                                    {p}
+                                {banks.map((b) => (
+                                  <option key={b.name} value={b.name}>
+                                    {b.name}
                                   </option>
                                 ))}
                               </select>{' '}

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -2,11 +2,12 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import MonthlyPage from '../MonthlyPage'
 import type { FinancialApiClient } from '../../api/financialApiClient'
-import type { CardStatementDto, CategoryTotalDto, ExpenseDto } from '../../api/types'
+import type { BankDto, CardStatementDto, CategoryTotalDto, ExpenseDto } from '../../api/types'
 
 const getExpensesByMonthMock = vi.fn<FinancialApiClient['getExpensesByMonth']>()
 const getCategoryTotalsByMonthMock = vi.fn<FinancialApiClient['getCategoryTotalsByMonth']>()
 const getCardStatementsByMonthMock = vi.fn<FinancialApiClient['getCardStatementsByMonth']>()
+const getBanksMock = vi.fn<FinancialApiClient['getBanks']>()
 const createExpenseMock = vi.fn<FinancialApiClient['createExpense']>()
 const updateExpenseMock = vi.fn<FinancialApiClient['updateExpense']>()
 const deleteExpenseMock = vi.fn<FinancialApiClient['deleteExpense']>()
@@ -18,6 +19,7 @@ vi.mock('../../api/financialApiClient', () => ({
     getExpensesByMonth: getExpensesByMonthMock,
     getCategoryTotalsByMonth: getCategoryTotalsByMonthMock,
     getCardStatementsByMonth: getCardStatementsByMonthMock,
+    getBanks: getBanksMock,
     createExpense: createExpenseMock,
     updateExpense: updateExpenseMock,
     deleteExpense: deleteExpenseMock,
@@ -25,6 +27,12 @@ vi.mock('../../api/financialApiClient', () => ({
     unmarkCardStatementPaid: unmarkCardStatementPaidMock,
   }),
 }))
+
+const BANKS: BankDto[] = [
+  { name: 'Barclays', roundUpEnabled: false },
+  { name: 'Trading212', roundUpEnabled: true },
+  { name: 'Chase', roundUpEnabled: true },
+]
 
 const EXPENSES: ExpenseDto[] = [
   {
@@ -37,6 +45,8 @@ const EXPENSES: ExpenseDto[] = [
     cardTag: null,
     settledAt: null,
     paymentStatus: 'ImmediatePayment',
+    roundUpAmount: null,
+    suggestedRoundUpAmount: null,
   },
 ]
 
@@ -53,6 +63,7 @@ describe('MonthlyPage', () => {
     getExpensesByMonthMock.mockResolvedValue(EXPENSES)
     getCategoryTotalsByMonthMock.mockResolvedValue(CATEGORY_TOTALS)
     getCardStatementsByMonthMock.mockResolvedValue(CARD_STATEMENTS)
+    getBanksMock.mockResolvedValue(BANKS)
     vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
 
@@ -241,5 +252,80 @@ describe('MonthlyPage', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'Delete expense' })[0])
 
     await waitFor(() => expect(deleteExpenseMock).toHaveBeenCalledWith('e1'))
+  })
+
+  it('bank picker and mark-paid picker list banks fetched from the API', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
+
+    const bankPicker = screen.getByLabelText('Payment Source')
+    expect(within(bankPicker).getByRole('option', { name: 'Barclays' })).toBeInTheDocument()
+    expect(within(bankPicker).getByRole('option', { name: 'Trading212' })).toBeInTheDocument()
+    expect(within(bankPicker).getByRole('option', { name: 'Chase' })).toBeInTheDocument()
+
+    const markPaidPicker = screen.getByLabelText('Paying bank for BaAmex')
+    expect(within(markPaidPicker).getByRole('option', { name: 'Trading212' })).toBeInTheDocument()
+  })
+
+  it('shows a pre-filled round-up field when a round-up-enabled bank is selected', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
+    fireEvent.change(screen.getByLabelText('Value'), { target: { value: '9.40' } })
+
+    expect(screen.queryByLabelText('Round-Up')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Payment Source'), { target: { value: 'Trading212' } })
+
+    expect(screen.getByLabelText('Round-Up')).toHaveValue(0.6)
+  })
+
+  it('hides the round-up field for a non-round-up bank and for card mode', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
+    fireEvent.change(screen.getByLabelText('Value'), { target: { value: '9.40' } })
+    fireEvent.change(screen.getByLabelText('Payment Source'), { target: { value: 'Trading212' } })
+    expect(screen.getByLabelText('Round-Up')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Payment Source'), { target: { value: 'Barclays' } })
+    expect(screen.queryByLabelText('Round-Up')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Charge to card' }))
+    expect(screen.queryByLabelText('Round-Up')).not.toBeInTheDocument()
+  })
+
+  it('submits a typed round-up amount with the new expense', async () => {
+    createExpenseMock.mockResolvedValue({ ...EXPENSES[0], id: 'e2' })
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
+    fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2026-07-16' } })
+    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'TfL' } })
+    fireEvent.change(screen.getByLabelText('Value'), { target: { value: '9.40' } })
+    fireEvent.change(screen.getByLabelText('Payment Source'), { target: { value: 'Trading212' } })
+    fireEvent.change(screen.getByLabelText('Round-Up'), { target: { value: '0.10' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add Expense' }))
+
+    await waitFor(() =>
+      expect(createExpenseMock).toHaveBeenCalledWith(expect.objectContaining({ roundUpAmount: 0.1 })),
+    )
+  })
+
+  it('pre-fills the edit round-up field with the saved amount', async () => {
+    getExpensesByMonthMock.mockResolvedValue([
+      { ...EXPENSES[0], paymentSource: 'Trading212', roundUpAmount: 0.6, suggestedRoundUpAmount: null },
+    ])
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByText('Lidl UK')).toBeInTheDocument())
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit expense' })[0])
+
+    expect(screen.getByLabelText('Round-Up')).toHaveValue(0.6)
   })
 })

--- a/Tests/Financial.Api.Tests/BanksEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/BanksEndpointsTests.cs
@@ -1,0 +1,25 @@
+using Financial.CashFlow.Application.DTOs;
+using FluentAssertions;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace Financial.Api.Tests;
+
+public class BanksEndpointsTests
+{
+    [Fact]
+    public async Task GetBanks_ReturnsTheThreeSeededBanksWithCorrectRoundUpFlags()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/banks");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var banks = await response.Content.ReadFromJsonAsync<List<BankDTO>>();
+        banks.Should().HaveCount(3);
+        banks.Should().ContainSingle(b => b.Name == "Barclays" && !b.RoundUpEnabled);
+        banks.Should().ContainSingle(b => b.Name == "Trading212" && b.RoundUpEnabled);
+        banks.Should().ContainSingle(b => b.Name == "Chase" && b.RoundUpEnabled);
+    }
+}

--- a/Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs
@@ -1,0 +1,72 @@
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Domain.Entities;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Application.Tests.Services;
+
+public class BankServiceTests
+{
+    [Fact]
+    public void Constructor_WithNullRepository_Throws()
+    {
+        Action act = () => new BankService(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public void GetBanks_MapsEveryRepositoryBankToADto()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Banks.Add(Bank.Create("Barclays", roundUpEnabled: false));
+        repository.Banks.Add(Bank.Create("Trading212", roundUpEnabled: true));
+        var service = new BankService(repository);
+
+        var result = service.GetBanks();
+
+        result.Should().HaveCount(2);
+        result.Should().ContainSingle(b => b.Name == "Barclays" && !b.RoundUpEnabled);
+        result.Should().ContainSingle(b => b.Name == "Trading212" && b.RoundUpEnabled);
+    }
+
+    [Fact]
+    public void GetBanks_WithNoBanks_ReturnsEmptyList()
+    {
+        var service = new BankService(new StubCashFlowRepository());
+
+        var result = service.GetBanks();
+
+        result.Should().BeEmpty();
+    }
+
+    private sealed class StubCashFlowRepository : ICashFlowRepository
+    {
+        public List<Bank> Banks { get; } = new();
+
+        public IEnumerable<Expense> GetExpenses() => Array.Empty<Expense>();
+        public void AddExpense(Expense expense) { }
+        public void DeleteExpense(Guid id) { }
+
+        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
+        public void AddReserveMovement(ReserveMovement movement) { }
+        public void DeleteReserveMovement(Guid id) { }
+
+        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
+        public void AddCardStatement(CardStatement statement) { }
+
+        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
+        public void AddRecurringBill(RecurringBill bill) { }
+        public void DeleteRecurringBill(Guid id) { }
+
+        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
+        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
+        public void DeleteMaeLedgerEntry(Guid id) { }
+
+        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
+        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
+
+        public IEnumerable<Bank> GetBanks() => Banks;
+
+        public Task SaveChangesAsync() => Task.CompletedTask;
+    }
+}

--- a/docs/P13-F03-expense-form-bank-picker-round-up-ux/plan.md
+++ b/docs/P13-F03-expense-form-bank-picker-round-up-ux/plan.md
@@ -1,0 +1,27 @@
+# Implementation Plan: F03. Expense Form Bank Picker & Round-Up UX
+
+**Prerequisites:**
+- F01 merged (`Bank` entity, `ICashFlowRepository.GetBanks()`) and F02 merged (`Expense.RoundUpAmount`/`RoundUpSuggestion`, DTO fields)
+- .NET SDK and Node toolchain; no new packages
+
+### Stage 1: Backend Banks Endpoint
+
+**1. Bank read model and service** - Add the DTO and a thin service that maps the repository's bank list to it, following the same constructor-injected, singleton-registered pattern as every other list-returning service in this layer. See spec Sections 3 and 4.
+
+**2. Banks controller** - Add the read-only endpoint exposing the bank list, following the existing controller conventions (route naming, `ProducesResponseType`, no business logic). See spec Section 5.
+
+### Stage 2: Frontend Data Layer
+
+**3. Frontend types and API client** - Add the bank type and the round-up fields to the expense types, and the new `getBanks` client method, matching the existing simple GET-list pattern. See spec Sections 4 and 5.
+
+**4. `useMonthly` bank state and form fields** - Fetch banks alongside the existing month data, replace the hardcoded bank list export with the fetched state everywhere it's used (bank pickers, bank totals), and add the round-up amount fields to the create/edit form state. See spec Sections 3 and 4.
+
+### Stage 3: Form UX
+
+**5. Bank pickers and round-up field** - Wire the expense form's bank picker and the card-statement mark-paid picker to the fetched bank list, and add the round-up input with its visibility rule, create-time auto-suggestion, and edit-time saved-value pre-fill. See spec Sections 3 and 4.
+
+**6. Submit wiring and client-side validation** - Update the create/update submit logic to send the round-up amount under the full-replace rule, including the mode/eligibility-based nulling and the client-side range check. See spec Section 3.
+
+### Stage 4: Verification
+
+**7. Full-solution verification** - Run the complete .NET and frontend test suites, and exercise the expense form manually (bank picker, round-up field appearance/disappearance, create and edit flows) against a running instance to confirm the UX matches the spec.

--- a/docs/P13-F03-expense-form-bank-picker-round-up-ux/spec.md
+++ b/docs/P13-F03-expense-form-bank-picker-round-up-ux/spec.md
@@ -1,0 +1,120 @@
+# F03. Expense Form Bank Picker & Round-Up UX
+
+## 1. Technical Overview
+
+**What:** The expense form's bank picker and the card-statement "mark paid" bank picker stop reading from the frontend's hardcoded `PAYMENT_SOURCES` constant and instead read from a new `GET /api/v1/financial/banks` endpoint (backed by F01's `Bank` entity via a new thin `IBankService`). When the user picks a `RoundUpEnabled` bank in "pay immediately" mode, a round-up amount field appears, pre-filled with a client-computed suggestion (`ceil(value) − value`) the moment the bank is picked — never overwriting a value the user has already typed. Editing an existing expense pre-fills the field from the expense's own saved `roundUpAmount` (never a freshly recomputed suggestion), and saving always resends whatever is currently in the field, so a `Value`-only edit leaves it untouched.
+
+**Why:** F01 already moved bank identity into a real `Bank` entity (`Name`, `RoundUpEnabled`), but nothing on the backend exposes that list over HTTP yet, and the frontend has no `roundUpAmount`/`suggestedRoundUpAmount` fields at all despite the backend DTOs (`ExpenseDTO`, `ExpenseCreateDTO`, `ExpenseUpdateDTO`) shipping them in F02. F03 closes both gaps together, since the round-up field's visibility rule depends directly on the fetched bank list's `RoundUpEnabled` flag.
+
+**Scope:**
+- Included: `GET /banks` endpoint (`BanksController` → new `IBankService`/`BankService` → `ICashFlowRepository.GetBanks()`); `BankDTO`; frontend `BankDto` type, `getBanks` API client method, `banks` state in `useMonthly`, replacing every `PAYMENT_SOURCES` usage (expense form bank picker, mark-paid bank picker, Banks-panel row list) with the fetched list; `roundUpAmount`/`suggestedRoundUpAmount` added to `ExpenseDto`, `roundUpAmount` added to `CreateExpenseDto`/`UpdateExpenseDto`; the round-up input field, its visibility rule, its create-time auto-suggestion, and its edit-time saved-value pre-fill.
+- Excluded: any change to the Banks panel's *balance/total calculation* (still `sum(Value)`, unchanged — F04's scope); a bank management screen (out of scope per PRD); categories/card-tag pickers (remain hardcoded, untouched); the round-up *validation/eligibility* business rules themselves (already enforced server-side by F02 — this feature only surfaces them in the UI and mirrors basic client-side range/mode checks for immediate feedback, exactly like the existing `value` non-zero check).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.CashFlow.Application/DTOs/BankDTO.cs` — new (`Name`, `RoundUpEnabled`)
+- `Financial.CashFlow.Application/Interfaces/IBankService.cs` — new
+- `Financial.CashFlow.Application/Services/BankService.cs` — new
+- `Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs` — registers `IBankService`
+- `Financial.Api/Controllers/BanksController.cs` — new (`GET /banks`)
+- `Financial.Web/src/api/types.ts` — `BankDto`; `roundUpAmount`/`suggestedRoundUpAmount` on `ExpenseDto`; `roundUpAmount` on `CreateExpenseDto`/`UpdateExpenseDto`
+- `Financial.Web/src/api/financialApiClient.ts` — `getBanks`
+- `Financial.Web/src/hooks/useMonthly.ts` — `banks` state (replacing the `PAYMENT_SOURCES` export), round-up form fields, bank-pick-triggered suggestion, full-replace submit wiring
+- `Financial.Web/src/pages/MonthlyPage.tsx` — round-up input field, bank pickers sourced from `banks`
+
+```mermaid
+graph TD
+  A["GET /api/v1/financial/banks"] --> B[BanksController]
+  B --> C[IBankService]
+  C --> D["ICashFlowRepository.GetBanks()"]
+  E[useMonthly] --> F["apiClient.getBanks()"]
+  F --> A
+  E --> G["ExpenseForm (bank picker + round-up field)"]
+  G --> H["onFieldChange('paymentSource') -> auto-suggest if blank"]
+  E --> I["Cards panel bank picker + Banks panel rows"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Bank list access pattern | New thin `IBankService`/`BankService` wrapping `ICashFlowRepository.GetBanks()`, mirroring every other list-returning service (`IMensaisService`, `ICardStatementService`, ...) | `BanksController` calling `ICashFlowRepository` directly | Every existing list endpoint in this codebase goes through a service, never straight from a controller to the repository — matching that convention keeps the Presentation layer free of business/data-access logic per this project's layering rules. |
+| Fetching banks in `useMonthly` | Add `apiClient.getBanks()` to the existing `Promise.all` in the mount effect, alongside `getExpensesByMonth`/`getCategoryTotalsByMonth`/`getCardStatementsByMonth`; store as `state.banks: BankDto[]` | A separate one-time fetch on mount, independent of the month-based refetch | Banks never change per month, but re-fetching them alongside the existing month fetch is one extra parallel network call with no added complexity, and keeps a single `isLoading`/`error` state covering the whole page rather than a second loading flag. |
+| Replacing the `PAYMENT_SOURCES` export | Remove the constant entirely; add `banks: BankDto[]` to `MonthlyData`; every current call site (expense-form bank picker, mark-paid bank picker, `bankTotals` names) reads from the hook's returned `banks` instead | Keep `PAYMENT_SOURCES` as a fallback/default and merge with fetched data | The PRD explicitly frames this as banks becoming backend-driven so "adding a new bank... doesn't require a form rewrite" (F01 user story) — keeping any hardcoded fallback defeats that goal. |
+| Create-time suggestion trigger | Compute the suggestion (`Math.ceil(value) - value`, mirroring backend `Expense.RoundUpSuggestion`) once, at the moment `paymentSource` changes to a `RoundUpEnabled` bank while in "pay immediately" mode — and only if `createRoundUpAmount` is currently blank (never overwrite what the user already typed) | Recompute on every `Value` keystroke while a round-up-enabled bank is selected | The form's natural field order (Date → Description → Category → Value → Payment section) means `Value` is already entered by the time the user reaches the bank picker, so triggering on bank selection captures the real value. Recomputing on every `Value` edit afterward would silently overwrite a suggestion the user may have already accepted or edited — inconsistent with the backend's "never recalculated once saved" philosophy extended sensibly to the create form. |
+| Edit-time pre-fill | `SHOW_EDIT_FORM` sets `editRoundUpAmount` straight from `expense.roundUpAmount` (nullable), never from `expense.suggestedRoundUpAmount` | Show the suggestion if `roundUpAmount` is null | AC requires the edit field to show "its currently saved round-up amount... not a freshly recomputed suggestion" — even when there is no saved amount yet, showing nothing (blank) is the correct "not yet decided" state, not a suggestion. |
+| Full-replace submit semantics | `submitCreate`/`saveEdit` always send `roundUpAmount: (mode === 'bank' && selectedBank?.roundUpEnabled && amount.trim() !== '') ? Number(amount) : null` | Only send the field when the user has explicitly interacted with it | Mirrors the existing `paymentSource`/`cardTag` mode-based nulling already in both functions; guarantees a stale value left over from a previously-selected round-up-enabled bank is never sent once the user switches to an ineligible bank or card mode, without needing extra "has the user touched this" tracking. |
+| Round-up field visibility | `paymentMode === 'bank' && banks.find(b => b.name === paymentSource)?.roundUpEnabled === true` | A separate `roundUpEnabled` flag threaded through form state | Deriving it directly from the already-available `banks` list and the selected `paymentSource` needs no additional state to keep in sync. |
+| Client-side range check | Mirror the backend's £0.00–£0.99 bounds with the same lightweight inline check pattern already used for `value` (`isFinite`/zero check in `submitCreate`/`saveEdit`) | Skip client validation, rely entirely on the server's 400 response | Consistent with this codebase's existing light-client/authoritative-server validation split; avoids a round-trip for the single most common mistake (typing outside range). |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Application/DTOs/BankDTO.cs` | New | Read model | `required string Name`, `required bool RoundUpEnabled` |
+| `Financial.CashFlow.Application/Interfaces/IBankService.cs` | New | Service contract | `IReadOnlyList<BankDTO> GetBanks();` |
+| `Financial.CashFlow.Application/Services/BankService.cs` | New | Service impl | Constructor-injects `ICashFlowRepository`; `GetBanks()` maps `_repository.GetBanks()` to `BankDTO` |
+| `Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs` | Modified | DI | `services.AddSingleton<IBankService, BankService>();` |
+| `Financial.Api/Controllers/BanksController.cs` | New | Endpoint | `[Route("banks")]`, constructor-injects `IBankService`, `[HttpGet]` → `Ok(_bankService.GetBanks())`, no body/params |
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/api/types.ts` | Modified | Types | `BankDto { name: string; roundUpEnabled: boolean }`; `ExpenseDto` gains `roundUpAmount: number \| null`, `suggestedRoundUpAmount: number \| null`; `CreateExpenseDto`/`UpdateExpenseDto` gain `roundUpAmount: number \| null` |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | API client | `FinancialApiClient.getBanks: () => Promise<BankDto[]>`; impl `getBanks: () => request<BankDto[]>('/banks')` |
+| `Financial.Web/src/hooks/useMonthly.ts` | Modified | State/logic | Removes the `PAYMENT_SOURCES` export; adds `banks: BankDto[]` to state (fetched in the mount effect's `Promise.all`) and to `MonthlyData`; adds `createRoundUpAmount`/`editRoundUpAmount` to `CreateFormField`/`EditField`/state/`MonthlyData`; `SET_CREATE_FIELD`/`SET_EDIT_FIELD` special-case the payment-source field to auto-suggest (Section 3); `bankTotals` iterates `state.banks` instead of `PAYMENT_SOURCES`; `BLANK_CREATE_FORM.createPaymentSource` starts `''` (no bank known yet); `SET_CREATE_MODE`/`SET_EDIT_MODE` default the payment source to `state.banks[0]?.name ?? ''` instead of the literal `'Barclays'`; `submitCreate`/`saveEdit` compute and send `roundUpAmount` per Section 3's full-replace rule, plus the client-side range check |
+| `Financial.Web/src/pages/MonthlyPage.tsx` | Modified | UI | Bank `<select>` (expense form) and mark-paid bank `<select>` (Cards panel) both render from `banks` instead of `PAYMENT_SOURCES`; new round-up `<input type="number" step="0.01">` field, shown per Section 3's visibility rule, wired through the existing `onFieldChange`/`CREATE_FIELD_BY_FORM_FIELD`/`EDIT_FIELD_BY_FORM_FIELD` plumbing (`roundUpAmount` added to `ExpenseFormField` and both maps) |
+
+## 5. API Contracts
+
+**Endpoint: List Banks**
+- **Method:** GET
+- **Path:** `/api/v1/financial/banks`
+- **Authentication:** None (matches every other endpoint in this app)
+
+**Request:** none.
+
+**Response (Success — 200):**
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `[].name` | `string` | Bank name |
+| `[].roundUpEnabled` | `boolean` | Whether this bank rounds up card payments |
+
+**Response Example:**
+```json
+[
+  { "name": "Barclays", "roundUpEnabled": false },
+  { "name": "Trading212", "roundUpEnabled": true },
+  { "name": "Chase", "roundUpEnabled": true }
+]
+```
+
+**Existing endpoints (extended, no route/method change):** `POST /expenses`, `PUT /expenses/{id}` request bodies gain `roundUpAmount: number | null`; their response body and `GET /expenses/month/{year}/{month}` responses gain `roundUpAmount`/`suggestedRoundUpAmount` — these were already shipped server-side in F02 (`ExpenseDTO`/`ExpenseCreateDTO`/`ExpenseUpdateDTO`), F03 only adds them to the frontend's TypeScript types and wires the form to use them.
+
+## 6. Data Model
+
+No new persisted data — `Bank` and `Expense.RoundUpAmount` already exist from F01/F02. This feature only adds a read endpoint over existing data and frontend types mirroring the existing backend DTO shapes.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs` | Unit | `BankService` | `GetBanks()` maps every repository bank to a `BankDTO` with matching `Name`/`RoundUpEnabled`; empty repository returns an empty list |
+| `Tests/Financial.Api.Tests/BanksEndpointsTests.cs` | Integration | `BanksController` | `GET /api/v1/financial/banks` returns 200 with the 3 seeded banks and their correct `roundUpEnabled` values (using the same `ApiTestFactory` bank-seeding fixture already in place from F01) |
+| `Financial.Web/src/hooks/useMonthly.test.ts` | Unit | `useMonthly` | `banks` populates from `getBanks`; `bankTotals` uses the fetched bank names, not a hardcoded list; `createPaymentSource` defaults to the first fetched bank once loaded; picking a round-up-enabled bank while `createRoundUpAmount` is blank fills it with the computed suggestion; picking one while it already has a value leaves it untouched; switching to a non-round-up bank or card mode sends `roundUpAmount: null` on submit; `showEditForm` pre-fills `editRoundUpAmount` from `expense.roundUpAmount`, not `suggestedRoundUpAmount`; `saveEdit` resends the current `editRoundUpAmount` unchanged when only `Value` was edited |
+| `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` | Component | `MonthlyPage`/`ExpenseForm` | Bank picker and mark-paid picker render options from the mocked `getBanks` response instead of a fixed list; round-up field appears only for a round-up-enabled bank in bank mode; hidden for a non-round-up bank and for card mode; typing a round-up amount and saving passes it through to `createExpense`/`updateExpense` |
+
+**Acceptance tests (PRD Section 9, F03):**
+- Bank picker lists banks from F01 rather than a fixed set → `useMonthly.test.ts` + `MonthlyPage.test.tsx`
+- Selecting a `RoundUpEnabled` bank in "pay immediately" mode shows a pre-filled round-up field → `MonthlyPage.test.tsx`
+- Selecting a non-round-up bank, or "charge to card" mode, hides the field entirely → `MonthlyPage.test.tsx`
+- Editing an existing expense shows its saved amount, not a recomputed suggestion → `useMonthly.test.ts`
+- Editing the round-up amount and saving persists the new value without altering `Value` → `useMonthly.test.ts`
+
+**Cross-Feature Integration criteria touching F03 (PRD Section 9):**
+- "F03's bank picker and round-up field correctly reflect the bank list and `RoundUpEnabled` flags from F01, and correctly read and write the round-up amount contract defined by F02" → covered end-to-end by `BanksEndpointsTests` (F01 data) + `useMonthly.test.ts`/`MonthlyPage.test.tsx` (F02 contract fields)

--- a/docs/prd/P13-prd-bank-round-up/prd-bank-round-up.md
+++ b/docs/prd/P13-prd-bank-round-up/prd-bank-round-up.md
@@ -224,11 +224,11 @@ graph TD
 - [x] A previously saved round-up amount can be directly edited to a new value at any time after the expense was created
 
 ### F03. Expense Form Bank Picker & Round-Up UX
-- [ ] The expense form's bank picker lists the banks resolved from F01 rather than a fixed set of options
-- [ ] Selecting a `RoundUpEnabled` bank in "pay immediately" mode shows a round-up field pre-filled with the suggested amount
-- [ ] Selecting a non-round-up bank, or switching to "charge to card" mode, hides the round-up field entirely
-- [ ] Editing an existing expense shows its currently saved round-up amount in the field, not a freshly recomputed suggestion
-- [ ] Editing an existing expense's round-up amount and saving persists the new value without altering the expense's value
+- [x] The expense form's bank picker lists the banks resolved from F01 rather than a fixed set of options
+- [x] Selecting a `RoundUpEnabled` bank in "pay immediately" mode shows a round-up field pre-filled with the suggested amount
+- [x] Selecting a non-round-up bank, or switching to "charge to card" mode, hides the round-up field entirely
+- [x] Editing an existing expense shows its currently saved round-up amount in the field, not a freshly recomputed suggestion
+- [x] Editing an existing expense's round-up amount and saving persists the new value without altering the expense's value
 
 ### F04. Bank Balance & Round-Up Totals
 - [ ] A bank's displayed balance for the selected month equals `sum(Expense.Value) − sum(Expense.RoundUpAmount)` across that bank's expenses
@@ -238,5 +238,5 @@ graph TD
 
 ### Cross-Feature Integration
 - [x] F02's round-up suggestion and eligibility check correctly read each bank's `RoundUpEnabled` flag as defined by F01, offering a suggestion only for banks where it is `true`
-- [ ] F03's bank picker and round-up field correctly reflect the bank list and `RoundUpEnabled` flags from F01, and correctly read and write the round-up amount contract defined by F02
+- [x] F03's bank picker and round-up field correctly reflect the bank list and `RoundUpEnabled` flags from F01, and correctly read and write the round-up amount contract defined by F02
 - [ ] F04's balance and round-up total calculations correctly group expenses by the bank identity defined by F01 and correctly sum the round-up amounts defined by F02


### PR DESCRIPTION
## Summary

Implements **F03 – Expense Form Bank Picker & Round-Up UX** from the P13 PRD, per the committed spec/plan in `docs/P13-F03-expense-form-bank-picker-round-up-ux/`.

- New `GET /api/v1/financial/banks` endpoint (`BanksController` → new `IBankService`/`BankService` → F01's `ICashFlowRepository.GetBanks()`), following the same controller-to-service pattern as every other list endpoint
- Frontend `BankDto`, `getBanks` client method, and `roundUpAmount`/`suggestedRoundUpAmount` added to `ExpenseDto`/`CreateExpenseDto`/`UpdateExpenseDto` (these backend fields shipped in F02 but were never added to the frontend types until now)
- `useMonthly` fetches banks alongside the existing month data and replaces every hardcoded `PAYMENT_SOURCES` usage (expense-form bank picker, mark-paid bank picker, Banks-panel row list) with the fetched list
- New round-up amount field: appears only in "pay immediately" mode against a `RoundUpEnabled` bank; auto-fills a suggested amount (`ceil(value) − value`) the moment an eligible bank is picked, but never overwrites a value the user already typed; editing an existing expense pre-fills the field from its **saved** amount, never a recomputed suggestion; submit always resends whatever is currently in the field (full-replace, same as every other field), with a client-side £0.00–£0.99 range check mirroring the backend's

## Acceptance Criteria (PRD Section 9 — F03)

- [x] The expense form's bank picker lists the banks resolved from F01 rather than a fixed set of options
- [x] Selecting a `RoundUpEnabled` bank in "pay immediately" mode shows a round-up field pre-filled with the suggested amount
- [x] Selecting a non-round-up bank, or switching to "charge to card" mode, hides the round-up field entirely
- [x] Editing an existing expense shows its currently saved round-up amount in the field, not a freshly recomputed suggestion
- [x] Editing an existing expense's round-up amount and saving persists the new value without altering the expense's value

Cross-feature: "F03's bank picker and round-up field correctly reflect the bank list and `RoundUpEnabled` flags from F01, and correctly read and write the round-up amount contract defined by F02" is also checked in the PRD (all three named features are now shipped). The F04 cross-feature bullet stays unchecked until that feature lands.

## Test plan

- New `BankServiceTests`, `BanksEndpointsTests` (backend)
- Updated `useMonthly.test.ts`/`MonthlyPage.test.tsx`/`ExpensesSection.test.tsx` fixtures for the new DTO fields, plus new cases covering bank-list sourcing, round-up field visibility/auto-suggestion/pre-fill, full-replace submit semantics, and the client-side range check
- Full .NET solution: all 13 test projects green (1,253 passed, 5 pre-existing skips unrelated to this change, 0 failures)
- Full frontend suite: 44 files / 569 tests green; `tsc -b` and `eslint` clean
- Manual smoke test: ran the real API + Vite dev server against a seeded scratch data file and drove the New Expense form with Playwright — confirmed the round-up field appears pre-filled (£0.60 for a £9.40 Trading212 expense), disappears when switching to Barclays or card mode, and a submitted expense persists correctly end-to-end with its round-up amount

🤖 Generated with [Claude Code](https://claude.com/claude-code)