### PR TITLE
feat(P14-F02): bank opening balance

### DIFF
--- a/Financial.Api/Controllers/BanksController.cs
+++ b/Financial.Api/Controllers/BanksController.cs
@@ -22,4 +22,30 @@ public sealed class BanksController : ControllerBase
         var result = _bankService.GetBanks();
         return Ok(result);
     }
+
+    [HttpPut("{name}/opening-balance")]
+    [ProducesResponseType(typeof(BankDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<BankDTO>> UpdateOpeningBalance(string name, [FromBody] BankOpeningBalanceUpdateDTO? request)
+    {
+        if (request is null)
+        {
+            return BadRequest();
+        }
+
+        try
+        {
+            var bank = await _bankService.UpdateOpeningBalanceAsync(name, request);
+            return Ok(bank);
+        }
+        catch (ArgumentException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound);
+        }
+    }
 }

--- a/Financial.CashFlow.Application/DTOs/BankOpeningBalanceUpdateDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/BankOpeningBalanceUpdateDTO.cs
@@ -1,16 +1,10 @@
 namespace Financial.CashFlow.Application.DTOs;
 
 /// <summary>
-/// Read model for a tracked bank.
+/// Request to update a bank's opening balance and effective date.
 /// </summary>
-public sealed class BankDTO
+public sealed class BankOpeningBalanceUpdateDTO
 {
-    /// <summary>Bank name.</summary>
-    public required string Name { get; init; }
-
-    /// <summary>Whether this bank rounds up card payments.</summary>
-    public required bool RoundUpEnabled { get; init; }
-
     /// <summary>Real-world balance as of <see cref="OpeningBalanceDate"/>.</summary>
     public required decimal OpeningBalance { get; init; }
 

--- a/Financial.CashFlow.Application/Interfaces/IBankService.cs
+++ b/Financial.CashFlow.Application/Interfaces/IBankService.cs
@@ -5,4 +5,5 @@ namespace Financial.CashFlow.Application.Interfaces;
 public interface IBankService
 {
     IReadOnlyList<BankDTO> GetBanks();
+    Task<BankDTO> UpdateOpeningBalanceAsync(string name, BankOpeningBalanceUpdateDTO request);
 }

--- a/Financial.CashFlow.Application/Services/BankService.cs
+++ b/Financial.CashFlow.Application/Services/BankService.cs
@@ -1,5 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Application.Validation;
+using Financial.CashFlow.Domain.Entities;
 
 namespace Financial.CashFlow.Application.Services;
 
@@ -13,7 +15,28 @@ public sealed class BankService : IBankService
     }
 
     public IReadOnlyList<BankDTO> GetBanks() =>
-        _repository.GetBanks()
-            .Select(bank => new BankDTO { Name = bank.Name, RoundUpEnabled = bank.RoundUpEnabled })
-            .ToList();
+        _repository.GetBanks().Select(ToDto).ToList();
+
+    public async Task<BankDTO> UpdateOpeningBalanceAsync(string name, BankOpeningBalanceUpdateDTO request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!BankNameResolver.TryResolve(name, _repository.GetBanks(), out var bank))
+        {
+            throw new KeyNotFoundException($"Bank '{name}' was not found.");
+        }
+
+        bank!.SetOpeningBalance(request.OpeningBalance, request.OpeningBalanceDate);
+        await _repository.SaveChangesAsync().ConfigureAwait(false);
+
+        return ToDto(bank);
+    }
+
+    private static BankDTO ToDto(Bank bank) => new()
+    {
+        Name = bank.Name,
+        RoundUpEnabled = bank.RoundUpEnabled,
+        OpeningBalance = bank.OpeningBalance,
+        OpeningBalanceDate = bank.OpeningBalanceDate
+    };
 }

--- a/Financial.CashFlow.Domain/Entities/Bank.cs
+++ b/Financial.CashFlow.Domain/Entities/Bank.cs
@@ -6,6 +6,8 @@ public class Bank
 {
     public string Name { get; private set; } = string.Empty;
     public bool RoundUpEnabled { get; private set; }
+    public decimal OpeningBalance { get; private set; }
+    public DateOnly OpeningBalanceDate { get; private set; }
 
     private Bank() { }
 
@@ -21,5 +23,16 @@ public class Bank
             Name = name,
             RoundUpEnabled = roundUpEnabled
         };
+    }
+
+    public void SetOpeningBalance(decimal openingBalance, DateOnly openingBalanceDate)
+    {
+        if (openingBalance < 0)
+        {
+            throw new ArgumentException("Opening balance cannot be negative.");
+        }
+
+        OpeningBalance = openingBalance;
+        OpeningBalanceDate = openingBalanceDate;
     }
 }

--- a/Financial.slnx
+++ b/Financial.slnx
@@ -16,6 +16,7 @@
 	<Folder Name="/Integrations/">
 		<Project Path="Integrations/CashFlowBankMigration/CashFlowBankMigration.csproj" />
 		<Project Path="Integrations/CashFlowIncomeMigration/CashFlowIncomeMigration.csproj" />
+		<Project Path="Integrations/CashFlowBankOpeningBalanceMigration/CashFlowBankOpeningBalanceMigration.csproj" />
 		<Project Path="Integrations/CashFlowPaymentStateMigration/CashFlowPaymentStateMigration.csproj" />
 		<Project Path="Integrations/CashFlowSpreadsheetImport/CashFlowSpreadsheetImport.csproj" />
 		<Project Path="Integrations/GoogleFinancialSupport/GoogleFinancialSupport.csproj" />
@@ -36,6 +37,7 @@
 		<Project Path="Tests/Financial.CashFlowPaymentStateMigration.Tests/Financial.CashFlowPaymentStateMigration.Tests.csproj" />
 		<Project Path="Tests/Financial.CashFlowBankMigration.Tests/Financial.CashFlowBankMigration.Tests.csproj" />
 		<Project Path="Tests/Financial.CashFlowIncomeMigration.Tests/Financial.CashFlowIncomeMigration.Tests.csproj" />
