### PR TITLE
feat(P14-F01): income entity and migration

### DIFF
--- a/Financial.Api/Controllers/IncomesController.cs
+++ b/Financial.Api/Controllers/IncomesController.cs
@@ -1,0 +1,88 @@
+using Financial.CashFlow.Application.DTOs;
+using Financial.CashFlow.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Financial.Api.Controllers;
+
+[ApiController]
+[Route("incomes")]
+public sealed class IncomesController : ControllerBase
+{
+    private readonly IIncomeService _incomeService;
+
+    public IncomesController(IIncomeService incomeService)
+    {
+        _incomeService = incomeService ?? throw new ArgumentNullException(nameof(incomeService));
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(IncomeDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IncomeDTO>> AddIncome([FromBody] IncomeCreateDTO? request)
+    {
+        if (request is null)
+        {
+            return BadRequest();
+        }
+
+        try
+        {
+            var income = await _incomeService.AddIncomeAsync(request);
+            return Ok(income);
+        }
+        catch (ArgumentException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(IncomeDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<IncomeDTO>> UpdateIncome(Guid id, [FromBody] IncomeUpdateDTO? request)
+    {
+        if (request is null)
+        {
+            return BadRequest();
+        }
+
+        try
+        {
+            var income = await _incomeService.UpdateIncomeAsync(id, request);
+            return Ok(income);
+        }
+        catch (ArgumentException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound);
+        }
+    }
+
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteIncome(Guid id)
+    {
+        try
+        {
+            await _incomeService.DeleteIncomeAsync(id);
+            return Ok();
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound);
+        }
+    }
+
+    [HttpGet("month/{year:int}/{month:int}")]
+    [ProducesResponseType(typeof(IReadOnlyList<IncomeDTO>), StatusCodes.Status200OK)]
+    public ActionResult<IReadOnlyList<IncomeDTO>> GetIncomesByMonth(int year, int month)
+    {
+        var result = _incomeService.GetIncomesByMonth(year, month);
+        return Ok(result);
+    }
+}

--- a/Financial.CashFlow.Application/DTOs/IncomeCreateDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/IncomeCreateDTO.cs
@@ -1,0 +1,22 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Request to create a new income entry. The server generates the identifier.
+/// </summary>
+public sealed class IncomeCreateDTO
+{
+    /// <summary>Income date.</summary>
+    public required DateOnly Date { get; init; }
+
+    /// <summary>Income source name.</summary>
+    public required string IncomeSource { get; init; }
+
+    /// <summary>Gross value. Only meaningful for Gleison/Ariana entries.</summary>
+    public decimal? GrossValue { get; init; }
+
+    /// <summary>Net value received.</summary>
+    public required decimal NetValue { get; init; }
+
+    /// <summary>Destination bank name.</summary>
+    public required string Bank { get; init; }
+}

--- a/Financial.CashFlow.Application/DTOs/IncomeDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/IncomeDTO.cs
@@ -1,0 +1,25 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Read model for an income record.
+/// </summary>
+public sealed class IncomeDTO
+{
+    /// <summary>Income identifier.</summary>
+    public required Guid Id { get; init; }
+
+    /// <summary>Income date.</summary>
+    public required DateOnly Date { get; init; }
+
+    /// <summary>Income source name.</summary>
+    public required string IncomeSource { get; init; }
+
+    /// <summary>Gross value. Only meaningful for Gleison/Ariana entries.</summary>
+    public decimal? GrossValue { get; init; }
+
+    /// <summary>Net value received.</summary>
+    public required decimal NetValue { get; init; }
+
+    /// <summary>Destination bank name.</summary>
+    public required string Bank { get; init; }
+}

--- a/Financial.CashFlow.Application/DTOs/IncomeUpdateDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/IncomeUpdateDTO.cs
@@ -1,0 +1,22 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Request to update an existing income entry's details. The identifier comes from the route.
+/// </summary>
+public sealed class IncomeUpdateDTO
+{
+    /// <summary>Income date.</summary>
+    public required DateOnly Date { get; init; }
+
+    /// <summary>Income source name.</summary>
+    public required string IncomeSource { get; init; }
+
+    /// <summary>Gross value. Only meaningful for Gleison/Ariana entries.</summary>
+    public decimal? GrossValue { get; init; }
+
+    /// <summary>Net value received.</summary>
+    public required decimal NetValue { get; init; }
+
+    /// <summary>Destination bank name.</summary>
+    public required string Bank { get; init; }
+}

--- a/Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs
+++ b/Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class CashFlowApplicationServiceCollectionExtensions
         services.AddSingleton<ICardStatementService, CardStatementService>();
         services.AddSingleton<IYearlySummaryService, YearlySummaryService>();
         services.AddSingleton<IBankService, BankService>();
+        services.AddSingleton<IIncomeService, IncomeService>();
 
         return services;
     }

--- a/Financial.CashFlow.Application/Interfaces/ICashFlowRepository.cs
+++ b/Financial.CashFlow.Application/Interfaces/ICashFlowRepository.cs
@@ -28,5 +28,9 @@ public interface ICashFlowRepository
 
     IEnumerable<Bank> GetBanks();
 
+    IEnumerable<Income> GetIncomes();
+    void AddIncome(Income income);
+    void DeleteIncome(Guid id);
+
     Task SaveChangesAsync();
 }

--- a/Financial.CashFlow.Application/Interfaces/IIncomeService.cs
+++ b/Financial.CashFlow.Application/Interfaces/IIncomeService.cs
@@ -1,0 +1,11 @@
+using Financial.CashFlow.Application.DTOs;
+
+namespace Financial.CashFlow.Application.Interfaces;
+
+public interface IIncomeService
+{
+    Task<IncomeDTO> AddIncomeAsync(IncomeCreateDTO request);
+    Task<IncomeDTO> UpdateIncomeAsync(Guid id, IncomeUpdateDTO request);
+    Task DeleteIncomeAsync(Guid id);
+    IReadOnlyList<IncomeDTO> GetIncomesByMonth(int year, int month);
+}

--- a/Financial.CashFlow.Application/Services/IncomeService.cs
+++ b/Financial.CashFlow.Application/Services/IncomeService.cs
@@ -1,0 +1,87 @@
+using Financial.CashFlow.Application.DTOs;
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Application.Validation;
+using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Domain.Enums;
+
+namespace Financial.CashFlow.Application.Services;
+
+public sealed class IncomeService : IIncomeService
+{
+    private readonly ICashFlowRepository _repository;
+
+    public IncomeService(ICashFlowRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<IncomeDTO> AddIncomeAsync(IncomeCreateDTO request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var (incomeSource, bank) = ValidateFields(request.IncomeSource, request.Bank);
+
+        var income = Income.Create(request.Date, incomeSource, request.GrossValue, request.NetValue, bank.Name);
+        _repository.AddIncome(income);
+        await _repository.SaveChangesAsync().ConfigureAwait(false);
+
+        return ToDto(income);
+    }
+
+    public async Task<IncomeDTO> UpdateIncomeAsync(Guid id, IncomeUpdateDTO request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var income = FindIncomeOrThrow(id);
+
+        var (incomeSource, bank) = ValidateFields(request.IncomeSource, request.Bank);
+
+        income.UpdateDetails(request.Date, incomeSource, request.GrossValue, request.NetValue, bank.Name);
+        await _repository.SaveChangesAsync().ConfigureAwait(false);
+
+        return ToDto(income);
+    }
+
+    public async Task DeleteIncomeAsync(Guid id)
+    {
+        FindIncomeOrThrow(id);
+
+        _repository.DeleteIncome(id);
+        await _repository.SaveChangesAsync().ConfigureAwait(false);
+    }
+
+    public IReadOnlyList<IncomeDTO> GetIncomesByMonth(int year, int month) =>
+        _repository.GetIncomes()
+            .Where(i => i.Date.Year == year && i.Date.Month == month)
+            .Select(ToDto)
+            .ToList();
+
+    private Income FindIncomeOrThrow(Guid id) =>
+        _repository.GetIncomes().FirstOrDefault(i => i.Id == id)
+            ?? throw new KeyNotFoundException($"Income '{id}' was not found.");
+
+    private (IncomeSource IncomeSource, Bank Bank) ValidateFields(string incomeSource, string bank)
+    {
+        if (!IncomeSourceParser.TryParse(incomeSource, out var parsedIncomeSource))
+        {
+            throw new ArgumentException($"Income source '{incomeSource}' is not recognized.");
+        }
+
+        if (!BankNameResolver.TryResolve(bank, _repository.GetBanks(), out var resolvedBank))
+        {
+            throw new ArgumentException($"Bank '{bank}' is not recognized.");
+        }
+
+        return (parsedIncomeSource, resolvedBank!);
+    }
+
+    private static IncomeDTO ToDto(Income income) => new()
+    {
+        Id = income.Id,
+        Date = income.Date,
+        IncomeSource = income.IncomeSource.ToString(),
+        GrossValue = income.GrossValue,
+        NetValue = income.NetValue,
+        Bank = income.Bank
+    };
+}

--- a/Financial.CashFlow.Application/Validation/IncomeSourceParser.cs
+++ b/Financial.CashFlow.Application/Validation/IncomeSourceParser.cs
@@ -1,0 +1,9 @@
+using Financial.CashFlow.Domain.Enums;
+
+namespace Financial.CashFlow.Application.Validation;
+
+public static class IncomeSourceParser
+{
+    public static bool TryParse(string? value, out IncomeSource incomeSource) =>
+        EnumParser.TryParseEnum(value, out incomeSource);
+}

--- a/Financial.CashFlow.Domain/Entities/CashFlowData.cs
+++ b/Financial.CashFlow.Domain/Entities/CashFlowData.cs
@@ -61,6 +61,14 @@ public class CashFlowData
         _banks.AddRange(data);
     }
 
+    private List<Income> _incomes = new List<Income>();
+    public IReadOnlyCollection<Income> Incomes { get => _incomes.AsReadOnly(); private set => SetIncomes(value); }
+    private void SetIncomes(IReadOnlyCollection<Income> data)
+    {
+        _incomes.Clear();
+        _incomes.AddRange(data);
+    }
+
     private CashFlowData() { }
 
     public static CashFlowData Create() => new();
@@ -86,4 +94,8 @@ public class CashFlowData
     public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) => _investmentSnapshots.Add(snapshot);
 
     public void AddBank(Bank bank) => _banks.Add(bank);
+
+    public void AddIncome(Income income) => _incomes.Add(income);
+
+    public void RemoveIncome(Guid id) => _incomes.RemoveAll(i => i.Id == id);
 }

--- a/Financial.CashFlow.Domain/Entities/Income.cs
+++ b/Financial.CashFlow.Domain/Entities/Income.cs
@@ -1,0 +1,75 @@
+using System;
+using Financial.CashFlow.Domain.Enums;
+
+namespace Financial.CashFlow.Domain.Entities;
+
+public class Income
+{
+    public Guid Id { get; private set; }
+    public DateOnly Date { get; private set; }
+    public IncomeSource IncomeSource { get; private set; }
+    public decimal? GrossValue { get; private set; }
+    public decimal NetValue { get; private set; }
+    public string Bank { get; private set; } = string.Empty;
+
+    private Income() { }
+
+    public static Income Create(
+        DateOnly date,
+        IncomeSource incomeSource,
+        decimal? grossValue,
+        decimal netValue,
+        string bank)
+    {
+        ValidateValues(grossValue, netValue);
+        ValidateBank(bank);
+
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Date = date,
+            IncomeSource = incomeSource,
+            GrossValue = grossValue,
+            NetValue = netValue,
+            Bank = bank
+        };
+    }
+
+    public void UpdateDetails(
+        DateOnly date,
+        IncomeSource incomeSource,
+        decimal? grossValue,
+        decimal netValue,
+        string bank)
+    {
+        ValidateValues(grossValue, netValue);
+        ValidateBank(bank);
+
+        Date = date;
+        IncomeSource = incomeSource;
+        GrossValue = grossValue;
+        NetValue = netValue;
+        Bank = bank;
+    }
+
+    private static void ValidateValues(decimal? grossValue, decimal netValue)
+    {
+        if (netValue < 0)
+        {
+            throw new ArgumentException("Net value cannot be negative.");
+        }
+
+        if (grossValue is not null && grossValue < netValue)
+        {
+            throw new ArgumentException("Gross value must be greater than or equal to net value.");
+        }
+    }
+
+    private static void ValidateBank(string bank)
+    {
+        if (string.IsNullOrWhiteSpace(bank))
+        {
+            throw new ArgumentException("Bank is required.");
+        }
+    }
+}

