### PR TITLE
feat(P15-F02): Monthly summary sub-tab grouping

### DIFF
--- a/Financial.Web/src/components/BanksGrid.tsx
+++ b/Financial.Web/src/components/BanksGrid.tsx
@@ -1,0 +1,39 @@
+import type { BankTotal } from '../hooks/useMonthly'
+import { formatN2 } from '../utils/formatters'
+
+interface BanksGridProps {
+  bankTotals: BankTotal[]
+  bankTotalsSum: number
+  roundUpTotalsSum: number
+}
+
+export default function BanksGrid({ bankTotals, bankTotalsSum, roundUpTotalsSum }: BanksGridProps) {
+  return (
+    <section className="monthly-page__section monthly-page__section--grid">
+      <h2>Banks</h2>
+      <div className="monthly-page__table-scroll">
+        <table className="monthly-page__table data-table">
+          <thead>
+            <tr>
+              <th>Bank</th>
+              <th className="data-table__col--numeric">Bank Balance</th>
+              <th className="data-table__col--numeric">Round-Up</th>
+            </tr>
+          </thead>
+          <tbody>
+            {bankTotals.map((b) => (
+              <tr key={b.bank}>
+                <td>{b.bank}</td>
+                <td className="data-table__col--numeric">{formatN2(b.balance)}</td>
+                <td className="data-table__col--numeric">{formatN2(b.roundUpTotal)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="monthly-page__section-total">
+        Bank Balance: <strong>{formatN2(bankTotalsSum)}</strong> · Round-Up: <strong>{formatN2(roundUpTotalsSum)}</strong>
+      </p>
+    </section>
+  )
+}

--- a/Financial.Web/src/components/CardsGrid.tsx
+++ b/Financial.Web/src/components/CardsGrid.tsx
@@ -1,0 +1,81 @@
+import type { BankDto, CardStatementDto } from '../api/types'
+import { formatN2 } from '../utils/formatters'
+
+interface CardsGridProps {
+  cardStatements: CardStatementDto[]
+  banks: BankDto[]
+  adjustmentTotal: number
+  markPaidSources: Record<string, string>
+  setMarkPaidSource: (id: string, bank: string) => void
+  markStatementPaid: (id: string, paymentSource: string) => void
+  unmarkStatementPaid: (id: string) => void
+}
+
+export default function CardsGrid({
+  cardStatements,
+  banks,
+  adjustmentTotal,
+  markPaidSources,
+  setMarkPaidSource,
+  markStatementPaid,
+  unmarkStatementPaid,
+}: CardsGridProps) {
+  return (
+    <section className="monthly-page__section monthly-page__section--grid">
+      <h2>Cards</h2>
+      <div className="monthly-page__table-scroll">
+        <table className="monthly-page__table data-table">
+          <thead>
+            <tr>
+              <th>Card</th>
+              <th className="data-table__col--numeric">Outstanding</th>
+              <th>Status</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {cardStatements.map((s) => (
+              <tr key={s.id}>
+                <td>{s.card}</td>
+                <td className="data-table__col--numeric">{formatN2(s.outstandingTotal)}</td>
+                <td>{s.isPaid ? 'Paid' : 'Unpaid'}</td>
+                <td>
+                  {s.isPaid ? (
+                    <button type="button" onClick={() => unmarkStatementPaid(s.id)}>
+                      Unmark Paid
+                    </button>
+                  ) : (
+                    <>
+                      <select
+                        aria-label={`Paying bank for ${s.card}`}
+                        value={markPaidSources[s.id] ?? ''}
+                        onChange={(e) => setMarkPaidSource(s.id, e.target.value)}
+                      >
+                        <option value="">Bank…</option>
+                        {banks.map((b) => (
+                          <option key={b.name} value={b.name}>
+                            {b.name}
+                          </option>
+                        ))}
+                      </select>{' '}
+                      <button
+                        type="button"
+                        disabled={!markPaidSources[s.id]}
+                        onClick={() => markStatementPaid(s.id, markPaidSources[s.id])}
+                      >
+                        Mark Paid
+                      </button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="monthly-page__section-total">
+        Combined adjustment figure: <strong>{formatN2(adjustmentTotal)}</strong>
+      </p>
+    </section>
+  )
+}

--- a/Financial.Web/src/components/CategoryTotalsGrid.tsx
+++ b/Financial.Web/src/components/CategoryTotalsGrid.tsx
@@ -1,0 +1,36 @@
+import type { CategoryTotalDto } from '../api/types'
+import { formatN2 } from '../utils/formatters'
+
+interface CategoryTotalsGridProps {
+  categoryTotals: CategoryTotalDto[]
+  categoryTotalsSum: number
+}
+
+export default function CategoryTotalsGrid({ categoryTotals, categoryTotalsSum }: CategoryTotalsGridProps) {
+  return (
+    <section className="monthly-page__section monthly-page__section--grid">
+      <h2>Category Totals</h2>
+      <div className="monthly-page__table-scroll">
+        <table className="monthly-page__table data-table">
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th className="data-table__col--numeric">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {categoryTotals.map((c) => (
+              <tr key={c.category}>
+                <td>{c.category}</td>
+                <td className="data-table__col--numeric">{formatN2(c.totalValue)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="monthly-page__section-total">
+        Total: <strong>{formatN2(categoryTotalsSum)}</strong>
+      </p>
+    </section>
+  )
+}

--- a/Financial.Web/src/components/IncomingGrid.tsx
+++ b/Financial.Web/src/components/IncomingGrid.tsx
@@ -1,0 +1,49 @@
+import type { IncomeTotal } from '../hooks/useMonthly'
+import type { TitheSummaryDto } from '../api/types'
+import { formatN2 } from '../utils/formatters'
+
+interface IncomingGridProps {
+  incomeTotals: IncomeTotal[]
+  totalIncoming: number
+  titheSummary: TitheSummaryDto | null
+}
+
+export default function IncomingGrid({ incomeTotals, totalIncoming, titheSummary }: IncomingGridProps) {
+  return (
+    <section className="monthly-page__section monthly-page__section--grid">
+      <h2>Incoming</h2>
+      <div className="monthly-page__table-scroll">
+        <table className="monthly-page__table data-table">
+          <thead>
+            <tr>
+              <th>Source</th>
+              <th className="data-table__col--numeric">Gross</th>
+              <th className="data-table__col--numeric">Net</th>
+            </tr>
+          </thead>
+          <tbody>
+            {incomeTotals.map((i) => (
+              <tr key={i.source}>
+                <td>{i.source}</td>
+                <td className="data-table__col--numeric">
+                  {i.grossValue != null ? formatN2(i.grossValue) : '—'}
+                </td>
+                <td className="data-table__col--numeric">{formatN2(i.netValue)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="monthly-page__section-total">
+        Total Incoming: <strong>{formatN2(totalIncoming)}</strong>
+        {titheSummary && (
+          <>
+            {' '}
+            · Calculated Tithe: <strong>{formatN2(titheSummary.calculatedTithe)}</strong> · Tithe Balance:{' '}
+            <strong>{formatN2(titheSummary.titheBalance)}</strong>
+          </>
+        )}
+      </p>
+    </section>
+  )
+}

--- a/Financial.Web/src/components/__tests__/BanksGrid.test.tsx
+++ b/Financial.Web/src/components/__tests__/BanksGrid.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import BanksGrid from '../BanksGrid'
+import type { BankTotal } from '../../hooks/useMonthly'
+
+const BANK_TOTALS: BankTotal[] = [
+  { bank: 'Barclays', balance: 42.5, roundUpTotal: 0 },
+  { bank: 'Trading212', balance: 8.8, roundUpTotal: 0.6 },
+]
+
+describe('BanksGrid', () => {
+  it('renders a row per bank with balance and round-up columns, plus footer totals', () => {
+    render(<BanksGrid bankTotals={BANK_TOTALS} bankTotalsSum={51.3} roundUpTotalsSum={0.6} />)
+
+    const barclaysRow = screen.getByRole('row', { name: /Barclays/ })
+    expect(within(barclaysRow).getByRole('cell', { name: '42.50' })).toBeInTheDocument()
+
+    const trading212Row = screen.getByRole('row', { name: /Trading212/ })
+    expect(within(trading212Row).getByRole('cell', { name: '8.80' })).toBeInTheDocument()
+    expect(within(trading212Row).getByRole('cell', { name: '0.60' })).toBeInTheDocument()
+
+    expect(screen.getByText('51.30')).toBeInTheDocument()
+  })
+})

--- a/Financial.Web/src/components/__tests__/CardsGrid.test.tsx
+++ b/Financial.Web/src/components/__tests__/CardsGrid.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import CardsGrid from '../CardsGrid'
+import type { BankDto, CardStatementDto } from '../../api/types'
+
+const BANKS: BankDto[] = [
+  { name: 'Barclays', roundUpEnabled: false },
+  { name: 'Trading212', roundUpEnabled: true },
+]
+
+const CARD_STATEMENTS: CardStatementDto[] = [
+  { id: 'c1', card: 'BaAmex', year: 2026, month: 7, isPaid: false, outstandingTotal: 100 },
+  { id: 'c2', card: 'ChaseMaster4023', year: 2026, month: 7, isPaid: true, outstandingTotal: 0 },
+]
+
+describe('CardsGrid', () => {
+  it('renders a row per card with status and the footer adjustment total', () => {
+    render(
+      <CardsGrid
+        cardStatements={CARD_STATEMENTS}
+        banks={BANKS}
+        adjustmentTotal={100}
+        markPaidSources={{}}
+        setMarkPaidSource={vi.fn()}
+        markStatementPaid={vi.fn()}
+        unmarkStatementPaid={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument()
+    expect(screen.getByText('Unpaid')).toBeInTheDocument()
+    expect(screen.getByText('Paid')).toBeInTheDocument()
+    expect(screen.getByText(/Combined adjustment figure/)).toBeInTheDocument()
+  })
+
+  it('disables Mark Paid until a bank is selected, then calls markStatementPaid with the chosen bank', () => {
+    const setMarkPaidSource = vi.fn()
+    const markStatementPaid = vi.fn()
+    render(
+      <CardsGrid
+        cardStatements={CARD_STATEMENTS}
+        banks={BANKS}
+        adjustmentTotal={100}
+        markPaidSources={{}}
+        setMarkPaidSource={setMarkPaidSource}
+        markStatementPaid={markStatementPaid}
+        unmarkStatementPaid={vi.fn()}
+      />,
+    )
+
+    const markPaidButton = screen.getByRole('button', { name: 'Mark Paid' })
+    expect(markPaidButton).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Paying bank for BaAmex'), { target: { value: 'Trading212' } })
+    expect(setMarkPaidSource).toHaveBeenCalledWith('c1', 'Trading212')
+  })
+
+  it('calls unmarkStatementPaid for a paid card', () => {
+    const unmarkStatementPaid = vi.fn()
+    render(
+      <CardsGrid
+        cardStatements={CARD_STATEMENTS}
+        banks={BANKS}
+        adjustmentTotal={100}
+        markPaidSources={{}}
+        setMarkPaidSource={vi.fn()}
+        markStatementPaid={vi.fn()}
+        unmarkStatementPaid={unmarkStatementPaid}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unmark Paid' }))
+    expect(unmarkStatementPaid).toHaveBeenCalledWith('c2')
+  })
+})

--- a/Financial.Web/src/components/__tests__/CategoryTotalsGrid.test.tsx
+++ b/Financial.Web/src/components/__tests__/CategoryTotalsGrid.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import CategoryTotalsGrid from '../CategoryTotalsGrid'
+import type { CategoryTotalDto } from '../../api/types'
+
+const CATEGORY_TOTALS: CategoryTotalDto[] = [
+  { category: 'Mercado', totalValue: 42.5 },
+  { category: 'Casa', totalValue: 100 },
+]
+
+describe('CategoryTotalsGrid', () => {
+  it('renders a row per category with the footer total', () => {
+    render(<CategoryTotalsGrid categoryTotals={CATEGORY_TOTALS} categoryTotalsSum={142.5} />)
+
+    expect(screen.getByText('Mercado')).toBeInTheDocument()
+    expect(screen.getByText('Casa')).toBeInTheDocument()
+    expect(screen.getByText('42.50')).toBeInTheDocument()
+    expect(screen.getByText('100.00')).toBeInTheDocument()
+    expect(screen.getByText('142.50')).toBeInTheDocument()
+  })
+})

--- a/Financial.Web/src/components/__tests__/IncomingGrid.test.tsx
+++ b/Financial.Web/src/components/__tests__/IncomingGrid.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import IncomingGrid from '../IncomingGrid'
+import type { IncomeTotal } from '../../hooks/useMonthly'
+
+const INCOME_TOTALS: IncomeTotal[] = [
+  { source: 'Gleison', grossValue: 3200, netValue: 2450 },
+  { source: 'Lottery', grossValue: null, netValue: 100 },
+]
+
+describe('IncomingGrid', () => {
+  it('renders a row per income source, using an em dash when gross value is absent', () => {
+    render(<IncomingGrid incomeTotals={INCOME_TOTALS} totalIncoming={2550} titheSummary={null} />)
+
+    expect(screen.getByRole('cell', { name: 'Gleison' })).toBeInTheDocument()
+    expect(screen.getByText('3,200.00')).toBeInTheDocument()
+    expect(screen.getByRole('cell', { name: 'Lottery' })).toBeInTheDocument()
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.getByText(/Total Incoming:/)).toBeInTheDocument()
+    expect(screen.queryByText(/Calculated Tithe:/)).not.toBeInTheDocument()
+  })
+
+  it('shows the calculated tithe and tithe balance when a tithe summary is provided', () => {
+    render(
+      <IncomingGrid
+        incomeTotals={INCOME_TOTALS}
+        totalIncoming={2550}
+        titheSummary={{ calculatedTithe: 245, titheBalance: 245 }}
+      />,
+    )
+
+    expect(screen.getByText(/Calculated Tithe:/)).toBeInTheDocument()
+    expect(screen.getByText(/Tithe Balance:/)).toBeInTheDocument()
+  })
+})

--- a/Financial.Web/src/pages/MonthlyPage.css
+++ b/Financial.Web/src/pages/MonthlyPage.css
@@ -81,6 +81,13 @@
   max-width: 960px;
 }
 
+.monthly-page__summary-groups {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
 .monthly-page__grids-row {
   flex-shrink: 0;
   display: flex;

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react'
+import BanksGrid from '../components/BanksGrid'
+import CardsGrid from '../components/CardsGrid'
+import CategoryTotalsGrid from '../components/CategoryTotalsGrid'
 import ErrorState from '../components/ErrorState'
 import ExpensesSection from '../components/ExpensesSection'
 import IncomeSection from '../components/IncomeSection'
+import IncomingGrid from '../components/IncomingGrid'
 import LoadingState from '../components/LoadingState'
 import {
   useMonthly,
@@ -13,7 +17,6 @@ import {
   type PaymentMode,
 } from '../hooks/useMonthly'
 import type { BankDto } from '../api/types'
-import { formatN2 } from '../utils/formatters'
 import './MonthlyPage.css'
 
 type MonthlyTabId = 'summary' | 'expense' | 'incoming'
@@ -506,151 +509,23 @@ export default function MonthlyPage() {
       ) : (
         <div className="monthly-page__content">
           {activeTab === 'summary' && (
-          <div className="monthly-page__grids-row">
-            <section className="monthly-page__section monthly-page__section--grid">
-              <h2>Category Totals</h2>
-              <div className="monthly-page__table-scroll">
-                <table className="monthly-page__table data-table">
-                  <thead>
-                    <tr>
-                      <th>Category</th>
-                      <th className="data-table__col--numeric">Total</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {categoryTotals.map((c) => (
-                      <tr key={c.category}>
-                        <td>{c.category}</td>
-                        <td className="data-table__col--numeric">{formatN2(c.totalValue)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-              <p className="monthly-page__section-total">
-                Total: <strong>{formatN2(categoryTotalsSum)}</strong>
-              </p>
-            </section>
-
-            <section className="monthly-page__section monthly-page__section--grid">
-              <h2>Cards</h2>
-              <div className="monthly-page__table-scroll">
-                <table className="monthly-page__table data-table">
-                  <thead>
-                    <tr>
-                      <th>Card</th>
-                      <th className="data-table__col--numeric">Outstanding</th>
-                      <th>Status</th>
-                      <th />
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {cardStatements.map((s) => (
-                      <tr key={s.id}>
-                        <td>{s.card}</td>
-                        <td className="data-table__col--numeric">{formatN2(s.outstandingTotal)}</td>
-                        <td>{s.isPaid ? 'Paid' : 'Unpaid'}</td>
-                        <td>
-                          {s.isPaid ? (
-                            <button type="button" onClick={() => unmarkStatementPaid(s.id)}>
-                              Unmark Paid
-                            </button>
-                          ) : (
-                            <>
-                              <select
-                                aria-label={`Paying bank for ${s.card}`}
-                                value={markPaidSources[s.id] ?? ''}
-                                onChange={(e) => setMarkPaidSource(s.id, e.target.value)}
-                              >
-                                <option value="">Bank…</option>
-                                {banks.map((b) => (
-                                  <option key={b.name} value={b.name}>
-                                    {b.name}
-                                  </option>
-                                ))}
-                              </select>{' '}
-                              <button
-                                type="button"
-                                disabled={!markPaidSources[s.id]}
-                                onClick={() => markStatementPaid(s.id, markPaidSources[s.id])}
-                              >
-                                Mark Paid
-                              </button>
-                            </>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-              <p className="monthly-page__section-total">
-                Combined adjustment figure: <strong>{formatN2(adjustmentTotal)}</strong>
-              </p>
-            </section>
-
-            <section className="monthly-page__section monthly-page__section--grid">
-              <h2>Banks</h2>
-              <div className="monthly-page__table-scroll">
-                <table className="monthly-page__table data-table">
-                  <thead>
-                    <tr>
-                      <th>Bank</th>
-                      <th className="data-table__col--numeric">Bank Balance</th>
-                      <th className="data-table__col--numeric">Round-Up</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {bankTotals.map((b) => (
-                      <tr key={b.bank}>
-                        <td>{b.bank}</td>
-                        <td className="data-table__col--numeric">{formatN2(b.balance)}</td>
-                        <td className="data-table__col--numeric">{formatN2(b.roundUpTotal)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-              <p className="monthly-page__section-total">
-                Bank Balance: <strong>{formatN2(bankTotalsSum)}</strong> · Round-Up: <strong>{formatN2(roundUpTotalsSum)}</strong>
-              </p>
-            </section>
-
-            <section className="monthly-page__section monthly-page__section--grid">
-              <h2>Incoming</h2>
-              <div className="monthly-page__table-scroll">
-                <table className="monthly-page__table data-table">
-                  <thead>
-                    <tr>
-                      <th>Source</th>
-                      <th className="data-table__col--numeric">Gross</th>
-                      <th className="data-table__col--numeric">Net</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {incomeTotals.map((i) => (
-                      <tr key={i.source}>
-                        <td>{i.source}</td>
-                        <td className="data-table__col--numeric">
-                          {i.grossValue != null ? formatN2(i.grossValue) : '—'}
-                        </td>
-                        <td className="data-table__col--numeric">{formatN2(i.netValue)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-              <p className="monthly-page__section-total">
-                Total Incoming: <strong>{formatN2(totalIncoming)}</strong>
-                {titheSummary && (
-                  <>
-                    {' '}
-                    · Calculated Tithe: <strong>{formatN2(titheSummary.calculatedTithe)}</strong> · Tithe Balance:{' '}
-                    <strong>{formatN2(titheSummary.titheBalance)}</strong>
-                  </>
-                )}
-              </p>
-            </section>
+          <div className="monthly-page__summary-groups">
+            <div className="monthly-page__grids-row">
+              <CategoryTotalsGrid categoryTotals={categoryTotals} categoryTotalsSum={categoryTotalsSum} />
+              <CardsGrid
+                cardStatements={cardStatements}
+                banks={banks}
+                adjustmentTotal={adjustmentTotal}
+                markPaidSources={markPaidSources}
+                setMarkPaidSource={setMarkPaidSource}
+                markStatementPaid={markStatementPaid}
+                unmarkStatementPaid={unmarkStatementPaid}
+              />
+            </div>
+            <div className="monthly-page__grids-row">
+              <BanksGrid bankTotals={bankTotals} bankTotalsSum={bankTotalsSum} roundUpTotalsSum={roundUpTotalsSum} />
+              <IncomingGrid incomeTotals={incomeTotals} totalIncoming={totalIncoming} titheSummary={titheSummary} />
+            </div>
           </div>
           )}
 

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -288,6 +288,25 @@ describe('MonthlyPage', () => {
     )
   })
 
+  it('renders Category Totals and Cards in the first Summary row, Banks and Incoming in the second, with no heading between them', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+
+    const groups = document.querySelector('.monthly-page__summary-groups')
+    expect(groups).not.toBeNull()
+    const rows = groups!.querySelectorAll(':scope > .monthly-page__grids-row')
+    expect(rows).toHaveLength(2)
+
+    const firstRowHeadings = Array.from(rows[0].querySelectorAll('h2')).map((h) => h.textContent)
+    expect(firstRowHeadings).toEqual(['Category Totals', 'Cards'])
+
+    const secondRowHeadings = Array.from(rows[1].querySelectorAll('h2')).map((h) => h.textContent)
+    expect(secondRowHeadings).toEqual(['Banks', 'Incoming'])
+
+    expect(groups!.querySelectorAll(':scope > :not(.monthly-page__grids-row)')).toHaveLength(0)
+  })
+
   it('unmarks a paid statement after confirmation', async () => {
     unmarkCardStatementPaidMock.mockResolvedValue({ ...CARD_STATEMENTS[1], isPaid: false, outstandingTotal: 0 })
     render(<MonthlyPage />)

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -148,6 +148,29 @@ describe('MonthlyPage', () => {
     expect(screen.getByRole('button', { name: 'Incoming' })).not.toHaveClass('monthly-page__tab--active')
   })
 
+  it('re-scopes all 4 Summary grids when the month/year value changes', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    expect(screen.getAllByText('Mercado').length).toBeGreaterThan(0)
+
+    getCategoryTotalsByMonthMock.mockResolvedValue([{ category: 'Viagem', totalValue: 300 }])
+    getCardStatementsByMonthMock.mockResolvedValue([
+      { id: 'c3', card: 'PaypalCredit', year: 2026, month: 8, isPaid: false, outstandingTotal: 55 },
+    ])
+    getBankBalancesByMonthMock.mockResolvedValue([{ bank: 'Barclays', balance: 300 }])
+    getIncomesByMonthMock.mockResolvedValue([
+      { id: 'i2', date: '2026-08-01', incomeSource: 'Lottery', grossValue: null, netValue: 50, bank: 'Barclays' },
+    ])
+
+    fireEvent.change(screen.getByLabelText('Month'), { target: { value: '2026-08' } })
+
+    await waitFor(() => expect(screen.getByText('Viagem')).toBeInTheDocument())
+    expect(screen.queryByText('Mercado')).not.toBeInTheDocument()
+    expect(screen.getByRole('cell', { name: 'PaypalCredit' })).toBeInTheDocument()
+    expect(screen.getByRole('cell', { name: 'Lottery' })).toBeInTheDocument()
+  })
+
   it('shows only the Expense tabs content after clicking Expense', async () => {
     render(<MonthlyPage />)
 

--- a/docs/P15-F02-monthly-summary-subtab/plan.md
+++ b/docs/P15-F02-monthly-summary-subtab/plan.md
@@ -1,0 +1,18 @@
+# Implementation Plan: Monthly Summary Sub-Tab
+
+**Prerequisites:**
+- F01 (Monthly Tab Navigation Shell) merged — this feature builds on the Summary tab guard it introduced in `MonthlyPage.tsx`.
+
+### Stage 1: Grid Extraction
+
+**1. Category Totals and Cards Grid Components** - Extract the Category Totals and Cards grids from `MonthlyPage.tsx` into their own components, carrying over their existing markup, props, and (for Cards) Mark/Unmark Paid interaction unchanged.
+
+**2. Banks and Incoming Grid Components** - Extract the Banks and Incoming totals grids from `MonthlyPage.tsx` into their own components, carrying over their existing markup and props unchanged.
+
+### Stage 2: Two-Row Grouping and Test Coverage
+
+**3. Compose the Summary Tab into Two Rows** - Replace the inline grid JSX in `MonthlyPage.tsx`'s Summary tab block with the 4 new components arranged in 2 grouped rows (Category Totals + Cards, then Banks + Incoming), with no heading or label between the rows.
+
+**4. Two-Row Layout Styling** - Add the CSS wrapper needed to stack the 2 grid rows with appropriate spacing, reusing the existing per-row and per-grid classes unchanged.
+
+**5. Update Test Coverage** - Add a component test file for each of the 4 new grids, and update `MonthlyPage.test.tsx` to verify the Summary tab's 2-row grouping structure and that Mark/Unmark Paid still works after the regrouping.

--- a/docs/P15-F02-monthly-summary-subtab/spec.md
+++ b/docs/P15-F02-monthly-summary-subtab/spec.md
@@ -1,0 +1,85 @@
+## 1. Technical Overview
+
+**What:** Extract the 4 grids currently inlined in `MonthlyPage.tsx`'s Summary tab block (Category Totals, Cards, Banks, Incoming) into their own presentational components under `src/components/`, and rearrange them into two visually separated rows: Row 1 (Category Totals, Cards), Row 2 (Banks, Incoming). No grid's data, columns, or interactive behavior changes.
+
+**Why:** F01 relocated the 4 grids into the Summary tab guard as-is, deliberately deferring this exact transformation. `ExpensesSection.tsx`/`IncomeSection.tsx` already establish this codebase's convention for a self-contained UI section owning its own file — the same pattern applies cleanly here, since each grid already has an independent responsibility (its own data, its own footer total, and in the Cards grid's case, its own Mark/Unmark Paid interaction). Extracting shrinks `MonthlyPage.tsx` (729 lines after F01) toward a coordinator role and gives each grid a clear, testable prop boundary, consistent with this project's Clean Code mandate without introducing any abstraction the codebase doesn't already use elsewhere.
+
+**Scope:**
+- Included: 4 new grid components, their extraction from `MonthlyPage.tsx`, the two-row grouping layout, and component-level tests for each new grid.
+- Excluded: any change to grid data, calculations, or the Cards grid's Mark/Unmark Paid business logic (all untouched, just relocated); the Expense and Incoming tabs' own content (F03/F04).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/components/CategoryTotalsGrid.tsx` (new)
+- `Financial.Web/src/components/CardsGrid.tsx` (new)
+- `Financial.Web/src/components/BanksGrid.tsx` (new)
+- `Financial.Web/src/components/IncomingGrid.tsx` (new)
+- `Financial.Web/src/pages/MonthlyPage.tsx` — Summary tab block now renders the 4 new components inside 2 grouped rows instead of inline JSX
+- `Financial.Web/src/pages/MonthlyPage.css` — new `.monthly-page__summary-groups` wrapper; existing `.monthly-page__grids-row`/`.monthly-page__section--grid` rules reused unchanged, one per row
+- New test files: `CategoryTotalsGrid.test.tsx`, `CardsGrid.test.tsx`, `BanksGrid.test.tsx`, `IncomingGrid.test.tsx` under `src/components/__tests__/`
+- `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` — assertions updated to check the 2-row grouping structure
+
+```mermaid
+graph TD
+    A[MonthlyPage - Summary tab] --> B["monthly-page__summary-groups"]
+    B --> C["Row 1: monthly-page__grids-row"]
+    B --> D["Row 2: monthly-page__grids-row"]
+    C --> E[CategoryTotalsGrid]
+    C --> F[CardsGrid]
+    D --> G[BanksGrid]
+    D --> H[IncomingGrid]
+    F --> I["useMonthly - markStatementPaid/unmarkStatementPaid"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Grid componentization | Extract each of the 4 grids into its own file under `src/components/`, mirroring `ExpensesSection.tsx`/`IncomeSection.tsx` | Keep grids inline in `MonthlyPage.tsx`, just wrap in 2 row `<div>`s | Confirmed with the user; extraction keeps `MonthlyPage.tsx` from growing further and gives each grid an independently testable prop boundary, at the cost of 4 new files instead of a pure layout tweak |
+| Row grouping implementation | A single `.monthly-page__summary-groups` flex-column wrapper containing two `.monthly-page__grids-row` rows (existing class, unchanged), each with its 2 grids | A CSS grid with `grid-template-areas` for the 2x2 layout | Reuses the existing flex-row class as-is (already handles the wrap/`min-width` behavior for narrow viewports); no new layout system introduced for a 2-row split |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/components/CategoryTotalsGrid.tsx` | New | Renders the Category Totals grid | Accepts `categoryTotals`, `categoryTotalsSum`; renders the existing table/footer markup verbatim |
+| `Financial.Web/src/components/CardsGrid.tsx` | New | Renders the Cards grid with Mark/Unmark Paid | Accepts `cardStatements`, `banks`, `adjustmentTotal`, `markPaidSources`, `setMarkPaidSource`, `markStatementPaid`, `unmarkStatementPaid`; renders the existing table/footer/action markup verbatim |
+| `Financial.Web/src/components/BanksGrid.tsx` | New | Renders the Banks grid | Accepts `bankTotals`, `bankTotalsSum`, `roundUpTotalsSum`; renders the existing table/footer markup verbatim |
+| `Financial.Web/src/components/IncomingGrid.tsx` | New | Renders the Incoming totals grid | Accepts `incomeTotals`, `totalIncoming`, `titheSummary`; renders the existing table/footer markup verbatim |
+| `Financial.Web/src/pages/MonthlyPage.tsx` | Modified | Summary tab now composes the 4 grid components into 2 grouped rows | Replace inline grid JSX with `<CategoryTotalsGrid>`/`<CardsGrid>`/`<BanksGrid>`/`<IncomingGrid>`, forwarding the same values/handlers already destructured from `useMonthly()`; no change to any other tab |
+| `Financial.Web/src/pages/MonthlyPage.css` | Modified | Two-row Summary layout | Add `.monthly-page__summary-groups` (flex column, gap matching the existing section spacing); no change to `.monthly-page__grids-row`/`.monthly-page__section--grid` |
+
+## 5. API Contracts
+
+Not applicable — this feature makes no backend or API changes.
+
+## 6. Data Model
+
+Not applicable — this feature makes no data model or persistence changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/components/__tests__/CategoryTotalsGrid.test.tsx` | Component | `CategoryTotalsGrid` | Renders rows and footer total from props |
+| `Financial.Web/src/components/__tests__/CardsGrid.test.tsx` | Component | `CardsGrid` | Renders rows, footer total, and Mark/Unmark Paid interactions |
+| `Financial.Web/src/components/__tests__/BanksGrid.test.tsx` | Component | `BanksGrid` | Renders rows and footer totals from props |
+| `Financial.Web/src/components/__tests__/IncomingGrid.test.tsx` | Component | `IncomingGrid` | Renders rows, footer total, and optional tithe summary |
+| `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` | Component/Integration | `MonthlyPage` Summary tab grouping | F02 acceptance criteria and Cross-Feature Integration coverage |
+
+**Test functions:**
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `it('renders a row per category with the footer total')` (`CategoryTotalsGrid`) | Basic render | Category rows and formatted total appear |
+| `it('renders a row per card with status and mark/unmark paid controls')` (`CardsGrid`) | Basic render + interaction | Card rows, adjustment total, and Mark Paid/Unmark Paid behavior (moved verbatim from the existing `MonthlyPage.test.tsx` Cards assertions) |
+| `it('renders a row per bank with balance and round-up columns')` (`BanksGrid`) | Basic render | Bank rows and the two footer totals |
+| `it('renders a row per income source, with tithe summary when provided')` (`IncomingGrid`) | Basic render | Source rows, total incoming, and conditional tithe/tithe-balance text |
+| `it('renders Category Totals and Cards in the first row, Banks and Incoming in the second')` (`MonthlyPage`) | Verifies F02 AC2 | DOM order/structure check: first `.monthly-page__grids-row` contains Category Totals + Cards headings, second contains Banks + Incoming headings |
+| `it('shows no heading or label between the two Summary rows')` (`MonthlyPage`) | Verifies F02 AC3 | No extra heading/text node exists between the two grouped rows beyond the grids' own `<h2>`s |
+| `it('keeps Mark Paid/Unmark Paid working after the Summary regrouping')` (`MonthlyPage`) | Verifies F02 AC5-AC6 and the F01→F02 Cross-Feature Integration criterion (grids still re-scope correctly when month/year changes while Summary is active) | Existing Mark Paid/Unmark Paid flow assertions, run against the regrouped Summary tab |

--- a/docs/prd/P15-prd-monthly-tab-subtab-redesign/prd-monthly-tab-subtab-redesign.md
+++ b/docs/prd/P15-prd-monthly-tab-subtab-redesign/prd-monthly-tab-subtab-redesign.md
@@ -214,12 +214,12 @@ graph TD
 - [x] If data loading fails, the error/retry state is shown regardless of the active sub-tab
 
 ### F02. Monthly Summary Sub-Tab
-- [ ] Summary sub-tab renders exactly 4 grids: Category Totals, Cards, Banks, Incoming
-- [ ] Category Totals and Cards render in the first row; Banks and Incoming render in the second row
-- [ ] No text label or heading appears above either row — only a vertical gap separates them
-- [ ] Each grid's totals/footer values match the values shown before the redesign for the same period
-- [ ] Marking a card statement paid (selecting a bank and confirming) updates its status and the adjustment total, identically to pre-redesign behavior
-- [ ] Unmarking a paid card statement reverts its status, identically to pre-redesign behavior
+- [x] Summary sub-tab renders exactly 4 grids: Category Totals, Cards, Banks, Incoming
+- [x] Category Totals and Cards render in the first row; Banks and Incoming render in the second row
+- [x] No text label or heading appears above either row — only a vertical gap separates them
+- [x] Each grid's totals/footer values match the values shown before the redesign for the same period
+- [x] Marking a card statement paid (selecting a bank and confirming) updates its status and the adjustment total, identically to pre-redesign behavior
+- [x] Unmarking a paid card statement reverts its status, identically to pre-redesign behavior
 
 ### F03. Monthly Expense Sub-Tab
 - [ ] Expense sub-tab renders the full expense list for the selected month
@@ -238,7 +238,7 @@ graph TD
 - [ ] Switching to another sub-tab while the create/edit form is open closes the form and discards unsaved input
 
 ### Cross-Feature Integration
-- [ ] Selecting a different month/year while Summary is active re-scopes all 4 grids to the new period (F01 → F02)
+- [x] Selecting a different month/year while Summary is active re-scopes all 4 grids to the new period (F01 → F02)
 - [ ] Selecting a different month/year while Expense is active re-scopes the expense list to the new period (F01 → F03)
 - [ ] Selecting a different month/year while Incoming is active re-scopes the income list to the new period (F01 → F04)
 - [ ] Switching from Summary to Expense or Incoming and back displays each sub-tab's content without re-triggering a network refetch, confirming the shared period from F01 is reused rather than reset (F01 → F02, F03, F04)


### PR DESCRIPTION
## Summary
- Extracts the 4 Summary grids (Category Totals, Cards, Banks, Incoming) into their own components under `src/components/`, following the existing `ExpensesSection`/`IncomeSection` pattern
- Regroups the Summary tab into two rows: Category Totals + Cards, then Banks + Incoming, with no heading or label between them
- No change to any grid's data, calculations, or the Cards grid's Mark/Unmark Paid behavior

## Test plan
### F02. Monthly Summary Sub-Tab
- [x] Summary sub-tab renders exactly 4 grids: Category Totals, Cards, Banks, Incoming
- [x] Category Totals and Cards render in the first row; Banks and Incoming render in the second row
- [x] No text label or heading appears above either row — only a vertical gap separates them
- [x] Each grid's totals/footer values match the values shown before the redesign for the same period
- [x] Marking a card statement paid (selecting a bank and confirming) updates its status and the adjustment total, identically to pre-redesign behavior
- [x] Unmarking a paid card statement reverts its status, identically to pre-redesign behavior

### Cross-Feature Integration
- [x] Selecting a different month/year while Summary is active re-scopes all 4 grids to the new period (F01 → F02)

### Validation run
- [x] `tsc -b --noEmit` clean
- [x] `eslint .` clean
- [x] Full frontend suite: 606/606 tests passing (49 files), including 4 new grid component test files and 39 in `MonthlyPage.test.tsx`
- [x] `vite build` production build succeeds
- [ ] Manual browser smoke test — skipped (same as F01), covered instead by the full automated test suite above

Spec/plan: `docs/P15-F02-monthly-summary-subtab/`