### PR TITLE
feat(P14-F07): yearly summary income rows

### DIFF
--- a/Financial.Api/Controllers/YearlySummaryController.cs
+++ b/Financial.Api/Controllers/YearlySummaryController.cs
@@ -28,4 +28,11 @@ public sealed class YearlySummaryController : ControllerBase
     {
         return Ok(_yearlySummaryService.GetInvestmentDiffsForYear(year));
     }
+
+    [HttpGet("{year:int}/income-summary")]
+    [ProducesResponseType(typeof(IncomeYearlySummaryDTO), StatusCodes.Status200OK)]
+    public ActionResult<IncomeYearlySummaryDTO> GetIncomeSummary(int year)
+    {
+        return Ok(_yearlySummaryService.GetIncomeSummaryForYear(year));
+    }
 }

--- a/Financial.CashFlow.Application/DTOs/IncomeYearlySummaryDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/IncomeYearlySummaryDTO.cs
@@ -1,0 +1,23 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Read model for the Yearly Summary page's Income Summary table.
+/// </summary>
+public sealed class IncomeYearlySummaryDTO
+{
+    /// <summary>Row 2 "Salary": sum of Gleison + Ariana gross values, per month.</summary>
+    public required decimal[] SalaryMonthly { get; init; }
+    public required decimal SalaryYearlyTotal { get; init; }
+
+    /// <summary>Row 3 "Salary after taxes": sum of Gleison + Ariana net values, per month.</summary>
+    public required decimal[] SalaryAfterTaxesMonthly { get; init; }
+    public required decimal SalaryAfterTaxesYearlyTotal { get; init; }
+
+    /// <summary>Row 4 "Tax difference": SalaryMonthly minus SalaryAfterTaxesMonthly, per month.</summary>
+    public required decimal[] TaxDifferenceMonthly { get; init; }
+    public required decimal TaxDifferenceYearlyTotal { get; init; }
+
+    /// <summary>Row 6 "Dividendo/Juros": sum of DividendoJuros net values, per month.</summary>
+    public required decimal[] DividendoJurosMonthly { get; init; }
+    public required decimal DividendoJurosYearlyTotal { get; init; }
+}

--- a/Financial.CashFlow.Application/Interfaces/IYearlySummaryService.cs
+++ b/Financial.CashFlow.Application/Interfaces/IYearlySummaryService.cs
@@ -6,4 +6,5 @@ public interface IYearlySummaryService
 {
     IReadOnlyList<CategoryYearlyTotalDTO> GetCategoryTotalsForYear(int year);
     InvestmentDiffsYearlyDTO GetInvestmentDiffsForYear(int year);
+    IncomeYearlySummaryDTO GetIncomeSummaryForYear(int year);
 }

--- a/Financial.CashFlow.Application/Services/YearlySummaryService.cs
+++ b/Financial.CashFlow.Application/Services/YearlySummaryService.cs
@@ -89,6 +89,46 @@ public sealed class YearlySummaryService : IYearlySummaryService
         };
     }
 
+    public IncomeYearlySummaryDTO GetIncomeSummaryForYear(int year)
+    {
+        var salaryMonthly = new decimal[MonthsInYear];
+        var salaryAfterTaxesMonthly = new decimal[MonthsInYear];
+        var dividendoJurosMonthly = new decimal[MonthsInYear];
+
+        foreach (var income in _repository.GetIncomes().Where(i => i.Date.Year == year))
+        {
+            var monthIndex = income.Date.Month - 1;
+
+            if (income.IncomeSource is IncomeSource.Gleison or IncomeSource.Ariana)
+            {
+                salaryMonthly[monthIndex] += income.GrossValue ?? 0m;
+                salaryAfterTaxesMonthly[monthIndex] += income.NetValue;
+            }
+            else if (income.IncomeSource == IncomeSource.DividendoJuros)
+            {
+                dividendoJurosMonthly[monthIndex] += income.NetValue;
+            }
+        }
+
+        var taxDifferenceMonthly = new decimal[MonthsInYear];
+        for (var month = 0; month < MonthsInYear; month++)
+        {
+            taxDifferenceMonthly[month] = salaryMonthly[month] - salaryAfterTaxesMonthly[month];
+        }
+
+        return new IncomeYearlySummaryDTO
+        {
+            SalaryMonthly = salaryMonthly,
+            SalaryYearlyTotal = salaryMonthly.Sum(),
+            SalaryAfterTaxesMonthly = salaryAfterTaxesMonthly,
+            SalaryAfterTaxesYearlyTotal = salaryAfterTaxesMonthly.Sum(),
+            TaxDifferenceMonthly = taxDifferenceMonthly,
+            TaxDifferenceYearlyTotal = taxDifferenceMonthly.Sum(),
+            DividendoJurosMonthly = dividendoJurosMonthly,
+            DividendoJurosYearlyTotal = dividendoJurosMonthly.Sum()
+        };
+    }
+
     private static decimal[] ComputeDiffs(decimal[] monthlyValues)
     {
         var diffs = new decimal[monthlyValues.Length - 1];

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -26,6 +26,7 @@ import type {
   IncomeDto,
   IncomeSplitRequestDto,
   IncomeSplitResultDto,
+  IncomeYearlySummaryDto,
   InvestmentDiffsYearlyDto,
   InvestmentScope,
   InvestmentSnapshotDto,
@@ -118,6 +119,7 @@ export interface FinancialApiClient {
   unmarkCardStatementPaid: (id: string) => Promise<CardStatementDto>
   getCategoryTotalsForYear: (year: number) => Promise<CategoryYearlyTotalDto[]>
   getInvestmentDiffsForYear: (year: number) => Promise<InvestmentDiffsYearlyDto>
+  getIncomeSummaryForYear: (year: number) => Promise<IncomeYearlySummaryDto>
 }
 
 export interface FinancialApiClientOptions {
@@ -372,5 +374,7 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       request<CategoryYearlyTotalDto[]>(`/yearly-summary/${year}/expense-categories`),
     getInvestmentDiffsForYear: (year) =>
       request<InvestmentDiffsYearlyDto>(`/yearly-summary/${year}/investment-diffs`),
+    getIncomeSummaryForYear: (year) =>
+      request<IncomeYearlySummaryDto>(`/yearly-summary/${year}/income-summary`),
   }
 }

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -467,6 +467,17 @@ export interface InvestmentDiffsYearlyDto {
   netPosition: NetPositionYearlyDiffDto
 }
 
+export interface IncomeYearlySummaryDto {
+  salaryMonthly: number[]
+  salaryYearlyTotal: number
+  salaryAfterTaxesMonthly: number[]
+  salaryAfterTaxesYearlyTotal: number
+  taxDifferenceMonthly: number[]
+  taxDifferenceYearlyTotal: number
+  dividendoJurosMonthly: number[]
+  dividendoJurosYearlyTotal: number
+}
+
 export interface InvestmentSnapshotDto {
   id: string
   account: string

--- a/Financial.Web/src/hooks/useYearlySummary.test.ts
+++ b/Financial.Web/src/hooks/useYearlySummary.test.ts
@@ -1,18 +1,20 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FinancialApiClient } from '../api/financialApiClient'
-import type { CategoryYearlyTotalDto, InvestmentDiffsYearlyDto } from '../api/types'
+import type { CategoryYearlyTotalDto, IncomeYearlySummaryDto, InvestmentDiffsYearlyDto } from '../api/types'
 import { useYearlySummary } from './useYearlySummary'
 
 const CURRENT_YEAR = new Date().getFullYear()
 
 const getCategoryTotalsForYearMock = vi.fn<FinancialApiClient['getCategoryTotalsForYear']>()
 const getInvestmentDiffsForYearMock = vi.fn<FinancialApiClient['getInvestmentDiffsForYear']>()
+const getIncomeSummaryForYearMock = vi.fn<FinancialApiClient['getIncomeSummaryForYear']>()
 
 vi.mock('../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
     getCategoryTotalsForYear: getCategoryTotalsForYearMock,
     getInvestmentDiffsForYear: getInvestmentDiffsForYearMock,
+    getIncomeSummaryForYear: getIncomeSummaryForYearMock,
   }),
 }))
 
