### PR TITLE
feat(P13-F04): bank balance and round-up totals

### DIFF
--- a/Financial.Web/src/hooks/useMonthly.test.ts
+++ b/Financial.Web/src/hooks/useMonthly.test.ts
@@ -105,11 +105,12 @@ describe('useMonthly', () => {
 
     expect(result.current.categoryTotalsSum).toBe(42.5)
     expect(result.current.bankTotals).toEqual([
-      { bank: 'Barclays', totalValue: 42.5 },
-      { bank: 'Trading212', totalValue: 0 },
-      { bank: 'Chase', totalValue: 0 },
+      { bank: 'Barclays', balance: 42.5, roundUpTotal: 0 },
+      { bank: 'Trading212', balance: 0, roundUpTotal: 0 },
+      { bank: 'Chase', balance: 0, roundUpTotal: 0 },
     ])
     expect(result.current.bankTotalsSum).toBe(42.5)
+    expect(result.current.roundUpTotalsSum).toBe(0)
   })
 
   it('re-fetches for a new month when the month input changes', async () => {
@@ -367,11 +368,30 @@ describe('useMonthly', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(result.current.bankTotals).toEqual([
-      { bank: 'Barclays', totalValue: 62.5 },
-      { bank: 'Trading212', totalValue: 0 },
-      { bank: 'Chase', totalValue: 0 },
+      { bank: 'Barclays', balance: 62.5, roundUpTotal: 0 },
+      { bank: 'Trading212', balance: 0, roundUpTotal: 0 },
+      { bank: 'Chase', balance: 0, roundUpTotal: 0 },
     ])
     expect(result.current.bankTotalsSum).toBe(62.5)
+    expect(result.current.roundUpTotalsSum).toBe(0)
+  })
+
+  it("subtracts a bank's round-up total from its balance and sums round-up totals separately", async () => {
+    getExpensesByMonthMock.mockResolvedValue([
+      { ...EXPENSES[0], id: 'e7', value: 9.4, paymentSource: 'Trading212', roundUpAmount: 0.6 },
+      { ...EXPENSES[0], id: 'e8', value: 5, paymentSource: 'Trading212', roundUpAmount: null },
+      { ...EXPENSES[0], id: 'e9', value: 20, paymentSource: 'Chase', roundUpAmount: 0.1 },
+    ])
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.bankTotals).toEqual([
+      { bank: 'Barclays', balance: 0, roundUpTotal: 0 },
+      { bank: 'Trading212', balance: 13.8, roundUpTotal: 0.6 },
+      { bank: 'Chase', balance: 19.9, roundUpTotal: 0.1 },
+    ])
+    expect(result.current.bankTotalsSum).toBeCloseTo(33.7)
+    expect(result.current.roundUpTotalsSum).toBeCloseTo(0.7)
   })
 
   it('picking a round-up-enabled bank auto-suggests when the field is blank', async () => {

--- a/Financial.Web/src/hooks/useMonthly.ts
+++ b/Financial.Web/src/hooks/useMonthly.ts
@@ -28,7 +28,8 @@ function suggestRoundUpAmount(banks: BankDto[], bankName: string, value: string)
 
 export interface BankTotal {
   bank: string
-  totalValue: number
+  balance: number
+  roundUpTotal: number
 }
 
 export type CreateFormField =
@@ -305,6 +306,7 @@ export interface MonthlyData {
   adjustmentTotal: number
   bankTotals: BankTotal[]
   bankTotalsSum: number
+  roundUpTotalsSum: number
   isLoading: boolean
   error: string | null
   retry: () => void
@@ -605,13 +607,14 @@ export function useMonthly(): MonthlyData {
 
   const categoryTotalsSum = state.categoryTotals.reduce((sum, c) => sum + c.totalValue, 0)
 
-  const bankTotals: BankTotal[] = state.banks.map((bank) => ({
-    bank: bank.name,
-    totalValue: state.expenses
-      .filter((expense) => expense.paymentSource === bank.name)
-      .reduce((sum, expense) => sum + expense.value, 0),
-  }))
-  const bankTotalsSum = bankTotals.reduce((sum, b) => sum + b.totalValue, 0)
+  const bankTotals: BankTotal[] = state.banks.map((bank) => {
+    const bankExpenses = state.expenses.filter((expense) => expense.paymentSource === bank.name)
+    const valueSum = bankExpenses.reduce((sum, expense) => sum + expense.value, 0)
+    const roundUpTotal = bankExpenses.reduce((sum, expense) => sum + (expense.roundUpAmount ?? 0), 0)
+    return { bank: bank.name, balance: valueSum - roundUpTotal, roundUpTotal }
+  })
+  const bankTotalsSum = bankTotals.reduce((sum, b) => sum + b.balance, 0)
+  const roundUpTotalsSum = bankTotals.reduce((sum, b) => sum + b.roundUpTotal, 0)
 
   return {
     monthInputValue,
@@ -624,6 +627,7 @@ export function useMonthly(): MonthlyData {
     adjustmentTotal,
     bankTotals,
     bankTotalsSum,
+    roundUpTotalsSum,
     isLoading: state.isLoading,
     error: state.error,
     retry,

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -239,6 +239,7 @@ export default function MonthlyPage() {
     adjustmentTotal,
     bankTotals,
     bankTotalsSum,
+    roundUpTotalsSum,
     isLoading,
     error,
     retry,
@@ -421,21 +422,23 @@ export default function MonthlyPage() {
                   <thead>
                     <tr>
                       <th>Bank</th>
-                      <th className="data-table__col--numeric">Total</th>
+                      <th className="data-table__col--numeric">Balance</th>
+                      <th className="data-table__col--numeric">Round-Up</th>
                     </tr>
                   </thead>
                   <tbody>
                     {bankTotals.map((b) => (
                       <tr key={b.bank}>
                         <td>{b.bank}</td>
-                        <td className="data-table__col--numeric">{formatN2(b.totalValue)}</td>
+                        <td className="data-table__col--numeric">{formatN2(b.balance)}</td>
+                        <td className="data-table__col--numeric">{formatN2(b.roundUpTotal)}</td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </div>
               <p className="monthly-page__section-total">
-                Total: <strong>{formatN2(bankTotalsSum)}</strong>
+                Balance: <strong>{formatN2(bankTotalsSum)}</strong> · Round-Up: <strong>{formatN2(roundUpTotalsSum)}</strong>
               </p>
             </section>
           </div>

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -105,10 +105,10 @@ describe('MonthlyPage', () => {
     expect(banksSection.getByRole('cell', { name: 'Trading212' })).toBeInTheDocument()
     expect(banksSection.getByRole('cell', { name: 'Chase' })).toBeInTheDocument()
 
-    // The single expense (42.50) is on Barclays, so Trading212/Chase are zero and the
-    // Barclays row plus the Banks total both show 42.50.
+    // The single expense (42.50) is on Barclays with no round-up amount, so its balance
+    // is unchanged and every round-up figure (per-bank and the footer) is zero.
     expect(banksSection.getAllByText('42.50').length).toBe(2)
-    expect(banksSection.getAllByText('0.00').length).toBe(2)
+    expect(banksSection.getAllByText('0.00').length).toBe(6)
 
     expect(screen.getByText('Category Totals').closest('section')).toHaveClass('monthly-page__section--grid')
     expect(screen.getByText('Cards').closest('section')).toHaveClass('monthly-page__section--grid')
@@ -315,6 +315,23 @@ describe('MonthlyPage', () => {
     await waitFor(() =>
       expect(createExpenseMock).toHaveBeenCalledWith(expect.objectContaining({ roundUpAmount: 0.1 })),
     )
+  })
+
+  it('shows a bank balance reduced by its round-up total, in a separate column', async () => {
+    getExpensesByMonthMock.mockResolvedValue([
+      { ...EXPENSES[0], paymentSource: 'Trading212', value: 9.4, roundUpAmount: 0.6 },
+    ])
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByText('Lidl UK')).toBeInTheDocument())
+    const banksSection = within(screen.getByText('Banks').closest('section')!)
+
+    const trading212Row = banksSection.getByRole('row', { name: /Trading212/ })
+    expect(within(trading212Row).getByRole('cell', { name: '8.80' })).toBeInTheDocument()
+    expect(within(trading212Row).getByRole('cell', { name: '0.60' })).toBeInTheDocument()
+
+    const barclaysRow = banksSection.getByRole('row', { name: /Barclays/ })
+    expect(within(barclaysRow).getAllByRole('cell', { name: '0.00' })).toHaveLength(2)
   })
 
   it('pre-fills the edit round-up field with the saved amount', async () => {

--- a/docs/P13-F04-bank-balance-round-up-totals/plan.md
+++ b/docs/P13-F04-bank-balance-round-up-totals/plan.md
@@ -1,0 +1,17 @@
+# Implementation Plan: F04. Bank Balance & Round-Up Totals
+
+**Prerequisites:**
+- F01, F02, and F03 merged (bank list, per-expense round-up amount, and both already available client-side)
+- Node toolchain; no new packages
+
+### Stage 1: Balance Computation
+
+**1. `bankTotals` adjusted balance and round-up total** - Change the per-bank aggregation to produce both an adjusted balance (value minus round-up) and a separate round-up total in a single pass over the month's expenses, and expose the round-up sum across all banks alongside the existing balance sum. See spec Sections 3 and 4.
+
+### Stage 2: Banks Panel UI
+
+**2. Round-up column and footer** - Add the round-up total as its own column in the Banks panel table, next to the renamed balance column, and extend the footer row to show both sums. See spec Section 4.
+
+### Stage 3: Verification
+
+**3. Full-solution verification** - Run the frontend test suite and confirm in a running instance that saving an expense with a round-up amount immediately updates both the balance and round-up figures for its bank, and that a non-round-up bank always shows a zero round-up total.

--- a/docs/P13-F04-bank-balance-round-up-totals/spec.md
+++ b/docs/P13-F04-bank-balance-round-up-totals/spec.md
@@ -1,0 +1,66 @@
+# F04. Bank Balance & Round-Up Totals
+
+## 1. Technical Overview
+
+**What:** The Banks panel's per-bank figure changes from `sum(Expense.Value)` to `sum(Expense.Value) − sum(Expense.RoundUpAmount)` (the adjusted balance), and gains a second figure, `sum(Expense.RoundUpAmount)` (the round-up total), displayed alongside it. Both update immediately after any expense is saved, exactly like every other panel figure — no new fetch is needed since the underlying data (`Value`, `RoundUpAmount`, `PaymentSource`) is already present on every fetched `ExpenseDto`.
+
+**Why:** `bankTotals` is already computed client-side in `useMonthly` from the month's already-fetched expense list (unlike `categoryTotals`, which is a backend-computed endpoint) — F01/F02/F03 already deliver everything this computation needs (the bank list, and each expense's value and round-up amount), so this is a pure aggregation change with no new data to fetch and no backend endpoint to add.
+
+**Scope:**
+- Included: `BankTotal`'s shape and the `bankTotals` reducer computation in `useMonthly`; the Banks panel table gaining a Round-Up Total column; the existing "Total" footer row extended to both figures.
+- Excluded: any backend change (no new endpoint — all figures are computed client-side from data already shipped by F01/F02/F03); the expense form itself (F03, already shipped); a bank management screen (out of scope per PRD).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/hooks/useMonthly.ts` — `BankTotal` interface, `bankTotals` computation, `bankTotalsSum`
+- `Financial.Web/src/pages/MonthlyPage.tsx` — Banks panel table (new column, updated footer)
+
+```mermaid
+graph TD
+  A["state.expenses (already fetched)"] --> B["bankTotals: per-bank balance + round-up total"]
+  C["state.banks (already fetched, F03)"] --> B
+  B --> D["Banks panel table"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Where the aggregation lives | Client-side in `useMonthly`'s `bankTotals` computation, same as today | A new backend "bank balances" endpoint, mirroring `getCategoryTotalsByMonth` | `bankTotals` is already computed client-side from the month's fetched expenses (an existing, if inconsistent-with-`categoryTotals`, precedent) and every field the formula needs (`value`, `roundUpAmount`, `paymentSource`) is already on `ExpenseDto`. Introducing a backend endpoint here would be new surface area for a computation the client can already do correctly with data it already has — over-engineering for this personal-scale app. |
+| `BankTotal` shape | Replace the single `totalValue` field with `balance` (adjusted) and `roundUpTotal`, both computed in the same `.map` pass over `state.banks` | Keep `totalValue` and add only a new `roundUpTotal` field alongside it | The PRD explicitly redefines what the panel's primary figure *means* (`sum(Value) − sum(RoundUpAmount)`, not raw `sum(Value)`) — keeping the old field name with a changed meaning risks confusion for anyone reading the code later; renaming to `balance` makes the semantic change explicit. |
+| Missing `RoundUpAmount` handling | Treat `expense.roundUpAmount ?? 0` in the reduction, so an expense with no recorded round-up contributes its full value to the balance and nothing to the round-up total | Filter such expenses out of the round-up sum separately | A single `reduce` computing both running totals per bank in one pass is simplest; nullish-coalescing to `0` is the natural "no round-up recorded" case and requires no special-casing. |
+| Barclays' round-up total | No special-casing needed — it falls out naturally: no expense on a non-`RoundUpEnabled` bank can ever carry a `RoundUpAmount` (enforced server-side since F02), so its computed round-up total is always `0` | Explicitly zero it out for banks where `roundUpEnabled` is `false` | The invariant is already guaranteed upstream (F02's `Expense.SetRoundUpAmount` rejects a round-up amount on a non-round-up bank), so no defensive client-side override is needed — trusting the already-enforced invariant avoids redundant logic. |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/hooks/useMonthly.ts` | Modified | State/logic | `BankTotal` becomes `{ bank: string; balance: number; roundUpTotal: number }`; `bankTotals` reduces each bank's expenses once into `{ balance: sum(value) - sum(roundUpAmount ?? 0), roundUpTotal: sum(roundUpAmount ?? 0) }`; `bankTotalsSum` sums `balance` (unchanged name/purpose, now reflecting the adjusted figure); new `roundUpTotalsSum` summing `roundUpTotal` across banks, added to `MonthlyData` |
+| `Financial.Web/src/pages/MonthlyPage.tsx` | Modified | UI | Banks panel table gains a "Round-Up" column (`b.roundUpTotal`) alongside the existing "Balance" column (`b.balance`, renamed from "Total"); footer row shows both sums |
+
+## 5. API Contracts
+
+None — no backend change. All data was already available via the existing `GET /expenses/month/{year}/{month}` response (`value`, `roundUpAmount`, `paymentSource` per expense, shipped in F02/F03) and `GET /banks` (shipped in F03).
+
+## 6. Data Model
+
+None — no persisted shape change.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Financial.Web/src/hooks/useMonthly.test.ts` | Unit | `useMonthly` | `bankTotals` computes `balance = sum(value) - sum(roundUpAmount)` per bank; a bank with no round-up amounts on any of its expenses has `roundUpTotal` of `0` and `balance` equal to the raw value sum; a bank with a mix of round-up and non-round-up expenses sums correctly; `bankTotalsSum`/`roundUpTotalsSum` sum across all banks; a settled/charge expense (no bank, `paymentSource` null) is excluded from every bank's figures, matching existing behavior |
+| `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` | Component | `MonthlyPage` | Banks panel renders a Round-Up column alongside Balance for each bank; Barclays (non-round-up) always shows £0.00 round-up regardless of its expenses; the footer shows both sums; the Banks panel reflects the new figures immediately after saving an expense with a round-up amount (reusing the existing retry/refetch flow) |
+
+**Acceptance tests (PRD Section 9, F04):**
+- A bank's balance equals `sum(Value) − sum(RoundUpAmount)` → `useMonthly.test.ts`
+- A bank's round-up total equals `sum(RoundUpAmount)`, shown separately from its balance → `useMonthly.test.ts` + `MonthlyPage.test.tsx`
+- Barclays always shows a round-up total of £0.00 → `useMonthly.test.ts` + `MonthlyPage.test.tsx`
+- The Banks panel's balance and round-up total both update immediately after an expense is saved → `MonthlyPage.test.tsx` (reuses the existing post-save refetch already covered by prior tests)
+
+**Cross-Feature Integration criteria touching F04 (PRD Section 9):**
+- "F04's balance and round-up total calculations correctly group expenses by the bank identity defined by F01 and correctly sum the round-up amounts defined by F02" → `useMonthly.test.ts` (grouping by `state.banks` from F01/F03, summing `expense.roundUpAmount` from F02)

--- a/docs/prd/P13-prd-bank-round-up/prd-bank-round-up.md
+++ b/docs/prd/P13-prd-bank-round-up/prd-bank-round-up.md
@@ -231,12 +231,12 @@ graph TD
 - [x] Editing an existing expense's round-up amount and saving persists the new value without altering the expense's value
 
 ### F04. Bank Balance & Round-Up Totals
-- [ ] A bank's displayed balance for the selected month equals `sum(Expense.Value) − sum(Expense.RoundUpAmount)` across that bank's expenses
-- [ ] A bank's round-up total for the selected month equals `sum(Expense.RoundUpAmount)` across that bank's expenses, displayed separately from its balance
-- [ ] Barclays (a non-round-up bank) always shows a round-up total of £0.00
-- [ ] The Banks panel's balance and round-up total both update immediately after an expense is saved
+- [x] A bank's displayed balance for the selected month equals `sum(Expense.Value) − sum(Expense.RoundUpAmount)` across that bank's expenses
+- [x] A bank's round-up total for the selected month equals `sum(Expense.RoundUpAmount)` across that bank's expenses, displayed separately from its balance
+- [x] Barclays (a non-round-up bank) always shows a round-up total of £0.00
+- [x] The Banks panel's balance and round-up total both update immediately after an expense is saved
 
 ### Cross-Feature Integration
 - [x] F02's round-up suggestion and eligibility check correctly read each bank's `RoundUpEnabled` flag as defined by F01, offering a suggestion only for banks where it is `true`
 - [x] F03's bank picker and round-up field correctly reflect the bank list and `RoundUpEnabled` flags from F01, and correctly read and write the round-up amount contract defined by F02
-- [ ] F04's balance and round-up total calculations correctly group expenses by the bank identity defined by F01 and correctly sum the round-up amounts defined by F02
+- [x] F04's balance and round-up total calculations correctly group expenses by the bank identity defined by F01 and correctly sum the round-up amounts defined by F02


### PR DESCRIPTION
## Summary

Implements **F04 – Bank Balance & Round-Up Totals** from the P13 PRD, per the committed spec/plan in `docs/P13-F04-bank-balance-round-up-totals/` — the final feature of the bank round-up PRD.

- `BankTotal` now carries `balance` (`sum(Expense.Value) − sum(Expense.RoundUpAmount)`) and `roundUpTotal` separately, computed in a single pass over the month's already-fetched expenses in `useMonthly`
- **No backend change** — every field the computation needs (`value`, `roundUpAmount`, `paymentSource` per expense, and the bank list) was already shipped by F01/F02/F03; this is a pure client-side aggregation change, consistent with how `bankTotals` was already computed client-side (unlike `categoryTotals`, which goes through a backend endpoint)
- Banks panel gains a Round-Up column next to the renamed Balance column; the footer shows both sums
- Barclays (round-up disabled) always shows £0.00 round-up — falls out naturally since no expense on a non-round-up bank can ever carry a `RoundUpAmount` (enforced server-side since F02), no special-casing needed

## Acceptance Criteria (PRD Section 9 — F04)

- [x] A bank's displayed balance for the selected month equals `sum(Expense.Value) − sum(Expense.RoundUpAmount)` across that bank's expenses
- [x] A bank's round-up total for the selected month equals `sum(Expense.RoundUpAmount)` across that bank's expenses, displayed separately from its balance
- [x] Barclays (a non-round-up bank) always shows a round-up total of £0.00
- [x] The Banks panel's balance and round-up total both update immediately after an expense is saved

All three Cross-Feature Integration criteria are now checked in the PRD as well — this closes out the P13 bank round-up PRD (F01–F04, all shipped).

## Test plan

- Updated `useMonthly.test.ts` for the new `balance`/`roundUpTotal` shape, plus a new case covering a bank with a mix of round-up and non-round-up expenses
- Updated `MonthlyPage.test.tsx` for the new Round-Up column, plus a new case asserting a round-up-enabled bank's reduced balance renders in its own column separate from a non-round-up bank's zero round-up
- Full frontend suite: 44 files / 571 tests green; `tsc -b` and `eslint` clean
- Full .NET solution: all 13 test projects green (1,253 passed, 5 pre-existing skips unrelated to this change, 0 failures) — confirming the backend is unaffected by this frontend-only change
- Manual smoke test: ran the real API + Vite dev server against a seeded scratch data file (a Trading212 expense with a £0.60 round-up, a Barclays expense with none) and confirmed the Banks panel renders Trading212 balance £8.80/round-up £0.60, Barclays balance £3.00/round-up £0.00, and the footer sums both correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)