### PR TITLE
feat(P14-F05): monthly incoming and tithe display

### DIFF
--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -39,6 +39,7 @@ import type {
   RecurringBillDto,
   ReserveBucketBalanceDto,
   ReserveMovementDto,
+  TitheSummaryDto,
   TransactionCreateDto,
   TransactionDeleteDto,
   TransactionSummaryItemDto,
@@ -111,6 +112,7 @@ export interface FinancialApiClient {
   updateExpense: (id: string, request: UpdateExpenseDto) => Promise<ExpenseDto>
   deleteExpense: (id: string) => Promise<void>
   getIncomesByMonth: (year: number, month: number) => Promise<IncomeDto[]>
+  getTitheSummaryByMonth: (year: number, month: number) => Promise<TitheSummaryDto>
   createIncome: (request: CreateIncomeDto) => Promise<IncomeDto>
   updateIncome: (id: string, request: UpdateIncomeDto) => Promise<IncomeDto>
   deleteIncome: (id: string) => Promise<void>
@@ -348,6 +350,7 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       }),
     deleteExpense: (id) => requestVoid(`/expenses/${encodeURIComponent(id)}`, { method: 'DELETE' }),
     getIncomesByMonth: (year, month) => request<IncomeDto[]>(`/incomes/month/${year}/${month}`),
