### PR TITLE
feat(P14-F03): tithe calculation

### DIFF
--- a/Financial.Api/Controllers/TitheController.cs
+++ b/Financial.Api/Controllers/TitheController.cs
@@ -1,0 +1,25 @@
+using Financial.CashFlow.Application.DTOs;
+using Financial.CashFlow.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Financial.Api.Controllers;
+
+[ApiController]
+[Route("tithe")]
+public sealed class TitheController : ControllerBase
+{
+    private readonly ITitheService _titheService;
+
+    public TitheController(ITitheService titheService)
+    {
+        _titheService = titheService ?? throw new ArgumentNullException(nameof(titheService));
+    }
+
+    [HttpGet("month/{year:int}/{month:int}")]
+    [ProducesResponseType(typeof(TitheSummaryDTO), StatusCodes.Status200OK)]
+    public ActionResult<TitheSummaryDTO> GetTitheSummaryByMonth(int year, int month)
+    {
+        var result = _titheService.GetTitheSummary(year, month);
+        return Ok(result);
+    }
+}

--- a/Financial.CashFlow.Application/DTOs/TitheSummaryDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/TitheSummaryDTO.cs
@@ -1,0 +1,13 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Read model for a month's calculated tithe and tithe balance.
+/// </summary>
+public sealed class TitheSummaryDTO
+{
+    /// <summary>10% of the month's total income net value.</summary>
+    public required decimal CalculatedTithe { get; init; }
+
+    /// <summary>Calculated tithe minus the month's Dizimo-category expense total. May be negative.</summary>
+    public required decimal TitheBalance { get; init; }
+}

--- a/Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs
+++ b/Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class CashFlowApplicationServiceCollectionExtensions
         services.AddSingleton<IYearlySummaryService, YearlySummaryService>();
         services.AddSingleton<IBankService, BankService>();
         services.AddSingleton<IIncomeService, IncomeService>();
+        services.AddSingleton<ITitheService, TitheService>();
 
         return services;
     }

--- a/Financial.CashFlow.Application/Interfaces/ITitheService.cs
+++ b/Financial.CashFlow.Application/Interfaces/ITitheService.cs
@@ -1,0 +1,8 @@
+using Financial.CashFlow.Application.DTOs;
+
+namespace Financial.CashFlow.Application.Interfaces;
+
+public interface ITitheService
+{
+    TitheSummaryDTO GetTitheSummary(int year, int month);
+}

--- a/Financial.CashFlow.Application/Services/TitheService.cs
+++ b/Financial.CashFlow.Application/Services/TitheService.cs
@@ -1,0 +1,36 @@
+using Financial.CashFlow.Application.DTOs;
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Domain.Enums;
+
+namespace Financial.CashFlow.Application.Services;
+
+public sealed class TitheService : ITitheService
+{
+    private const decimal TithePercentage = 0.10m;
+
+    private readonly ICashFlowRepository _repository;
+
+    public TitheService(ICashFlowRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public TitheSummaryDTO GetTitheSummary(int year, int month)
+    {
+        var titheBase = _repository.GetIncomes()
+            .Where(i => i.Date.Year == year && i.Date.Month == month)
+            .Sum(i => i.NetValue);
+
+        var calculatedTithe = titheBase * TithePercentage;
+
+        var dizimoTotal = _repository.GetExpenses()
+            .Where(e => e.Date.Year == year && e.Date.Month == month && e.Category == Category.Dizimo)
+            .Sum(e => e.Value);
+
+        return new TitheSummaryDTO
+        {
+            CalculatedTithe = calculatedTithe,
+            TitheBalance = calculatedTithe - dizimoTotal
+        };
+    }
+}

--- a/Tests/Financial.Api.Tests/TitheEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/TitheEndpointsTests.cs
@@ -1,0 +1,54 @@
+using Financial.CashFlow.Application.DTOs;
+using FluentAssertions;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace Financial.Api.Tests;
+
+public class TitheEndpointsTests
+{
+    [Fact]
+    public async Task GetTitheSummaryByMonth_WithIncomeAndDizimoExpense_ReturnsCalculatedFigures()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 1),
+            IncomeSource = "Gleison",
+            GrossValue = null,
+            NetValue = 3000m,
+            Bank = "Barclays"
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 10),
+            Description = "Tithe payment",
+            Value = 200m,
+            Category = "Dizimo",
+            PaymentSource = "Barclays",
+            CardTag = null
+        });
+
+        var response = await client.GetAsync("/api/v1/financial/tithe/month/2026/7");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var summary = await response.Content.ReadFromJsonAsync<TitheSummaryDTO>();
+        summary!.CalculatedTithe.Should().Be(300m);
+        summary.TitheBalance.Should().Be(100m);
+    }
+
+    [Fact]
+    public async Task GetTitheSummaryByMonth_WithNoData_ReturnsZeros()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/tithe/month/2026/7");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var summary = await response.Content.ReadFromJsonAsync<TitheSummaryDTO>();
+        summary!.CalculatedTithe.Should().Be(0m);
+        summary.TitheBalance.Should().Be(0m);
+    }
+}