+		<Project Path="Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests.csproj" />
 	</Folder>
 	<Folder Name="/Presentation/">
 		<Project Path="Financial.App/Financial.App.csproj" />

--- a/Integrations/CashFlowBankOpeningBalanceMigration/BankOpeningBalanceMigrationSummary.cs
+++ b/Integrations/CashFlowBankOpeningBalanceMigration/BankOpeningBalanceMigrationSummary.cs
@@ -1,0 +1,24 @@
+using System.Text;
+
+namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowBankOpeningBalanceMigration;
+
+/// <summary>
+/// Outcome of one migration run: how many banks had their opening balance defaulted
+/// versus how many already carried a real value from a previous run or manual edit.
+/// </summary>
+public sealed class BankOpeningBalanceMigrationSummary
+{
+    public int BanksDefaultedCount { get; private set; }
+    public int BanksAlreadySetCount { get; private set; }
+
+    public void CountBankDefaulted() => BanksDefaultedCount++;
+    public void CountBankAlreadySet() => BanksAlreadySetCount++;
+
+    public string Render()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Bank opening balance migration summary");
+        builder.AppendLine($"  Banks: {BanksDefaultedCount} defaulted, {BanksAlreadySetCount} already set");
+        return builder.ToString();
+    }
+}

--- a/Integrations/CashFlowBankOpeningBalanceMigration/BankOpeningBalanceMigrator.cs
+++ b/Integrations/CashFlowBankOpeningBalanceMigration/BankOpeningBalanceMigrator.cs
@@ -1,0 +1,34 @@
+using Financial.CashFlow.Domain.Entities;
+
+namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowBankOpeningBalanceMigration;
+
+/// <summary>
+/// Idempotently defaults every bank's opening balance to £0.00 as of the migration run date.
+/// A bank whose OpeningBalanceDate is still the CLR default (0001-01-01) has never been
+/// migrated or manually set, since no real bank balance is ever dated year 1; any other
+/// date — including one set by a prior run or a manual correction — is left untouched.
+/// </summary>
+public static class BankOpeningBalanceMigrator
+{
+    public static BankOpeningBalanceMigrationSummary Migrate(CashFlowData data, DateOnly runDate)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        var summary = new BankOpeningBalanceMigrationSummary();
+
+        foreach (var bank in data.Banks)
+        {
+            if (bank.OpeningBalanceDate == default)
+            {
+                bank.SetOpeningBalance(0m, runDate);
+                summary.CountBankDefaulted();
+            }
+            else
+            {
+                summary.CountBankAlreadySet();
+            }
+        }
+
+        return summary;
+    }
+}

--- a/Integrations/CashFlowBankOpeningBalanceMigration/CashFlowBankOpeningBalanceMigration.csproj
+++ b/Integrations/CashFlowBankOpeningBalanceMigration/CashFlowBankOpeningBalanceMigration.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Financial.CashFlow.Infrastructure.Integrations.CashFlowBankOpeningBalanceMigration</RootNamespace>
+    <AssemblyName>Financial.CashFlow.Infrastructure.Integrations.CashFlowBankOpeningBalanceMigration</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Financial.CashFlow.Domain\Financial.CashFlow.Domain.csproj" />
+    <ProjectReference Include="..\..\Financial.CashFlow.Infrastructure\Financial.CashFlow.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\Financial.Shared.Infrastructure\Financial.Shared.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Integrations/CashFlowBankOpeningBalanceMigration/MigrationBackup.cs
+++ b/Integrations/CashFlowBankOpeningBalanceMigration/MigrationBackup.cs
@@ -1,0 +1,34 @@
+namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowBankOpeningBalanceMigration;
+
+/// <summary>
+/// Copies the data file to a timestamped sibling before the migration touches it,
+/// so a failed or interrupted run can always be recovered from.
+/// </summary>
+public static class MigrationBackup
+{
+    private const string BackupTimestampFormat = "yyyyMMdd-HHmmss";
+
+    public static string Create(string dataPath)
+    {
+        if (!File.Exists(dataPath))
+        {
+            throw new FileNotFoundException($"Data file not found at '{dataPath}'.", dataPath);
+        }
+
+        var directory = Path.GetDirectoryName(Path.GetFullPath(dataPath))!;
+        var name = Path.GetFileNameWithoutExtension(dataPath);
+        var extension = Path.GetExtension(dataPath);
+        var timestamp = DateTime.Now.ToString(BackupTimestampFormat);
+        var backupPath = Path.Combine(directory, $"{name}.backup-bank-opening-balance-migration-{timestamp}{extension}");
+
+        var suffix = 1;
+        while (File.Exists(backupPath))
+        {
+            backupPath = Path.Combine(directory, $"{name}.backup-bank-opening-balance-migration-{timestamp}-{suffix}{extension}");
+            suffix++;
+        }
+
+        File.Copy(dataPath, backupPath);
+        return backupPath;
+    }
+}

--- a/Integrations/CashFlowBankOpeningBalanceMigration/Program.cs
+++ b/Integrations/CashFlowBankOpeningBalanceMigration/Program.cs
@@ -1,0 +1,31 @@
+using Financial.CashFlow.Infrastructure.Integrations.CashFlowBankOpeningBalanceMigration;
+using Financial.CashFlow.Infrastructure.Persistence;
+using Financial.CashFlow.Infrastructure.Repositories;
+using Financial.Shared.Infrastructure.Persistence;
+
+var dataPath = args.Length > 0
+    ? args[0]
+    : Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "data", "data-cashflow.json"));
+
+if (!File.Exists(dataPath))
+{
+    Console.Error.WriteLine($"Data file not found at '{dataPath}'.");
+    return 1;
+}
+
+var backupPath = MigrationBackup.Create(dataPath);
+Console.WriteLine($"Backed up data file to '{backupPath}'.");
+
+var serializer = new CashFlowSerializerAdapter();
+var storage = new LocalJsonStorage(dataPath);
+var data = CashFlowLoader.LoadSync(storage, serializer);
+
+var summary = BankOpeningBalanceMigrator.Migrate(data, DateOnly.FromDateTime(DateTime.Now));
+
+var repository = new CashFlowJsonRepository(data, storage, serializer);
+await repository.SaveChangesAsync();
+
+Console.WriteLine($"Wrote migrated data to '{dataPath}'.");
+Console.WriteLine();
+Console.WriteLine(summary.Render());
+return 0;