+    getTitheSummaryByMonth: (year, month) => request<TitheSummaryDto>(`/tithe/month/${year}/${month}`),
     createIncome: (requestBody) =>
       request<IncomeDto>('/incomes', {
         method: 'POST',

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -400,6 +400,11 @@ export interface BankBalanceDto {
   balance: number
 }
 
+export interface TitheSummaryDto {
+  calculatedTithe: number
+  titheBalance: number
+}
+
 export interface IncomeDto {
   id: string
   date: string

--- a/Financial.Web/src/hooks/useMonthly.test.ts
+++ b/Financial.Web/src/hooks/useMonthly.test.ts
@@ -1,7 +1,15 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FinancialApiClient } from '../api/financialApiClient'
-import type { BankBalanceDto, BankDto, CardStatementDto, CategoryTotalDto, ExpenseDto, IncomeDto } from '../api/types'
+import type {
+  BankBalanceDto,
+  BankDto,
+  CardStatementDto,
+  CategoryTotalDto,
+  ExpenseDto,
+  IncomeDto,
+  TitheSummaryDto,
+} from '../api/types'
 import { useMonthly } from './useMonthly'
 
 const NOW = new Date()
@@ -26,6 +34,7 @@ const createIncomeMock = vi.fn<FinancialApiClient['createIncome']>()
 const updateIncomeMock = vi.fn<FinancialApiClient['updateIncome']>()
 const deleteIncomeMock = vi.fn<FinancialApiClient['deleteIncome']>()
 const getBankBalancesByMonthMock = vi.fn<FinancialApiClient['getBankBalancesByMonth']>()
+const getTitheSummaryByMonthMock = vi.fn<FinancialApiClient['getTitheSummaryByMonth']>()
 
 vi.mock('../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
@@ -43,6 +52,7 @@ vi.mock('../api/financialApiClient', () => ({
     updateIncome: updateIncomeMock,
     deleteIncome: deleteIncomeMock,
     getBankBalancesByMonth: getBankBalancesByMonthMock,
+    getTitheSummaryByMonth: getTitheSummaryByMonthMock,
   }),
 }))
 
@@ -92,6 +102,8 @@ const BANK_BALANCES: BankBalanceDto[] = [
   { bank: 'Chase', balance: 0 },
 ]
 
+const TITHE_SUMMARY: TitheSummaryDto = { calculatedTithe: 245, titheBalance: 245 }
+
 describe('useMonthly', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -101,6 +113,7 @@ describe('useMonthly', () => {
     getBanksMock.mockResolvedValue(BANKS)
     getIncomesByMonthMock.mockResolvedValue(INCOMES)
     getBankBalancesByMonthMock.mockResolvedValue(BANK_BALANCES)
+    getTitheSummaryByMonthMock.mockResolvedValue(TITHE_SUMMARY)
     vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
 
@@ -550,5 +563,32 @@ describe('useMonthly', () => {
     await waitFor(() =>
       expect(updateExpenseMock).toHaveBeenCalledWith('e9', expect.objectContaining({ roundUpAmount: null })),
     )
+  })
+
+  it('fetches the tithe summary for the current month and exposes it', async () => {
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(getTitheSummaryByMonthMock).toHaveBeenCalledWith(CURRENT_YEAR, CURRENT_MONTH)
+    expect(result.current.titheSummary).toEqual(TITHE_SUMMARY)
+  })
+
+  it('groups income totals by source, summing net values and gross values only when present', async () => {
+    getIncomesByMonthMock.mockResolvedValue([
+      { id: 'i1', date: `${CURRENT_YEAR}-07-01`, incomeSource: 'Ariana', grossValue: 400, netValue: 350, bank: 'Chase' },
+      { id: 'i2', date: `${CURRENT_YEAR}-07-08`, incomeSource: 'Ariana', grossValue: 420, netValue: 370, bank: 'Chase' },
+      { id: 'i3', date: `${CURRENT_YEAR}-07-10`, incomeSource: 'Lottery', grossValue: null, netValue: 50, bank: 'Chase' },
+    ])
+    const { result } = renderHook(() => useMonthly())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.incomeTotals).toEqual(
+      expect.arrayContaining([
+        { source: 'Ariana', netValue: 720, grossValue: 820 },
+        { source: 'Lottery', netValue: 50, grossValue: null },
+      ]),
+    )
+    expect(result.current.incomeTotals).toHaveLength(2)
+    expect(result.current.totalIncoming).toBe(770)
   })
 })

--- a/Financial.Web/src/hooks/useMonthly.ts
+++ b/Financial.Web/src/hooks/useMonthly.ts
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { createFinancialApiClient } from '../api/financialApiClient'
-import type { BankBalanceDto, BankDto, CardStatementDto, CategoryTotalDto, ExpenseDto, IncomeDto } from '../api/types'
+import type {
+  BankBalanceDto,
+  BankDto,
+  CardStatementDto,
+  CategoryTotalDto,
+  ExpenseDto,
+  IncomeDto,
+  TitheSummaryDto,
+} from '../api/types'
 import { currentYearMonth, formatMonthInputValue, parseMonthInputValue } from '../utils/formatters'
 
 export type PaymentMode = 'bank' | 'card'
@@ -32,6 +40,12 @@ export interface BankTotal {
   bank: string
   balance: number
   roundUpTotal: number
+}
+
+export interface IncomeTotal {
+  source: string
+  netValue: number
+  grossValue: number | null
 }
 
 export type CreateFormField =
@@ -73,6 +87,7 @@ interface MonthlyState {
   banks: BankDto[]
   bankBalances: BankBalanceDto[]
   incomes: IncomeDto[]
+  titheSummary: TitheSummaryDto | null
   isLoading: boolean
   error: string | null
   retryCount: number
@@ -130,6 +145,7 @@ type MonthlyAction =
         banks: BankDto[]
         bankBalances: BankBalanceDto[]
         incomes: IncomeDto[]
+        titheSummary: TitheSummaryDto
       }
     }
   | { type: 'FETCH_ERROR'; payload: string }