--- a/Tests/Financial.CashFlow.Application.Tests/Services/TitheServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/TitheServiceTests.cs
@@ -1,0 +1,136 @@
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Domain.Enums;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Application.Tests.Services;
+
+public class TitheServiceTests
+{
+    [Fact]
+    public void Constructor_WithNullRepository_Throws()
+    {
+        Action act = () => new TitheService(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public void GetTitheSummary_CalculatesTenPercentOfMonthlyNetIncomeAcrossSources()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Gleison, 3200m, 2450m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 7, 8), IncomeSource.Ariana, null, 400m, "Chase"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 7, 15), IncomeSource.DividendoJuros, null, 150m, "Trading212"));
+        var service = new TitheService(repository);
+
+        var result = service.GetTitheSummary(2026, 7);
+
+        result.CalculatedTithe.Should().Be(300m);
+    }
+
+    [Fact]
+    public void GetTitheSummary_SubtractsDizimoExpensesFromCalculatedTithe()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Gleison, null, 3000m, "Barclays"));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 10), "Tithe payment", 200m, Category.Dizimo, "Barclays", null));
+        var service = new TitheService(repository);
+
+        var result = service.GetTitheSummary(2026, 7);
+
+        result.CalculatedTithe.Should().Be(300m);
+        result.TitheBalance.Should().Be(100m);
+    }
+
+    [Fact]
+    public void GetTitheSummary_DizimoExceedingCalculatedTithe_ReturnsNegativeBalanceWithoutError()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Gleison, null, 1000m, "Barclays"));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 10), "Tithe payment", 200m, Category.Dizimo, "Barclays", null));
+        var service = new TitheService(repository);
+
+        var result = service.GetTitheSummary(2026, 7);
+
+        result.CalculatedTithe.Should().Be(100m);
+        result.TitheBalance.Should().Be(-100m);
+    }
+
+    [Fact]
+    public void GetTitheSummary_NonDizimoExpenses_AreIgnored()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Gleison, null, 1000m, "Barclays"));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 5), "Groceries", 50m, Category.Mercado, "Barclays", null));
+        var service = new TitheService(repository);
+
+        var result = service.GetTitheSummary(2026, 7);
+
+        result.TitheBalance.Should().Be(100m);
+    }
+
+    [Fact]
+    public void GetTitheSummary_ExcludesIncomeAndExpensesOutsideSelectedMonth()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Gleison, null, 1000m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 8, 1), IncomeSource.Gleison, null, 5000m, "Barclays"));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 5), "July tithe", 50m, Category.Dizimo, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 8, 5), "August tithe", 500m, Category.Dizimo, "Barclays", null));
+        var service = new TitheService(repository);
+
+        var result = service.GetTitheSummary(2026, 7);
+
+        result.CalculatedTithe.Should().Be(100m);
+        result.TitheBalance.Should().Be(50m);
+    }
+
+    [Fact]
+    public void GetTitheSummary_NoIncomeNoExpenses_ReturnsZeros()
+    {
+        var service = new TitheService(new StubCashFlowRepository());
+
+        var result = service.GetTitheSummary(2026, 7);
+
+        result.CalculatedTithe.Should().Be(0m);
+        result.TitheBalance.Should().Be(0m);
+    }
+
+    private sealed class StubCashFlowRepository : ICashFlowRepository
+    {
+        public List<Income> Incomes { get; } = new();
+        public List<Expense> Expenses { get; } = new();
+        public List<Bank> Banks { get; } = new();
+
+        public IEnumerable<Expense> GetExpenses() => Expenses;
+        public void AddExpense(Expense expense) => Expenses.Add(expense);
+        public void DeleteExpense(Guid id) { }
+
+        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
+        public void AddReserveMovement(ReserveMovement movement) { }
+        public void DeleteReserveMovement(Guid id) { }
+
+        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
+        public void AddCardStatement(CardStatement statement) { }
+
+        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
+        public void AddRecurringBill(RecurringBill bill) { }
+        public void DeleteRecurringBill(Guid id) { }
+
+        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
+        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
+        public void DeleteMaeLedgerEntry(Guid id) { }
+
+        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
+        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
+
+        public IEnumerable<Bank> GetBanks() => Banks;
+
+        public IEnumerable<Income> GetIncomes() => Incomes;
+        public void AddIncome(Income income) => Incomes.Add(income);
+        public void DeleteIncome(Guid id) { }
+
+        public Task SaveChangesAsync() => Task.CompletedTask;
+    }
+}