--- a/Financial.CashFlow.Domain/Enums/IncomeSource.cs
+++ b/Financial.CashFlow.Domain/Enums/IncomeSource.cs
@@ -1,0 +1,9 @@
+namespace Financial.CashFlow.Domain.Enums;
+
+public enum IncomeSource
+{
+    Gleison,
+    Ariana,
+    Lottery,
+    DividendoJuros
+}

--- a/Financial.CashFlow.Infrastructure/Persistence/CashFlowTypeInfoResolver.cs
+++ b/Financial.CashFlow.Infrastructure/Persistence/CashFlowTypeInfoResolver.cs
@@ -16,7 +16,8 @@ public class CashFlowTypeInfoResolver : DefaultJsonTypeInfoResolver
         typeof(RecurringBill),
         typeof(MaeLedgerEntry),
         typeof(InvestmentSnapshot),
-        typeof(Bank)
+        typeof(Bank),
+        typeof(Income)
     ];
 
     public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)

--- a/Financial.CashFlow.Infrastructure/Repositories/CashFlowJsonRepository.cs
+++ b/Financial.CashFlow.Infrastructure/Repositories/CashFlowJsonRepository.cs
@@ -42,6 +42,10 @@ public sealed class CashFlowJsonRepository : ICashFlowRepository
 
     public IEnumerable<Bank> GetBanks() => _data.Banks;
 
+    public IEnumerable<Income> GetIncomes() => _data.Incomes;
+    public void AddIncome(Income income) => _data.AddIncome(income);
+    public void DeleteIncome(Guid id) => _data.RemoveIncome(id);
+
     public async Task SaveChangesAsync()
     {
         var json = _serializer.Serialize(_data);

--- a/Financial.slnx
+++ b/Financial.slnx
@@ -15,6 +15,7 @@
 	</Folder>
 	<Folder Name="/Integrations/">
 		<Project Path="Integrations/CashFlowBankMigration/CashFlowBankMigration.csproj" />
+		<Project Path="Integrations/CashFlowIncomeMigration/CashFlowIncomeMigration.csproj" />
 		<Project Path="Integrations/CashFlowPaymentStateMigration/CashFlowPaymentStateMigration.csproj" />
 		<Project Path="Integrations/CashFlowSpreadsheetImport/CashFlowSpreadsheetImport.csproj" />
 		<Project Path="Integrations/GoogleFinancialSupport/GoogleFinancialSupport.csproj" />
@@ -34,6 +35,7 @@
 		<Project Path="Tests/Financial.CashFlowSpreadsheetImport.Tests/Financial.CashFlowSpreadsheetImport.Tests.csproj" />
 		<Project Path="Tests/Financial.CashFlowPaymentStateMigration.Tests/Financial.CashFlowPaymentStateMigration.Tests.csproj" />
 		<Project Path="Tests/Financial.CashFlowBankMigration.Tests/Financial.CashFlowBankMigration.Tests.csproj" />
+		<Project Path="Tests/Financial.CashFlowIncomeMigration.Tests/Financial.CashFlowIncomeMigration.Tests.csproj" />
 	</Folder>
 	<Folder Name="/Presentation/">
 		<Project Path="Financial.App/Financial.App.csproj" />

--- a/Integrations/CashFlowIncomeMigration/CashFlowIncomeMigration.csproj
+++ b/Integrations/CashFlowIncomeMigration/CashFlowIncomeMigration.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Financial.CashFlow.Infrastructure.Integrations.CashFlowIncomeMigration</RootNamespace>
+    <AssemblyName>Financial.CashFlow.Infrastructure.Integrations.CashFlowIncomeMigration</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Financial.CashFlow.Domain\Financial.CashFlow.Domain.csproj" />
+    <ProjectReference Include="..\..\Financial.CashFlow.Infrastructure\Financial.CashFlow.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\Financial.Shared.Infrastructure\Financial.Shared.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Integrations/CashFlowIncomeMigration/IncomeMigrationSummary.cs
+++ b/Integrations/CashFlowIncomeMigration/IncomeMigrationSummary.cs
@@ -1,0 +1,25 @@
+using System.Text;
+
+namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowIncomeMigration;
+
+/// <summary>
+/// Outcome of one migration run: confirms the Incomes collection is present
+/// and reports how many entries it currently holds.
+/// </summary>
+public sealed class IncomeMigrationSummary
+{
+    public int IncomeCount { get; }
+
+    public IncomeMigrationSummary(int incomeCount)
+    {
+        IncomeCount = incomeCount;
+    }
+
+    public string Render()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Income migration summary");
+        builder.AppendLine($"  Incomes collection present with {IncomeCount} entries.");
+        return builder.ToString();
+    }
+}

--- a/Integrations/CashFlowIncomeMigration/IncomeMigrator.cs
+++ b/Integrations/CashFlowIncomeMigration/IncomeMigrator.cs
@@ -1,0 +1,18 @@
+using Financial.CashFlow.Domain.Entities;
+
+namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowIncomeMigration;
+
+/// <summary>
+/// Confirms the Incomes collection exists on the data file. There is no fixed data to seed
+/// (unlike the P13 bank migration) — CashFlowData.Incomes already default-initializes to an
+/// empty list, so this run's only job is to make the run auditable and backed up, per the PRD.
+/// </summary>
+public static class IncomeMigrator
+{
+    public static IncomeMigrationSummary Migrate(CashFlowData data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        return new IncomeMigrationSummary(data.Incomes.Count);
+    }
+}

--- a/Integrations/CashFlowIncomeMigration/MigrationBackup.cs
+++ b/Integrations/CashFlowIncomeMigration/MigrationBackup.cs
@@ -1,0 +1,34 @@
+namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowIncomeMigration;
+
+/// <summary>
+/// Copies the data file to a timestamped sibling before the migration touches it,
+/// so a failed or interrupted run can always be recovered from.
+/// </summary>
+public static class MigrationBackup
+{
+    private const string BackupTimestampFormat = "yyyyMMdd-HHmmss";
+
+    public static string Create(string dataPath)
+    {
+        if (!File.Exists(dataPath))
+        {
+            throw new FileNotFoundException($"Data file not found at '{dataPath}'.", dataPath);
+        }
+
+        var directory = Path.GetDirectoryName(Path.GetFullPath(dataPath))!;
+        var name = Path.GetFileNameWithoutExtension(dataPath);
+        var extension = Path.GetExtension(dataPath);
+        var timestamp = DateTime.Now.ToString(BackupTimestampFormat);
+        var backupPath = Path.Combine(directory, $"{name}.backup-income-migration-{timestamp}{extension}");
+
+        var suffix = 1;
+        while (File.Exists(backupPath))
+        {
+            backupPath = Path.Combine(directory, $"{name}.backup-income-migration-{timestamp}-{suffix}{extension}");
+            suffix++;
+        }
+
+        File.Copy(dataPath, backupPath);
+        return backupPath;
+    }
+}

--- a/Integrations/CashFlowIncomeMigration/Program.cs
+++ b/Integrations/CashFlowIncomeMigration/Program.cs
@@ -1,0 +1,31 @@
+using Financial.CashFlow.Infrastructure.Integrations.CashFlowIncomeMigration;
+using Financial.CashFlow.Infrastructure.Persistence;
+using Financial.CashFlow.Infrastructure.Repositories;
+using Financial.Shared.Infrastructure.Persistence;
+
+var dataPath = args.Length > 0
+    ? args[0]
+    : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "data", "data-cashflow.json"));
+
+if (!File.Exists(dataPath))
+{
+    Console.Error.WriteLine($"Data file not found at '{dataPath}'.");
+    return 1;
+}
+
+var backupPath = MigrationBackup.Create(dataPath);
+Console.WriteLine($"Backed up data file to '{backupPath}'.");
+
+var serializer = new CashFlowSerializerAdapter();
+var storage = new LocalJsonStorage(dataPath);
+var data = CashFlowLoader.LoadSync(storage, serializer);
+
+var summary = IncomeMigrator.Migrate(data);
+
+var repository = new CashFlowJsonRepository(data, storage, serializer);
+await repository.SaveChangesAsync();
+
+Console.WriteLine($"Wrote migrated data to '{dataPath}'.");
+Console.WriteLine();
+Console.WriteLine(summary.Render());
+return 0;

--- a/Tests/Financial.Api.Tests/IncomesEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/IncomesEndpointsTests.cs
@@ -1,0 +1,212 @@
+using Financial.CashFlow.Application.DTOs;
+using FluentAssertions;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace Financial.Api.Tests;
+
+public class IncomesEndpointsTests
+{
+    [Fact]
+    public async Task AddIncome_ValidRequest_ReturnsOk()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 25),
+            IncomeSource = "Gleison",
+            GrossValue = 3200.00m,
+            NetValue = 2450.00m,
+            Bank = "Barclays"
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/incomes", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var income = await response.Content.ReadFromJsonAsync<IncomeDTO>();
+        income.Should().NotBeNull();
+        income!.IncomeSource.Should().Be("Gleison");
+        income.GrossValue.Should().Be(3200.00m);
+        income.NetValue.Should().Be(2450.00m);
+        income.Bank.Should().Be("Barclays");
+    }
+
+    [Fact]
+    public async Task AddIncome_WithoutBank_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 25),
+            IncomeSource = "Lottery",
+            GrossValue = null,
+            NetValue = 50m,
+            Bank = ""
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/incomes", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AddIncome_GrossValueBelowNetValue_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 25),
+            IncomeSource = "Ariana",
+            GrossValue = 100m,
+            NetValue = 200m,
+            Bank = "Chase"
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/incomes", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AddIncome_NegativeNetValue_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 25),
+            IncomeSource = "Lottery",
+            GrossValue = null,
+            NetValue = -1m,
+            Bank = "Chase"
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/incomes", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdateIncome_ExistingId_ReturnsOkAndUpdatesFields()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var created = await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 1),
+            IncomeSource = "Lottery",
+            GrossValue = null,
+            NetValue = 10m,
+            Bank = "Chase"
+        });
+        var createdIncome = await created.Content.ReadFromJsonAsync<IncomeDTO>();
+
+        var response = await client.PutAsJsonAsync($"/api/v1/financial/incomes/{createdIncome!.Id}", new IncomeUpdateDTO
+        {
+            Date = new DateOnly(2026, 7, 2),
+            IncomeSource = "DividendoJuros",
+            GrossValue = null,
+            NetValue = 25m,
+            Bank = "Trading212"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await response.Content.ReadFromJsonAsync<IncomeDTO>();
+        updated!.IncomeSource.Should().Be("DividendoJuros");
+        updated.NetValue.Should().Be(25m);
+        updated.Bank.Should().Be("Trading212");
+    }
+
+    [Fact]
+    public async Task UpdateIncome_UnknownId_ReturnsNotFound()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PutAsJsonAsync($"/api/v1/financial/incomes/{Guid.NewGuid()}", new IncomeUpdateDTO
+        {
+            Date = new DateOnly(2026, 7, 1),
+            IncomeSource = "Lottery",
+            GrossValue = null,
+            NetValue = 10m,
+            Bank = "Chase"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteIncome_ExistingId_ReturnsOkAndRemovesIncome()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var created = await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 5),
+            IncomeSource = "Lottery",
+            GrossValue = null,
+            NetValue = 10m,
+            Bank = "Chase"
+        });
+        var createdIncome = await created.Content.ReadFromJsonAsync<IncomeDTO>();
+
+        var response = await client.DeleteAsync($"/api/v1/financial/incomes/{createdIncome!.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var list = await client.GetFromJsonAsync<List<IncomeDTO>>("/api/v1/financial/incomes/month/2026/7");
+        list.Should().NotContain(i => i.Id == createdIncome.Id);
+    }
+
+    [Fact]
+    public async Task DeleteIncome_UnknownId_ReturnsNotFound()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.DeleteAsync($"/api/v1/financial/incomes/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetIncomesByMonth_ReturnsOnlyIncomesForThatMonthAndAllowsMultiplePerSource()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 1),
+            IncomeSource = "Ariana",
+            GrossValue = null,
+            NetValue = 400m,
+            Bank = "Chase"
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 8),
+            IncomeSource = "Ariana",
+            GrossValue = null,
+            NetValue = 420m,
+            Bank = "Chase"
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 8, 1),
+            IncomeSource = "Ariana",
+            GrossValue = null,
+            NetValue = 410m,
+            Bank = "Chase"
+        });
+
+        var response = await client.GetAsync("/api/v1/financial/incomes/month/2026/7");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await response.Content.ReadFromJsonAsync<List<IncomeDTO>>();
+        items.Should().HaveCount(2);
+        items.Should().OnlyContain(i => i.Date.Month == 7);
+    }
+}

