### PR TITLE
feat(P15-F01): Monthly tab navigation shell

### DIFF
--- a/Financial.Web/src/pages/MonthlyPage.css
+++ b/Financial.Web/src/pages/MonthlyPage.css
@@ -21,6 +21,33 @@
   gap: 8px;
 }
 
+.monthly-page__tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border, #e5e4e7);
+  flex-shrink: 0;
+}
+
+.monthly-page__tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 8px 16px;
+  color: var(--text, #333);
+  margin-bottom: -1px;
+}
+
+.monthly-page__tab:hover {
+  color: #007acc;
+}
+
+.monthly-page__tab--active {
+  border-bottom-color: #007acc;
+  font-weight: 600;
+  color: #007acc;
+}
+
 .monthly-page__form-panel {
   flex-shrink: 0;
   padding: 12px 16px;

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import ErrorState from '../components/ErrorState'
 import ExpensesSection from '../components/ExpensesSection'
 import IncomeSection from '../components/IncomeSection'
@@ -14,6 +15,14 @@ import {
 import type { BankDto } from '../api/types'
 import { formatN2 } from '../utils/formatters'
 import './MonthlyPage.css'
+
+type MonthlyTabId = 'summary' | 'expense' | 'incoming'
+
+const MONTHLY_TABS: { id: MonthlyTabId; label: string }[] = [
+  { id: 'summary', label: 'Summary' },
+  { id: 'expense', label: 'Expense' },
+  { id: 'incoming', label: 'Incoming' },
+]
 
 type ExpenseFormField = 'date' | 'description' | 'value' | 'category' | 'paymentSource' | 'cardTag' | 'roundUpAmount'
 
@@ -444,10 +453,24 @@ export default function MonthlyPage() {
     titheSummary,
   } = useMonthly()
 
+  const [activeTab, setActiveTab] = useState<MonthlyTabId>('summary')
+
   const isEditing = editingId !== null
   const isFormVisible = isCreateFormOpen || isEditing
   const isIncomeEditing = editingIncomeId !== null
   const isIncomeFormVisible = isIncomeCreateFormOpen || isIncomeEditing
+
+  const handleTabClick = (tabId: MonthlyTabId) => {
+    if (activeTab === 'expense' && isFormVisible) {
+      if (isEditing) cancelEdit()
+      else cancelCreateForm()
+    }
+    if (activeTab === 'incoming' && isIncomeFormVisible) {
+      if (isIncomeEditing) cancelEditIncome()
+      else cancelCreateIncomeForm()
+    }
+    setActiveTab(tabId)
+  }
 
   return (
     <div className="monthly-page">
@@ -463,52 +486,18 @@ export default function MonthlyPage() {
         </div>
       </div>
 
-      {isFormVisible && (
-        <ExpenseForm
-          isEditing={isEditing}
-          date={isEditing ? editDate : createDate}
-          description={isEditing ? editDescription : createDescription}
-          value={isEditing ? editValue : createValue}
-          category={isEditing ? editCategory : createCategory}
-          paymentSource={isEditing ? editPaymentSource : createPaymentSource}
-          cardTag={isEditing ? editCardTag : createCardTag}
-          roundUpAmount={isEditing ? editRoundUpAmount : createRoundUpAmount}
-          paymentMode={isEditing ? editPaymentMode : createPaymentMode}
-          banks={banks}
-          isSettled={isEditing && editIsSettled}
-          isSaving={isEditing ? isSaving : isCreating}
-          saveError={isEditing ? saveError : createError}
-          onFieldChange={(field, value) =>
-            isEditing
-              ? setEditField(EDIT_FIELD_BY_FORM_FIELD[field], value)
-              : setCreateField(CREATE_FIELD_BY_FORM_FIELD[field], value)
-          }
-          onModeChange={isEditing ? setEditPaymentMode : setCreatePaymentMode}
-          onSave={isEditing ? saveEdit : submitCreate}
-          onCancel={isEditing ? cancelEdit : cancelCreateForm}
-        />
-      )}
-
-      {isIncomeFormVisible && (
-        <IncomeForm
-          isEditing={isIncomeEditing}
-          date={isIncomeEditing ? editIncomeDate : createIncomeDate}
-          incomeSource={isIncomeEditing ? editIncomeSource : createIncomeSource}
-          grossValue={isIncomeEditing ? editIncomeGrossValue : createIncomeGrossValue}
-          netValue={isIncomeEditing ? editIncomeNetValue : createIncomeNetValue}
-          bank={isIncomeEditing ? editIncomeBank : createIncomeBank}
-          banks={banks}
-          isSaving={isIncomeEditing ? isSavingIncome : isCreatingIncome}
-          saveError={isIncomeEditing ? saveIncomeError : createIncomeError}
-          onFieldChange={(field, value) =>
-            isIncomeEditing
-              ? setEditIncomeField(EDIT_INCOME_FIELD_BY_FORM_FIELD[field], value)
-              : setCreateIncomeField(CREATE_INCOME_FIELD_BY_FORM_FIELD[field], value)
-          }
-          onSave={isIncomeEditing ? saveEditIncome : submitCreateIncome}
-          onCancel={isIncomeEditing ? cancelEditIncome : cancelCreateIncomeForm}
-        />
-      )}
+      <div className="monthly-page__tabs">
+        {MONTHLY_TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            className={`monthly-page__tab${activeTab === tab.id ? ' monthly-page__tab--active' : ''}`}
+            onClick={() => handleTabClick(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
 
       {isLoading ? (
         <LoadingState />
@@ -516,6 +505,7 @@ export default function MonthlyPage() {
         <ErrorState message={error} onRetry={retry} />
       ) : (
         <div className="monthly-page__content">
+          {activeTab === 'summary' && (
           <div className="monthly-page__grids-row">
             <section className="monthly-page__section monthly-page__section--grid">
               <h2>Category Totals</h2>
@@ -662,20 +652,76 @@ export default function MonthlyPage() {
               </p>
             </section>
           </div>
+          )}
 
-          <ExpensesSection
-            expenses={expenses}
-            onEdit={showEditForm}
-            onDelete={deleteExpense}
-            onNewExpense={showCreateForm}
-          />
+          {activeTab === 'expense' && (
+            <>
+              {isFormVisible && (
+                <ExpenseForm
+                  isEditing={isEditing}
+                  date={isEditing ? editDate : createDate}
+                  description={isEditing ? editDescription : createDescription}
+                  value={isEditing ? editValue : createValue}
+                  category={isEditing ? editCategory : createCategory}
+                  paymentSource={isEditing ? editPaymentSource : createPaymentSource}
+                  cardTag={isEditing ? editCardTag : createCardTag}
+                  roundUpAmount={isEditing ? editRoundUpAmount : createRoundUpAmount}
+                  paymentMode={isEditing ? editPaymentMode : createPaymentMode}
+                  banks={banks}
+                  isSettled={isEditing && editIsSettled}
+                  isSaving={isEditing ? isSaving : isCreating}
+                  saveError={isEditing ? saveError : createError}
+                  onFieldChange={(field, value) =>
+                    isEditing
+                      ? setEditField(EDIT_FIELD_BY_FORM_FIELD[field], value)
+                      : setCreateField(CREATE_FIELD_BY_FORM_FIELD[field], value)
+                  }
+                  onModeChange={isEditing ? setEditPaymentMode : setCreatePaymentMode}
+                  onSave={isEditing ? saveEdit : submitCreate}
+                  onCancel={isEditing ? cancelEdit : cancelCreateForm}
+                />
+              )}
 
-          <IncomeSection
-            incomes={incomes}
-            onEdit={showEditIncomeForm}
-            onDelete={deleteIncome}
-            onNewIncome={showCreateIncomeForm}
-          />
+              <ExpensesSection
+                expenses={expenses}
+                onEdit={showEditForm}
+                onDelete={deleteExpense}
+                onNewExpense={showCreateForm}
+              />
+            </>
+          )}
+
+          {activeTab === 'incoming' && (
+            <>
+              {isIncomeFormVisible && (
+                <IncomeForm
+                  isEditing={isIncomeEditing}
+                  date={isIncomeEditing ? editIncomeDate : createIncomeDate}
+                  incomeSource={isIncomeEditing ? editIncomeSource : createIncomeSource}
+                  grossValue={isIncomeEditing ? editIncomeGrossValue : createIncomeGrossValue}
+                  netValue={isIncomeEditing ? editIncomeNetValue : createIncomeNetValue}
+                  bank={isIncomeEditing ? editIncomeBank : createIncomeBank}
+                  banks={banks}
+                  isSaving={isIncomeEditing ? isSavingIncome : isCreatingIncome}
+                  saveError={isIncomeEditing ? saveIncomeError : createIncomeError}
+                  onFieldChange={(field, value) =>
+                    isIncomeEditing
+                      ? setEditIncomeField(EDIT_INCOME_FIELD_BY_FORM_FIELD[field], value)
+                      : setCreateIncomeField(CREATE_INCOME_FIELD_BY_FORM_FIELD[field], value)
+                  }
+                  onSave={isIncomeEditing ? saveEditIncome : submitCreateIncome}
+                  onCancel={isIncomeEditing ? cancelEditIncome : cancelCreateIncomeForm}
+                />
+              )}
+
+              <IncomeSection
+                incomes={incomes}
+                onEdit={showEditIncomeForm}
+                onDelete={deleteIncome}
+                onNewIncome={showCreateIncomeForm}
+              />
+            </>
+          )}
         </div>
       )}
     </div>

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -117,22 +117,134 @@ describe('MonthlyPage', () => {
     expect(screen.getByText('Network down')).toBeInTheDocument()
   })
 
-  it('renders category totals, card statements with the combined adjustment figure, and the expense list together', async () => {
+  it('shows the error/retry state regardless of the active tab', async () => {
+    getExpensesByMonthMock.mockRejectedValue(new Error('Network down'))
+
+    render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByText('Network down')).toBeInTheDocument()
+  })
+
+  it('defaults to the Summary tab on load, showing only the total grids', async () => {
     render(<MonthlyPage />)
 
-    await waitFor(() => expect(screen.getByText('Lidl UK')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    expect(screen.getByText('Category Totals')).toBeInTheDocument()
+    expect(screen.getByText('Cards')).toBeInTheDocument()
+    expect(screen.getByText('Banks')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Incoming' })).toBeInTheDocument()
+    expect(screen.queryByText('Expenses')).not.toBeInTheDocument()
+    expect(screen.queryByText('Income')).not.toBeInTheDocument()
+  })
+
+  it('marks Summary as the active tab button by default', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Summary' })).toHaveClass('monthly-page__tab--active')
+    expect(screen.getByRole('button', { name: 'Expense' })).not.toHaveClass('monthly-page__tab--active')
+    expect(screen.getByRole('button', { name: 'Incoming' })).not.toHaveClass('monthly-page__tab--active')
+  })
+
+  it('shows only the Expense tabs content after clicking Expense', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
+
+    expect(screen.queryByText('Category Totals')).not.toBeInTheDocument()
+    expect(screen.queryByText('Income')).not.toBeInTheDocument()
+    expect(screen.getByText('Expenses')).toBeInTheDocument()
+    expect(screen.getByText('Lidl UK')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Expense' })).toHaveClass('monthly-page__tab--active')
+  })
+
+  it('shows only the Incoming tabs content after clicking Incoming', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
+
+    expect(screen.queryByText('Category Totals')).not.toBeInTheDocument()
+    expect(screen.queryByText('Expenses')).not.toBeInTheDocument()
+    expect(screen.getByText('Income')).toBeInTheDocument()
+    expect(screen.getByText('Gleison')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Incoming' })).toHaveClass('monthly-page__tab--active')
+  })
+
+  it('does not change the month/year picker value when switching tabs', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    const monthInput = screen.getByLabelText('Month') as HTMLInputElement
+    const valueBefore = monthInput.value
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
+
+    expect(monthInput.value).toBe(valueBefore)
+  })
+
+  it('does not refetch data when switching tabs', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    const callCountBefore = getExpensesByMonthMock.mock.calls.length
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Summary' }))
+
+    expect(getExpensesByMonthMock.mock.calls.length).toBe(callCountBefore)
+  })
+
+  it('keeps the active tab unchanged when the month/year value changes', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
+    await waitFor(() => expect(screen.getByText('Expenses')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByLabelText('Month'), { target: { value: '2026-08' } })
+
+    await waitFor(() => expect(screen.getByText('Expenses')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Expense' })).toHaveClass('monthly-page__tab--active')
+  })
+
+  it('closes an open create form when switching tabs away and back', async () => {
+    render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
+    expect(screen.getByRole('button', { name: 'Add Expense' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Summary' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
+
+    expect(screen.queryByRole('button', { name: 'Add Expense' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument()
+  })
+
+  it('renders category totals and card statements with the combined adjustment on Summary, and the expense list on the Expense tab', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
     expect(screen.getByText('Category Totals')).toBeInTheDocument()
     expect(screen.getAllByText('Mercado').length).toBeGreaterThan(0)
     expect(screen.getByText('Cards')).toBeInTheDocument()
-    expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument()
     expect(screen.getByText(/Combined adjustment figure/)).toBeInTheDocument()
     expect(screen.getAllByText('100.00').length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
+    expect(screen.getByText('Lidl UK')).toBeInTheDocument()
   })
 
   it('renders a Banks grid with a row per payment source and its own total, alongside the other grids', async () => {
     render(<MonthlyPage />)
 
-    await waitFor(() => expect(screen.getByText('Lidl UK')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
     expect(screen.getByText('Banks')).toBeInTheDocument()
 
     const banksSection = within(screen.getByText('Banks').closest('section')!)
@@ -188,6 +300,7 @@ describe('MonthlyPage', () => {
 
   it('bank mode shows only the bank picker and card mode only the card picker', async () => {
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
@@ -204,6 +317,7 @@ describe('MonthlyPage', () => {
   it('submits a card-mode expense with a null payment source', async () => {
     createExpenseMock.mockResolvedValue({ ...EXPENSES[0], id: 'e2' })
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
@@ -232,6 +346,7 @@ describe('MonthlyPage', () => {
       },
     ])
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
     await waitFor(() => expect(screen.getByText('Lidl UK')).toBeInTheDocument())
     fireEvent.click(screen.getAllByRole('button', { name: 'Edit expense' })[0])
@@ -245,6 +360,7 @@ describe('MonthlyPage', () => {
   it('shows the add-expense form only after New Expense is clicked, and submits a new expense', async () => {
     createExpenseMock.mockResolvedValue({ ...EXPENSES[0], id: 'e2' })
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
     expect(screen.queryByLabelText('Date')).not.toBeInTheDocument()
@@ -263,6 +379,7 @@ describe('MonthlyPage', () => {
   it('edits an expense value via the toggled panel and saves, updating the displayed row', async () => {
     updateExpenseMock.mockResolvedValue({ ...EXPENSES[0], value: 50 })
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
     await waitFor(() => expect(screen.getByText('Lidl UK')).toBeInTheDocument())
 
@@ -282,6 +399,7 @@ describe('MonthlyPage', () => {
   it('deletes an expense after confirmation', async () => {
     deleteExpenseMock.mockResolvedValue(undefined)
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
     await waitFor(() => expect(screen.getByText('Lidl UK')).toBeInTheDocument())
     fireEvent.click(screen.getAllByRole('button', { name: 'Delete expense' })[0])
@@ -289,8 +407,9 @@ describe('MonthlyPage', () => {
     await waitFor(() => expect(deleteExpenseMock).toHaveBeenCalledWith('e1'))
   })
 
-  it('renders the income list alongside the expense list', async () => {
+  it('renders the income list on the Incoming tab', async () => {
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
 
     await waitFor(() => expect(screen.getByText('Income')).toBeInTheDocument())
     const incomeSection = within(screen.getByText('Income').closest('section')!)
@@ -301,6 +420,7 @@ describe('MonthlyPage', () => {
   it('shows the add-income form only after New Income is clicked, and submits a new income entry', async () => {
     createIncomeMock.mockResolvedValue({ ...INCOMES[0], id: 'i2' })
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Income' })).toBeInTheDocument())
     expect(screen.queryByLabelText('Net Value')).not.toBeInTheDocument()
@@ -319,6 +439,7 @@ describe('MonthlyPage', () => {
 
   it('hides the gross value field for Lottery and DividendoJuros sources', async () => {
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Income' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'New Income' }))
@@ -329,21 +450,10 @@ describe('MonthlyPage', () => {
     expect(screen.queryByLabelText('Gross Value')).not.toBeInTheDocument()
   })
 
-  it('opening New Income closes an open expense form, and vice versa', async () => {
-    render(<MonthlyPage />)
-
-    await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
-    expect(screen.getByRole('button', { name: 'Add Expense' })).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: 'New Income' }))
-    expect(screen.queryByRole('button', { name: 'Add Expense' })).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Add Income' })).toBeInTheDocument()
-  })
-
   it('shows a validation error and does not call the API when no bank is available to select', async () => {
     getBanksMock.mockResolvedValue([])
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Income' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'New Income' }))
@@ -358,6 +468,7 @@ describe('MonthlyPage', () => {
   it('edits an income entry via the toggled panel and saves, updating the displayed row', async () => {
     updateIncomeMock.mockResolvedValue({ ...INCOMES[0], netValue: 500 })
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
 
     await waitFor(() => expect(screen.getAllByRole('button', { name: 'Edit income' }).length).toBeGreaterThan(0))
 
@@ -377,6 +488,7 @@ describe('MonthlyPage', () => {
   it('deletes an income entry after confirmation', async () => {
     deleteIncomeMock.mockResolvedValue(undefined)
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
 
     await waitFor(() => expect(screen.getAllByRole('button', { name: 'Delete income' }).length).toBeGreaterThan(0))
     fireEvent.click(screen.getAllByRole('button', { name: 'Delete income' })[0])
@@ -387,8 +499,8 @@ describe('MonthlyPage', () => {
   it('renders the Incoming card with one row per source and the calculated tithe and tithe balance', async () => {
     render(<MonthlyPage />)
 
-    await waitFor(() => expect(screen.getByText('Incoming')).toBeInTheDocument())
-    const incomingSection = within(screen.getByText('Incoming').closest('section')!)
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Incoming' })).toBeInTheDocument())
+    const incomingSection = within(screen.getByRole('heading', { name: 'Incoming' }).closest('section')!)
     expect(incomingSection.getByRole('cell', { name: 'Gleison' })).toBeInTheDocument()
     expect(incomingSection.getByText('3,200.00')).toBeInTheDocument()
     expect(incomingSection.getAllByText('2,450.00').length).toBeGreaterThanOrEqual(1)
@@ -400,6 +512,7 @@ describe('MonthlyPage', () => {
   it('updates the Incoming card after a new income entry is added', async () => {
     createIncomeMock.mockResolvedValue({ id: 'i2', date: '2026-07-15', incomeSource: 'Lottery', grossValue: null, netValue: 100, bank: 'Chase' })
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Income' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'New Income' }))
@@ -418,12 +531,16 @@ describe('MonthlyPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Add Income' }))
 
     await waitFor(() => expect(createIncomeMock).toHaveBeenCalled())
-    const incomingSection = within(screen.getByText('Incoming').closest('section')!)
+    await waitFor(() => expect(screen.getByText('Gleison')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Summary' }))
+    const incomingSection = within(screen.getByRole('heading', { name: 'Incoming' }).closest('section')!)
     await waitFor(() => expect(incomingSection.getByRole('cell', { name: 'Lottery' })).toBeInTheDocument())
   })
 
-  it('bank picker and mark-paid picker list banks fetched from the API', async () => {
+  it('bank picker lists banks fetched from the API in the expense form', async () => {
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
@@ -432,13 +549,19 @@ describe('MonthlyPage', () => {
     expect(within(bankPicker).getByRole('option', { name: 'Barclays' })).toBeInTheDocument()
     expect(within(bankPicker).getByRole('option', { name: 'Trading212' })).toBeInTheDocument()
     expect(within(bankPicker).getByRole('option', { name: 'Chase' })).toBeInTheDocument()
+  })
 
+  it('mark-paid picker on the Cards grid lists banks fetched from the API', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
     const markPaidPicker = screen.getByLabelText('Paying bank for BaAmex')
     expect(within(markPaidPicker).getByRole('option', { name: 'Trading212' })).toBeInTheDocument()
   })
 
   it('shows a pre-filled round-up field when a round-up-enabled bank is selected', async () => {
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
@@ -453,6 +576,7 @@ describe('MonthlyPage', () => {
 
   it('hides the round-up field for a non-round-up bank and for card mode', async () => {
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
@@ -470,6 +594,7 @@ describe('MonthlyPage', () => {
   it('submits a typed round-up amount with the new expense', async () => {
     createExpenseMock.mockResolvedValue({ ...EXPENSES[0], id: 'e2' })
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'New Expense' }))
@@ -496,10 +621,10 @@ describe('MonthlyPage', () => {
     ])
     render(<MonthlyPage />)
 
-    await waitFor(() => expect(screen.getByText('Lidl UK')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('Banks')).toBeInTheDocument())
     const banksSection = within(screen.getByText('Banks').closest('section')!)
 
-    const trading212Row = banksSection.getByRole('row', { name: /Trading212/ })
+    const trading212Row = await banksSection.findByRole('row', { name: /Trading212/ })
     expect(within(trading212Row).getByRole('cell', { name: '8.80' })).toBeInTheDocument()
     expect(within(trading212Row).getByRole('cell', { name: '0.60' })).toBeInTheDocument()
 
@@ -512,6 +637,7 @@ describe('MonthlyPage', () => {
       { ...EXPENSES[0], paymentSource: 'Trading212', roundUpAmount: 0.6, suggestedRoundUpAmount: null },
     ])
     render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
     await waitFor(() => expect(screen.getByText('Lidl UK')).toBeInTheDocument())
     fireEvent.click(screen.getAllByRole('button', { name: 'Edit expense' })[0])

--- a/docs/P15-F01-monthly-tab-navigation-shell/plan.md
+++ b/docs/P15-F01-monthly-tab-navigation-shell/plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan: Monthly Tab Navigation Shell
+
+**Prerequisites:**
+- None — this feature only touches existing frontend files (`Financial.Web/src/pages/MonthlyPage.tsx`, `MonthlyPage.css`, `pages/__tests__/MonthlyPage.test.tsx`); no new dependencies, environment variables, or configuration.
+
+### Stage 1: Tab Shell Foundation
+
+**1. Tab State and Type Definitions** - Add a `MonthlyTabId` union and a `TABS` array of `{id, label}` to `MonthlyPage.tsx`, plus `useState` for the active tab defaulting to Summary, following the same shape as `DetailPanel.tsx`'s tab-state definitions.
+
+**2. Tab Button Row** - Render a row of tab buttons below the existing month/year picker header, each switching the active tab on click and visually reflecting which tab is currently active, reusing the button/active-class pattern already established by `DetailPanel`.
+
+**3. Tab Bar Styling** - Add the CSS rules for the tab row and its active/inactive button states to `MonthlyPage.css`, visually matching the styling already defined for `DetailPanel`'s tab bar.
+
+### Stage 2: Content Relocation and Test Coverage
+
+**4. Relocate Existing Content Behind Tab Guards** - Wrap the current Summary grids block, Expense form/list block, and Incoming form/list block each in a conditional guarded by the active tab, with no other change to their existing markup or behavior, so exactly one block renders at a time.
+
+**5. Preserve Shared Loading/Error State** - Confirm the existing loading and error states keep rendering above/instead of the tab content regardless of which tab is active, since they reflect the one data fetch shared by all three tabs.
+
+**6. Update Test Coverage** - Extend the Monthly tab test suite with coverage for the default active tab, tab switching, active-tab visual state, and the independence of period selection from tab state, and add a tab-click step to every existing test that interacts with expense or income content.

--- a/docs/P15-F01-monthly-tab-navigation-shell/spec.md
+++ b/docs/P15-F01-monthly-tab-navigation-shell/spec.md
@@ -1,0 +1,76 @@
+## 1. Technical Overview
+
+**What:** Add a local three-tab shell (Summary, Expense, Incoming) to `MonthlyPage.tsx`, with the existing month/year picker relocated above the tab row so it applies to all three tabs. The existing content — the 4 total grids, the Expense form/list, and the Incoming form/list — is relocated as-is into its matching tab's conditional block, with no visual regrouping or component extraction yet (that work belongs to F02/F03/F04).
+
+**Why:** The codebase has no tab library and no prior in-page multi-tab pattern besides `DetailPanel.tsx` (`src/components/DetailPanel.tsx`), which already solves exactly this shape of problem — a `TabId` union, a `TABS` array, `useState` for the active tab, a button row, and conditional rendering — with matching CSS (`DetailPanel.css:72-97`). Reusing that pattern keeps the codebase's tab-switching mechanism consistent across pages instead of introducing a second, different implementation. Month/year state already lives entirely inside `useMonthly()` and is owned by `MonthlyPage.tsx` today, so no state needs to be lifted — it already sits at the right level to be shared across tabs once the tab row is added below it.
+
+**Scope:**
+- Included: `MonthlyTabId` type and `TABS` definition, `activeTab` state, tab button row, tab bar CSS, relocating the 3 existing content blocks (grids row, expense form+list, income form+list) behind tab guards, and updated/added tests for the tab mechanism itself.
+- Excluded: splitting the 4 grids into 2 groups (F02), extracting `ExpenseForm`/`ExpensesSection` into their own tab component (F03), extracting `IncomeForm`/`IncomeSection` into their own tab component (F04). These features build on top of the tab guards this feature introduces, without changing the tab mechanism itself.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/pages/MonthlyPage.tsx` — gains tab state/types, the tab button row, and conditional guards around its 3 existing content blocks
+- `Financial.Web/src/pages/MonthlyPage.css` — gains the tab bar's visual styling
+- `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` — gains tab-mechanism tests; existing expense/income interaction tests gain a tab-click step
+
+```mermaid
+graph TD
+    A[Developer] --> B[MonthlyPage]
+    B --> C["useState(activeTab)"]
+    C --> D[Tab Button Row]
+    D --> C
+    B --> E["useMonthly() - month/year + data state"]
+    E --> F["Conditional block: Summary / Expense / Incoming"]
+    C --> F
+    F --> G[Existing grids / ExpensesSection / IncomeSection - unchanged]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Active-tab state ownership | Local `useState<MonthlyTabId>` inside `MonthlyPage.tsx`, mirroring `DetailPanel.tsx`'s `activeTab` pattern | URL search param (`?tab=expense`) for deep-linking | PRD Section 7 explicitly excludes deep-linking/persistence of the active tab; local state is simpler and matches the one existing precedent in this codebase |
+| F01 content scope | Relocate the 3 existing content blocks into their tab guard as-is (no grouping/extraction yet) | Ship F01 with empty/placeholder tab bodies and defer all content moves to F02-F04 | Keeps the app fully functional immediately after F01 merges (confirmed with the user); F02-F04 diffs stay focused only on the specific transformation they own, with no rework of code F01 already moved |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/pages/MonthlyPage.tsx` | Modified | Hosts the month/year picker, tab bar, and per-tab content guards | Define `MonthlyTabId`/`TABS`; own `activeTab` state defaulting to `'summary'`; render the tab button row; wrap each of the 3 existing content blocks in an `activeTab === '...'` guard; no change to `useMonthly()` usage or to the wrapped JSX itself |
+| `Financial.Web/src/pages/MonthlyPage.css` | Modified | Tab bar visual styling | Add `.monthly-page__tabs`, `.monthly-page__tab`, `.monthly-page__tab--active`, matching the look already established by `.detail-panel__tabs`/`__tab`/`__tab--active` in `DetailPanel.css:72-97` |
+| `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` | Modified | Cover the tab mechanism; keep existing coverage passing under the new structure | Add tests for default tab, tab switching, active-tab visual state, and period/tab-state independence; add a tab-click step before every existing test that queries `ExpensesSection`/`IncomeSection` content |
+
+## 5. API Contracts
+
+Not applicable — this feature makes no backend or API changes.
+
+## 6. Data Model
+
+Not applicable — this feature makes no data model or persistence changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` | Component | `MonthlyPage` tab shell | All 6 F01 acceptance criteria and the tab-related Cross-Feature Integration criteria covered |
+
+**Test functions:**
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `it('defaults to the Summary tab on load')` | Verifies F01 AC1 | Category Totals/Cards/Banks/Incoming grids are visible on initial render; expense/income list content is not rendered |
+| `it('marks Summary as the active tab button by default')` | Verifies F01 AC1 | Summary tab button carries the active CSS class; Expense/Incoming buttons do not |
+| `it('shows only the Expense tabs content after clicking Expense')` | Verifies F01 AC2 | After clicking "Expense", the 4 Summary grids are gone, `ExpensesSection` content is visible, `IncomeSection` content is not |
+| `it('shows only the Incoming tabs content after clicking Incoming')` | Verifies F01 AC2 | After clicking "Incoming", the 4 Summary grids and `ExpensesSection` content are gone, `IncomeSection` content is visible |
+| `it('does not change the month/year picker value when switching tabs')` | Verifies F01 AC4 and the F01→F02/F03/F04 Cross-Feature Integration criterion on shared period state | Month input value identical before and after a tab click |
+| `it('does not refetch data when switching tabs')` | Verifies F01 AC4 and the F01→F02/F03/F04 Cross-Feature Integration criterion on avoiding redundant refetch | Mocked API client call counts are unchanged across a tab switch |
+| `it('keeps the active tab unchanged when the month/year value changes')` | Verifies F01 AC5 | While Expense is active, changing the month input keeps Expense's content visible (does not revert to Summary) |
+| `it('shows the error/retry state regardless of the active tab')` | Verifies F01 AC6 | With the mocked API client rejecting, the error message and retry button render whether Summary, Expense, or Incoming was last active |
+| Existing expense interaction tests (create/edit/delete, mark/unmark paid, round-up field) | Modified | Add `fireEvent.click(screen.getByText('Expense'))` (or `'Summary'`/`'Cards'` context as applicable) before the existing interaction steps; all prior assertions unchanged |
+| Existing income interaction tests (create/edit/delete) | Modified | Add `fireEvent.click(screen.getByText('Incoming'))` before the existing interaction steps; all prior assertions unchanged |

--- a/docs/prd/P15-prd-monthly-tab-subtab-redesign/prd-monthly-tab-subtab-redesign.md
+++ b/docs/prd/P15-prd-monthly-tab-subtab-redesign/prd-monthly-tab-subtab-redesign.md
@@ -206,12 +206,12 @@ graph TD
 ## 9. Acceptance Criteria
 
 ### F01. Monthly Tab Navigation Shell
-- [ ] Opening the Monthly tab shows the month/year picker, the three sub-tab buttons (Summary, Expense, Incoming), and Summary content by default
-- [ ] Exactly one sub-tab's content is visible/mounted at any time
-- [ ] Clicking a sub-tab button switches the visible content and marks that button as active
-- [ ] Switching sub-tabs does not change the month/year picker's value and does not trigger a new data fetch
-- [ ] Changing the month/year value refetches data and updates the currently active sub-tab's content without changing which sub-tab is active
-- [ ] If data loading fails, the error/retry state is shown regardless of the active sub-tab
+- [x] Opening the Monthly tab shows the month/year picker, the three sub-tab buttons (Summary, Expense, Incoming), and Summary content by default
+- [x] Exactly one sub-tab's content is visible/mounted at any time
+- [x] Clicking a sub-tab button switches the visible content and marks that button as active
+- [x] Switching sub-tabs does not change the month/year picker's value and does not trigger a new data fetch
+- [x] Changing the month/year value refetches data and updates the currently active sub-tab's content without changing which sub-tab is active
+- [x] If data loading fails, the error/retry state is shown regardless of the active sub-tab
 
 ### F02. Monthly Summary Sub-Tab
 - [ ] Summary sub-tab renders exactly 4 grids: Category Totals, Cards, Banks, Incoming


### PR DESCRIPTION
## Summary
- Adds a Summary/Expense/Incoming tab bar to the Monthly tab, below the shared month/year picker (which now applies to all three tabs instead of being duplicated)
- Relocates the existing 4 total grids, the expense form/list, and the income form/list as-is behind tab guards — no visual regrouping or component extraction yet (that's F02/F03/F04)
- Switching tabs closes any open create/edit form and discards unsaved input, since forms are scoped to the tab that hosts them

## Test plan
### F01. Monthly Tab Navigation Shell
- [x] Opening the Monthly tab shows the month/year picker, the three sub-tab buttons (Summary, Expense, Incoming), and Summary content by default
- [x] Exactly one sub-tab's content is visible/mounted at any time
- [x] Clicking a sub-tab button switches the visible content and marks that button as active
- [x] Switching sub-tabs does not change the month/year picker's value and does not trigger a new data fetch
- [x] Changing the month/year value refetches data and updates the currently active sub-tab's content without changing which sub-tab is active
- [x] If data loading fails, the error/retry state is shown regardless of the active sub-tab

### Validation run
- [x] `tsc -b --noEmit` clean
- [x] `eslint .` clean
- [x] Full frontend suite: 597/597 tests passing (45 files), including 37 in `MonthlyPage.test.tsx`
- [x] `vite build` production build succeeds
- [ ] Manual browser smoke test — skipped at the user's request (dev-server + Chrome check was taking too long); covered instead by the full automated test suite above

Spec/plan: `docs/P15-F01-monthly-tab-navigation-shell/`