--- a/Tests/Financial.Api.Tests/BanksEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/BanksEndpointsTests.cs
@@ -22,4 +22,73 @@ public class BanksEndpointsTests
         banks.Should().ContainSingle(b => b.Name == "Trading212" && b.RoundUpEnabled);
         banks.Should().ContainSingle(b => b.Name == "Chase" && b.RoundUpEnabled);
     }
+
+    [Fact]
+    public async Task UpdateOpeningBalance_ValidRequest_ReturnsOkAndUpdatesFields()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new BankOpeningBalanceUpdateDTO
+        {
+            OpeningBalance = 1250.75m,
+            OpeningBalanceDate = new DateOnly(2026, 7, 1)
+        };
+
+        var response = await client.PutAsJsonAsync("/api/v1/financial/banks/Barclays/opening-balance", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var bank = await response.Content.ReadFromJsonAsync<BankDTO>();
+        bank!.OpeningBalance.Should().Be(1250.75m);
+        bank.OpeningBalanceDate.Should().Be(new DateOnly(2026, 7, 1));
+    }
+
+    [Fact]
+    public async Task UpdateOpeningBalance_NegativeBalance_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new BankOpeningBalanceUpdateDTO
+        {
+            OpeningBalance = -1m,
+            OpeningBalanceDate = new DateOnly(2026, 7, 1)
+        };
+
+        var response = await client.PutAsJsonAsync("/api/v1/financial/banks/Barclays/opening-balance", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdateOpeningBalance_UnknownBankName_ReturnsNotFound()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new BankOpeningBalanceUpdateDTO
+        {
+            OpeningBalance = 10m,
+            OpeningBalanceDate = new DateOnly(2026, 7, 1)
+        };
+
+        var response = await client.PutAsJsonAsync("/api/v1/financial/banks/NotABank/opening-balance", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateOpeningBalance_ThenGetBanks_ReflectsTheUpdate()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PutAsJsonAsync("/api/v1/financial/banks/Chase/opening-balance", new BankOpeningBalanceUpdateDTO
+        {
+            OpeningBalance = 500m,
+            OpeningBalanceDate = new DateOnly(2026, 6, 15)
+        });
+
+        var response = await client.GetAsync("/api/v1/financial/banks");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var banks = await response.Content.ReadFromJsonAsync<List<BankDTO>>();
+        banks.Should().ContainSingle(b => b.Name == "Chase" && b.OpeningBalance == 500m && b.OpeningBalanceDate == new DateOnly(2026, 6, 15));
+    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs
@@ -1,3 +1,4 @@
+using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
 using Financial.CashFlow.Domain.Entities;
@@ -39,9 +40,62 @@ public class BankServiceTests
         result.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task UpdateOpeningBalanceAsync_WithValidRequest_UpdatesAndSaves()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Banks.Add(Bank.Create("Barclays", roundUpEnabled: false));
+        var service = new BankService(repository);
+        var request = new BankOpeningBalanceUpdateDTO { OpeningBalance = 1250.75m, OpeningBalanceDate = new DateOnly(2026, 7, 1) };
+
+        var result = await service.UpdateOpeningBalanceAsync("Barclays", request);
+
+        result.OpeningBalance.Should().Be(1250.75m);
+        result.OpeningBalanceDate.Should().Be(new DateOnly(2026, 7, 1));
+        repository.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UpdateOpeningBalanceAsync_ResolvesNameCaseInsensitively()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Banks.Add(Bank.Create("Barclays", roundUpEnabled: false));
+        var service = new BankService(repository);
+        var request = new BankOpeningBalanceUpdateDTO { OpeningBalance = 10m, OpeningBalanceDate = new DateOnly(2026, 7, 1) };
+
+        var result = await service.UpdateOpeningBalanceAsync("barclays", request);
+
+        result.Name.Should().Be("Barclays");
+    }
+
+    [Fact]
+    public async Task UpdateOpeningBalanceAsync_WithUnknownName_ThrowsKeyNotFoundException()
+    {
+        var service = new BankService(new StubCashFlowRepository());
+        var request = new BankOpeningBalanceUpdateDTO { OpeningBalance = 10m, OpeningBalanceDate = new DateOnly(2026, 7, 1) };
+
+        var act = async () => await service.UpdateOpeningBalanceAsync("NotABank", request);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task UpdateOpeningBalanceAsync_WithNegativeBalance_ThrowsArgumentException()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Banks.Add(Bank.Create("Barclays", roundUpEnabled: false));
+        var service = new BankService(repository);
+        var request = new BankOpeningBalanceUpdateDTO { OpeningBalance = -1m, OpeningBalanceDate = new DateOnly(2026, 7, 1) };
+
+        var act = async () => await service.UpdateOpeningBalanceAsync("Barclays", request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
     private sealed class StubCashFlowRepository : ICashFlowRepository
     {
         public List<Bank> Banks { get; } = new();
+        public int SaveChangesCallCount { get; private set; }
 
         public IEnumerable<Expense> GetExpenses() => Array.Empty<Expense>();
         public void AddExpense(Expense expense) { }
@@ -71,6 +125,10 @@ public class BankServiceTests
         public void AddIncome(Income income) { }
         public void DeleteIncome(Guid id) { }
 
-        public Task SaveChangesAsync() => Task.CompletedTask;
+        public Task SaveChangesAsync()
+        {
+            SaveChangesCallCount++;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/BankTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/BankTests.cs
@@ -15,6 +15,40 @@ public class BankTests
     }
 
     [Fact]
+    public void Create_DefaultsOpeningBalanceToZeroAndDateToDefault()
+    {
+        var bank = Bank.Create("Chase", roundUpEnabled: true);
+
+        bank.OpeningBalance.Should().Be(0m);
+        bank.OpeningBalanceDate.Should().Be(default(DateOnly));
+    }
+
+    [Fact]
+    public void SetOpeningBalance_UpdatesBothFields()
+    {
+        var bank = Bank.Create("Chase", roundUpEnabled: true);
+        var date = new DateOnly(2026, 7, 1);
+
+        bank.SetOpeningBalance(1250.75m, date);
+
+        bank.OpeningBalance.Should().Be(1250.75m);
+        bank.OpeningBalanceDate.Should().Be(date);
+    }
+
+    [Fact]
+    public void SetOpeningBalance_WithNegativeValue_ThrowsAndLeavesPriorValuesUntouched()
+    {
+        var bank = Bank.Create("Chase", roundUpEnabled: true);
+        bank.SetOpeningBalance(100m, new DateOnly(2026, 7, 1));
+
+        var act = () => bank.SetOpeningBalance(-1m, new DateOnly(2026, 8, 1));
+
+        act.Should().Throw<ArgumentException>();
+        bank.OpeningBalance.Should().Be(100m);
+        bank.OpeningBalanceDate.Should().Be(new DateOnly(2026, 7, 1));
+    }
+
+    [Fact]
     public void Create_WithRoundUpDisabled_AssignsFalse()
     {
         var bank = Bank.Create("Barclays", roundUpEnabled: false);

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs
@@ -26,6 +26,7 @@ public class CashFlowSerializerAdapterTests
         var maeLedgerEntry = MaeLedgerEntry.Create(new DateOnly(2026, 7, 15), "School supplies", "Note", Currency.BRL, 350m, 51.23m);
         var investmentSnapshot = InvestmentSnapshot.Create(InvestmentAccount.PlatinumVisa8003, 2026, 7, 1250.00m);
         var bank = Bank.Create("Barclays", roundUpEnabled: false);
+        bank.SetOpeningBalance(1250.75m, new DateOnly(2026, 7, 1));
         var income = Income.Create(new DateOnly(2026, 7, 25), IncomeSource.Gleison, 3200.00m, 2450.00m, "Barclays");
 
         original.AddExpense(expense);
@@ -62,6 +63,8 @@ public class CashFlowSerializerAdapterTests
         var resultBank = result.Banks.Should().ContainSingle().Which;
         resultBank.Name.Should().Be(bank.Name);
         resultBank.RoundUpEnabled.Should().Be(bank.RoundUpEnabled);
+        resultBank.OpeningBalance.Should().Be(bank.OpeningBalance);
+        resultBank.OpeningBalanceDate.Should().Be(bank.OpeningBalanceDate);
         var resultIncome = result.Incomes.Should().ContainSingle().Which;
         resultIncome.Id.Should().Be(income.Id);
         resultIncome.Date.Should().Be(income.Date);

--- a/Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/BankOpeningBalanceMigratorTests.cs
+++ b/Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/BankOpeningBalanceMigratorTests.cs
@@ -1,0 +1,79 @@
+using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Infrastructure.Integrations.CashFlowBankOpeningBalanceMigration;
+using FluentAssertions;
+
+namespace Financial.CashFlowBankOpeningBalanceMigration.Tests;
+
+public class BankOpeningBalanceMigratorTests
+{
+    private static readonly DateOnly RunDate = new(2026, 7, 24);
+
+    [Fact]
+    public void Migrate_BankWithUnsetDate_DefaultsToZeroAndRunDate()
+    {
+        var data = CashFlowData.Create();
+        data.AddBank(Bank.Create("Barclays", roundUpEnabled: false));
+
+        var summary = BankOpeningBalanceMigrator.Migrate(data, RunDate);
+
+        summary.BanksDefaultedCount.Should().Be(1);
+        summary.BanksAlreadySetCount.Should().Be(0);
+        var bank = data.Banks.Should().ContainSingle().Which;
+        bank.OpeningBalance.Should().Be(0m);
+        bank.OpeningBalanceDate.Should().Be(RunDate);
+    }
+
+    [Fact]
+    public void Migrate_BankWithAlreadySetDate_IsLeftUntouched()
+    {
+        var data = CashFlowData.Create();
+        var bank = Bank.Create("Barclays", roundUpEnabled: false);
+        bank.SetOpeningBalance(500m, new DateOnly(2026, 1, 1));
+        data.AddBank(bank);
+
+        var summary = BankOpeningBalanceMigrator.Migrate(data, RunDate);
+
+        summary.BanksDefaultedCount.Should().Be(0);
+        summary.BanksAlreadySetCount.Should().Be(1);
+        bank.OpeningBalance.Should().Be(500m);
+        bank.OpeningBalanceDate.Should().Be(new DateOnly(2026, 1, 1));
+    }
+
+    [Fact]
+    public void Migrate_CalledTwice_IsIdempotent()
+    {
+        var data = CashFlowData.Create();
+        data.AddBank(Bank.Create("Barclays", roundUpEnabled: false));
+        BankOpeningBalanceMigrator.Migrate(data, RunDate);
+
+        var secondSummary = BankOpeningBalanceMigrator.Migrate(data, RunDate.AddDays(1));
+
+        secondSummary.BanksDefaultedCount.Should().Be(0);
+        secondSummary.BanksAlreadySetCount.Should().Be(1);
+        data.Banks.Should().ContainSingle().Which.OpeningBalanceDate.Should().Be(RunDate);
+    }
+
+    [Fact]
+    public void Migrate_WithMixOfSetAndUnsetBanks_OnlyDefaultsTheUnsetOnes()
+    {
+        var data = CashFlowData.Create();
+        var alreadySet = Bank.Create("Chase", roundUpEnabled: true);
+        alreadySet.SetOpeningBalance(100m, new DateOnly(2026, 2, 1));
+        data.AddBank(alreadySet);
+        data.AddBank(Bank.Create("Barclays", roundUpEnabled: false));
+        data.AddBank(Bank.Create("Trading212", roundUpEnabled: true));
+
+        var summary = BankOpeningBalanceMigrator.Migrate(data, RunDate);
+
+        summary.BanksDefaultedCount.Should().Be(2);
+        summary.BanksAlreadySetCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Migrate_WithNullData_Throws()
+    {
+        var act = () => BankOpeningBalanceMigrator.Migrate(null!, RunDate);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests.csproj
+++ b/Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Integrations\CashFlowBankOpeningBalanceMigration\CashFlowBankOpeningBalanceMigration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/MigrationBackupTests.cs
+++ b/Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/MigrationBackupTests.cs
@@ -1,0 +1,61 @@
+using Financial.CashFlow.Infrastructure.Integrations.CashFlowBankOpeningBalanceMigration;
+using FluentAssertions;
+
+namespace Financial.CashFlowBankOpeningBalanceMigration.Tests;
+
+public class MigrationBackupTests
+{
+    [Fact]
+    public void Create_CopiesTheDataFileToATimestampedSibling()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dataPath = Path.Combine(directory.FullName, "data-cashflow.json");
+            File.WriteAllText(dataPath, "{\"Banks\":[]}");
+
+            var backupPath = MigrationBackup.Create(dataPath);
+
+            File.Exists(backupPath).Should().BeTrue();
+            Path.GetDirectoryName(backupPath).Should().Be(directory.FullName);
+            Path.GetFileName(backupPath).Should().StartWith("data-cashflow.backup-bank-opening-balance-migration-").And.EndWith(".json");
+            File.ReadAllText(backupPath).Should().Be("{\"Banks\":[]}");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Create_CalledTwice_ProducesDistinctBackups()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dataPath = Path.Combine(directory.FullName, "data-cashflow.json");
+            File.WriteAllText(dataPath, "{}");
+
+            var first = MigrationBackup.Create(dataPath);
+            var second = MigrationBackup.Create(dataPath);
+
+            second.Should().NotBe(first);
+            File.Exists(first).Should().BeTrue();
+            File.Exists(second).Should().BeTrue();
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Create_WhenSourceMissing_Throws()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.json");
+
+        var act = () => MigrationBackup.Create(missingPath);
+
+        act.Should().Throw<FileNotFoundException>();
+    }
+}

--- a/docs/P14-F02-bank-opening-balance/plan.md
+++ b/docs/P14-F02-bank-opening-balance/plan.md
@@ -1,0 +1,21 @@
+# Implementation Plan: Bank Opening Balance
+
+**Prerequisites:**
+- .NET 10 SDK (existing solution target)
+- No new external dependencies or environment variables
+
+### Stage 1: Domain
+
+**1. Bank Opening Balance Fields** - Extend the `Bank` entity with an opening balance and its effective date, with the entity itself enforcing that the balance can never be negative, following the existing entity-owns-its-invariants pattern in this domain.
+
+### Stage 2: Application and Presentation
+
+**2. Bank DTOs and Service Update** - Extend the bank read model with the two new fields, add the update request DTO, and implement the update workflow: resolving the target bank by name, delegating the non-negative check to the entity, and persisting the change.
+
+**3. Bank Opening Balance API Endpoint** - Add the HTTP endpoint for updating a bank's opening balance and effective date, following the existing controllers' routing, status code, and error response conventions.
+
+### Stage 3: Migration Tool
+
+**4. Bank Opening Balance Migration Console Project** - Create a new console project that takes a timestamped backup of the data file before writing, loads the data, defaults the opening balance and effective date on any bank that has never been migrated, and prints a run summary — following the exact structure of the existing bank migration tool.
+
+**5. Solution Registration** - Register the new console project and its test project in the solution file.

--- a/docs/P14-F02-bank-opening-balance/spec.md
+++ b/docs/P14-F02-bank-opening-balance/spec.md
@@ -1,0 +1,156 @@
+# F02. Bank Opening Balance
+
+## 1. Technical Overview
+
+**What:** Add `OpeningBalance` (decimal, defaults to £0.00) and `OpeningBalanceDate` (date) to the existing `Bank` entity, both editable after creation. A one-time, backup-first, idempotent console migration sets the default `OpeningBalanceDate` (the migration run date) on the 3 banks already seeded by P13-F01, since a missing JSON key alone would leave the date at `DateOnly.MinValue`, not "today". A new API endpoint lets the developer correct each bank's opening balance and effective date at any time, as the PRD's Banks-panel edit affordance requires.
+
+**Why:** F06's real bank balance formula (`OpeningBalance + Σ(Income.NetValue) − Σ(Expense.Value − Expense.RoundUpAmount)` from `OpeningBalanceDate` forward) needs a concrete starting point per bank; without it, every bank's running balance would implicitly start from £0.00 on the epoch date, which is wrong for the 3 banks that already hold real money today. This feature only adds the two fields and their edit contract — F06 is the feature that actually consumes them in a balance calculation.
+
+**Scope:**
+- Included: `Bank.OpeningBalance`/`Bank.OpeningBalanceDate` fields with a `SetOpeningBalance(decimal, DateOnly)` mutator enforcing the non-negative invariant; `BankDTO` exposes both fields; a new `IBankService.UpdateOpeningBalanceAsync` + `BankOpeningBalanceUpdateDTO` + `PUT /banks/{name}/opening-balance` endpoint; a new console migration project (`Integrations/CashFlowBankOpeningBalanceMigration`) that sets the default `OpeningBalanceDate` on already-seeded banks.
+- Excluded: any bank-management screen (creating/renaming/removing a bank remains out of scope, per PRD); the actual balance calculation that reads these fields (F06); the Banks-panel UI edit affordance itself (frontend work is out of scope for this backend-only PRD's F02, matching how F01 shipped its API without a UI and F04 will build the Income form separately — there is no frontend feature for F02 in this PRD's Section 6, so this spec covers the API contract the (not-yet-specified) UI would call).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.CashFlow.Domain/Entities/Bank.cs` — `OpeningBalance`, `OpeningBalanceDate` fields + `SetOpeningBalance` mutator
+- `Financial.CashFlow.Application/DTOs/BankDTO.cs` — 2 fields added
+- `Financial.CashFlow.Application/DTOs/BankOpeningBalanceUpdateDTO.cs` — new
+- `Financial.CashFlow.Application/Interfaces/IBankService.cs` — `UpdateOpeningBalanceAsync` added
+- `Financial.CashFlow.Application/Services/BankService.cs` — implements the update, resolves bank by name, throws on unknown name or negative balance
+- `Financial.Api/Controllers/BanksController.cs` — `PUT /banks/{name}/opening-balance`
+- `Integrations/CashFlowBankOpeningBalanceMigration/` — new console project (default-and-audit)
+- `Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/` — new xUnit project
+- `Financial.slnx` — registers both new projects
+
+```mermaid
+graph TD
+  A["BanksController"] --> B[BankService]
+  B --> C["ICashFlowRepository.GetBanks()"]
+  C --> D["Bank.SetOpeningBalance"]
+  E["Program.cs (console)"] --> F["File backup (timestamped copy)"]
+  E --> G["CashFlowLoader.LoadSync + LocalJsonStorage"]
+  E --> H[BankOpeningBalanceMigrator]
+  H --> D
+  E --> I["CashFlowJsonRepository.SaveChangesAsync"]
+  E --> J["BankOpeningBalanceMigrationSummary.Render()"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Where the mutator lives | `Bank.SetOpeningBalance(decimal, DateOnly)` on the entity, enforcing "not negative" as a domain invariant (mirrors `Income`'s own value validation) | Validate only in `BankService`, keep `Bank` a pure data holder | `Bank.Create` already validates its own invariant (blank name); keeping the new invariant on the entity means it can never be violated regardless of caller, consistent with how this domain already treats entities as the source of truth for their own shape |
+| Idempotency sentinel for the migration | A bank whose `OpeningBalanceDate == default(DateOnly)` (`0001-01-01`, i.e. never migrated) gets the run date set once; already-migrated banks (any non-default date, including a date the developer manually corrected) are left untouched | Track a separate `Migrated` flag per bank | No extra field is needed: `DateOnly.MinValue` cannot occur from real-world data entry (no one's bank balance is dated year 1), so it's a safe, self-documenting "unset" sentinel — same spirit as P13-F01 treating an existing matching bank name as its own idempotency check |
+| Update endpoint keying | `PUT /banks/{name}/opening-balance`, keyed by the existing name-as-identity convention (`Bank` has no surrogate `Id`, confirmed in P13-F01) | Add a `Guid Id` to `Bank` now to key the endpoint conventionally | Introducing an `Id` now would be a bigger, unrelated change to an entity every other feature already references by name; the name-keyed route matches how `BankNameResolver` already works throughout the codebase |
+| Frontend scope | This spec covers only the backend contract (`PUT` endpoint); no PRD Section 6 feature in P14 names a Banks-panel edit UI as a numbered feature, so building it now would be scope not requested by any tracked acceptance criterion | Build the edit affordance described in F02's "Experience" prose now, since it's mentioned there | The PRD's Section 9 acceptance criteria for F02 only test that the fields exist, default correctly, are editable via the app's data layer, and reject negative values — nothing in Section 9 requires a specific UI control. Documented here as the largest scope judgment call in this spec, flagged for review; a UI affordance can be added in a later pass if the developer wants one before F06 ships, since F06's spec will need the Banks panel anyway to display the new running balance |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Domain/Entities/Bank.cs` | Modified | Opening balance fields | `OpeningBalance` (decimal, private-set, defaults to `0m`), `OpeningBalanceDate` (`DateOnly`, private-set); `SetOpeningBalance(decimal openingBalance, DateOnly openingBalanceDate)` throws `ArgumentException` when `openingBalance < 0` |
+| `Financial.CashFlow.Application/DTOs/BankDTO.cs` | Modified | Read model | `OpeningBalance` (decimal), `OpeningBalanceDate` (DateOnly) added |
+| `Financial.CashFlow.Application/DTOs/BankOpeningBalanceUpdateDTO.cs` | New | Update request | `OpeningBalance` (decimal), `OpeningBalanceDate` (DateOnly) |
+| `Financial.CashFlow.Application/Interfaces/IBankService.cs` | Modified | Service contract | `Task<BankDTO> UpdateOpeningBalanceAsync(string name, BankOpeningBalanceUpdateDTO request)` added |
+| `Financial.CashFlow.Application/Services/BankService.cs` | Modified | Bank update | Resolves the bank via `BankNameResolver` against `_repository.GetBanks()`; throws `KeyNotFoundException` for an unknown name; calls `bank.SetOpeningBalance(...)` (which throws `ArgumentException` on a negative value); saves; `ToDto` extended with the 2 new fields |
+| `Financial.Api/Controllers/BanksController.cs` | Modified | HTTP surface | `PUT /banks/{name}/opening-balance` — mirrors `ExpensesController`'s `Problem()` error shape; 404 on unknown name, 400 on negative balance |
+| `Integrations/CashFlowBankOpeningBalanceMigration/CashFlowBankOpeningBalanceMigration.csproj` | New | Console project | Mirrors `CashFlowBankMigration.csproj`: `net10.0` exe, references CashFlow Domain, CashFlow Infrastructure, Shared Infrastructure |
+| `Integrations/CashFlowBankOpeningBalanceMigration/Program.cs` | New | Entry point | Args: `[dataPath]` (same default-resolution pattern); abort if missing; `MigrationBackup.Create`; `CashFlowLoader.LoadSync`; `BankOpeningBalanceMigrator.Migrate`; `CashFlowJsonRepository.SaveChangesAsync`; print summary; exit 0/1 |
+| `Integrations/CashFlowBankOpeningBalanceMigration/MigrationBackup.cs` | New | Backup helper | Copied from `CashFlowBankMigration`'s helper with a `bank-opening-balance-migration` timestamp segment |
+| `Integrations/CashFlowBankOpeningBalanceMigration/BankOpeningBalanceMigrator.cs` | New | Default-and-audit | Static `Migrate(CashFlowData data, DateOnly runDate) : BankOpeningBalanceMigrationSummary`; for each bank with `OpeningBalanceDate == default`, calls `SetOpeningBalance(0m, runDate)` and counts it as defaulted; banks already carrying a non-default date are counted as already-set and left untouched |
+| `Integrations/CashFlowBankOpeningBalanceMigration/BankOpeningBalanceMigrationSummary.cs` | New | Run report | Counts: banks defaulted / already set; `Render()` string |
+| `Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests.csproj` | New | Test project | Same package set as `Financial.CashFlowBankMigration.Tests`; references the console project |
+| `Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/BankOpeningBalanceMigratorTests.cs`, `MigrationBackupTests.cs` | New | Unit tests | See Section 7 |
+| `Financial.slnx` | Modified | Solution | Registers `Integrations/CashFlowBankOpeningBalanceMigration` and `Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests` |
+
+## 5. API Contracts
+
+**Endpoint: Update Bank Opening Balance**
+- **Method:** PUT
+- **Path:** `/banks/{name}/opening-balance`
+- **Authentication:** None (matches every other endpoint in this single-user app)
+
+**Request:**
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|--------------|
+| `openingBalance` | `decimal` | Yes | `>= 0` | Real-world balance as of the effective date |
+| `openingBalanceDate` | `date` | Yes | — | The date `openingBalance` is accurate as of |
+
+**Request Example:**
+```json
+{
+  "openingBalance": 1250.75,
+  "openingBalanceDate": "2026-07-01"
+}
+```
+
+**Response (Success - 200):**
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `name` | `string` | Bank name |
+| `roundUpEnabled` | `bool` | Whether this bank rounds up card payments |
+| `openingBalance` | `decimal` | Updated opening balance |
+| `openingBalanceDate` | `date` | Updated effective date |
+
+**Response Example:**
+```json
+{
+  "name": "Barclays",
+  "roundUpEnabled": false,
+  "openingBalance": 1250.75,
+  "openingBalanceDate": "2026-07-01"
+}
+```
+
+**Error Codes:**
+
+| Code | HTTP Status | Description |
+|------|-------------|--------------|
+| — | 400 | `openingBalance` is negative (via `Problem()` with the exception message) |
+| — | 404 | `name` does not resolve to a tracked bank |
+
+**Endpoint: Get Banks** (existing, extended)
+- **Method:** GET
+- **Path:** `/banks`
+- **Response:** unchanged shape, now includes `openingBalance` and `openingBalanceDate` per bank.
+
+## 6. Data Model
+
+Each `Bank` record in `data-cashflow.json`'s `Banks` array gains two fields:
+
+```json
+{
+  "Banks": [
+    { "Name": "Barclays", "RoundUpEnabled": false, "OpeningBalance": 0.00, "OpeningBalanceDate": "2026-07-24" },
+    { "Name": "Trading212", "RoundUpEnabled": true, "OpeningBalance": 0.00, "OpeningBalanceDate": "2026-07-24" },
+    { "Name": "Chase", "RoundUpEnabled": true, "OpeningBalance": 0.00, "OpeningBalanceDate": "2026-07-24" }
+  ]
+}
+```
+
+`OpeningBalanceDate` above is the migration run date; the developer is expected to correct both fields per bank afterward via the new `PUT` endpoint, per the PRD. The backup file `data-cashflow.backup-bank-opening-balance-migration-<timestamp>.json` is created beside the data file before any write.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Tests/Financial.CashFlow.Domain.Tests/Entities/BankTests.cs` | Unit | `Bank` | `Create` still defaults `OpeningBalance` to `0m` and `OpeningBalanceDate` to `default(DateOnly)`; `SetOpeningBalance` updates both fields; `SetOpeningBalance` with a negative value throws and leaves prior values untouched |
+| `Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs` | Unit | `BankService` | `UpdateOpeningBalanceAsync` with a valid request updates and saves; unknown bank name throws `KeyNotFoundException`; negative `OpeningBalance` throws `ArgumentException`; `GetBanks` round-trips the 2 new fields |
+| `Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs` | Unit | Serializer | `Bank` round-trip test extended to assert `OpeningBalance`/`OpeningBalanceDate` survive serialize/deserialize |
+| `Tests/Financial.Api.Tests/BanksEndpointsTests.cs` | Integration | `BanksController` | `PUT` updates and returns 200 with the new fields; `PUT` with a negative balance returns 400; `PUT` on an unknown bank name returns 404; `GET` reflects an update immediately after |
+| `Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/BankOpeningBalanceMigratorTests.cs` | Unit | `BankOpeningBalanceMigrator` | Defaults every bank whose date is unset to `(0m, runDate)`; leaves a bank with a non-default date untouched; second run is idempotent (0 newly defaulted) |
+| `Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests/MigrationBackupTests.cs` | Unit | Backup helper | Creates a timestamped copy with identical content beside the source; distinct name per call; throws when source missing |
+
+**Acceptance tests (PRD Section 9, F02):**
+- Each existing bank has `OpeningBalance`/`OpeningBalanceDate` populated with defaults immediately after migration → `BankOpeningBalanceMigratorTests`
+- Fields can be edited after migration and are reflected in the next balance calculation → `BankServiceTests`, `BanksEndpointsTests` (F06's balance calculation itself is out of scope here; this spec verifies the edit is persisted and readable)
+- Setting `OpeningBalance` negative is rejected with a validation message → `BankTests`, `BankServiceTests`, `BanksEndpointsTests`
+- The migration takes a backup before writing → `MigrationBackupTests`, `Program.cs` ordering (backup is the first side effect, by construction)
+
+**Cross-Feature Integration criteria touching F02 (PRD Section 9):**
+- "F06 correctly combines F01's income data with F02's opening balance and date to produce each bank's balance" — guaranteed by `BankDTO`/`ICashFlowRepository.GetBanks()` exposing the correctly-typed, correctly-persisted `OpeningBalance`/`OpeningBalanceDate` to any consumer; covered here by `BankServiceTests` and the serializer round-trip test, with F06's own calculation verified in F06's spec

--- a/docs/prd/P14-prd-monthly-income-bank-balance/prd-monthly-income-bank-balance.md
+++ b/docs/prd/P14-prd-monthly-income-bank-balance/prd-monthly-income-bank-balance.md
@@ -274,10 +274,10 @@ graph TD
 - [x] Running the migration a second time against already-migrated data produces the same result (idempotent)
 
 ### F02. Bank Opening Balance
-- [ ] Each existing bank has `OpeningBalance` and `OpeningBalanceDate` fields populated with default values immediately after migration
-- [ ] `OpeningBalance` and `OpeningBalanceDate` can be edited after migration, and the new values are reflected in the next balance calculation
-- [ ] Setting `OpeningBalance` to a negative value is rejected with a validation message
-- [ ] The migration takes a backup of the data file before writing
+- [x] Each existing bank has `OpeningBalance` and `OpeningBalanceDate` fields populated with default values immediately after migration
+- [x] `OpeningBalance` and `OpeningBalanceDate` can be edited after migration, and the new values are reflected in the next balance calculation
+- [x] Setting `OpeningBalance` to a negative value is rejected with a validation message
+- [x] The migration takes a backup of the data file before writing
 
 ### F03. Tithe Calculation
 - [ ] The calculated tithe for a month equals 10% of the sum of `NetValue` across all that month's `Income` entries, matching a manual reference calculation to the penny


### PR DESCRIPTION
## Summary

Implements **F02 – Bank Opening Balance** from the P14 PRD, per the committed spec/plan in `docs/P14-F02-bank-opening-balance/`.

- `Bank` gains `OpeningBalance` (decimal, defaults to £0.00) and `OpeningBalanceDate` (date), with a `SetOpeningBalance(decimal, DateOnly)` mutator enforcing "not negative" as a domain invariant
- New `PUT /banks/{name}/opening-balance` endpoint lets the developer correct a bank's opening balance and effective date at any time, keyed by name (`Bank` has no surrogate `Id`, per P13-F01) — both fields remain editable after migration, not just once
- New console tool `Integrations/CashFlowBankOpeningBalanceMigration` that backs up the data file and defaults every bank's opening balance to `(£0.00, migration run date)`, using `OpeningBalanceDate == default(DateOnly)` as the idempotency sentinel — no real bank balance is ever dated year 1, so it's a safe "never migrated" marker that also survives a later manual correction without re-triggering
- A timestamped backup (`data-cashflow.backup-bank-opening-balance-migration-<ts>.json`) is written beside the data file before anything is loaded

**Scope note (flagged in the spec for review):** this PR ships only the backend contract for editing the opening balance — no PRD Section 6 feature in P14 names a dedicated Banks-panel edit UI as its own numbered item, and Section 9's F02 acceptance criteria only test that the fields exist, default correctly, are editable, and reject negative values. A UI affordance can be added alongside F06, which will need the Banks panel anyway to display the new running balance.

**Note:** this PR only ships the tool. The actual one-time run against the live `data/data-cashflow.json` is yours to trigger after merge:
`dotnet run --project Integrations/CashFlowBankOpeningBalanceMigration` (then restart the container — data loads once at startup). Smoke-tested here against a scratch copy of the live file: backup created, all 3 banks defaulted to `£0.00` / today's date, re-run confirmed idempotent.

## Acceptance Criteria (PRD Section 9 — F02)

- [x] Each existing bank has `OpeningBalance` and `OpeningBalanceDate` fields populated with default values immediately after migration
- [x] `OpeningBalance` and `OpeningBalanceDate` can be edited after migration, and the new values are reflected in the next balance calculation
- [x] Setting `OpeningBalance` to a negative value is rejected with a validation message
- [x] The migration takes a backup of the data file before writing

Cross-feature integration criteria referencing F02 are left unchecked in the PRD until F06 (which it also names) is implemented.

## Test plan

- New `Tests/Financial.CashFlowBankOpeningBalanceMigration.Tests`: 8 tests covering the default-and-audit migrator and the backup helper
- Updated `BankTests`, `BankServiceTests`, `BanksEndpointsTests` (integration, via `ApiTestFactory`), `CashFlowSerializerAdapterTests` for the two new fields
- Full .NET solution: all 14 test projects green (1,524 passed, 5 pre-existing skips unrelated to this change, 0 failures)
- End-to-end smoke run of the migration console tool against a scratch copy of the live data file

🤖 Generated with [Claude Code](https://claude.com/claude-code)