--- a/Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs
@@ -67,6 +67,10 @@ public class BankServiceTests
 
         public IEnumerable<Bank> GetBanks() => Banks;
 
+        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
+        public void AddIncome(Income income) { }
+        public void DeleteIncome(Guid id) { }
+
         public Task SaveChangesAsync() => Task.CompletedTask;
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/CardStatementServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/CardStatementServiceTests.cs
@@ -298,6 +298,10 @@ public class CardStatementServiceTests
 
         public IEnumerable<Bank> GetBanks() => Banks;
 
+        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
+        public void AddIncome(Income income) { }
+        public void DeleteIncome(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ControleMaeServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ControleMaeServiceTests.cs
@@ -269,6 +269,10 @@ public class ControleMaeServiceTests
 
         public IEnumerable<Bank> GetBanks() => Array.Empty<Bank>();
 
+        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
+        public void AddIncome(Income income) { }
+        public void DeleteIncome(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
@@ -467,6 +467,10 @@ public class ExpenseServiceTests
 
         public IEnumerable<Bank> GetBanks() => Banks;
 
+        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
+        public void AddIncome(Income income) { }
+        public void DeleteIncome(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/IncomeServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/IncomeServiceTests.cs
@@ -1,0 +1,239 @@
+using Financial.CashFlow.Application.DTOs;
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Domain.Entities;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Application.Tests.Services;
+
+public class IncomeServiceTests
+{
+    [Fact]
+    public void Constructor_WithNullRepository_Throws()
+    {
+        Action act = () => new IncomeService(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public async Task AddIncomeAsync_WithValidRequest_SavesAndReturnsIncome()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new IncomeService(repository);
+
+        var result = await service.AddIncomeAsync(ToCreateDto(ValidCreateRequest()));
+
+        result.Date.Should().Be(new DateOnly(2026, 7, 25));
+        result.IncomeSource.Should().Be("Gleison");
+        result.GrossValue.Should().Be(3200.00m);
+        result.NetValue.Should().Be(2450.00m);
+        result.Bank.Should().Be("Barclays");
+        repository.Incomes.Should().ContainSingle();
+        repository.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AddIncomeAsync_WithoutGrossValue_SavesNull()
+    {
+        var service = new IncomeService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { GrossValue = null });
+
+        var result = await service.AddIncomeAsync(request);
+
+        result.GrossValue.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddIncomeAsync_MultipleEntriesForSameSourceAndMonth_AllPersist()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new IncomeService(repository);
+        var request = ValidCreateRequest() with { IncomeSource = "Ariana", GrossValue = null };
+
+        await service.AddIncomeAsync(ToCreateDto(request with { Date = new DateOnly(2026, 7, 1) }));
+        await service.AddIncomeAsync(ToCreateDto(request with { Date = new DateOnly(2026, 7, 8) }));
+        await service.AddIncomeAsync(ToCreateDto(request with { Date = new DateOnly(2026, 7, 15) }));
+
+        repository.Incomes.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task AddIncomeAsync_WithGrossValueBelowNetValue_ThrowsArgumentException()
+    {
+        var service = new IncomeService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { GrossValue = 100m, NetValue = 200m });
+
+        var act = async () => await service.AddIncomeAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task AddIncomeAsync_WithNegativeNetValue_ThrowsArgumentException()
+    {
+        var service = new IncomeService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { GrossValue = null, NetValue = -1m });
+
+        var act = async () => await service.AddIncomeAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task AddIncomeAsync_WithUnrecognizedIncomeSource_ThrowsArgumentException()
+    {
+        var service = new IncomeService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { IncomeSource = "NotASource" });
+
+        var act = async () => await service.AddIncomeAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Income source*not recognized*");
+    }
+
+    [Fact]
+    public async Task AddIncomeAsync_WithUnrecognizedBank_ThrowsArgumentException()
+    {
+        var service = new IncomeService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { Bank = "NotABank" });
+
+        var act = async () => await service.AddIncomeAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Bank*not recognized*");
+    }
+
+    [Fact]
+    public async Task UpdateIncomeAsync_WithExistingId_UpdatesInPlace()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new IncomeService(repository);
+        var added = await service.AddIncomeAsync(ToCreateDto(ValidCreateRequest()));
+
+        var updateRequest = ToUpdateDto(ValidCreateRequest() with { NetValue = 500m, GrossValue = null, IncomeSource = "Lottery" });
+        var result = await service.UpdateIncomeAsync(added.Id, updateRequest);
+
+        result.Id.Should().Be(added.Id);
+        result.NetValue.Should().Be(500m);
+        result.IncomeSource.Should().Be("Lottery");
+        repository.Incomes.Should().ContainSingle();
+        repository.SaveChangesCallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task UpdateIncomeAsync_WithUnknownId_ThrowsKeyNotFoundException()
+    {
+        var service = new IncomeService(new StubCashFlowRepository());
+
+        var act = async () => await service.UpdateIncomeAsync(Guid.NewGuid(), ToUpdateDto(ValidCreateRequest()));
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task DeleteIncomeAsync_WithExistingId_RemovesAndSaves()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new IncomeService(repository);
+        var added = await service.AddIncomeAsync(ToCreateDto(ValidCreateRequest()));
+
+        await service.DeleteIncomeAsync(added.Id);
+
+        repository.Incomes.Should().BeEmpty();
+        repository.SaveChangesCallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DeleteIncomeAsync_WithUnknownId_ThrowsKeyNotFoundException()
+    {
+        var service = new IncomeService(new StubCashFlowRepository());
+
+        var act = async () => await service.DeleteIncomeAsync(Guid.NewGuid());
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task GetIncomesByMonth_ReturnsOnlyIncomesInThatMonth()
+    {
+        var service = new IncomeService(new StubCashFlowRepository());
+        await service.AddIncomeAsync(ToCreateDto(ValidCreateRequest() with { Date = new DateOnly(2026, 7, 10) }));
+        await service.AddIncomeAsync(ToCreateDto(ValidCreateRequest() with { Date = new DateOnly(2026, 8, 10) }));
+
+        var result = service.GetIncomesByMonth(2026, 7);
+
+        result.Should().ContainSingle().Which.Date.Should().Be(new DateOnly(2026, 7, 10));
+    }
+
+    private static IncomeCreateRequest ValidCreateRequest() => new(
+        new DateOnly(2026, 7, 25),
+        "Gleison",
+        3200.00m,
+        2450.00m,
+        "Barclays");
+
+    private static IncomeCreateDTO ToCreateDto(IncomeCreateRequest r) => new()
+    {
+        Date = r.Date,
+        IncomeSource = r.IncomeSource,
+        GrossValue = r.GrossValue,
+        NetValue = r.NetValue,
+        Bank = r.Bank
+    };
+
+    private static IncomeUpdateDTO ToUpdateDto(IncomeCreateRequest r) => new()
+    {
+        Date = r.Date,
+        IncomeSource = r.IncomeSource,
+        GrossValue = r.GrossValue,
+        NetValue = r.NetValue,
+        Bank = r.Bank
+    };
+
+    private sealed record IncomeCreateRequest(
+        DateOnly Date, string IncomeSource, decimal? GrossValue, decimal NetValue, string Bank);
+
+    private sealed class StubCashFlowRepository : ICashFlowRepository
+    {
+        public List<Income> Incomes { get; } = new();
+        public List<Bank> Banks { get; } = new()
+        {
+            Bank.Create("Barclays", roundUpEnabled: false),
+            Bank.Create("Trading212", roundUpEnabled: true),
+            Bank.Create("Chase", roundUpEnabled: true)
+        };
+        public int SaveChangesCallCount { get; private set; }
+
+        public IEnumerable<Expense> GetExpenses() => Array.Empty<Expense>();
+        public void AddExpense(Expense expense) { }
+        public void DeleteExpense(Guid id) { }
+
+        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
+        public void AddReserveMovement(ReserveMovement movement) { }
+        public void DeleteReserveMovement(Guid id) { }
+
+        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
+        public void AddCardStatement(CardStatement statement) { }
+
+        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
+        public void AddRecurringBill(RecurringBill bill) { }
+        public void DeleteRecurringBill(Guid id) { }
+
+        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
+        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
+        public void DeleteMaeLedgerEntry(Guid id) { }
+
+        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
+        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
+
+        public IEnumerable<Bank> GetBanks() => Banks;
+
+        public IEnumerable<Income> GetIncomes() => Incomes;
+        public void AddIncome(Income income) => Incomes.Add(income);
+        public void DeleteIncome(Guid id) => Incomes.RemoveAll(i => i.Id == id);
+
+        public Task SaveChangesAsync()
+        {
+            SaveChangesCallCount++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Tests/Financial.CashFlow.Application.Tests/Services/InvestmentSnapshotServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/InvestmentSnapshotServiceTests.cs
@@ -127,6 +127,10 @@ public class InvestmentSnapshotServiceTests
 
         public IEnumerable<Bank> GetBanks() => Array.Empty<Bank>();
 
+        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
+        public void AddIncome(Income income) { }
+        public void DeleteIncome(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/MensaisServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/MensaisServiceTests.cs
@@ -241,6 +241,10 @@ public class MensaisServiceTests
 
         public IEnumerable<Bank> GetBanks() => Array.Empty<Bank>();
 
+        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
+        public void AddIncome(Income income) { }
+        public void DeleteIncome(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
@@ -353,6 +353,10 @@ public class ReserveServiceTests
 
         public IEnumerable<Bank> GetBanks() => Array.Empty<Bank>();
 
+        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
+        public void AddIncome(Income income) { }
+        public void DeleteIncome(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
@@ -167,6 +167,10 @@ public class YearlySummaryServiceTests
 
         public IEnumerable<Bank> GetBanks() => Array.Empty<Bank>();
 
+        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
+        public void AddIncome(Income income) { }
+        public void DeleteIncome(Guid id) { }
+
         public Task SaveChangesAsync() => Task.CompletedTask;
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Validation/IncomeSourceParserTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Validation/IncomeSourceParserTests.cs
@@ -1,0 +1,48 @@
+using Financial.CashFlow.Application.Validation;
+using Financial.CashFlow.Domain.Enums;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Application.Tests.Validation;
+
+public class IncomeSourceParserTests
+{
+    [Theory]
+    [InlineData("Gleison", IncomeSource.Gleison)]
+    [InlineData("Ariana", IncomeSource.Ariana)]
+    [InlineData("Lottery", IncomeSource.Lottery)]
+    [InlineData("DividendoJuros", IncomeSource.DividendoJuros)]
+    public void TryParse_ValidValue_ReturnsTrueAndTheSource(string value, IncomeSource expected)
+    {
+        var result = IncomeSourceParser.TryParse(value, out var incomeSource);
+
+        result.Should().BeTrue();
+        incomeSource.Should().Be(expected);
+    }
+
+    [Fact]
+    public void TryParse_DifferentCasing_ResolvesCaseInsensitively()
+    {
+        var result = IncomeSourceParser.TryParse("gleison", out var incomeSource);
+
+        result.Should().BeTrue();
+        incomeSource.Should().Be(IncomeSource.Gleison);
+    }
+
+    [Fact]
+    public void TryParse_UnrecognizedValue_ReturnsFalse()
+    {
+        var result = IncomeSourceParser.TryParse("NotASource", out _);
+
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void TryParse_NullOrEmptyValue_ReturnsFalse(string? value)
+    {
+        var result = IncomeSourceParser.TryParse(value, out _);
+
+        result.Should().BeFalse();
+    }
+}

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/CashFlowDataTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/CashFlowDataTests.cs
@@ -7,7 +7,7 @@ namespace Financial.CashFlow.Domain.Tests;
 public class CashFlowDataTests
 {
     [Fact]
-    public void Create_StartsWithAllSevenCollectionsEmpty()
+    public void Create_StartsWithAllEightCollectionsEmpty()
     {
         var data = CashFlowData.Create();
 
@@ -18,6 +18,7 @@ public class CashFlowDataTests
         data.MaeLedgerEntries.Should().BeEmpty();
         data.InvestmentSnapshots.Should().BeEmpty();
         data.Banks.Should().BeEmpty();
+        data.Incomes.Should().BeEmpty();
     }
 
     [Fact]
@@ -208,4 +209,43 @@ public class CashFlowDataTests
         data.InvestmentSnapshots.Should().ContainSingle();
         data.Expenses.Should().BeEmpty();
     }
+
+    [Fact]
+    public void AddIncome_AddsOnlyToIncomesCollection()
+    {
+        var data = CashFlowData.Create();
+
+        data.AddIncome(CreateIncome());
+
+        data.Incomes.Should().ContainSingle();
+        data.Expenses.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RemoveIncome_RemovesOnlyTheMatchingIncome()
+    {
+        var data = CashFlowData.Create();
+        var toKeep = CreateIncome();
+        var toRemove = CreateIncome();
+        data.AddIncome(toKeep);
+        data.AddIncome(toRemove);
+
+        data.RemoveIncome(toRemove.Id);
+
+        data.Incomes.Should().ContainSingle().Which.Id.Should().Be(toKeep.Id);
+    }
+
+    [Fact]
+    public void RemoveIncome_WithUnknownId_LeavesCollectionUnchanged()
+    {
+        var data = CashFlowData.Create();
+        data.AddIncome(CreateIncome());
+
+        data.RemoveIncome(Guid.NewGuid());
+
+        data.Incomes.Should().ContainSingle();
+    }
+
+    private static Income CreateIncome() =>
+        Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Lottery, null, 10m, "Chase");
 }

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/IncomeTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/IncomeTests.cs
@@ -1,0 +1,110 @@
+using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Domain.Enums;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Domain.Tests;
+
+public class IncomeTests
+{
+    [Fact]
+    public void Create_AssignsAllFieldsAndANewId()
+    {
+        var date = new DateOnly(2026, 7, 25);
+
+        var income = Income.Create(date, IncomeSource.Gleison, 3200.00m, 2450.00m, "Barclays");
+
+        income.Id.Should().NotBeEmpty();
+        income.Date.Should().Be(date);
+        income.IncomeSource.Should().Be(IncomeSource.Gleison);
+        income.GrossValue.Should().Be(3200.00m);
+        income.NetValue.Should().Be(2450.00m);
+        income.Bank.Should().Be("Barclays");
+    }
+
+    [Fact]
+    public void Create_TwoIncomes_HaveDifferentIds()
+    {
+        var first = Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Lottery, null, 10m, "Chase");
+        var second = Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Lottery, null, 20m, "Chase");
+
+        first.Id.Should().NotBe(second.Id);
+    }
+
+    [Fact]
+    public void Create_WithoutGrossValue_AllowsNull()
+    {
+        var income = Income.Create(new DateOnly(2026, 7, 1), IncomeSource.DividendoJuros, null, 15.50m, "Trading212");
+
+        income.GrossValue.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithGrossValueBelowNetValue_Throws()
+    {
+        var act = () => Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Ariana, 100m, 150m, "Chase");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Create_WithGrossValueEqualToNetValue_DoesNotThrow()
+    {
+        var act = () => Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Ariana, 100m, 100m, "Chase");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Create_WithNegativeNetValue_Throws()
+    {
+        var act = () => Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Lottery, null, -1m, "Chase");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithoutABank_Throws(string? bank)
+    {
+        var act = () => Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Lottery, null, 10m, bank!);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void UpdateDetails_ReplacesAllFields()
+    {
+        var income = Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Gleison, 3000m, 2400m, "Barclays");
+        var newDate = new DateOnly(2026, 7, 2);
+
+        income.UpdateDetails(newDate, IncomeSource.Ariana, 500m, 400m, "Chase");
+
+        income.Date.Should().Be(newDate);
+        income.IncomeSource.Should().Be(IncomeSource.Ariana);
+        income.GrossValue.Should().Be(500m);
+        income.NetValue.Should().Be(400m);
+        income.Bank.Should().Be("Chase");
+    }
+
+    [Fact]
+    public void UpdateDetails_WithGrossValueBelowNetValue_Throws()
+    {
+        var income = Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Gleison, 3000m, 2400m, "Barclays");
+
+        var act = () => income.UpdateDetails(income.Date, income.IncomeSource, 100m, 200m, income.Bank);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void UpdateDetails_WithNegativeNetValue_Throws()
+    {
+        var income = Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Gleison, 3000m, 2400m, "Barclays");
+
+        var act = () => income.UpdateDetails(income.Date, income.IncomeSource, null, -5m, income.Bank);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs
@@ -8,7 +8,7 @@ namespace Financial.CashFlow.Infrastructure.Tests.Persistence;
 public class CashFlowSerializerAdapterTests
 {
     [Fact]
-    public void SerializeThenDeserialize_RoundTripsAllEightCollections()
+    public void SerializeThenDeserialize_RoundTripsAllNineCollections()
     {
         var serializer = new CashFlowSerializerAdapter();
         var original = CashFlowData.Create();
@@ -26,6 +26,7 @@ public class CashFlowSerializerAdapterTests
         var maeLedgerEntry = MaeLedgerEntry.Create(new DateOnly(2026, 7, 15), "School supplies", "Note", Currency.BRL, 350m, 51.23m);
         var investmentSnapshot = InvestmentSnapshot.Create(InvestmentAccount.PlatinumVisa8003, 2026, 7, 1250.00m);
         var bank = Bank.Create("Barclays", roundUpEnabled: false);
+        var income = Income.Create(new DateOnly(2026, 7, 25), IncomeSource.Gleison, 3200.00m, 2450.00m, "Barclays");
 
         original.AddExpense(expense);
         original.AddReserveMovement(reserveMovement);
@@ -34,6 +35,7 @@ public class CashFlowSerializerAdapterTests
         original.AddMaeLedgerEntry(maeLedgerEntry);
         original.AddInvestmentSnapshot(investmentSnapshot);
         original.AddBank(bank);
+        original.AddIncome(income);
 
         var json = serializer.Serialize(original);
         var result = serializer.Deserialize(json);
@@ -60,6 +62,13 @@ public class CashFlowSerializerAdapterTests
         var resultBank = result.Banks.Should().ContainSingle().Which;
         resultBank.Name.Should().Be(bank.Name);
         resultBank.RoundUpEnabled.Should().Be(bank.RoundUpEnabled);
+        var resultIncome = result.Incomes.Should().ContainSingle().Which;
+        resultIncome.Id.Should().Be(income.Id);
+        resultIncome.Date.Should().Be(income.Date);
+        resultIncome.IncomeSource.Should().Be(income.IncomeSource);
+        resultIncome.GrossValue.Should().Be(income.GrossValue);
+        resultIncome.NetValue.Should().Be(income.NetValue);
+        resultIncome.Bank.Should().Be(income.Bank);
     }
 
     [Fact]
@@ -78,5 +87,6 @@ public class CashFlowSerializerAdapterTests
         result.MaeLedgerEntries.Should().BeEmpty();
         result.InvestmentSnapshots.Should().BeEmpty();
         result.Banks.Should().BeEmpty();
+        result.Incomes.Should().BeEmpty();
     }
 }

--- a/Tests/Financial.CashFlowIncomeMigration.Tests/Financial.CashFlowIncomeMigration.Tests.csproj
+++ b/Tests/Financial.CashFlowIncomeMigration.Tests/Financial.CashFlowIncomeMigration.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Integrations\CashFlowIncomeMigration\CashFlowIncomeMigration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Financial.CashFlowIncomeMigration.Tests/IncomeMigratorTests.cs
+++ b/Tests/Financial.CashFlowIncomeMigration.Tests/IncomeMigratorTests.cs
@@ -1,0 +1,53 @@
+using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Domain.Enums;
+using Financial.CashFlow.Infrastructure.Integrations.CashFlowIncomeMigration;
+using FluentAssertions;
+
+namespace Financial.CashFlowIncomeMigration.Tests;
+
+public class IncomeMigratorTests
+{
+    [Fact]
+    public void Migrate_OnEmptyData_ReportsEmptyIncomesCollection()
+    {
+        var data = CashFlowData.Create();
+
+        var summary = IncomeMigrator.Migrate(data);
+
+        summary.IncomeCount.Should().Be(0);
+        data.Incomes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Migrate_WithExistingIncomes_ReportsTheCorrectCount()
+    {
+        var data = CashFlowData.Create();
+        data.AddIncome(Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Lottery, null, 10m, "Chase"));
+        data.AddIncome(Income.Create(new DateOnly(2026, 7, 2), IncomeSource.Ariana, null, 400m, "Barclays"));
+
+        var summary = IncomeMigrator.Migrate(data);
+
+        summary.IncomeCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Migrate_CalledTwice_ProducesTheSameResult()
+    {
+        var data = CashFlowData.Create();
+        data.AddIncome(Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Lottery, null, 10m, "Chase"));
+
+        var first = IncomeMigrator.Migrate(data);
+        var second = IncomeMigrator.Migrate(data);
+
+        first.IncomeCount.Should().Be(second.IncomeCount);
+        data.Incomes.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Migrate_WithNullData_Throws()
+    {
+        var act = () => IncomeMigrator.Migrate(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/Tests/Financial.CashFlowIncomeMigration.Tests/MigrationBackupTests.cs
+++ b/Tests/Financial.CashFlowIncomeMigration.Tests/MigrationBackupTests.cs
@@ -1,0 +1,61 @@
+using Financial.CashFlow.Infrastructure.Integrations.CashFlowIncomeMigration;
+using FluentAssertions;
+
+namespace Financial.CashFlowIncomeMigration.Tests;
+
+public class MigrationBackupTests
+{
+    [Fact]
+    public void Create_CopiesTheDataFileToATimestampedSibling()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dataPath = Path.Combine(directory.FullName, "data-cashflow.json");
+            File.WriteAllText(dataPath, "{\"Incomes\":[]}");
+
+            var backupPath = MigrationBackup.Create(dataPath);
+
+            File.Exists(backupPath).Should().BeTrue();
+            Path.GetDirectoryName(backupPath).Should().Be(directory.FullName);
+            Path.GetFileName(backupPath).Should().StartWith("data-cashflow.backup-income-migration-").And.EndWith(".json");
+            File.ReadAllText(backupPath).Should().Be("{\"Incomes\":[]}");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Create_CalledTwice_ProducesDistinctBackups()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dataPath = Path.Combine(directory.FullName, "data-cashflow.json");
+            File.WriteAllText(dataPath, "{}");
+
+            var first = MigrationBackup.Create(dataPath);
+            var second = MigrationBackup.Create(dataPath);
+
+            second.Should().NotBe(first);
+            File.Exists(first).Should().BeTrue();
+            File.Exists(second).Should().BeTrue();
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Create_WhenSourceMissing_Throws()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.json");
+
+        var act = () => MigrationBackup.Create(missingPath);
+
+        act.Should().Throw<FileNotFoundException>();
+    }
+}

--- a/docs/P14-F01-income-entity-and-migration/plan.md
+++ b/docs/P14-F01-income-entity-and-migration/plan.md
@@ -1,0 +1,31 @@
+# Implementation Plan: Income Entity and Migration
+
+**Prerequisites:**
+- .NET 10 SDK (existing solution target)
+- No new external dependencies or environment variables
+
+### Stage 1: Domain
+
+**1. Income Entity and IncomeSource Enum** - Add the `Income` entity (date, income source, optional gross value, net value, destination bank) and the new `IncomeSource` enum, with the entity validating its own value-shape invariant (gross not below net, net not negative) on creation and update, following the existing entity patterns in this domain.
+
+**2. CashFlowData Income Collection** - Extend `CashFlowData` with an `Incomes` collection and add/remove operations, following the same private-list-plus-readonly-property pattern used for every other collection on that aggregate.
+
+### Stage 2: Application
+
+**3. Repository Contract and Income Source Parser** - Extend the repository interface with income query/add/delete operations, and add a parser that resolves an income source string against the new enum, mirroring the existing category parser.
+
+**4. Income DTOs** - Add the read, create, and update data transfer objects for an income entry, matching the field set and nullability established in the domain entity.
+
+**5. Income Service** - Implement the create/update/delete/get-by-month workflow: validating the income source, resolving the destination bank against the live bank list, delegating value-shape validation to the entity, and mapping to the read DTO. Register the service for dependency injection.
+
+### Stage 3: Infrastructure and Presentation
+
+**6. Repository and Serializer Wiring** - Implement the new repository operations against the JSON-backed data store, and register the `Income` entity with the serializer's private-member wiring so it persists and reloads correctly.
+
+**7. Incomes API Endpoints** - Add the HTTP endpoints for creating, updating, deleting, and listing income entries by month, following the existing controller's routing, status code, and error response conventions.
+
+### Stage 4: Migration Tool
+
+**8. Income Migration Console Project** - Create a new console project that takes a timestamped backup of the data file before writing, loads the data, confirms the income collection is present, and prints a run summary — following the exact structure of the existing bank migration tool.
+
+**9. Solution Registration** - Register the new console project and its test project in the solution file.

--- a/docs/P14-F01-income-entity-and-migration/spec.md
+++ b/docs/P14-F01-income-entity-and-migration/spec.md
@@ -1,0 +1,206 @@
+# F01. Income Entity and Migration
+
+## 1. Technical Overview
+
+**What:** Introduce a new `Income` entity (`Date`, `IncomeSource`, `GrossValue`, `NetValue`, `Bank`) to the CashFlow domain, together with the full create/edit/delete/query contract (Application services, DTOs, and API endpoints) that F04's UI, F03's tithe calculation, F05's Incoming card, F06's bank balance, and F07's Yearly Summary will all consume. A new `IncomeSource` enum (`Gleison`, `Ariana`, `Lottery`, `DividendoJuros`) is added, distinct from the expense `Category` enum. A one-time, idempotent, backup-first console migration adds the new, initially-empty `Income` collection to the live data file, following the exact pattern established by P12's `CashFlowPaymentStateMigration` and P13's `CashFlowBankMigration`.
+
+**Why:** `Income` is a brand-new concept with no prior representation anywhere in the codebase (unlike P13's `Bank`, which replaced an existing `PaymentSource` enum). Every other feature in this PRD reads or writes `Income` data — F03 sums it for the tithe base, F04 is the form that creates/edits/deletes it, F05 displays it grouped by source, F06 folds it into the bank balance, F07 aggregates it across a year. Establishing the entity, persistence, and the full CRUD contract in one feature (rather than splitting the contract across F01 and F04) mirrors how `Expense` already ships as a complete CRUD surface from its own foundational feature — F04 then only has to build a form and list UI against an API that already exists, exactly as later Expense-form work in this project builds against the pre-existing `ExpensesController`.
+
+**Scope:**
+- Included: `Income` domain entity; `IncomeSource` enum; `CashFlowData.Incomes` collection with add/remove; `ICashFlowRepository` additions (`GetIncomes`, `AddIncome`, `DeleteIncome`); `IIncomeService`/`IncomeService` (add, update, delete, get-by-month); `IncomeDTO`/`IncomeCreateDTO`/`IncomeUpdateDTO`; `IncomeSourceParser` validation helper; `IncomesController` (POST, PUT, DELETE, GET by month); serializer wiring for the new entity; a new console migration project (`Integrations/CashFlowIncomeMigration`) that backs up the data file and confirms the `Incomes` collection is present; solution file registration for the new console + test projects.
+- Excluded: any frontend UI (F04); the tithe calculation (F03); the Incoming card (F05); bank balance changes (F06); the Yearly Summary table (F07); historical income backfill (out of scope per PRD).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.CashFlow.Domain/Entities/Income.cs` — new entity
+- `Financial.CashFlow.Domain/Enums/IncomeSource.cs` — new enum
+- `Financial.CashFlow.Domain/Entities/CashFlowData.cs` — new `Incomes` collection + `AddIncome`/`RemoveIncome`
+- `Financial.CashFlow.Application/Interfaces/ICashFlowRepository.cs` — `GetIncomes()`, `AddIncome(Income)`, `DeleteIncome(Guid)` added
+- `Financial.CashFlow.Application/Interfaces/IIncomeService.cs` — new
+- `Financial.CashFlow.Application/Services/IncomeService.cs` — new
+- `Financial.CashFlow.Application/DTOs/IncomeDTO.cs`, `IncomeCreateDTO.cs`, `IncomeUpdateDTO.cs` — new
+- `Financial.CashFlow.Application/Validation/IncomeSourceParser.cs` — new
+- `Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs` — registers `IIncomeService`
+- `Financial.CashFlow.Infrastructure/Persistence/CashFlowTypeInfoResolver.cs` — `Income` added to `ManagedTypes`
+- `Financial.CashFlow.Infrastructure/Repositories/CashFlowJsonRepository.cs` — implements the 3 new repository members
+- `Financial.Api/Controllers/IncomesController.cs` — new
+- `Integrations/CashFlowIncomeMigration/` — new console project (backup + confirm)
+- `Tests/Financial.CashFlowIncomeMigration.Tests/` — new xUnit project
+- `Financial.slnx` — registers both new projects
+
+```mermaid
+graph TD
+  A["IncomesController"] --> B[IncomeService]
+  B --> C["IncomeSourceParser / BankNameResolver"]
+  B --> D["ICashFlowRepository"]
+  D --> E["CashFlowJsonRepository"]
+  E --> F["CashFlowData.Incomes"]
+  G["Program.cs (console)"] --> H["File backup (timestamped copy)"]
+  G --> I["CashFlowLoader.LoadSync + LocalJsonStorage"]
+  G --> J[IncomeMigrator]
+  J --> F
+  G --> K["CashFlowJsonRepository.SaveChangesAsync"]
+  G --> L["IncomeMigrationSummary.Render()"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| F01 delivers the full CRUD contract, not just the entity | `IncomeService`, `IncomesController`, and all 3 DTOs are built in F01, alongside the domain entity and migration | Scope F01 to domain + migration only (mirroring P13-F01's `Bank`, which added no service/controller) | The PRD states F04 "Consumes: F01: income entry create/edit/delete contract" — unlike `Bank` (permanent, no management UI, no CRUD ever), `Income` is user-editable from day one via F04. Building the contract now means F04 is a pure UI feature layered on a stable, independently-testable API, matching how `Expense`'s CRUD already predates every UI feature that touches it in this codebase. This is the single largest scope judgment call in this spec — flagged here for review. |
+| Income's bank reference shape | `string Bank` (bank name), validated at the Application layer via the existing `BankNameResolver` against the live `Bank` list — same pattern as `Expense.PaymentSource` | A `Guid`/foreign-key reference to `Bank` | `Bank` has no surrogate `Id` (per P13-F01) — it is identified by name everywhere in this codebase. Reusing `BankNameResolver` avoids introducing a second bank-referencing convention. |
+| `IncomeSource` representation on the wire | `string` in DTOs, parsed via a new `IncomeSourceParser` (mirrors `CategoryParser`) | Reuse the existing `Category` enum with an `Income`-only subset | The PRD explicitly calls `IncomeSource` "a new enum distinct from the expense `Category` enum" — this is a direct PRD requirement, not an open decision. |
+| Value validation location | `GrossValue >= NetValue` (when `GrossValue` is provided) and `NetValue >= 0` enforced as a domain invariant inside `Income.Create`/`UpdateDetails`; bank-name resolution and source-enum parsing done in `IncomeService` (Application layer), mirroring `ExpenseService.ValidateFields` | Push all validation into the Application layer, keeping the entity a pure data holder | `Expense` already validates its own cross-field shape invariant internally (`ValidatePaymentShape`) while `ExpenseService` handles lookups needing repository access (bank/category resolution). The same split is the smallest change that keeps the entity self-consistent without duplicating repository-dependent logic into the domain layer. |
+| Migration content | `IncomeMigrator.Migrate(data)` performs no seeding (there is no fixed data to seed, unlike `Bank`'s 3 known rows) — it only confirms the `Incomes` collection exists and reports its current count; the tool still follows the full backup-first, load-mutate-save, summary-printing shape of `CashFlowBankMigration`/`CashFlowPaymentStateMigration` | Skip the migration tool entirely, since `CashFlowData.Incomes` already default-initializes to an empty list and a normal save would add the JSON key automatically | The PRD explicitly requires "a migration that adds the `Income` collection to back up the data file first" as an F01 user story and Section 9 acceptance criterion — the backup-first guarantee and the idempotent, auditable run are the point, not the data mutation itself. Keeping the tool trivial (no seed rows) is the correct proportionate implementation, not a reason to omit it. |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Domain/Entities/Income.cs` | New | Income entry identity | Private ctor + `Create(date, incomeSource, grossValue, netValue, bank)` factory; `UpdateDetails(...)`; `Id`, `Date`, `IncomeSource`, `GrossValue` (nullable), `NetValue`, `Bank`, all private-set; validates `GrossValue >= NetValue` (when provided) and `NetValue >= 0` |
+| `Financial.CashFlow.Domain/Enums/IncomeSource.cs` | New | Source classification | `Gleison`, `Ariana`, `Lottery`, `DividendoJuros` |
+| `Financial.CashFlow.Domain/Entities/CashFlowData.cs` | Modified | Income collection | `_incomes`/`Incomes` (`IReadOnlyCollection<Income>`) following the existing private-list-plus-readonly-property pattern; `AddIncome(Income)`; `RemoveIncome(Guid id)` |
+| `Financial.CashFlow.Application/Interfaces/ICashFlowRepository.cs` | Modified | Repository contract | `IEnumerable<Income> GetIncomes(); void AddIncome(Income income); void DeleteIncome(Guid id);` added |
+| `Financial.CashFlow.Application/Interfaces/IIncomeService.cs` | New | Service contract | `AddIncomeAsync`, `UpdateIncomeAsync`, `DeleteIncomeAsync`, `GetIncomesByMonth(int year, int month)` |
+| `Financial.CashFlow.Application/Services/IncomeService.cs` | New | Income CRUD | Validates fields (`NetValue >= 0` domain-checked; `IncomeSource` via `IncomeSourceParser`; `Bank` via `BankNameResolver` against `_repository.GetBanks()`); throws `ArgumentException` on invalid input, `KeyNotFoundException` on update/delete of a missing id; `ToDto` maps entity to `IncomeDTO` |
+| `Financial.CashFlow.Application/DTOs/IncomeDTO.cs` | New | Read model | `Id`, `Date`, `IncomeSource` (string), `GrossValue` (nullable), `NetValue`, `Bank` |
+| `Financial.CashFlow.Application/DTOs/IncomeCreateDTO.cs` | New | Create request | `Date`, `IncomeSource` (string), `GrossValue` (nullable), `NetValue`, `Bank` |
+| `Financial.CashFlow.Application/DTOs/IncomeUpdateDTO.cs` | New | Update request | Same shape as create; id comes from the route |
+| `Financial.CashFlow.Application/Validation/IncomeSourceParser.cs` | New | Enum resolution | Static `TryParse(string? value, out IncomeSource incomeSource)`, delegating to the existing `EnumParser.TryParseEnum`, mirroring `CategoryParser` |
+| `Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs` | Modified | DI registration | `services.AddSingleton<IIncomeService, IncomeService>();` added |
+| `Financial.CashFlow.Infrastructure/Persistence/CashFlowTypeInfoResolver.cs` | Modified | Serializer wiring | `typeof(Income)` added to `ManagedTypes` |
+| `Financial.CashFlow.Infrastructure/Repositories/CashFlowJsonRepository.cs` | Modified | Repository impl | `GetIncomes() => _data.Incomes;`, `AddIncome`, `DeleteIncome` delegating to `CashFlowData` |
+| `Financial.Api/Controllers/IncomesController.cs` | New | HTTP surface | `POST /incomes`, `PUT /incomes/{id}`, `DELETE /incomes/{id}`, `GET /incomes/month/{year}/{month}` — mirrors `ExpensesController`'s status codes and `Problem()` error shape exactly |
+| `Integrations/CashFlowIncomeMigration/CashFlowIncomeMigration.csproj` | New | Console project | Mirrors `CashFlowBankMigration.csproj`: `net10.0` exe, references CashFlow Domain, CashFlow Infrastructure, Shared Infrastructure |
+| `Integrations/CashFlowIncomeMigration/Program.cs` | New | Entry point | Args: `[dataPath]` (same default-resolution pattern as `CashFlowBankMigration`); abort if missing; `MigrationBackup.Create`; `CashFlowLoader.LoadSync`; `IncomeMigrator.Migrate`; `CashFlowJsonRepository.SaveChangesAsync`; print `IncomeMigrationSummary.Render()`; exit 0/1 |
+| `Integrations/CashFlowIncomeMigration/MigrationBackup.cs` | New | Backup helper | Copied from `CashFlowBankMigration`'s helper with an `income-migration` timestamp segment |
+| `Integrations/CashFlowIncomeMigration/IncomeMigrator.cs` | New | Confirm collection | Static `Migrate(CashFlowData data) : IncomeMigrationSummary`; performs no mutation beyond ensuring `data.Incomes` is accessible (it always is, via `CashFlowData`'s default-initialized empty list); records the current income count for the summary |
+| `Integrations/CashFlowIncomeMigration/IncomeMigrationSummary.cs` | New | Run report | `IncomeCount` at run time; `Render()` string confirming the collection is present |
+| `Tests/Financial.CashFlowIncomeMigration.Tests/Financial.CashFlowIncomeMigration.Tests.csproj` | New | Test project | Same package set as `Financial.CashFlowBankMigration.Tests`; references the console project |
+| `Tests/Financial.CashFlowIncomeMigration.Tests/IncomeMigratorTests.cs`, `MigrationBackupTests.cs` | New | Unit tests | See Section 7 |
+| `Financial.slnx` | Modified | Solution | Registers `Integrations/CashFlowIncomeMigration` and `Tests/Financial.CashFlowIncomeMigration.Tests` |
+
+## 5. API Contracts
+
+**Endpoint: Add Income**
+- **Method:** POST
+- **Path:** `/incomes`
+- **Authentication:** None (matches every other endpoint in this single-user app)
+
+**Request:**
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|--------------|
+| `date` | `date` | Yes | — | Income date |
+| `incomeSource` | `string` | Yes | one of `Gleison`, `Ariana`, `Lottery`, `DividendoJuros` | Source classification |
+| `grossValue` | `decimal` | No | must be `>= netValue` when provided | Gross pay, meaningful only for `Gleison`/`Ariana` |
+| `netValue` | `decimal` | Yes | `>= 0` | Net amount received |
+| `bank` | `string` | Yes | must resolve against the live `Bank` list | Destination bank name |
+
+**Request Example:**
+```json
+{
+  "date": "2026-07-25",
+  "incomeSource": "Gleison",
+  "grossValue": 3200.00,
+  "netValue": 2450.00,
+  "bank": "Barclays"
+}
+```
+
+**Response (Success - 200):**
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `id` | `uuid` | Generated identifier |
+| `date` | `date` | Income date |
+| `incomeSource` | `string` | Source classification |
+| `grossValue` | `decimal?` | Gross pay, if provided |
+| `netValue` | `decimal` | Net amount received |
+| `bank` | `string` | Destination bank name |
+
+**Response Example:**
+```json
+{
+  "id": "7c1b1e2a-1234-4a11-9abc-0f1e2d3c4b5a",
+  "date": "2026-07-25",
+  "incomeSource": "Gleison",
+  "grossValue": 3200.00,
+  "netValue": 2450.00,
+  "bank": "Barclays"
+}
+```
+
+**Error Codes:**
+
+| Code | HTTP Status | Description |
+|------|-------------|--------------|
+| — | 400 | Invalid income source, bank not recognized, `grossValue < netValue`, or negative `netValue` (via `Problem()` with the exception message) |
+
+**Endpoint: Update Income**
+- **Method:** PUT
+- **Path:** `/incomes/{id}`
+- Same request/response shape as Add, plus a 404 (`Problem()`) when `id` does not resolve to an existing income entry.
+
+**Endpoint: Delete Income**
+- **Method:** DELETE
+- **Path:** `/incomes/{id}`
+- **Response (Success - 200):** empty body. **Error:** 404 (`Problem()`) when `id` does not resolve.
+
+**Endpoint: Get Incomes by Month**
+- **Method:** GET
+- **Path:** `/incomes/month/{year}/{month}`
+- **Response (Success - 200):** `IncomeDTO[]` — every income entry dated within that year/month, same shape as the Add response.
+
+## 6. Data Model
+
+`data-cashflow.json` gains one new top-level array, `Incomes`, empty immediately after migration:
+
+```json
+{
+  "Incomes": []
+}
+```
+
+Each entry created afterward through the API takes this shape:
+
+```json
+{
+  "Id": "7c1b1e2a-1234-4a11-9abc-0f1e2d3c4b5a",
+  "Date": "2026-07-25",
+  "IncomeSource": "Gleison",
+  "GrossValue": 3200.00,
+  "NetValue": 2450.00,
+  "Bank": "Barclays"
+}
+```
+
+No other top-level collection's shape changes. The backup file `data-cashflow.backup-income-migration-<timestamp>.json` is created beside the data file before any write.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Tests/Financial.CashFlow.Domain.Tests/Entities/IncomeTests.cs` | Unit | `Income` | `Create` sets all fields; rejects `grossValue < netValue`; rejects negative `netValue`; accepts a null `grossValue`; `UpdateDetails` re-validates and updates all fields |
+| `Tests/Financial.CashFlow.Domain.Tests/Entities/CashFlowDataTests.cs` | Unit | `CashFlowData` | `AddIncome` appends to `Incomes`; `Incomes` starts empty on `Create()`; `RemoveIncome` removes by id and no-ops on an unknown id |
+| `Tests/Financial.CashFlow.Application.Tests/Validation/IncomeSourceParserTests.cs` | Unit | `IncomeSourceParser` | Parses each of the 4 valid values (case-insensitive); returns `false` for an unrecognized or null/empty value |
+| `Tests/Financial.CashFlow.Application.Tests/Services/IncomeServiceTests.cs` | Unit | `IncomeService` | Valid create/update/delete round-trip; unrecognized `incomeSource` throws `ArgumentException`; unrecognized `bank` throws `ArgumentException`; `grossValue < netValue` throws; negative `netValue` throws; update/delete of an unknown id throws `KeyNotFoundException`; `GetIncomesByMonth` filters by year and month and returns entries for any number of same-source entries in the month |
+| `Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs` | Unit | Serializer | `Income` round-trips through `CashFlowTypeInfoResolver`'s private-setter wiring |
+| `Tests/Financial.Api.Tests/IncomesEndpointsTests.cs` | Integration | `IncomesController` | POST creates and returns 200; POST with invalid fields returns 400; PUT updates and returns 200; PUT on unknown id returns 404; DELETE removes and returns 200; DELETE on unknown id returns 404; GET by month returns only that month's entries |
+| `Tests/Financial.CashFlowIncomeMigration.Tests/IncomeMigratorTests.cs` | Unit | `IncomeMigrator` | Reports an empty `Incomes` collection on a fresh `CashFlowData`; reports the correct count when incomes already exist; second run against already-migrated data produces the same result (idempotent) |
+| `Tests/Financial.CashFlowIncomeMigration.Tests/MigrationBackupTests.cs` | Unit | Backup helper | Creates a timestamped copy with identical content beside the source; distinct name per call; throws when source missing |
+
+**Acceptance tests (PRD Section 9, F01):**
+- An `Income` entry can be created with `Date`, `IncomeSource`, `NetValue`, and `Bank`; `GrossValue` optional → `IncomeTests`, `IncomeServiceTests`, `IncomesEndpointsTests`
+- Multiple `Income` entries can exist for the same month and `IncomeSource` with no upper limit → `IncomeServiceTests.GetIncomesByMonth`
+- Creating an entry with `GrossValue < NetValue` is rejected → `IncomeTests`, `IncomeServiceTests`
+- The migration adds an empty `Income` collection and takes a backup before writing → `IncomeMigratorTests`, `MigrationBackupTests`, `Program.cs` ordering (backup is the first side effect, by construction)
+- Running the migration a second time is idempotent → `IncomeMigratorTests`
+
+**Cross-Feature Integration criteria touching F01 (PRD Section 9):**
+- "F03's tithe calculation correctly reads the net income totals produced by F01" — guaranteed by `ICashFlowRepository.GetIncomes()` exposing every `Income.NetValue`, verified here only insofar as `IncomeService`/`GetIncomes()` round-trip `NetValue` correctly; the consuming calculation is verified in F03's own spec
+- "F04's create/edit/delete actions correctly read and write through F01's `Income` entity contract" — the entire Section 5 API contract and `IncomeServiceTests` suite is the direct guarantee this criterion depends on
+- "F07 correctly aggregates F01's income data across all 12 months" — depends on `GetIncomes()` exposing `GrossValue`/`NetValue`/`IncomeSource` correctly across an arbitrary date range, covered here by `IncomeServiceTests` and `CashFlowDataTests`; the yearly aggregation itself is verified in F07's own spec

--- a/docs/prd/P14-prd-monthly-income-bank-balance/prd-monthly-income-bank-balance.md
+++ b/docs/prd/P14-prd-monthly-income-bank-balance/prd-monthly-income-bank-balance.md
@@ -1,0 +1,318 @@
+# Monthly Income Tracking and Real Bank Balance
+
+## 1. Executive Summary
+
+Monthly Income Tracking and Real Bank Balance gives `Financial.CashFlow`'s Monthly tab the income side of cash flow it has never had, and fixes the bank figure that has been mislabeled since P13. It is used by the same single developer-maintainer that PRD P11, P12, and P13 already serve, replacing the last surviving piece of their retired spreadsheet: an income block (J2:L5), a tithe calculation (J6:L6), and a manually-maintained tithe balance (K7) that today only exists as hand-typed spreadsheet formulas, disconnected from the expenses the tithe balance depends on. The core value is completeness and accuracy — without an income side, the Monthly tab can only ever show half the picture, and without a real bank balance, the figure the developer checks after every expense entry silently ignores every pound that ever came in.
+
+At a high level, a new `Income` entity captures one entry per pay event — date, source (`Gleison`, `Ariana`, `Lottery`, or `DividendoJuros`), gross value (where applicable), net value, and destination bank — with no limit on how many entries exist per month per source. This one shape handles Gleison's single monthly paycheck, Ariana's 4-5 weekly paychecks, and the roughly 8 (but variable) Dividendo/Juros entries the developer currently tracks, without special-casing any of them. From these entries, the tithe (a fixed 10% of the month's total net income) is calculated automatically, and the tithe balance — the calculated tithe minus whatever the developer has already recorded as `Dizimo`-category expenses that month — replaces the manual subtraction they do today. Separately, each `Bank` (from P13) gains a one-time opening balance and effective date, turning its displayed figure from a single month's net expense total into a real, running balance: opening balance plus every pound of income and minus every pound of expense recorded against that bank from the opening date forward.
+
+This PRD does not touch how the developer actually pays their tithe — recording a `Dizimo` expense stays exactly as manual as it is today; this feature only calculates the balance against it. It also does not add a bank management screen, backfill historical income, or make the tithe percentage configurable — all deliberate simplifications consistent with this project's no-over-engineering standing rule for a single-user personal tool.
+
+## 2. Problem and Opportunity
+
+### The Problem
+
+**The Monthly tab has no income side at all**
+- Every figure on the Monthly page today — Category Totals, Cards, Banks — is derived purely from expenses; there is no field, entity, or screen anywhere that records money coming in
+- The developer's retired spreadsheet always tracked 4 income sources (Salario Gleison, Salario Ariana, Lottery, Dividendo/Juros) side by side with the tithe they generate; none of that exists in the app today
+
+**The tithe balance is a manual, disconnected calculation**
+- The tithe itself (a tenth of net salaries, lottery, and dividends/interest) is computed by hand in the spreadsheet today
+- The tithe balance — tithe owed minus what's already been paid via `Dizimo`-category expenses — requires the developer to manually look up that month's Dizimo expenses and subtract them from the calculated tithe every time either figure changes
+- This manual step is exactly the kind of disconnected, error-prone aggregate that P11-P13 already eliminated for expenses, round-up, and card settlement
+
+**The bank balance figure is not a real balance**
+- Per P13, a bank's displayed balance is `sum(Expense.Value) − sum(Expense.RoundUpAmount)` for the selected month only — it has no opening balance, doesn't carry forward between months, and (until this PRD) has no way to add money in at all
+- The panel is effectively labeled as a running total ("Balance") but behaves like a single month's net spend, which is not what the developer means when they say "bank balance"
+
+**The Yearly Summary has no income visibility**
+- `YearlySummaryPage` today shows only expense Category Totals and Investment Diffs; salary, taxes withheld, and dividends/interest — figures the developer's spreadsheet has always summarized per month across the year — aren't represented anywhere
+
+### The Opportunity
+
+- No income side on the Monthly tab → **F01's `Income` entity** and **F04's capture UI** give the developer a place to enter every pay event, with no limit on entries per source per month
+- Tithe balance is a manual, disconnected calculation → **F03's tithe calculation** computes both the tithe and the tithe balance automatically from `Income` and existing `Dizimo`-category expenses, and **F05** surfaces both on the Monthly page
+- Bank balance isn't a real balance → **F02's opening balance** and **F06's balance recalculation** turn the Banks panel into a running account balance that includes income and carries forward month to month
+- No income visibility in the Yearly Summary → **F07** adds a per-month Income Summary table alongside the existing Category Totals and Investment Diffs tables
+
+## 3. Target Audience
+
+### Primary Users
+
+**Developer-Maintainer**
+- The same sole developer and sole end user as PRD P11, P12, and P13, who has already retired their spreadsheet for expenses, round-up, and card settlement, and now wants its last surviving piece — the income and tithe block — replaced too
+- Currently re-derives the tithe balance by hand every time they check it, and reads a "bank balance" that they already know undercounts reality because it ignores income entirely
+- Values a figure that reflects real money over a convenient but incomplete one — the same standing rule that drove P13's round-up work
+
+## 4. Objectives
+
+**Give the Monthly tab a real income side matching the retired spreadsheet**
+- Metric: all 4 income sources (Gleison, Ariana, Lottery, DividendoJuros) are capturable with an unlimited number of entries per source per month, verified against representative fixtures (a single Gleison entry, 4-5 Ariana entries, ~8 DividendoJuros entries) in 100% of test cases
+
+**Automate the tithe balance calculation**
+- Metric: the calculated tithe (10% of the month's total net income) and the tithe balance (tithe minus that month's `Dizimo`-category expenses) match a manually-computed reference value to the penny in 100% of test fixtures
+
+**Make bank balance reflect real money**
+- Metric: each bank's displayed balance equals `OpeningBalance + Σ(Income.NetValue) − Σ(Expense.Value − Expense.RoundUpAmount)` for that bank from its `OpeningBalanceDate` forward, matching to the penny in 100% of test fixtures
+
+**Surface income in the Yearly Summary**
+- Metric: the Income Summary table's rows 2 (Salary), 3 (Salary after taxes), 4 (Tax difference), and 6 (Dividendo/Juros) compute correctly for every month with income data, matching a manually-computed reference to the penny in 100% of test fixtures
+
+## 5. User Stories
+
+### F01. Income Entity and Migration
+- As the system, I want a single `Income` entity that can hold any number of entries per source per month so that Gleison's one paycheck, Ariana's weekly paychecks, and the variable count of Dividendo/Juros entries are all handled the same way without special-casing
+- As the developer, I want the migration that adds the `Income` collection to back up the data file first so that a failed run can be recovered from
+
+### F02. Bank Opening Balance
+- As the developer, I want to set each bank's real balance as of a known date so that the app's running balance starts from reality instead of zero
+- As the developer, I want to correct a bank's opening balance or its effective date later if I got it wrong, so that a mistake doesn't require a data migration to fix
+
+### F03. Tithe Calculation
+- As the system, I want to calculate the month's tithe as 10% of total net income so that the developer never has to compute it by hand
+- As the system, I want to calculate the tithe balance as the tithe minus that month's `Dizimo`-category expenses so that the developer can see at a glance whether they've paid enough
+
+### F04. Monthly Income Capture UI
+- As the developer, I want to add an income entry with a date, source, gross/net value, and bank so that I can record a paycheck, lottery win, or dividend payment the same way I already record an expense
+- As the developer, I want to add as many entries as I need for the same source in the same month so that Ariana's weekly paychecks and multiple Dividendo/Juros payments don't need to be pre-summed by hand
+- As the developer, I want to edit or delete an income entry after saving it so that I can correct a mistake
+
+### F05. Monthly Incoming and Tithe Display
+- As the developer, I want to see each income source's monthly total, the calculated tithe, and the tithe balance on the Monthly page so that I have the same at-a-glance view my spreadsheet's income block used to give me
+
+### F06. Real Bank Balance
+- As the developer, I want each bank's displayed balance to include income, not just expenses, so that the figure reflects money actually available in the account
+- As the developer, I want that balance to carry forward from a real opening balance rather than resetting to a single month's net spend, so that it behaves like an actual account balance
+
+### F07. Yearly Summary Income Rows
+- As the developer, I want to see salary (gross and net), the tax difference, and Dividendo/Juros totals per month across the year so that I can review my income the same way I already review expense category totals
+
+## 6. Functionalities
+
+### F01. Income Entity and Migration
+
+**Provides:**
+- Income entries (date, income source, gross value, net value, destination bank), queryable by month and year (used by F03, F04, F05, F06, F07)
+
+**Capabilities:**
+- A new `Income` entity is introduced with 5 fields: `Date`, `IncomeSource` (a new enum distinct from the expense `Category` enum, with members `Gleison`, `Ariana`, `Lottery`, `DividendoJuros`), `GrossValue` (nullable, only meaningful for `Gleison`/`Ariana` entries), `NetValue` (always required), and `Bank` (a required reference to the existing `Bank` entity from P13)
+- Any number of `Income` entries can exist for the same month and the same `IncomeSource` — there is no one-per-category-per-month limit, so Ariana's 4-5 weekly paychecks and a variable count of Dividendo/Juros entries are each just multiple dated `Income` rows
+- `GrossValue`, when provided, must be greater than or equal to `NetValue`
+- A one-time migration adds the new, initially-empty `Income` collection to the live data file, following the same backup-before-write, idempotent pattern used by P12 and P13's migrations
+- No historical income backfill is performed; the developer enters past months manually if they choose to
+
+**Experience:**
+- No screen of its own; this is the data shape F04 reads and writes and every other feature in this PRD consumes.
+
+**Error Handling:**
+- The migration takes a full backup of the data file before writing, so a failed or interrupted run can be recovered from
+- Running the migration a second time against already-migrated data is a no-op (idempotent)
+
+### F02. Bank Opening Balance
+
+**Provides:**
+- Each bank's opening balance and opening balance effective date (used by F06)
+
+**Capabilities:**
+- The existing `Bank` entity gains two fields: `OpeningBalance` (decimal, defaults to £0.00) and `OpeningBalanceDate` (date, defaults to the migration run date)
+- A one-time migration adds these fields to all existing banks with the defaults above; the developer is expected to manually correct each bank's `OpeningBalance` and `OpeningBalanceDate` afterward to match its real-world balance as of a known date
+- Both fields remain editable at any time after migration, not just once, so a wrong initial value can be corrected without another migration
+- No screen is added to create a new bank; this feature only adds the two fields to the 3 banks already seeded by P13
+
+**Experience:**
+- The Banks panel gains a small edit affordance per bank to set or update its opening balance and effective date; editing takes effect immediately in F06's balance calculation.
+
+**Error Handling:**
+- The migration takes a full backup of the data file before writing
+- Setting `OpeningBalance` to a negative value is rejected with a validation message
+
+### F03. Tithe Calculation
+
+**Consumes:**
+- F01: income entries' net values for the selected month
+
+**Provides:**
+- Calculated tithe and tithe balance for the selected month (used by F05)
+
+**Capabilities:**
+- The tithe base for a month is the sum of `NetValue` across every `Income` entry dated that month, regardless of `IncomeSource`
+- The calculated tithe is a fixed 10% of the tithe base, computed on demand — not stored — whenever the selected month, its income, or its expenses change
+- The tithe balance is the calculated tithe minus the sum of `Expense.Value` for that month's expenses tagged `Category.Dizimo`
+- The tithe balance can be negative (more paid via Dizimo expenses than the calculated tithe) or positive (owed but not yet paid); both are valid and shown as-is, with no clamping
+
+**Experience:**
+- No screen of its own; this is the calculation F05 displays.
+
+### F04. Monthly Income Capture UI
+
+**Consumes:**
+- F01: income entry create/edit/delete contract (date, income source, gross value, net value, bank)
+
+**Capabilities:**
+- The Monthly page gains an income entry form, structurally mirroring the existing `ExpenseForm`: a date picker (defaulting to the selected month), an `IncomeSource` dropdown, a gross value field (shown only when the source is `Gleison` or `Ariana`), a net value field, and a bank picker reusing the existing Bank list
+- Saved income entries for the selected month appear in a list below the form (mirroring `ExpensesSection`), each editable or deletable inline
+- Deleting an income entry is a hard delete with no undo, consistent with expense deletion
+
+**Experience:**
+- The developer adds an income entry the same way they add an expense: fill the form, save, see it appear in the list immediately, edit or delete inline. Adding Ariana's next weekly paycheck, or an additional Dividendo/Juros entry for the month, works exactly the same way as the first one — there is no separate "add another" step.
+
+**Error Handling:**
+- Saving an entry with `GrossValue < NetValue` is rejected with a validation message
+- Saving an entry with no `Bank` selected is rejected with a validation message
+- Saving an entry with a negative `NetValue` is rejected with a validation message
+
+### F05. Monthly Incoming and Tithe Display
+
+**Consumes:**
+- F01: income entries for the selected month, grouped by `IncomeSource`
+- F03: calculated tithe and tithe balance for the selected month
+
+**Capabilities:**
+- The Monthly page gains an "Incoming" card, alongside the existing Category Totals, Cards, and Banks cards, showing one row per `IncomeSource` with that category's summed `NetValue` for the month (Gleison and Ariana rows also show summed `GrossValue`), plus a total incoming row
+- The card also shows the calculated tithe and the tithe balance, clearly labeled, so the developer can see at a glance whether that month's Dizimo expenses cover the tithe owed
+
+**Experience:**
+- The Incoming card updates immediately whenever an income entry is added, edited, or deleted, and whenever a Dizimo-category expense changes — the same immediacy as every other panel figure on this page.
+
+### F06. Real Bank Balance
+
+**Consumes:**
+- F01: income entries' net values and destination bank, dated on or after each bank's opening balance date
+- F02: each bank's opening balance and opening balance date
+
+**Capabilities:**
+- Each bank's displayed balance changes from P13's `sum(Expense.Value) − sum(Expense.RoundUpAmount)` for the selected month only, to: `OpeningBalance + Σ(Income.NetValue) − Σ(Expense.Value − Expense.RoundUpAmount)`, both sums running over that bank's income and expenses dated from `OpeningBalanceDate` through the end of the selected month
+- Activity dated before a bank's `OpeningBalanceDate` never contributes to its balance, since it is already reflected in the opening balance itself
+- The Banks panel's balance label is renamed to "Bank Balance" to reflect that it is now a real, running account balance rather than a single month's net expense total
+
+**Experience:**
+- The Banks panel the developer already checks after entering expenses now also updates when income is entered, and the balance carries forward month to month instead of resetting.
+
+### F07. Yearly Summary Income Rows
+
+**Consumes:**
+- F01: income entries' gross and net values by category, across all 12 months of the selected year
+
+**Capabilities:**
+- The Yearly Summary page gains a new Income Summary table, laid out like the existing Category Totals table (one row per metric, 12 monthly columns plus a yearly total column):
+  - Row 1: section header ("Income"), no numeric value
+  - Row 2 "Salary": sum of `GrossValue` for that month's `Gleison` and `Ariana` entries
+  - Row 3 "Salary after taxes": sum of `NetValue` for that month's `Gleison` and `Ariana` entries
+  - Row 4 "Tax difference": row 2 minus row 3 for that month
+  - Row 5: intentionally left blank
+  - Row 6 "Dividendo/Juros": sum of `NetValue` for that month's `DividendoJuros` entries
+- Lottery, the calculated tithe, and the tithe balance are not shown in the Yearly Summary — they remain Monthly-page-only
+
+**Experience:**
+- The Income Summary table appears on the Yearly Summary page alongside the existing Category Totals and Investment Diffs tables, using the same per-month column layout.
+
+## 7. Out of Scope
+
+**Configurable tithe percentage**
+- The tithe is always a fixed 10%; there is no settings screen or per-install configuration for a different rate
+
+**Bank management screen**
+- Unchanged from P13: no in-app way to add, rename, or remove a bank. This feature only adds an editable opening balance and effective date to the 3 already-seeded banks
+
+**Historical income backfill**
+- No import or reconciliation of past months' income against the spreadsheet's history; the migration only adds an empty `Income` collection, and the developer enters historical data manually if they choose to
+
+**Automatic tithe payment or expense creation**
+- Recording that a tithe was actually paid still means manually adding a `Dizimo`-category expense, exactly as today; this feature only calculates the balance against whatever `Dizimo` expenses already exist
+
+**Lottery and tithe rows in the Yearly Summary**
+- Per the developer's explicit scope, the Yearly Summary's Income Summary table only carries rows 2, 3, 4, and 6 — Lottery, tithe, and tithe balance are not represented there
+
+**Multi-currency income**
+- All income amounts are in the same currency as the rest of `Financial.CashFlow` (£); no currency selection or conversion is introduced
+
+**Bank/Open Banking integration**
+- Unchanged from PRD P11-P13's existing out-of-scope boundary — all income and opening balances remain manually entered, with no live bank API sync
+
+## 8. Dependency Graph
+
+| # | Feature | Priority | Dependencies |
+|---|---------|----------|--------------|
+| F01 | Income Entity and Migration | 1 | None |
+| F02 | Bank Opening Balance | 1 | None |
+| F03 | Tithe Calculation | 1 | F01 |
+| F04 | Monthly Income Capture UI | 1 | F01 |
+| F05 | Monthly Incoming and Tithe Display | 1 | F01, F03 |
+| F06 | Real Bank Balance | 1 | F01, F02 |
+| F07 | Yearly Summary Income Rows | 2 | F01 |
+
+### Execution Waves
+Features within the same wave can be built in parallel. A wave starts only after every feature in earlier waves is complete.
+
+- **Wave 1**: F01, F02
+- **Wave 2**: F03, F04, F06, F07
+- **Wave 3**: F05
+
+### Priority levels
+- **1** = Essential — product does not work without it
+- **2** = Important — significant value addition
+- **3** = Desirable — incremental improvement
+
+```mermaid
+graph TD
+  F01[Income Entity] --> F03[Tithe Calc]
+  F01 --> F04[Income Capture]
+  F01 --> F06[Bank Balance]
+  F02[Bank Opening Balance] --> F06
+  F01 --> F07[Yearly Summary]
+  F01 --> F05[Incoming Display]
+  F03 --> F05
+```
+
+## 9. Acceptance Criteria
+
+### F01. Income Entity and Migration
+- [x] An `Income` entry can be created with `Date`, `IncomeSource`, `NetValue`, and `Bank`; `GrossValue` is optional
+- [x] Multiple `Income` entries can exist for the same month and the same `IncomeSource` with no upper limit enforced
+- [x] Creating an entry with `GrossValue` less than `NetValue` is rejected
+- [x] The migration adds an empty `Income` collection to the data file and takes a backup before writing
+- [x] Running the migration a second time against already-migrated data produces the same result (idempotent)
+
+### F02. Bank Opening Balance
+- [ ] Each existing bank has `OpeningBalance` and `OpeningBalanceDate` fields populated with default values immediately after migration
+- [ ] `OpeningBalance` and `OpeningBalanceDate` can be edited after migration, and the new values are reflected in the next balance calculation
+- [ ] Setting `OpeningBalance` to a negative value is rejected with a validation message
+- [ ] The migration takes a backup of the data file before writing
+
+### F03. Tithe Calculation
+- [ ] The calculated tithe for a month equals 10% of the sum of `NetValue` across all that month's `Income` entries, matching a manual reference calculation to the penny
+- [ ] The tithe balance equals the calculated tithe minus the sum of that month's `Dizimo`-category expenses, matching a manual reference calculation to the penny
+- [ ] A tithe balance can display as a negative value without error when Dizimo expenses exceed the calculated tithe
+
+### F04. Monthly Income Capture UI
+- [ ] An income entry can be added via the form with all required fields and appears in the month's list immediately after saving
+- [ ] The gross value field is shown only when `Gleison` or `Ariana` is selected as the source
+- [ ] An existing income entry can be edited and the change is reflected in the list and in any dependent totals
+- [ ] An existing income entry can be deleted and is removed from the list immediately
+- [ ] Saving an entry with no bank selected, a negative net value, or gross less than net is rejected with a validation message
+
+### F05. Monthly Incoming and Tithe Display
+- [ ] The Incoming card shows one row per `IncomeSource` with the correct summed value for the selected month
+- [ ] The Incoming card shows the calculated tithe and tithe balance for the selected month
+- [ ] The Incoming card updates immediately after an income entry or a Dizimo-category expense is added, edited, or deleted
+
+### F06. Real Bank Balance
+- [ ] A bank's displayed balance equals `OpeningBalance + Σ(Income.NetValue) − Σ(Expense.Value − Expense.RoundUpAmount)` for that bank from its `OpeningBalanceDate` through the selected month, matching a manual reference calculation to the penny
+- [ ] Income or expenses dated before a bank's `OpeningBalanceDate` do not affect its displayed balance
+- [ ] The Banks panel label reads "Bank Balance" instead of the prior expense-only label
+- [ ] The displayed balance updates immediately after an income entry or expense is saved
+
+### F07. Yearly Summary Income Rows
+- [ ] The Income Summary table's Salary row (row 2) equals the sum of Gleison and Ariana gross values for each month, matching a manual reference calculation
+- [ ] The Salary after taxes row (row 3) equals the sum of Gleison and Ariana net values for each month
+- [ ] The Tax difference row (row 4) equals row 2 minus row 3 for each month
+- [ ] The Dividendo/Juros row (row 6) equals the sum of that month's DividendoJuros net values
+- [ ] Row 5 renders with no numeric value
+- [ ] Lottery, tithe, and tithe balance do not appear anywhere in the Yearly Summary page
+
+### Cross-Feature Integration
+- [ ] F03's tithe calculation correctly reads the net income totals produced by F01 for the selected month
+- [ ] F04's create/edit/delete actions correctly read and write through F01's `Income` entity contract
+- [ ] F05 correctly displays the income totals from F01 and the tithe/tithe balance from F03 for the selected month
+- [ ] F06 correctly combines F01's income data with F02's opening balance and date to produce each bank's balance
+- [ ] F07 correctly aggregates F01's income data across all 12 months of the selected year into the Yearly Summary's Income Summary table


### PR DESCRIPTION
## Summary

Implements **F01 – Income Entity and Migration** from the P14 PRD, per the committed spec/plan in `docs/P14-F01-income-entity-and-migration/`.

- New `Income` entity (`Date`, `IncomeSource`, `GrossValue` nullable, `NetValue`, `Bank`) on `CashFlowData.Incomes`, plus a new `IncomeSource` enum (`Gleison`, `Ariana`, `Lottery`, `DividendoJuros`), distinct from the expense `Category` enum
- Full CRUD contract built now rather than deferred to F04: `IIncomeService`/`IncomeService` (add/update/delete/get-by-month), `IncomeDTO`/`IncomeCreateDTO`/`IncomeUpdateDTO`, and a new `IncomesController` (`POST`/`PUT`/`DELETE`/`GET month/{year}/{month}`), mirroring `ExpensesController`'s status codes and error shape exactly — this is the single biggest scope judgment call in the spec, flagged there for review: since `Income` gets a management UI (F04) unlike the permanent, UI-less `Bank`, F01 delivers the whole contract so F04 is a pure UI feature layered on a stable, already-tested API
- `Income`'s bank reference reuses the existing `BankNameResolver` against the live `Bank` list (same pattern as `Expense.PaymentSource`); `IncomeSourceParser` mirrors `CategoryParser`
- Domain-level validation: `GrossValue >= NetValue` when provided, `NetValue >= 0`, non-blank `Bank`
- New console tool `Integrations/CashFlowIncomeMigration` (mirrors P13-F01's `CashFlowBankMigration` layout) that backs up the data file, loads it, and confirms/reports the `Incomes` collection — there's no fixed data to seed here (unlike banks), so the tool's job is the backup-first guarantee and an auditable, idempotent run, per the PRD's F01 user story
- A timestamped backup (`data-cashflow.backup-income-migration-<ts>.json`) is written beside the data file before anything is loaded

**Note:** this PR only ships the tool. The actual one-time run against the live `data/data-cashflow.json` is yours to trigger after merge:
`dotnet run --project Integrations/CashFlowIncomeMigration` (then restart the container — data loads once at startup). Smoke-tested here against a scratch copy of the live file: backup created, `Incomes: []` added, re-run confirmed idempotent.

## Acceptance Criteria (PRD Section 9 — F01)

- [x] An `Income` entry can be created with `Date`, `IncomeSource`, `NetValue`, and `Bank`; `GrossValue` is optional
- [x] Multiple `Income` entries can exist for the same month and the same `IncomeSource` with no upper limit enforced
- [x] Creating an entry with `GrossValue` less than `NetValue` is rejected
- [x] The migration adds an empty `Income` collection to the data file and takes a backup before writing
- [x] Running the migration a second time against already-migrated data produces the same result (idempotent)

Cross-feature integration criteria referencing F01 are left unchecked in the PRD until F03/F04/F05/F06/F07 (which they also name) are implemented.

## Test plan

- New `Tests/Financial.CashFlowIncomeMigration.Tests`: 7 tests covering the confirm-and-report migrator and the backup helper
- New `IncomeTests`, `IncomeSourceParserTests`, `IncomeServiceTests`, `IncomesEndpointsTests` (integration, via `ApiTestFactory`); updated `CashFlowDataTests` and `CashFlowSerializerAdapterTests` for the new collection; updated every `StubCashFlowRepository` test double across `Financial.CashFlow.Application.Tests` for the 3 new `ICashFlowRepository` members
- Full .NET solution: all 13 test projects green (1,505 passed, 5 pre-existing skips unrelated to this change, 0 failures)
- End-to-end smoke run of the migration console tool against a scratch copy of the live data file

🤖 Generated with [Claude Code](https://claude.com/claude-code)