@@ -36,14 +38,26 @@ const INVESTMENT_DIFFS: InvestmentDiffsYearlyDto = {
   },
 }
 
+const INCOME_SUMMARY: IncomeYearlySummaryDto = {
+  salaryMonthly: new Array(12).fill(3200),
+  salaryYearlyTotal: 38400,
+  salaryAfterTaxesMonthly: new Array(12).fill(2450),
+  salaryAfterTaxesYearlyTotal: 29400,
+  taxDifferenceMonthly: new Array(12).fill(750),
+  taxDifferenceYearlyTotal: 9000,
+  dividendoJurosMonthly: new Array(12).fill(15.5),
+  dividendoJurosYearlyTotal: 186,
+}
+
 describe('useYearlySummary', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getCategoryTotalsForYearMock.mockResolvedValue(CATEGORY_TOTALS)
     getInvestmentDiffsForYearMock.mockResolvedValue(INVESTMENT_DIFFS)
+    getIncomeSummaryForYearMock.mockResolvedValue(INCOME_SUMMARY)
   })
 
-  it('fetches category totals and investment diffs for the current year on mount', async () => {
+  it('fetches category totals, investment diffs, and income summary for the current year on mount', async () => {
     const { result } = renderHook(() => useYearlySummary())
 
     expect(result.current.isLoading).toBe(true)
@@ -51,9 +65,11 @@ describe('useYearlySummary', () => {
 
     expect(getCategoryTotalsForYearMock).toHaveBeenCalledWith(CURRENT_YEAR)
     expect(getInvestmentDiffsForYearMock).toHaveBeenCalledWith(CURRENT_YEAR)
+    expect(getIncomeSummaryForYearMock).toHaveBeenCalledWith(CURRENT_YEAR)
     expect(result.current.year).toBe(CURRENT_YEAR)
     expect(result.current.categoryTotals).toEqual(CATEGORY_TOTALS)
     expect(result.current.investmentDiffs).toEqual(INVESTMENT_DIFFS)
+    expect(result.current.incomeSummary).toEqual(INCOME_SUMMARY)
   })
 
   it('re-fetches for a new year when the year changes', async () => {

--- a/Financial.Web/src/hooks/useYearlySummary.ts
+++ b/Financial.Web/src/hooks/useYearlySummary.ts
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { createFinancialApiClient } from '../api/financialApiClient'
-import type { CategoryYearlyTotalDto, InvestmentDiffsYearlyDto } from '../api/types'
+import type { CategoryYearlyTotalDto, IncomeYearlySummaryDto, InvestmentDiffsYearlyDto } from '../api/types'
 
 interface YearlySummaryState {
   year: number
   categoryTotals: CategoryYearlyTotalDto[]
   investmentDiffs: InvestmentDiffsYearlyDto | null
+  incomeSummary: IncomeYearlySummaryDto | null
   isLoading: boolean
   error: string | null
   retryCount: number
@@ -14,7 +15,14 @@ interface YearlySummaryState {
 type YearlySummaryAction =
   | { type: 'SET_YEAR'; payload: number }
   | { type: 'FETCH_START' }
-  | { type: 'FETCH_SUCCESS'; payload: { categoryTotals: CategoryYearlyTotalDto[]; investmentDiffs: InvestmentDiffsYearlyDto } }
+  | {
+      type: 'FETCH_SUCCESS'
+      payload: {
+        categoryTotals: CategoryYearlyTotalDto[]
+        investmentDiffs: InvestmentDiffsYearlyDto
+        incomeSummary: IncomeYearlySummaryDto
+      }
+    }
   | { type: 'FETCH_ERROR'; payload: string }
   | { type: 'RETRY' }
 
@@ -22,6 +30,7 @@ const INITIAL_STATE: YearlySummaryState = {
   year: new Date().getFullYear(),
   categoryTotals: [],
   investmentDiffs: null,
+  incomeSummary: null,
   isLoading: true,
   error: null,
   retryCount: 0,
@@ -39,6 +48,7 @@ function reducer(state: YearlySummaryState, action: YearlySummaryAction): Yearly
         isLoading: false,
         categoryTotals: action.payload.categoryTotals,
         investmentDiffs: action.payload.investmentDiffs,
+        incomeSummary: action.payload.incomeSummary,
       }
     case 'FETCH_ERROR':
       return { ...state, isLoading: false, error: action.payload }
@@ -54,6 +64,7 @@ export interface YearlySummaryData {
   setYear: (year: number) => void
   categoryTotals: CategoryYearlyTotalDto[]
   investmentDiffs: InvestmentDiffsYearlyDto | null
+  incomeSummary: IncomeYearlySummaryDto | null
   isLoading: boolean
   error: string | null
   retry: () => void
@@ -65,9 +76,13 @@ export function useYearlySummary(): YearlySummaryData {
 
   useEffect(() => {
     dispatch({ type: 'FETCH_START' })
-    void Promise.all([apiClient.getCategoryTotalsForYear(state.year), apiClient.getInvestmentDiffsForYear(state.year)])
-      .then(([categoryTotals, investmentDiffs]) =>
-        dispatch({ type: 'FETCH_SUCCESS', payload: { categoryTotals, investmentDiffs } }),
+    void Promise.all([
+      apiClient.getCategoryTotalsForYear(state.year),
+      apiClient.getInvestmentDiffsForYear(state.year),
+      apiClient.getIncomeSummaryForYear(state.year),
+    ])
+      .then(([categoryTotals, investmentDiffs, incomeSummary]) =>
+        dispatch({ type: 'FETCH_SUCCESS', payload: { categoryTotals, investmentDiffs, incomeSummary } }),
       )
       .catch((err: unknown) => {
         dispatch({
@@ -89,6 +104,7 @@ export function useYearlySummary(): YearlySummaryData {
     setYear,
     categoryTotals: state.categoryTotals,
     investmentDiffs: state.investmentDiffs,
+    incomeSummary: state.incomeSummary,
     isLoading: state.isLoading,
     error: state.error,
     retry,

--- a/Financial.Web/src/pages/YearlySummaryPage.tsx
+++ b/Financial.Web/src/pages/YearlySummaryPage.tsx
@@ -7,7 +7,7 @@ import './YearlySummaryPage.css'
 const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
 export default function YearlySummaryPage() {
-  const { year, setYear, categoryTotals, investmentDiffs, isLoading, error, retry } = useYearlySummary()
+  const { year, setYear, categoryTotals, investmentDiffs, incomeSummary, isLoading, error, retry } = useYearlySummary()
 
   return (
     <div className="yearly-summary-page">
@@ -105,6 +105,79 @@ export default function YearlySummaryPage() {
                     ))}
                     <td className="data-table__col--numeric">
                       <strong>{formatN2(investmentDiffs.netPosition.fullYearNetChange)}</strong>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </section>
+          )}
+
+          {incomeSummary && (
+            <section className="yearly-summary-page__section">
+              <h2>Income Summary</h2>
+              <table className="yearly-summary-page__table data-table">
+                <thead>
+                  <tr>
+                    <th />
+                    {MONTH_LABELS.map((m) => (
+                      <th key={m} className="data-table__col--numeric">
+                        {m}
+                      </th>
+                    ))}
+                    <th className="data-table__col--numeric">Yearly Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td colSpan={MONTH_LABELS.length + 2}>
+                      <strong>Income</strong>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Salary</td>
+                    {incomeSummary.salaryMonthly.map((v, i) => (
+                      <td key={i} className="data-table__col--numeric">
+                        {formatN2(v)}
+                      </td>
+                    ))}
+                    <td className="data-table__col--numeric">
+                      <strong>{formatN2(incomeSummary.salaryYearlyTotal)}</strong>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Salary after taxes</td>
+                    {incomeSummary.salaryAfterTaxesMonthly.map((v, i) => (
+                      <td key={i} className="data-table__col--numeric">
+                        {formatN2(v)}
+                      </td>
+                    ))}
+                    <td className="data-table__col--numeric">
+                      <strong>{formatN2(incomeSummary.salaryAfterTaxesYearlyTotal)}</strong>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Tax difference</td>
+                    {incomeSummary.taxDifferenceMonthly.map((v, i) => (
+                      <td key={i} className="data-table__col--numeric">
+                        {formatN2(v)}
+                      </td>
+                    ))}
+                    <td className="data-table__col--numeric">
+                      <strong>{formatN2(incomeSummary.taxDifferenceYearlyTotal)}</strong>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td colSpan={MONTH_LABELS.length + 2} />
+                  </tr>
+                  <tr>
+                    <td>Dividendo/Juros</td>
+                    {incomeSummary.dividendoJurosMonthly.map((v, i) => (
+                      <td key={i} className="data-table__col--numeric">
+                        {formatN2(v)}
+                      </td>
+                    ))}
+                    <td className="data-table__col--numeric">
+                      <strong>{formatN2(incomeSummary.dividendoJurosYearlyTotal)}</strong>
                     </td>
                   </tr>
                 </tbody>

--- a/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
@@ -1,16 +1,18 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import YearlySummaryPage from '../YearlySummaryPage'
 import type { FinancialApiClient } from '../../api/financialApiClient'
-import type { CategoryYearlyTotalDto, InvestmentDiffsYearlyDto } from '../../api/types'
+import type { CategoryYearlyTotalDto, IncomeYearlySummaryDto, InvestmentDiffsYearlyDto } from '../../api/types'
 
 const getCategoryTotalsForYearMock = vi.fn<FinancialApiClient['getCategoryTotalsForYear']>()
 const getInvestmentDiffsForYearMock = vi.fn<FinancialApiClient['getInvestmentDiffsForYear']>()
+const getIncomeSummaryForYearMock = vi.fn<FinancialApiClient['getIncomeSummaryForYear']>()
 
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
     getCategoryTotalsForYear: getCategoryTotalsForYearMock,
     getInvestmentDiffsForYear: getInvestmentDiffsForYearMock,
+    getIncomeSummaryForYear: getIncomeSummaryForYearMock,
   }),
 }))
 
@@ -44,11 +46,23 @@ const INVESTMENT_DIFFS: InvestmentDiffsYearlyDto = {
   },
 }
 
+const INCOME_SUMMARY: IncomeYearlySummaryDto = {
+  salaryMonthly: [3200, 3200, 3200, 3200, 3200, 3200, 3200, 3200, 3200, 3200, 3200, 3600],
+  salaryYearlyTotal: 38800,
+  salaryAfterTaxesMonthly: [2450, 2450, 2450, 2450, 2450, 2450, 2450, 2450, 2450, 2450, 2450, 2650],
+  salaryAfterTaxesYearlyTotal: 29350,
+  taxDifferenceMonthly: [750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 950],
+  taxDifferenceYearlyTotal: 9450,
+  dividendoJurosMonthly: [0, 0, 15.5, 0, 0, 0, 0, 0, 0, 0, 0, 4.5],
+  dividendoJurosYearlyTotal: 20,
+}
+
 describe('YearlySummaryPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getCategoryTotalsForYearMock.mockResolvedValue(CATEGORY_TOTALS)
     getInvestmentDiffsForYearMock.mockResolvedValue(INVESTMENT_DIFFS)
+    getIncomeSummaryForYearMock.mockResolvedValue(INCOME_SUMMARY)
   })
 
   it('shows a loading state before data arrives', () => {
@@ -82,5 +96,32 @@ describe('YearlySummaryPage', () => {
     expect(screen.getByText('PlatinumVisa8003 (liability)')).toBeInTheDocument()
     expect(screen.getByText('Net Position')).toBeInTheDocument()
     expect(screen.getByText('550.00')).toBeInTheDocument()
+  })
+
+  it('renders the income-summary table with the header row and the four data rows', async () => {
+    render(<YearlySummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Income Summary')).toBeInTheDocument())
+    const incomeSection = screen.getByText('Income Summary').closest('section')!
+    expect(within(incomeSection).getByText('Income')).toBeInTheDocument()
+    expect(within(incomeSection).getByRole('cell', { name: 'Salary' })).toBeInTheDocument()
+    expect(within(incomeSection).getByRole('cell', { name: 'Salary after taxes' })).toBeInTheDocument()
+    expect(within(incomeSection).getByRole('cell', { name: 'Tax difference' })).toBeInTheDocument()
+    expect(within(incomeSection).getByRole('cell', { name: 'Dividendo/Juros' })).toBeInTheDocument()
+    expect(within(incomeSection).getByText('38,800.00')).toBeInTheDocument()
+    expect(within(incomeSection).getByText('9,450.00')).toBeInTheDocument()
+  })
+
+  it('renders row 5 of the income-summary table blank, and shows no Lottery, tithe, or tithe-balance content anywhere', async () => {
+    render(<YearlySummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Income Summary')).toBeInTheDocument())
+    const incomeSection = screen.getByText('Income Summary').closest('section')!
+    const rows = within(incomeSection).getAllByRole('row')
+    const blankRow = rows[5]
+    expect(blankRow.textContent).toBe('')
+
+    expect(screen.queryByText(/Lottery/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Tithe/i)).not.toBeInTheDocument()
   })
 })

--- a/Tests/Financial.Api.Tests/YearlySummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/YearlySummaryEndpointsTests.cs
@@ -65,4 +65,54 @@ public class YearlySummaryEndpointsTests
         result.NetPosition.MonthlyValues[0].Should().Be(1000m);
         result.NetPosition.FullYearNetChange.Should().Be(-1000m);
     }
+
+    [Fact]
+    public async Task GetIncomeSummary_ReturnsFiguresMatchingSeededIncomeAcrossSourcesAndMonths()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 1, 1),
+            IncomeSource = "Gleison",
+            GrossValue = 3200m,
+            NetValue = 2450m,
+            Bank = "Barclays"
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 1, 8),
+            IncomeSource = "Ariana",
+            GrossValue = 400m,
+            NetValue = 350m,
+            Bank = "Chase"
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 3, 1),
+            IncomeSource = "DividendoJuros",
+            GrossValue = null,
+            NetValue = 15.50m,
+            Bank = "Trading212"
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 4, 1),
+            IncomeSource = "Lottery",
+            GrossValue = null,
+            NetValue = 500m,
+            Bank = "Chase"
+        });
+
+        var response = await client.GetAsync("/api/v1/financial/yearly-summary/2026/income-summary");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<IncomeYearlySummaryDTO>();
+        result!.SalaryMonthly[0].Should().Be(3600m);
+        result.SalaryAfterTaxesMonthly[0].Should().Be(2800m);
+        result.TaxDifferenceMonthly[0].Should().Be(800m);
+        result.DividendoJurosMonthly[2].Should().Be(15.50m);
+        result.SalaryMonthly[3].Should().Be(0m);
+        result.SalaryYearlyTotal.Should().Be(3600m);
+    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
@@ -138,10 +138,122 @@ public class YearlySummaryServiceTests
         result.NetPosition.FullYearNetChange.Should().Be(800m);
     }
 
+    [Fact]
+    public void GetIncomeSummaryForYear_SalaryRowSumsGleisonAndArianaGrossValuesPerMonth()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 1), IncomeSource.Gleison, 3200m, 2450m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 8), IncomeSource.Ariana, 400m, 350m, "Chase"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 2, 1), IncomeSource.Gleison, 3300m, 2500m, "Barclays"));
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetIncomeSummaryForYear(2026);
+
+        result.SalaryMonthly[0].Should().Be(3600m);
+        result.SalaryMonthly[1].Should().Be(3300m);
+        result.SalaryYearlyTotal.Should().Be(result.SalaryMonthly.Sum());
+    }
+
+    [Fact]
+    public void GetIncomeSummaryForYear_SalaryAfterTaxesRowSumsGleisonAndArianaNetValuesPerMonth()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 1), IncomeSource.Gleison, 3200m, 2450m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 8), IncomeSource.Ariana, 400m, 350m, "Chase"));
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetIncomeSummaryForYear(2026);
+
+        result.SalaryAfterTaxesMonthly[0].Should().Be(2800m);
+        result.SalaryAfterTaxesYearlyTotal.Should().Be(result.SalaryAfterTaxesMonthly.Sum());
+    }
+
+    [Fact]
+    public void GetIncomeSummaryForYear_TaxDifferenceRowEqualsSalaryMinusSalaryAfterTaxes()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 1), IncomeSource.Gleison, 3200m, 2450m, "Barclays"));
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetIncomeSummaryForYear(2026);
+
+        result.TaxDifferenceMonthly[0].Should().Be(750m);
+        result.TaxDifferenceYearlyTotal.Should().Be(result.TaxDifferenceMonthly.Sum());
+    }
+
+    [Fact]
+    public void GetIncomeSummaryForYear_DividendoJurosRowSumsOnlyThatSourcesNetValues()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 1), IncomeSource.DividendoJuros, null, 15.50m, "Trading212"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 5), IncomeSource.DividendoJuros, null, 4.50m, "Trading212"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 10), IncomeSource.Gleison, 3200m, 2450m, "Barclays"));
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetIncomeSummaryForYear(2026);
+
+        result.DividendoJurosMonthly[2].Should().Be(20m);
+        result.DividendoJurosYearlyTotal.Should().Be(20m);
+    }
+
+    [Fact]
+    public void GetIncomeSummaryForYear_LotteryEntriesContributeToNoRow()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 4, 1), IncomeSource.Lottery, null, 500m, "Chase"));
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetIncomeSummaryForYear(2026);
+
+        result.SalaryMonthly.Should().OnlyContain(v => v == 0m);
+        result.SalaryAfterTaxesMonthly.Should().OnlyContain(v => v == 0m);
+        result.DividendoJurosMonthly.Should().OnlyContain(v => v == 0m);
+    }
+
+    [Fact]
+    public void GetIncomeSummaryForYear_EntryWithNullGrossValue_ContributesZeroToSalary()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 5, 1), IncomeSource.Ariana, null, 350m, "Chase"));
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetIncomeSummaryForYear(2026);
+
+        result.SalaryMonthly[4].Should().Be(0m);
+        result.SalaryAfterTaxesMonthly[4].Should().Be(350m);
+    }
+
+    [Fact]
+    public void GetIncomeSummaryForYear_ExcludesIncomeFromOtherYears()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 1), IncomeSource.Gleison, 3200m, 2450m, "Barclays"));
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetIncomeSummaryForYear(2026);
+
+        result.SalaryYearlyTotal.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetIncomeSummaryForYear_WithNoIncome_ReturnsAllZeros()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetIncomeSummaryForYear(2026);
+
+        result.SalaryMonthly.Should().OnlyContain(v => v == 0m);
+        result.SalaryAfterTaxesMonthly.Should().OnlyContain(v => v == 0m);
+        result.TaxDifferenceMonthly.Should().OnlyContain(v => v == 0m);
+        result.DividendoJurosMonthly.Should().OnlyContain(v => v == 0m);
+    }
+
     private sealed class StubCashFlowRepository : ICashFlowRepository
     {
         public List<Expense> Expenses { get; } = new();
         public List<InvestmentSnapshot> Snapshots { get; } = new();
+        public List<Income> Incomes { get; } = new();
 
         public IEnumerable<Expense> GetExpenses() => Expenses;
         public void AddExpense(Expense expense) => Expenses.Add(expense);
@@ -167,7 +279,7 @@ public class YearlySummaryServiceTests
 
         public IEnumerable<Bank> GetBanks() => Array.Empty<Bank>();
 
-        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
+        public IEnumerable<Income> GetIncomes() => Incomes;
         public void AddIncome(Income income) { }
         public void DeleteIncome(Guid id) { }
 

--- a/docs/P14-F07-yearly-summary-income-rows/plan.md
+++ b/docs/P14-F07-yearly-summary-income-rows/plan.md
@@ -1,0 +1,15 @@
+# Implementation Plan: Yearly Summary Income Rows
+
+**Prerequisites:**
+- .NET 10 SDK and Node/npm toolchain already configured
+- No new dependencies
+
+### Stage 1: Backend Calculation
+
+**1. Income Yearly Summary DTO and Service** - Add the read model and the aggregation itself: per month, sum Gleison/Ariana gross and net values into the Salary and Salary-after-taxes rows, derive the Tax difference row from their gap, and sum DividendoJuros net values into their own row, each with a yearly total.
+
+**2. Income Summary API Endpoint** - Add the read-only HTTP endpoint that returns the year's income summary, following the existing Yearly Summary endpoints' routing and response conventions.
+
+### Stage 2: Frontend Integration
+
+**3. Fetch and Render the Income Summary Table** - Add the corresponding type and API client method, fetch the income summary alongside the page's existing data, and render a new table matching the Category Totals table's column layout, with the header row, four data rows, and the intentionally blank row in their specified order.

--- a/docs/P14-F07-yearly-summary-income-rows/spec.md
+++ b/docs/P14-F07-yearly-summary-income-rows/spec.md
@@ -1,0 +1,120 @@
+# F07. Yearly Summary Income Rows
+
+## 1. Technical Overview
+
+**What:** A new Income Summary table on the Yearly Summary page, laid out like the existing Category Totals table (12 monthly columns + a yearly total), with 4 fixed metric rows — Salary (gross), Salary after taxes (net), Tax difference (gross minus net), and Dividendo/Juros — plus a section-header row and an intentionally blank row, replicating the retired spreadsheet's income block layout (rows 1-6, with row 5 always blank).
+
+**Why:** F01 made `Income` a real, queryable entity; this feature is the last piece that surfaces it across a full year the same way `Category Totals` already does for expenses, so the developer can review income the same way they review everything else in this app — per month, per year, at a glance.
+
+**Scope:**
+- Included: `IYearlySummaryService.GetIncomeSummaryForYear(year)` and `IncomeYearlySummaryDTO`; `GET /yearly-summary/{year}/income-summary`; a new Income Summary table on `YearlySummaryPage`, fetched alongside the existing Category Totals and Investment Diffs data.
+- Excluded: Lottery, the calculated tithe, and the tithe balance — none appear in the Yearly Summary, per PRD Out-of-Scope; any change to the Monthly page's own Incoming card (F05).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.CashFlow.Application/DTOs/IncomeYearlySummaryDTO.cs` — new
+- `Financial.CashFlow.Application/Interfaces/IYearlySummaryService.cs` — `GetIncomeSummaryForYear` added
+- `Financial.CashFlow.Application/Services/YearlySummaryService.cs` — implements the calculation
+- `Financial.Api/Controllers/YearlySummaryController.cs` — `GET /yearly-summary/{year}/income-summary`
+- `Financial.Web/src/api/types.ts` — `IncomeYearlySummaryDto`
+- `Financial.Web/src/api/financialApiClient.ts` — `getIncomeSummaryForYear`
+- `Financial.Web/src/hooks/useYearlySummary.ts` — fetches the new data alongside the existing two
+- `Financial.Web/src/pages/YearlySummaryPage.tsx` — new Income Summary table
+
+```mermaid
+graph TD
+  A["YearlySummaryController"] --> B[YearlySummaryService]
+  B --> C["ICashFlowRepository.GetIncomes()"]
+  D[useYearlySummary] --> E["financialApiClient.getIncomeSummaryForYear"]
+  E --> A
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| DTO shape | `IncomeYearlySummaryDTO` with 4 named row pairs (`SalaryMonthly`/`SalaryYearlyTotal`, `SalaryAfterTaxesMonthly`/`...YearlyTotal`, `TaxDifferenceMonthly`/`...YearlyTotal`, `DividendoJurosMonthly`/`...YearlyTotal`) rather than a generic list of rows | Reuse `CategoryYearlyTotalDTO`'s generic `{ Category, MonthlyTotals, YearlyTotal }` shape, one entry per row | `CategoryYearlyTotalDTO` works generically because it loops over every `Category` enum value uniformly; this feature's 4 rows have fixed, distinct semantics (two are raw sums, one is a derived difference, one skips two income sources entirely) that don't reduce to one generic loop, so 4 explicit named fields is more direct than forcing a generic shape that would need an artificial "row kind" discriminator |
+| Row 1 (header) and Row 5 (blank) | Rendered directly in the frontend table markup, not modeled in the DTO — the backend has no reason to represent "a label with no data" or "nothing" as data | Add placeholder fields for rows 1 and 5 to the DTO for structural completeness | These two rows carry no computed value; putting them in the DTO would mean the backend ships fields that are always constants or always empty, purely to satisfy a frontend layout detail. The table structure (which rows exist, in which order) is presentation, not business logic — the backend's job ends at "here are the 4 real numbers," matching how `InvestmentDiffsYearlyDTO` doesn't encode the Net Position row's bold styling either |
+| Salary aggregation | `IncomeSource.Gleison` and `IncomeSource.Ariana` entries are summed together into the same monthly bucket (both `GrossValue` for row 2 and `NetValue` for row 3) — matching the PRD's literal "sum of GrossValue for that month's Gleison and Ariana entries" | Two separate Salary rows, one per source | The PRD Capabilities explicitly describe a single combined Salary row summing both sources, mirroring the retired spreadsheet's single J2 "Salario" cell that already combined both incomes; splitting them would be a scope addition the PRD doesn't ask for |
+| Missing `GrossValue` | Treated as `0m` when summing row 2 (an income entry with no `GrossValue` — e.g. a `Lottery`/`DividendoJuros` entry, or theoretically a `Gleison`/`Ariana` entry saved without one) contributes nothing to Salary | Skip such entries entirely | Since row 2 only sums `Gleison`/`Ariana` entries in the first place, and F04's validation makes `GrossValue` effectively expected (though not required) for those two sources, treating a missing value as `0` is the simplest correct behavior and avoids a null-reference distinction the PRD doesn't call for |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Application/DTOs/IncomeYearlySummaryDTO.cs` | New | Read model | `SalaryMonthly`/`SalaryYearlyTotal` (row 2), `SalaryAfterTaxesMonthly`/`SalaryAfterTaxesYearlyTotal` (row 3), `TaxDifferenceMonthly`/`TaxDifferenceYearlyTotal` (row 4), `DividendoJurosMonthly`/`DividendoJurosYearlyTotal` (row 6) — each `Monthly` field a 12-element `decimal[]` |
+| `Financial.CashFlow.Application/Interfaces/IYearlySummaryService.cs` | Modified | Service contract | `IncomeYearlySummaryDTO GetIncomeSummaryForYear(int year)` added |
+| `Financial.CashFlow.Application/Services/YearlySummaryService.cs` | Modified | Calculation | Filters `Income` entries to the requested year; for `Gleison`/`Ariana` entries, accumulates `GrossValue ?? 0` into `SalaryMonthly[month]` and `NetValue` into `SalaryAfterTaxesMonthly[month]`; for `DividendoJuros` entries, accumulates `NetValue` into `DividendoJurosMonthly[month]`; `Lottery` entries contribute to none of the 4 rows; `TaxDifferenceMonthly[month] = SalaryMonthly[month] - SalaryAfterTaxesMonthly[month]`; each yearly total is the sum of its 12 monthly values |
+| `Financial.Api/Controllers/YearlySummaryController.cs` | Modified | HTTP surface | `GET /yearly-summary/{year}/income-summary` — mirrors the existing 2 endpoints' `Ok()` shape |
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/api/types.ts` | Modified | DTO | `IncomeYearlySummaryDto` mirroring the 8 backend fields (camelCase) |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | HTTP method | `getIncomeSummaryForYear(year)` → `GET /yearly-summary/${year}/income-summary` |
+| `Financial.Web/src/hooks/useYearlySummary.ts` | Modified | State + fetch | `incomeSummary: IncomeYearlySummaryDto \| null` fetched in the existing `Promise.all` alongside `categoryTotals`/`investmentDiffs` |
+| `Financial.Web/src/pages/YearlySummaryPage.tsx` | Modified | New table | "Income Summary" section, same column layout (`MONTH_LABELS` + Yearly Total) as Category Totals; table body: row 1 a full-width "Income" label row; row 2 "Salary"; row 3 "Salary after taxes"; row 4 "Tax difference"; row 5 a full-width empty row; row 6 "Dividendo/Juros" |
+
+## 5. API Contracts
+
+**Endpoint: Get Income Summary for Year**
+- **Method:** GET
+- **Path:** `/yearly-summary/{year}/income-summary`
+- **Authentication:** None (matches every other endpoint in this single-user app)
+
+**Response (Success - 200):**
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `salaryMonthly` | `decimal[12]` | Row 2: Gleison + Ariana gross values, per month |
+| `salaryYearlyTotal` | `decimal` | Sum of `salaryMonthly` |
+| `salaryAfterTaxesMonthly` | `decimal[12]` | Row 3: Gleison + Ariana net values, per month |
+| `salaryAfterTaxesYearlyTotal` | `decimal` | Sum of `salaryAfterTaxesMonthly` |
+| `taxDifferenceMonthly` | `decimal[12]` | Row 4: `salaryMonthly[i] - salaryAfterTaxesMonthly[i]` |
+| `taxDifferenceYearlyTotal` | `decimal` | Sum of `taxDifferenceMonthly` |
+| `dividendoJurosMonthly` | `decimal[12]` | Row 6: DividendoJuros net values, per month |
+| `dividendoJurosYearlyTotal` | `decimal` | Sum of `dividendoJurosMonthly` |
+
+**Response Example (abridged to 3 months):**
+```json
+{
+  "salaryMonthly": [2450.00, 0, 0],
+  "salaryYearlyTotal": 2450.00,
+  "salaryAfterTaxesMonthly": [2450.00, 0, 0],
+  "salaryAfterTaxesYearlyTotal": 2450.00,
+  "taxDifferenceMonthly": [0, 0, 0],
+  "taxDifferenceYearlyTotal": 0,
+  "dividendoJurosMonthly": [15.50, 0, 0],
+  "dividendoJurosYearlyTotal": 15.50
+}
+```
+
+**Error Codes:** none — a year with no income data returns all zeros.
+
+## 6. Data Model
+
+None. This feature reads existing `Income` records and stores nothing new.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs` | Unit | `YearlySummaryService` | Salary row sums Gleison + Ariana gross values per month; Salary-after-taxes row sums their net values per month; Tax difference row equals gross minus net per month; Dividendo/Juros row sums only `DividendoJuros` net values; `Lottery` entries contribute to no row; an income with a null `GrossValue` contributes `0` to Salary; entries outside the requested year are excluded; yearly totals equal the sum of their 12 monthly values; a year with no income returns all zeros |
+| `Tests/Financial.Api.Tests/YearlySummaryEndpointsTests.cs` | Integration | `YearlySummaryController` | `GET .../income-summary` returns figures matching a seeded fixture across multiple sources and months |
+| `Financial.Web/src/hooks/useYearlySummary.test.ts` | Hook | `useYearlySummary` | `incomeSummary` reflects the fetched data |
+| `Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx` | Page | `YearlySummaryPage` | Income Summary table renders with the "Income" header row, Salary/Salary-after-taxes/Tax-difference/Dividendo-Juros rows showing the fetched figures, a blank row 5, and no Lottery/tithe/tithe-balance row or label anywhere on the page |
+
+**Acceptance tests (PRD Section 9, F07):**
+- Salary row = sum of Gleison + Ariana gross values per month → `YearlySummaryServiceTests`
+- Salary after taxes row = sum of their net values per month → `YearlySummaryServiceTests`
+- Tax difference row = row 2 minus row 3 per month → `YearlySummaryServiceTests`
+- Dividendo/Juros row = sum of that month's DividendoJuros net values → `YearlySummaryServiceTests`
+- Row 5 renders with no numeric value → `YearlySummaryPage.test.tsx`
+- Lottery, tithe, and tithe balance do not appear anywhere in the Yearly Summary → `YearlySummaryPage.test.tsx`
+
+**Cross-Feature Integration criteria touching F07 (PRD Section 9):**
+- "F07 correctly aggregates F01's income data across all 12 months of the selected year into the Yearly Summary's Income Summary table" — verified directly here: `YearlySummaryServiceTests` seeds `Income` entries (F01's entity) across multiple sources/months and asserts every row of the aggregation

--- a/docs/prd/P14-prd-monthly-income-bank-balance/prd-monthly-income-bank-balance.md
+++ b/docs/prd/P14-prd-monthly-income-bank-balance/prd-monthly-income-bank-balance.md
@@ -303,16 +303,16 @@ graph TD
 - [x] The displayed balance updates immediately after an income entry or expense is saved
 
 ### F07. Yearly Summary Income Rows
-- [ ] The Income Summary table's Salary row (row 2) equals the sum of Gleison and Ariana gross values for each month, matching a manual reference calculation
-- [ ] The Salary after taxes row (row 3) equals the sum of Gleison and Ariana net values for each month
-- [ ] The Tax difference row (row 4) equals row 2 minus row 3 for each month
-- [ ] The Dividendo/Juros row (row 6) equals the sum of that month's DividendoJuros net values
-- [ ] Row 5 renders with no numeric value
-- [ ] Lottery, tithe, and tithe balance do not appear anywhere in the Yearly Summary page
+- [x] The Income Summary table's Salary row (row 2) equals the sum of Gleison and Ariana gross values for each month, matching a manual reference calculation
+- [x] The Salary after taxes row (row 3) equals the sum of Gleison and Ariana net values for each month
+- [x] The Tax difference row (row 4) equals row 2 minus row 3 for each month
+- [x] The Dividendo/Juros row (row 6) equals the sum of that month's DividendoJuros net values
+- [x] Row 5 renders with no numeric value
+- [x] Lottery, tithe, and tithe balance do not appear anywhere in the Yearly Summary page
 
 ### Cross-Feature Integration
 - [x] F03's tithe calculation correctly reads the net income totals produced by F01 for the selected month
 - [x] F04's create/edit/delete actions correctly read and write through F01's `Income` entity contract
 - [ ] F05 correctly displays the income totals from F01 and the tithe/tithe balance from F03 for the selected month
 - [x] F06 correctly combines F01's income data with F02's opening balance and date to produce each bank's balance
-- [ ] F07 correctly aggregates F01's income data across all 12 months of the selected year into the Yearly Summary's Income Summary table
+- [x] F07 correctly aggregates F01's income data across all 12 months of the selected year into the Yearly Summary's Income Summary table


### PR DESCRIPTION
## Summary

Implements **F07 – Yearly Summary Income Rows** from the P14 PRD, per the committed spec/plan in `docs/P14-F07-yearly-summary-income-rows/`.

- New Income Summary table on the Yearly Summary page, laid out like the existing Category Totals table (12 monthly columns + a yearly total), replicating the retired spreadsheet's income block rows: 1 (header), 2 Salary, 3 Salary after taxes, 4 Tax difference, 5 (intentionally blank), 6 Dividendo/Juros
- New `YearlySummaryService.GetIncomeSummaryForYear` (extending the existing service) and `GET /yearly-summary/{year}/income-summary` endpoint
- Salary and Salary-after-taxes rows combine Gleison + Ariana into the same monthly bucket, per the PRD's wording; Lottery contributes to no row; a missing GrossValue contributes 0

Verified live in the browser: seeded a January salary, a March dividend, and an April lottery win, and confirmed the Income Summary table showed the correct figures with zero Lottery/Tithe text anywhere on the page.

## Acceptance Criteria (PRD Section 9 — F07)

- [x] Salary row (row 2) equals the sum of Gleison and Ariana gross values for each month
- [x] Salary after taxes row (row 3) equals the sum of Gleison and Ariana net values for each month
- [x] Tax difference row (row 4) equals row 2 minus row 3 for each month
- [x] Dividendo/Juros row (row 6) equals the sum of that month's DividendoJuros net values
- [x] Row 5 renders with no numeric value
- [x] Lottery, tithe, and tithe balance do not appear anywhere in the Yearly Summary page

## Cross-feature integration

- [x] F07 correctly aggregates F01's income data across all 12 months of the selected year into the Income Summary table

## Test plan

- Backend: 8 new YearlySummaryServiceTests, 1 new integration test
- Frontend: hook and page tests extended; full suite 584 tests passing, tsc/eslint clean, production build succeeds
- Full .NET solution: 1,550 tests passing, 0 failures
- End-to-end Playwright smoke test against the real published app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