@@ -193,6 +209,7 @@ const INITIAL_STATE: MonthlyState = {
   banks: [],
   bankBalances: [],
   incomes: [],
+  titheSummary: null,
   isLoading: true,
   error: null,
   retryCount: 0,
@@ -245,6 +262,7 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
         banks: action.payload.banks,
         bankBalances: action.payload.bankBalances,
         incomes: action.payload.incomes,
+        titheSummary: action.payload.titheSummary,
         createPaymentSource: defaultBankStillUnset
           ? (action.payload.banks[0]?.name ?? '')
           : state.createPaymentSource,
@@ -514,6 +532,9 @@ export interface MonthlyData {
   markStatementPaid: (id: string, paymentSource: string) => void
   unmarkStatementPaid: (id: string) => void
   incomes: IncomeDto[]
+  incomeTotals: IncomeTotal[]
+  totalIncoming: number
+  titheSummary: TitheSummaryDto | null
   isIncomeCreateFormOpen: boolean
   createIncomeDate: string
   createIncomeSource: string
@@ -554,11 +575,12 @@ export function useMonthly(): MonthlyData {
       apiClient.getBanks(),
       apiClient.getIncomesByMonth(state.year, state.month),
       apiClient.getBankBalancesByMonth(state.year, state.month),
+      apiClient.getTitheSummaryByMonth(state.year, state.month),
     ])
-      .then(([expenses, categoryTotals, cardStatements, banks, incomes, bankBalances]) =>
+      .then(([expenses, categoryTotals, cardStatements, banks, incomes, bankBalances, titheSummary]) =>
         dispatch({
           type: 'FETCH_SUCCESS',
-          payload: { expenses, categoryTotals, cardStatements, banks, incomes, bankBalances },
+          payload: { expenses, categoryTotals, cardStatements, banks, incomes, bankBalances, titheSummary },
         }),
       )
       .catch((err: unknown) => {
@@ -964,6 +986,26 @@ export function useMonthly(): MonthlyData {
   const bankTotalsSum = bankTotals.reduce((sum, b) => sum + b.balance, 0)
   const roundUpTotalsSum = bankTotals.reduce((sum, b) => sum + b.roundUpTotal, 0)
 
+  const incomeTotals: IncomeTotal[] = Array.from(
+    state.incomes
+      .reduce((bySource, income) => {
+        const entry = bySource.get(income.incomeSource) ?? { netValue: 0, grossValue: 0, hasGross: false }
+        entry.netValue += income.netValue
+        if (income.grossValue != null) {
+          entry.grossValue += income.grossValue
+          entry.hasGross = true
+        }
+        bySource.set(income.incomeSource, entry)
+        return bySource
+      }, new Map<string, { netValue: number; grossValue: number; hasGross: boolean }>())
+      .entries(),
+  ).map(([source, v]) => ({
+    source,
+    netValue: v.netValue,
+    grossValue: v.hasGross ? v.grossValue : null,
+  }))
+  const totalIncoming = incomeTotals.reduce((sum, i) => sum + i.netValue, 0)
+
   return {
     monthInputValue,
     setMonthInputValue,
@@ -1018,6 +1060,9 @@ export function useMonthly(): MonthlyData {
     markStatementPaid,
     unmarkStatementPaid,
     incomes: state.incomes,
+    incomeTotals,
+    totalIncoming,
+    titheSummary: state.titheSummary,
     isIncomeCreateFormOpen: state.isIncomeCreateFormOpen,
     createIncomeDate: state.createIncomeDate,
     createIncomeSource: state.createIncomeSource,

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -439,6 +439,9 @@ export default function MonthlyPage() {
     cancelEditIncome,
     saveEditIncome,
     deleteIncome,
+    incomeTotals,
+    totalIncoming,
+    titheSummary,
   } = useMonthly()
 
   const isEditing = editingId !== null
@@ -620,6 +623,42 @@ export default function MonthlyPage() {
               </div>
               <p className="monthly-page__section-total">
                 Bank Balance: <strong>{formatN2(bankTotalsSum)}</strong> · Round-Up: <strong>{formatN2(roundUpTotalsSum)}</strong>
+              </p>
+            </section>
+
+            <section className="monthly-page__section monthly-page__section--grid">
+              <h2>Incoming</h2>
+              <div className="monthly-page__table-scroll">
+                <table className="monthly-page__table data-table">
+                  <thead>
+                    <tr>
+                      <th>Source</th>
+                      <th className="data-table__col--numeric">Gross</th>
+                      <th className="data-table__col--numeric">Net</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {incomeTotals.map((i) => (
+                      <tr key={i.source}>
+                        <td>{i.source}</td>
+                        <td className="data-table__col--numeric">
+                          {i.grossValue != null ? formatN2(i.grossValue) : '—'}
+                        </td>
+                        <td className="data-table__col--numeric">{formatN2(i.netValue)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="monthly-page__section-total">
+                Total Incoming: <strong>{formatN2(totalIncoming)}</strong>
+                {titheSummary && (
+                  <>
+                    {' '}
+                    · Calculated Tithe: <strong>{formatN2(titheSummary.calculatedTithe)}</strong> · Tithe Balance:{' '}
+                    <strong>{formatN2(titheSummary.titheBalance)}</strong>
+                  </>
+                )}
               </p>
             </section>
           </div>

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -2,7 +2,15 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import MonthlyPage from '../MonthlyPage'
 import type { FinancialApiClient } from '../../api/financialApiClient'
-import type { BankBalanceDto, BankDto, CardStatementDto, CategoryTotalDto, ExpenseDto, IncomeDto } from '../../api/types'
+import type {
+  BankBalanceDto,
+  BankDto,
+  CardStatementDto,
+  CategoryTotalDto,
+  ExpenseDto,
+  IncomeDto,
+  TitheSummaryDto,
+} from '../../api/types'
 
 const getExpensesByMonthMock = vi.fn<FinancialApiClient['getExpensesByMonth']>()
 const getCategoryTotalsByMonthMock = vi.fn<FinancialApiClient['getCategoryTotalsByMonth']>()
@@ -18,6 +26,7 @@ const createIncomeMock = vi.fn<FinancialApiClient['createIncome']>()
 const updateIncomeMock = vi.fn<FinancialApiClient['updateIncome']>()
 const deleteIncomeMock = vi.fn<FinancialApiClient['deleteIncome']>()
 const getBankBalancesByMonthMock = vi.fn<FinancialApiClient['getBankBalancesByMonth']>()
+const getTitheSummaryByMonthMock = vi.fn<FinancialApiClient['getTitheSummaryByMonth']>()
 
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
@@ -35,6 +44,7 @@ vi.mock('../../api/financialApiClient', () => ({
     updateIncome: updateIncomeMock,
     deleteIncome: deleteIncomeMock,
     getBankBalancesByMonth: getBankBalancesByMonthMock,
+    getTitheSummaryByMonth: getTitheSummaryByMonthMock,
   }),
 }))
 
@@ -77,6 +87,8 @@ const BANK_BALANCES: BankBalanceDto[] = [
   { bank: 'Chase', balance: 0 },
 ]
 
+const TITHE_SUMMARY: TitheSummaryDto = { calculatedTithe: 245, titheBalance: 245 }
+
 describe('MonthlyPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -86,6 +98,7 @@ describe('MonthlyPage', () => {
     getBanksMock.mockResolvedValue(BANKS)
     getIncomesByMonthMock.mockResolvedValue(INCOMES)
     getBankBalancesByMonthMock.mockResolvedValue(BANK_BALANCES)
+    getTitheSummaryByMonthMock.mockResolvedValue(TITHE_SUMMARY)
     vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
 
@@ -346,7 +359,7 @@ describe('MonthlyPage', () => {
     updateIncomeMock.mockResolvedValue({ ...INCOMES[0], netValue: 500 })
     render(<MonthlyPage />)
 
-    await waitFor(() => expect(screen.getByText('Gleison')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Edit income' }).length).toBeGreaterThan(0))
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Edit income' })[0])
     expect(screen.getByText('Edit Income')).toBeInTheDocument()
@@ -365,10 +378,48 @@ describe('MonthlyPage', () => {
     deleteIncomeMock.mockResolvedValue(undefined)
     render(<MonthlyPage />)
 
-    await waitFor(() => expect(screen.getByText('Gleison')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Delete income' }).length).toBeGreaterThan(0))
     fireEvent.click(screen.getAllByRole('button', { name: 'Delete income' })[0])
 
     await waitFor(() => expect(deleteIncomeMock).toHaveBeenCalledWith('i1'))
+  })
+
+  it('renders the Incoming card with one row per source and the calculated tithe and tithe balance', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByText('Incoming')).toBeInTheDocument())
+    const incomingSection = within(screen.getByText('Incoming').closest('section')!)
+    expect(incomingSection.getByRole('cell', { name: 'Gleison' })).toBeInTheDocument()
+    expect(incomingSection.getByText('3,200.00')).toBeInTheDocument()
+    expect(incomingSection.getAllByText('2,450.00').length).toBeGreaterThanOrEqual(1)
+    expect(incomingSection.getByText(/Total Incoming:/)).toBeInTheDocument()
+    expect(incomingSection.getByText(/Calculated Tithe:/)).toBeInTheDocument()
+    expect(incomingSection.getByText(/Tithe Balance:/)).toBeInTheDocument()
+  })
+
+  it('updates the Incoming card after a new income entry is added', async () => {
+    createIncomeMock.mockResolvedValue({ id: 'i2', date: '2026-07-15', incomeSource: 'Lottery', grossValue: null, netValue: 100, bank: 'Chase' })
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New Income' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'New Income' }))
+    fireEvent.change(screen.getByLabelText('Date'), { target: { value: '2026-07-15' } })
+    fireEvent.change(screen.getByLabelText('Source'), { target: { value: 'Lottery' } })
+    fireEvent.change(screen.getByLabelText('Net Value'), { target: { value: '100' } })
+
+    getIncomesByMonthMock.mockResolvedValue([...INCOMES, {
+      id: 'i2',
+      date: '2026-07-15',
+      incomeSource: 'Lottery',
+      grossValue: null,
+      netValue: 100,
+      bank: 'Chase',
+    }])
+    fireEvent.click(screen.getByRole('button', { name: 'Add Income' }))
+
+    await waitFor(() => expect(createIncomeMock).toHaveBeenCalled())
+    const incomingSection = within(screen.getByText('Incoming').closest('section')!)
+    await waitFor(() => expect(incomingSection.getByRole('cell', { name: 'Lottery' })).toBeInTheDocument())
   })
 
   it('bank picker and mark-paid picker list banks fetched from the API', async () => {

--- a/docs/P14-F05-monthly-incoming-tithe-display/plan.md
+++ b/docs/P14-F05-monthly-incoming-tithe-display/plan.md
@@ -1,0 +1,13 @@
+# Implementation Plan: Monthly Incoming and Tithe Display
+
+**Prerequisites:**
+- Node/npm toolchain already configured for `Financial.Web`
+- No backend changes and no new dependencies — F01 and F03's API contracts already exist
+
+### Stage 1: Fetch Tithe Data and Derive Income Totals
+
+**1. Tithe Summary Client Call and Income Grouping** - Add the tithe summary type and API client method for F03's existing endpoint, fetch it alongside the Monthly page's other month-scoped data, and derive a per-income-source summary (net total, and gross total where applicable) from the income entries already being fetched for the income form and list.
+
+### Stage 2: Incoming Card
+
+**2. Render the Incoming Card** - Add a new card to the Monthly page's grid row showing one row per income source present that month, plus a summary line with the total incoming amount, the calculated tithe, and the tithe balance.

--- a/docs/P14-F05-monthly-incoming-tithe-display/spec.md
+++ b/docs/P14-F05-monthly-incoming-tithe-display/spec.md
@@ -1,0 +1,76 @@
+# F05. Monthly Incoming and Tithe Display
+
+## 1. Technical Overview
+
+**What:** A new "Incoming" card on the Monthly page, alongside the existing Category Totals, Cards, and Banks cards: one row per `IncomeSource` present that month showing its summed `NetValue` (Gleison/Ariana rows also show summed `GrossValue`), plus the month's calculated tithe and tithe balance from F03.
+
+**Why:** F01 and F03 are both fully-shipped backend contracts with no UI of their own yet — F01's income data is already being fetched by `useMonthly` for the income form/list (F04), and F03's tithe endpoint exists but nothing on the frontend calls it. This feature is the last piece that makes both visible together on the page the developer already checks after every entry, the same "immediately visible" pattern every other panel on this page already follows.
+
+**Scope:**
+- Included: `TitheSummaryDto` + `getTitheSummaryByMonth` API client method (F03's backend contract has existed since its own feature; only the frontend call was missing); `useMonthly` fetches it alongside the rest of the month's data; a client-side `incomeTotals` derivation grouping the already-fetched `incomes` by `IncomeSource`; a new "Incoming" card in `MonthlyPage`'s grids row.
+- Excluded: any backend change (F01 and F03's contracts are already complete and unmodified by this feature); the Income entry form/list itself (F04, already shipped).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/api/types.ts` — `TitheSummaryDto`
+- `Financial.Web/src/api/financialApiClient.ts` — `getTitheSummaryByMonth`
+- `Financial.Web/src/hooks/useMonthly.ts` — fetches `titheSummary`; derives `incomeTotals` from the already-fetched `incomes`
+- `Financial.Web/src/pages/MonthlyPage.tsx` — new "Incoming" card
+
+```mermaid
+graph TD
+  A[useMonthly] --> B["financialApiClient.getTitheSummaryByMonth"]
+  B --> C["GET /tithe/month/{year}/{month} (F03, already live)"]
+  A --> D["state.incomes (F01, already fetched for F04)"]
+  D --> E["incomeTotals derivation (client-side groupby)"]
+  F[MonthlyPage] --> G["Incoming card"]
+  A --> F
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Where `incomeTotals` is computed | Client-side, grouping the `incomes` array `useMonthly` already fetches for the income form/list (F04) | A new backend endpoint (e.g. `GET /incomes/month/{year}/{month}/totals`, mirroring `GetCategoryTotalsByMonth`) | The data needed (that month's `Income` rows) is already on the client in full — F04 already fetches every field this card needs. A grouping reduction over an array already in memory is a client-side concern; adding a backend endpoint here would duplicate `GetExpensesByMonth`+`GetCategoryTotalsByMonth`'s existing "raw list vs. pre-aggregated" split for no reason, since nothing here needs data beyond what's already fetched |
+| Which sources get a row | Only `IncomeSource` values with at least one entry that month (derived by grouping, not by enumerating all 4 enum values) | Always render all 4 sources, zero-filled when absent | Mirrors exactly how the existing Category Totals card behaves — it lists only categories with expense data that month, not the full `Category` enum. `IncomeSource` is a smaller, similarly-shaped enum; treating it the same way keeps the two "totals" cards on this page consistent with each other |
+| Gross value display | A source's row shows a Gross column figure only if at least one of its entries that month has a non-null `GrossValue`; otherwise the cell reads "—" (matching `IncomeSection`'s existing null-gross placeholder) | Hard-code "show Gross only for Gleison/Ariana" | The domain already enforces that only `Gleison`/`Ariana` entries carry a `GrossValue` (F04's form only shows the field for those two sources) — deriving "has gross" from the data itself is equivalent in practice and avoids a second, redundant source-name check that could drift out of sync with the domain rule |
+| Tithe display | `Calculated Tithe` and `Tithe Balance` shown in the card's footer summary line (mirrors the Banks card's `Bank Balance: X · Round-Up: Y` footer pattern), not as table rows | Add "Tithe" and "Tithe Balance" as extra rows in the same table as the income sources | The PRD's F05 Capabilities describe the tithe/tithe balance as accompanying the per-source rows, "clearly labeled" — not as rows sharing the same Source/Gross/Net columns (which don't make sense for a single derived figure). The footer-summary pattern already used by every other card on this page is the natural fit |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/api/types.ts` | Modified | DTO | `TitheSummaryDto { calculatedTithe: number, titheBalance: number }` |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | HTTP method | `getTitheSummaryByMonth(year, month)` → `GET /tithe/month/${year}/${month}` |
+| `Financial.Web/src/hooks/useMonthly.ts` | Modified | State + derivation | `titheSummary: TitheSummaryDto \| null` fetched in the existing `Promise.all`; `incomeTotals: IncomeTotal[]` (`{ source, netValue, grossValue: number \| null }`) derived from `state.incomes` by grouping on `incomeSource`, summing `netValue` always and `grossValue` only when at least one entry in the group has a non-null value; `totalIncoming` = sum of `incomeTotals[].netValue` |
+| `Financial.Web/src/pages/MonthlyPage.tsx` | Modified | New card | "Incoming" `<section>` added to `.monthly-page__grids-row` alongside Category Totals/Cards/Banks; table columns Source/Gross/Net, one row per `incomeTotals` entry; footer line "Total Incoming: X · Calculated Tithe: Y · Tithe Balance: Z" |
+
+## 5. UX Flow
+
+- The Incoming card is populated from the same month-scoped fetch every other panel on the page already uses; adding, editing, or deleting an income entry (F04) or any expense (including a `Dizimo`-category one) triggers the existing `RETRY`-driven refetch, which re-pulls both `incomes` and `titheSummary` together — no new refresh mechanism needed, since both already live inside the one `Promise.all` this hook already re-runs on every mutation.
+
+## 6. API Contracts
+
+No new backend endpoints. This feature is the frontend's first caller of F03's existing `GET /tithe/month/{year}/{month}` (documented in F03's own spec) and reuses F01's existing `GET /incomes/month/{year}/{month}` (already called by `useMonthly` for F04).
+
+## 7. Data Model
+
+None. No new storage.
+
+## 8. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Financial.Web/src/hooks/useMonthly.test.ts` | Hook | `useMonthly` | `titheSummary` reflects the fetched tithe data; `incomeTotals` groups multiple entries of the same source into one row, summing `netValue`; a source with no `GrossValue` on any entry shows `grossValue: null`; a source with at least one `GrossValue` sums only the non-null ones; `totalIncoming` equals the sum across all sources; a source with no income that month produces no row |
+| `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` | Page | `MonthlyPage` | Incoming card shows one row per source present that month with the correct summed net (and gross, where applicable) values; the footer shows the calculated tithe and tithe balance from the mocked tithe endpoint; adding a new income entry causes the card to reflect the updated totals after refetch |
+
+**Acceptance tests (PRD Section 9, F05):**
+- One row per `IncomeSource` with the correct summed value → `useMonthly.test.ts`, `MonthlyPage.test.tsx`
+- Calculated tithe and tithe balance shown → `MonthlyPage.test.tsx`
+- Card updates immediately after an income entry or Dizimo expense change → guaranteed by the existing shared `RETRY`-triggered refetch already covered by F04's mutation tests; `MonthlyPage.test.tsx` adds one direct assertion for the income-add case
+
+**Cross-Feature Integration criteria touching F05 (PRD Section 9):**
+- "F05 correctly displays the income totals from F01 and the tithe/tithe balance from F03 for the selected month" — verified directly here: `MonthlyPage.test.tsx` mocks both `getIncomesByMonth` (F01) and `getTitheSummaryByMonth` (F03) and asserts the card renders both correctly combined

--- a/docs/prd/P14-prd-monthly-income-bank-balance/prd-monthly-income-bank-balance.md
+++ b/docs/prd/P14-prd-monthly-income-bank-balance/prd-monthly-income-bank-balance.md
@@ -292,9 +292,9 @@ graph TD
 - [x] Saving an entry with no bank selected, a negative net value, or gross less than net is rejected with a validation message
 
 ### F05. Monthly Incoming and Tithe Display
-- [ ] The Incoming card shows one row per `IncomeSource` with the correct summed value for the selected month
-- [ ] The Incoming card shows the calculated tithe and tithe balance for the selected month
-- [ ] The Incoming card updates immediately after an income entry or a Dizimo-category expense is added, edited, or deleted
+- [x] The Incoming card shows one row per `IncomeSource` with the correct summed value for the selected month
+- [x] The Incoming card shows the calculated tithe and tithe balance for the selected month
+- [x] The Incoming card updates immediately after an income entry or a Dizimo-category expense is added, edited, or deleted
 
 ### F06. Real Bank Balance
 - [x] A bank's displayed balance equals `OpeningBalance + Σ(Income.NetValue) − Σ(Expense.Value − Expense.RoundUpAmount)` for that bank from its `OpeningBalanceDate` through the selected month, matching a manual reference calculation to the penny
@@ -313,6 +313,6 @@ graph TD
 ### Cross-Feature Integration
 - [x] F03's tithe calculation correctly reads the net income totals produced by F01 for the selected month
 - [x] F04's create/edit/delete actions correctly read and write through F01's `Income` entity contract
-- [ ] F05 correctly displays the income totals from F01 and the tithe/tithe balance from F03 for the selected month
+- [x] F05 correctly displays the income totals from F01 and the tithe/tithe balance from F03 for the selected month
 - [x] F06 correctly combines F01's income data with F02's opening balance and date to produce each bank's balance
 - [x] F07 correctly aggregates F01's income data across all 12 months of the selected year into the Yearly Summary's Income Summary table


### PR DESCRIPTION
## Summary

Implements **F05 – Monthly Incoming and Tithe Display** from the P14 PRD, per the committed spec/plan in `docs/P14-F05-monthly-incoming-tithe-display/`. This is the final feature in P14 — closing it out completely.

- New "Incoming" card on the Monthly page, alongside Category Totals, Cards, and Banks: one row per `IncomeSource` present that month with its summed Net value (Gleison/Ariana rows also show summed Gross), plus a footer with Total Incoming, Calculated Tithe, and Tithe Balance
- No backend changes — F01's income data was already being fetched for the F04 form/list, and F03's tithe endpoint has existed since its own feature; this is simply the frontend's first caller of it
- `incomeTotals` is derived client-side by grouping the already-fetched `incomes` array (no new endpoint), mirroring exactly how the existing Category Totals card only lists categories with data that month rather than the full enum
- The card updates immediately after any income or expense mutation for free, since both `incomes` and `titheSummary` are fetched in the same `Promise.all` every other panel on this page already re-runs on every `RETRY`

**Verified live in the browser**: seeded a Gleison paycheck, an Ariana paycheck, and a £100 Dizimo expense; confirmed the Incoming card showed both income rows with correct Gross/Net figures and the exact footer "Total Incoming: 2,800.00 · Calculated Tithe: 280.00 · Tithe Balance: 180.00" (10% of £2,800 minus the £100 already paid) — screenshot captured during this run, alongside confirmation that the Bank Balance card correctly reflects the same income and expense.

## Acceptance Criteria (PRD Section 9 — F05)

- [x] The Incoming card shows one row per `IncomeSource` with the correct summed value for the selected month
- [x] The Incoming card shows the calculated tithe and tithe balance for the selected month
- [x] The Incoming card updates immediately after an income entry or a Dizimo-category expense is added, edited, or deleted

## Cross-feature integration

- [x] F05 correctly displays the income totals from F01 and the tithe/tithe balance from F03 for the selected month — all three features are now implemented and verified together live

## Test plan

- `useMonthly.test.ts`: 2 new tests — tithe summary fetched/exposed; income totals correctly grouped by source with gross summed only when present
- `MonthlyPage.test.tsx`: 2 new tests — Incoming card renders rows + tithe footer; card updates after a new income entry is added; 2 pre-existing income tests fixed for the now-ambiguous "Gleison" text (appears in both the income list and the new card)
- Full frontend suite: 45 files, 588 tests passing; `tsc -b --noEmit` and `eslint .` clean; production build succeeds
- Full .NET solution: unaffected, still green (14 test projects, 0 failures) — this PR is frontend-only
- End-to-end Playwright smoke test against the real published app confirming the exact calculated figures with no console errors

**This completes PRD P14 (Monthly Income Tracking and Real Bank Balance) — all 7 features (F01-F07) implemented and merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