--- a/docs/P14-F03-tithe-calculation/plan.md
+++ b/docs/P14-F03-tithe-calculation/plan.md
@@ -1,0 +1,11 @@
+# Implementation Plan: Tithe Calculation
+
+**Prerequisites:**
+- .NET 10 SDK (existing solution target)
+- No new external dependencies or environment variables
+
+### Stage 1: Application and Presentation
+
+**1. Tithe Summary DTO and Service** - Add the read model for a month's calculated tithe and tithe balance, and implement the calculation: summing that month's income to derive the tithe base, applying the fixed 10% rate, and subtracting that month's Dizimo-category expense total. Register the service for dependency injection.
+
+**2. Tithe API Endpoint** - Add the read-only HTTP endpoint that returns a month's tithe summary, following the existing controllers' routing and response conventions.

--- a/docs/P14-F03-tithe-calculation/spec.md
+++ b/docs/P14-F03-tithe-calculation/spec.md
@@ -1,0 +1,91 @@
+# F03. Tithe Calculation
+
+## 1. Technical Overview
+
+**What:** A new, on-demand calculation — not a stored value — that computes a month's tithe (10% of that month's total `Income.NetValue`) and tithe balance (the calculated tithe minus that month's `Category.Dizimo`-tagged `Expense.Value`), exposed through a new read-only endpoint.
+
+**Why:** F05's Incoming card needs a ready-to-display tithe figure, and the PRD is explicit that the tithe is "computed on demand — not stored — whenever the selected month, its income, or its expenses change." A stored value would need active invalidation every time an `Income` or `Dizimo` `Expense` entry changes; computing it fresh on every read is the correct, minimal way to guarantee it's always current, and mirrors how `ExpenseService.GetCategoryTotalsByMonth` already computes category totals on demand rather than maintaining running totals.
+
+**Scope:**
+- Included: `ITitheService`/`TitheService` computing the tithe base, calculated tithe, and tithe balance for a given year/month by reading `ICashFlowRepository.GetIncomes()` and `GetExpenses()`; `TitheSummaryDTO`; a new `GET /tithe/month/{year}/{month}` endpoint, following the same read-only, no-auth, `Ok()`-wrapped shape as `ExpensesController.GetCategoryTotalsByMonth`.
+- Excluded: any UI (F05 owns the Incoming card that displays this); persisting the tithe or tithe balance anywhere; a configurable tithe percentage (fixed 10%, per PRD Out-of-Scope).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.CashFlow.Application/DTOs/TitheSummaryDTO.cs` — new
+- `Financial.CashFlow.Application/Interfaces/ITitheService.cs` — new
+- `Financial.CashFlow.Application/Services/TitheService.cs` — new
+- `Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs` — registers `ITitheService`
+- `Financial.Api/Controllers/TitheController.cs` — new
+
+```mermaid
+graph TD
+  A["TitheController"] --> B[TitheService]
+  B --> C["ICashFlowRepository.GetIncomes()"]
+  B --> D["ICashFlowRepository.GetExpenses()"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Where the calculation lives | A new, dedicated `TitheService` reading both `GetIncomes()` and `GetExpenses()`, rather than extending `IncomeService` or `ExpenseService` | Add a `GetTitheSummary` method onto `IncomeService` (it already owns income queries) | The tithe calculation genuinely spans two aggregates (`Income` for the base, `Expense` for the offset) and belongs to neither one's single responsibility; a dedicated service keeps `IncomeService`/`ExpenseService` focused on their own entity's CRUD and avoids a cross-entity dependency that would otherwise live awkwardly inside either |
+| Rounding | The 10% multiplication (`titheBase * 0.10m`) uses `decimal` arithmetic with no explicit rounding step — `decimal`'s native precision (28-29 significant digits) means the PRD's "to the penny" acceptance criterion is satisfied without a `Math.Round` call, and any storage/display formatting stays a JSON-serialization/UI concern rather than a business rule | Explicitly round to 2 decimal places in the service | Rounding in the service would silently discard precision the domain doesn't ask for; `decimal` multiplication of penny-precision inputs by `0.10m` never produces a value needing more than 2-3 decimal digits in practice for GBP amounts, and the PRD names no rounding rule to encode. Kept as the simplest correct behavior for this single-user tool. |
+| DTO shape | `TitheSummaryDTO` carries only `CalculatedTithe` and `TitheBalance` — no `TitheBase`/income-total field | Also expose the tithe base (sum of net income) for transparency | The PRD's F05 Capabilities and F03 Provides block name exactly these two figures ("the calculated tithe and the tithe balance"); the income total itself is already available from F01's `GetIncomesByMonth` endpoint, so duplicating it here would be redundant, not additive |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Application/DTOs/TitheSummaryDTO.cs` | New | Read model | `CalculatedTithe` (decimal), `TitheBalance` (decimal) |
+| `Financial.CashFlow.Application/Interfaces/ITitheService.cs` | New | Service contract | `TitheSummaryDTO GetTitheSummary(int year, int month)` |
+| `Financial.CashFlow.Application/Services/TitheService.cs` | New | Calculation | Sums `Income.NetValue` for the month → tithe base; `CalculatedTithe = titheBase * 0.10m`; sums `Expense.Value` for the month's `Category.Dizimo` expenses; `TitheBalance = CalculatedTithe - dizimoTotal`, no clamping (can be negative) |
+| `Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs` | Modified | DI registration | `services.AddSingleton<ITitheService, TitheService>();` added |
+| `Financial.Api/Controllers/TitheController.cs` | New | HTTP surface | `GET /tithe/month/{year}/{month}` — mirrors `ExpensesController`'s read-only `Ok()` shape; no error path (a month with no data simply returns zeros) |
+
+## 5. API Contracts
+
+**Endpoint: Get Tithe Summary by Month**
+- **Method:** GET
+- **Path:** `/tithe/month/{year}/{month}`
+- **Authentication:** None (matches every other endpoint in this single-user app)
+
+**Response (Success - 200):**
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `calculatedTithe` | `decimal` | 10% of the month's total `Income.NetValue` |
+| `titheBalance` | `decimal` | `calculatedTithe` minus the month's `Dizimo`-category `Expense.Value` total; may be negative |
+
+**Response Example:**
+```json
+{
+  "calculatedTithe": 350.00,
+  "titheBalance": -25.50
+}
+```
+
+**Error Codes:** none — a month with no income or Dizimo expenses returns `{ "calculatedTithe": 0, "titheBalance": 0 }`.
+
+## 6. Data Model
+
+None. This feature reads existing `Income` and `Expense` records and stores nothing new.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Tests/Financial.CashFlow.Application.Tests/Services/TitheServiceTests.cs` | Unit | `TitheService` | Calculated tithe equals 10% of summed `NetValue` for the month, across multiple `IncomeSource`s; tithe balance equals calculated tithe minus summed `Dizimo` expense values for the month; tithe balance is negative without error when Dizimo expenses exceed the calculated tithe; income/expenses outside the selected month are excluded; income with no matching `Dizimo` expenses yields a tithe balance equal to the full calculated tithe; a month with neither income nor Dizimo expenses returns zeros |
+| `Tests/Financial.Api.Tests/TitheEndpointsTests.cs` | Integration | `TitheController` | `GET` returns the calculated tithe and tithe balance matching a manually seeded fixture; `GET` for a month with no data returns zeros |
+
+**Acceptance tests (PRD Section 9, F03):**
+- Calculated tithe equals 10% of summed month `NetValue`, matching a manual reference to the penny → `TitheServiceTests`
+- Tithe balance equals calculated tithe minus that month's Dizimo expenses, matching a manual reference to the penny → `TitheServiceTests`
+- A negative tithe balance displays without error → `TitheServiceTests`, `TitheEndpointsTests`
+
+**Cross-Feature Integration criteria touching F03 (PRD Section 9):**
+- "F03's tithe calculation correctly reads the net income totals produced by F01 for the selected month" — verified directly here: `TitheServiceTests` seeds `Income` entries (F01's entity) across multiple sources and asserts the resulting tithe base/calculated tithe, exercising the exact contract F01 provides
+- "F05 correctly displays... the tithe/tithe balance from F03" — depends on F05, verified in F05's own spec once F05 consumes this endpoint

--- a/docs/prd/P14-prd-monthly-income-bank-balance/prd-monthly-income-bank-balance.md
+++ b/docs/prd/P14-prd-monthly-income-bank-balance/prd-monthly-income-bank-balance.md
@@ -280,9 +280,9 @@ graph TD
 - [x] The migration takes a backup of the data file before writing
 
 ### F03. Tithe Calculation
-- [ ] The calculated tithe for a month equals 10% of the sum of `NetValue` across all that month's `Income` entries, matching a manual reference calculation to the penny
-- [ ] The tithe balance equals the calculated tithe minus the sum of that month's `Dizimo`-category expenses, matching a manual reference calculation to the penny
-- [ ] A tithe balance can display as a negative value without error when Dizimo expenses exceed the calculated tithe
+- [x] The calculated tithe for a month equals 10% of the sum of `NetValue` across all that month's `Income` entries, matching a manual reference calculation to the penny
+- [x] The tithe balance equals the calculated tithe minus the sum of that month's `Dizimo`-category expenses, matching a manual reference calculation to the penny
+- [x] A tithe balance can display as a negative value without error when Dizimo expenses exceed the calculated tithe
 
 ### F04. Monthly Income Capture UI
 - [ ] An income entry can be added via the form with all required fields and appears in the month's list immediately after saving
@@ -311,7 +311,7 @@ graph TD
 - [ ] Lottery, tithe, and tithe balance do not appear anywhere in the Yearly Summary page
 
 ### Cross-Feature Integration
-- [ ] F03's tithe calculation correctly reads the net income totals produced by F01 for the selected month
+- [x] F03's tithe calculation correctly reads the net income totals produced by F01 for the selected month
 - [ ] F04's create/edit/delete actions correctly read and write through F01's `Income` entity contract
 - [ ] F05 correctly displays the income totals from F01 and the tithe/tithe balance from F03 for the selected month
 - [ ] F06 correctly combines F01's income data with F02's opening balance and date to produce each bank's balance


### PR DESCRIPTION
## Summary

Implements **F03 – Tithe Calculation** from the P14 PRD, per the committed spec/plan in `docs/P14-F03-tithe-calculation/`.

- New `TitheService` computes a month's tithe on demand — never stored — as 10% of that month's total `Income.NetValue`, and the tithe balance as that figure minus the month's `Dizimo`-category `Expense.Value` total (no clamping, so it can be negative)
- New read-only `GET /tithe/month/{year}/{month}` endpoint, following `ExpensesController`'s existing `Ok()`-wrapped read pattern
- The calculation lives in its own service rather than being bolted onto `IncomeService`/`ExpenseService`, since it genuinely spans both aggregates and belongs to neither one's single responsibility
- No new storage, no configurable rate (fixed 10%, per PRD Out-of-Scope)

## Acceptance Criteria (PRD Section 9 — F03)

- [x] The calculated tithe for a month equals 10% of the sum of `NetValue` across all that month's `Income` entries, matching a manual reference calculation to the penny
- [x] The tithe balance equals the calculated tithe minus the sum of that month's `Dizimo`-category expenses, matching a manual reference calculation to the penny
- [x] A tithe balance can display as a negative value without error when Dizimo expenses exceed the calculated tithe

## Cross-feature integration

- [x] F03's tithe calculation correctly reads the net income totals produced by F01 for the selected month — both features are now implemented, and `TitheServiceTests` exercises the exact `Income` contract F01 provides across multiple sources

## Test plan

- New `TitheServiceTests`: 7 tests covering multi-source income summation, Dizimo offset, negative balances, month filtering, and the zero-data case
- New `TitheEndpointsTests` (integration, via `ApiTestFactory`): calculated figures from seeded income/expense data, and the zero-data response
- Full .NET solution: all 14 test projects green (1,533 passed, 5 pre-existing skips unrelated to this change, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)