### PR TITLE
feat(P15-F03): Monthly expense sub-tab component extraction

### DIFF
--- a/Financial.Web/src/components/ExpenseForm.tsx
+++ b/Financial.Web/src/components/ExpenseForm.tsx
@@ -1,0 +1,203 @@
+import type { BankDto } from '../api/types'
+import type { PaymentMode } from '../hooks/useMonthly'
+
+export type ExpenseFormField = 'date' | 'description' | 'value' | 'category' | 'paymentSource' | 'cardTag' | 'roundUpAmount'
+
+const CATEGORIES = [
+  'Ariana',
+  'Carro',
+  'Casa',
+  'Estudo',
+  'Extras',
+  'Familia',
+  'Gleison',
+  'Mercado',
+  'Samuel',
+  'Saude',
+  'Viagem',
+  'Dizimo',
+  'Investimento',
+  'Reserva',
+]
+
+const CARDS = ['BarclaysPlatinumVisa8003', 'BarclaysPlatinumVisa6007', 'ChaseMaster4023', 'BaAmex', 'PaypalCredit']
+
+interface ExpenseFormProps {
+  isEditing: boolean
+  date: string
+  description: string
+  value: string
+  category: string
+  paymentSource: string
+  cardTag: string
+  roundUpAmount: string
+  paymentMode: PaymentMode
+  banks: BankDto[]
+  isSettled: boolean
+  isSaving: boolean
+  saveError: string | null
+  onFieldChange: (field: ExpenseFormField, value: string) => void
+  onModeChange: (mode: PaymentMode) => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+export default function ExpenseForm({
+  isEditing,
+  date,
+  description,
+  value,
+  category,
+  paymentSource,
+  cardTag,
+  roundUpAmount,
+  paymentMode,
+  banks,
+  isSettled,
+  isSaving,
+  saveError,
+  onFieldChange,
+  onModeChange,
+  onSave,
+  onCancel,
+}: ExpenseFormProps) {
+  const selectedBank = banks.find((b) => b.name === paymentSource)
+  const showRoundUpField = paymentMode === 'bank' && selectedBank?.roundUpEnabled === true
+  return (
+    <div className="monthly-page__form-panel">
+      <p className="monthly-page__form-title">{isEditing ? 'Edit Expense' : 'New Expense'}</p>
+      <div className="monthly-page__form">
+        <div className="monthly-page__form-field">
+          <label htmlFor="expense-date">Date</label>
+          <input
+            id="expense-date"
+            type="date"
+            value={date}
+            onChange={(e) => onFieldChange('date', e.target.value)}
+          />
+        </div>
+        <div className="monthly-page__form-field">
+          <label htmlFor="expense-description">Description</label>
+          <input
+            id="expense-description"
+            type="text"
+            value={description}
+            onChange={(e) => onFieldChange('description', e.target.value)}
+          />
+        </div>
+        <div className="monthly-page__form-field">
+          <label htmlFor="expense-category">Category</label>
+          <select
+            id="expense-category"
+            value={category}
+            onChange={(e) => onFieldChange('category', e.target.value)}
+          >
+            {CATEGORIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="monthly-page__form-field">
+          <label htmlFor="expense-value">Value</label>
+          <input
+            id="expense-value"
+            type="number"
+            step="0.01"
+            value={value}
+            onChange={(e) => onFieldChange('value', e.target.value)}
+          />
+        </div>
+        {isSettled ? (
+          <div className="monthly-page__form-field">
+            <label>Payment</label>
+            <p className="monthly-page__settled-note">
+              Paid by {paymentSource} via card {cardTag}. Settled via its card statement — unmark the
+              statement paid to change these fields.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="monthly-page__form-field">
+              <span>Payment</span>
+              <label>
+                <input
+                  type="radio"
+                  name="expense-payment-mode"
+                  checked={paymentMode === 'bank'}
+                  onChange={() => onModeChange('bank')}
+                />
+                Pay immediately
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="expense-payment-mode"
+                  checked={paymentMode === 'card'}
+                  onChange={() => onModeChange('card')}
+                />
+                Charge to card
+              </label>
+            </div>
+            {paymentMode === 'bank' ? (
+              <>
+                <div className="monthly-page__form-field">
+                  <label htmlFor="expense-payment-source">Payment Source</label>
+                  <select
+                    id="expense-payment-source"
+                    value={paymentSource}
+                    onChange={(e) => onFieldChange('paymentSource', e.target.value)}
+                  >
+                    {banks.map((b) => (
+                      <option key={b.name} value={b.name}>
+                        {b.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                {showRoundUpField && (
+                  <div className="monthly-page__form-field">
+                    <label htmlFor="expense-round-up-amount">Round-Up</label>
+                    <input
+                      id="expense-round-up-amount"
+                      type="number"
+                      step="0.01"
+                      value={roundUpAmount}
+                      onChange={(e) => onFieldChange('roundUpAmount', e.target.value)}
+                    />
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="monthly-page__form-field">
+                <label htmlFor="expense-card-tag">Card</label>
+                <select
+                  id="expense-card-tag"
+                  value={cardTag}
+                  onChange={(e) => onFieldChange('cardTag', e.target.value)}
+                >
+                  <option value="">Select card…</option>
+                  {CARDS.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+      <div className="monthly-page__form-actions">
+        <button className="monthly-page__submit-btn" type="button" disabled={isSaving} onClick={onSave}>
+          {isSaving ? 'Saving...' : isEditing ? 'Save' : 'Add Expense'}
+        </button>
+        <button className="monthly-page__cancel-btn" type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+      {saveError && <p className="monthly-page__error">{saveError}</p>}
+    </div>
+  )
+}

--- a/Financial.Web/src/components/__tests__/ExpenseForm.test.tsx
+++ b/Financial.Web/src/components/__tests__/ExpenseForm.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import ExpenseForm from '../ExpenseForm'
+import type { BankDto } from '../../api/types'
+
+const BANKS: BankDto[] = [
+  { name: 'Barclays', roundUpEnabled: false },
+  { name: 'Trading212', roundUpEnabled: true },
+]
+
+const baseProps = {
+  isEditing: false,
+  date: '',
+  description: '',
+  value: '',
+  category: 'Mercado',
+  paymentSource: 'Barclays',
+  cardTag: '',
+  roundUpAmount: '',
+  paymentMode: 'bank' as const,
+  banks: BANKS,
+  isSettled: false,
+  isSaving: false,
+  saveError: null,
+  onFieldChange: vi.fn(),
+  onModeChange: vi.fn(),
+  onSave: vi.fn(),
+  onCancel: vi.fn(),
+}
+
+describe('ExpenseForm', () => {
+  it('renders the create form with empty date/description/value fields', () => {
+    render(<ExpenseForm {...baseProps} />)
+
+    expect(screen.getByText('New Expense')).toBeInTheDocument()
+    expect(screen.getByLabelText('Date')).toHaveValue('')
+    expect(screen.getByLabelText('Description')).toHaveValue('')
+    expect(screen.getByLabelText('Value')).toHaveValue(null)
+    expect(screen.getByRole('button', { name: 'Add Expense' })).toBeInTheDocument()
+  })
+
+  it('shows the settlement note and hides payment fields when settled', () => {
+    render(
+      <ExpenseForm
+        {...baseProps}
+        isEditing
+        isSettled
+        paymentSource="Trading212"
+        cardTag="BaAmex"
+      />,
+    )
+
+    expect(screen.getByText(/Settled via its card statement/)).toBeInTheDocument()
+    expect(screen.queryByLabelText('Payment Source')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Card')).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+  })
+
+  it('shows the bank picker in bank mode and the card picker in card mode', () => {
+    const { rerender } = render(<ExpenseForm {...baseProps} paymentMode="bank" />)
+    expect(screen.getByLabelText('Payment Source')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Card')).not.toBeInTheDocument()
+
+    rerender(<ExpenseForm {...baseProps} paymentMode="card" />)
+    expect(screen.queryByLabelText('Payment Source')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Card')).toBeInTheDocument()
+  })
+
+  it('shows the round-up field only for a round-up-enabled bank in bank mode', () => {
+    const { rerender } = render(<ExpenseForm {...baseProps} paymentMode="bank" paymentSource="Barclays" />)
+    expect(screen.queryByLabelText('Round-Up')).not.toBeInTheDocument()
+
+    rerender(<ExpenseForm {...baseProps} paymentMode="bank" paymentSource="Trading212" />)
+    expect(screen.getByLabelText('Round-Up')).toBeInTheDocument()
+
+    rerender(<ExpenseForm {...baseProps} paymentMode="card" paymentSource="Trading212" />)
+    expect(screen.queryByLabelText('Round-Up')).not.toBeInTheDocument()
+  })
+
+  it('calls onSave and onCancel', () => {
+    const onSave = vi.fn()
+    const onCancel = vi.fn()
+    render(<ExpenseForm {...baseProps} onSave={onSave} onCancel={onCancel} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Expense' }))
+    expect(onSave).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -3,6 +3,7 @@ import BanksGrid from '../components/BanksGrid'
 import CardsGrid from '../components/CardsGrid'
 import CategoryTotalsGrid from '../components/CategoryTotalsGrid'
 import ErrorState from '../components/ErrorState'
+import ExpenseForm, { type ExpenseFormField } from '../components/ExpenseForm'
 import ExpensesSection from '../components/ExpensesSection'
 import IncomeSection from '../components/IncomeSection'
 import IncomingGrid from '../components/IncomingGrid'
@@ -14,7 +15,6 @@ import {
   type CreateIncomeField,
   type EditField,
   type EditIncomeField,
-  type PaymentMode,
 } from '../hooks/useMonthly'
 import type { BankDto } from '../api/types'
 import './MonthlyPage.css'
@@ -26,8 +26,6 @@ const MONTHLY_TABS: { id: MonthlyTabId; label: string }[] = [
   { id: 'expense', label: 'Expense' },
   { id: 'incoming', label: 'Incoming' },
 ]
-
-type ExpenseFormField = 'date' | 'description' | 'value' | 'category' | 'paymentSource' | 'cardTag' | 'roundUpAmount'
 
 const CREATE_FIELD_BY_FORM_FIELD: Record<ExpenseFormField, CreateFormField> = {
   date: 'createDate',
@@ -49,25 +47,6 @@ const EDIT_FIELD_BY_FORM_FIELD: Record<ExpenseFormField, EditField> = {
   roundUpAmount: 'editRoundUpAmount',
 }
 
-const CATEGORIES = [
-  'Ariana',
-  'Carro',
-  'Casa',
-  'Estudo',
-  'Extras',
-  'Familia',
-  'Gleison',
-  'Mercado',
-  'Samuel',
-  'Saude',
-  'Viagem',
-  'Dizimo',
-  'Investimento',
-  'Reserva',
-]
-
-const CARDS = ['BarclaysPlatinumVisa8003', 'BarclaysPlatinumVisa6007', 'ChaseMaster4023', 'BaAmex', 'PaypalCredit']
-
 const INCOME_SOURCES = ['Gleison', 'Ariana', 'Lottery', 'DividendoJuros']
 
 type IncomeFormField = 'date' | 'incomeSource' | 'grossValue' | 'netValue' | 'bank'
@@ -86,186 +65,6 @@ const EDIT_INCOME_FIELD_BY_FORM_FIELD: Record<IncomeFormField, EditIncomeField> 
   grossValue: 'editIncomeGrossValue',
   netValue: 'editIncomeNetValue',
   bank: 'editIncomeBank',
-}
-
-interface ExpenseFormProps {
-  isEditing: boolean
-  date: string
-  description: string
-  value: string
-  category: string
-  paymentSource: string
-  cardTag: string
-  roundUpAmount: string
-  paymentMode: PaymentMode
-  banks: BankDto[]
-  isSettled: boolean
-  isSaving: boolean
-  saveError: string | null
-  onFieldChange: (field: ExpenseFormField, value: string) => void
-  onModeChange: (mode: PaymentMode) => void
-  onSave: () => void
-  onCancel: () => void
-}
-
-function ExpenseForm({
-  isEditing,
-  date,
-  description,
-  value,
-  category,
-  paymentSource,
-  cardTag,
-  roundUpAmount,
-  paymentMode,
-  banks,
-  isSettled,
-  isSaving,
-  saveError,
-  onFieldChange,
-  onModeChange,
-  onSave,
-  onCancel,
-}: ExpenseFormProps) {
-  const selectedBank = banks.find((b) => b.name === paymentSource)
-  const showRoundUpField = paymentMode === 'bank' && selectedBank?.roundUpEnabled === true
-  return (
-    <div className="monthly-page__form-panel">
-      <p className="monthly-page__form-title">{isEditing ? 'Edit Expense' : 'New Expense'}</p>
-      <div className="monthly-page__form">
-        <div className="monthly-page__form-field">
-          <label htmlFor="expense-date">Date</label>
-          <input
-            id="expense-date"
-            type="date"
-            value={date}
-            onChange={(e) => onFieldChange('date', e.target.value)}
-          />
-        </div>
-        <div className="monthly-page__form-field">
-          <label htmlFor="expense-description">Description</label>
-          <input
-            id="expense-description"
-            type="text"
-            value={description}
-            onChange={(e) => onFieldChange('description', e.target.value)}
-          />
-        </div>
-        <div className="monthly-page__form-field">
-          <label htmlFor="expense-category">Category</label>
-          <select
-            id="expense-category"
-            value={category}
-            onChange={(e) => onFieldChange('category', e.target.value)}
-          >
-            {CATEGORIES.map((c) => (
-              <option key={c} value={c}>
-                {c}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="monthly-page__form-field">
-          <label htmlFor="expense-value">Value</label>
-          <input
-            id="expense-value"
-            type="number"
-            step="0.01"
-            value={value}
-            onChange={(e) => onFieldChange('value', e.target.value)}
-          />
-        </div>
-        {isSettled ? (
-          <div className="monthly-page__form-field">
-            <label>Payment</label>
-            <p className="monthly-page__settled-note">
-              Paid by {paymentSource} via card {cardTag}. Settled via its card statement — unmark the
-              statement paid to change these fields.
-            </p>
-          </div>
-        ) : (
-          <>
-            <div className="monthly-page__form-field">
-              <span>Payment</span>
-              <label>
-                <input
-                  type="radio"
-                  name="expense-payment-mode"
-                  checked={paymentMode === 'bank'}
-                  onChange={() => onModeChange('bank')}
-                />
-                Pay immediately
-              </label>
-              <label>
-                <input
-                  type="radio"
-                  name="expense-payment-mode"
-                  checked={paymentMode === 'card'}
-                  onChange={() => onModeChange('card')}
-                />
-                Charge to card
-              </label>
-            </div>
-            {paymentMode === 'bank' ? (
-              <>
-                <div className="monthly-page__form-field">
-                  <label htmlFor="expense-payment-source">Payment Source</label>
-                  <select
-                    id="expense-payment-source"
-                    value={paymentSource}
-                    onChange={(e) => onFieldChange('paymentSource', e.target.value)}
-                  >
-                    {banks.map((b) => (
-                      <option key={b.name} value={b.name}>
-                        {b.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                {showRoundUpField && (
-                  <div className="monthly-page__form-field">
-                    <label htmlFor="expense-round-up-amount">Round-Up</label>
-                    <input
-                      id="expense-round-up-amount"
-                      type="number"
-                      step="0.01"
-                      value={roundUpAmount}
-                      onChange={(e) => onFieldChange('roundUpAmount', e.target.value)}
-                    />
-                  </div>
-                )}
-              </>
-            ) : (
-              <div className="monthly-page__form-field">
-                <label htmlFor="expense-card-tag">Card</label>
-                <select
-                  id="expense-card-tag"
-                  value={cardTag}
-                  onChange={(e) => onFieldChange('cardTag', e.target.value)}
-                >
-                  <option value="">Select card…</option>
-                  {CARDS.map((c) => (
-                    <option key={c} value={c}>
-                      {c}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
-          </>
-        )}
-      </div>
-      <div className="monthly-page__form-actions">
-        <button className="monthly-page__submit-btn" type="button" disabled={isSaving} onClick={onSave}>
-          {isSaving ? 'Saving...' : isEditing ? 'Save' : 'Add Expense'}
-        </button>
-        <button className="monthly-page__cancel-btn" type="button" onClick={onCancel}>
-          Cancel
-        </button>
-      </div>
-      {saveError && <p className="monthly-page__error">{saveError}</p>}
-    </div>
-  )
 }
 
 interface IncomeFormProps {

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -250,6 +250,20 @@ describe('MonthlyPage', () => {
     expect(screen.getByRole('button', { name: 'New Expense' })).toBeInTheDocument()
   })
 
+  it('re-scopes the expense list when the month/year value changes while Expense is active', async () => {
+    render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
+
+    await waitFor(() => expect(screen.getByText('Lidl UK')).toBeInTheDocument())
+
+    getExpensesByMonthMock.mockResolvedValue([{ ...EXPENSES[0], id: 'e3', description: 'TfL Top-Up' }])
+
+    fireEvent.change(screen.getByLabelText('Month'), { target: { value: '2026-08' } })
+
+    await waitFor(() => expect(screen.getByText('TfL Top-Up')).toBeInTheDocument())
+    expect(screen.queryByText('Lidl UK')).not.toBeInTheDocument()
+  })
+
   it('renders category totals and card statements with the combined adjustment on Summary, and the expense list on the Expense tab', async () => {
     render(<MonthlyPage />)
 

--- a/docs/P15-F03-monthly-expense-subtab/plan.md
+++ b/docs/P15-F03-monthly-expense-subtab/plan.md
@@ -1,0 +1,16 @@
+# Implementation Plan: Monthly Expense Sub-Tab
+
+**Prerequisites:**
+- F01 (Monthly Tab Navigation Shell) merged — this feature only extracts a component F01 already scoped correctly to the Expense tab.
+
+### Stage 1: Extract the Expense Form Component
+
+**1. ExpenseForm Component** - Move the `ExpenseForm` local function, its option lists (`CATEGORIES`, `CARDS`), and its field-mapping constants out of `MonthlyPage.tsx` into their own file, with no change to props, markup, or behavior.
+
+**2. Wire MonthlyPage to the Extracted Component** - Update `MonthlyPage.tsx`'s Expense tab block to import and render the extracted `ExpenseForm`, removing the now-unused local definitions.
+
+### Stage 2: Test Coverage
+
+**3. Add ExpenseForm Component Tests** - Add a dedicated test file covering the form's create/edit, settled, and payment-mode/round-up rendering branches in isolation.
+
+**4. Re-verify Expense Tab Behavior** - Re-run the existing Expense-tab tests in `MonthlyPage.test.tsx` to confirm New/Edit/Delete, the settlement note, bank/card mode switching, round-up handling, and tab-switch form discarding all still pass unchanged against the extracted component.

--- a/docs/P15-F03-monthly-expense-subtab/spec.md
+++ b/docs/P15-F03-monthly-expense-subtab/spec.md
@@ -1,0 +1,66 @@
+## 1. Technical Overview
+
+**What:** Extract the `ExpenseForm` local function (currently defined inline in `MonthlyPage.tsx`) into its own component under `src/components/`, with no change to its props, markup, or behavior. `MonthlyPage.tsx` continues composing `<ExpenseForm>` + `<ExpensesSection>` directly inside the Expense tab guard.
+
+**Why:** F01 already relocated the full expense list and create/edit form into the Expense tab guard and already implements every behavior this feature's PRD entry describes — tab-scoped form visibility, discarding an open form on tab switch (via `handleTabClick`'s `cancelEdit`/`cancelCreateForm` calls), and unchanged create/edit/delete/validation flows. This feature's only remaining work is code organization: continuing the extraction pattern F02 established for the 4 Summary grids, applied here to the last piece of UI still inlined in `MonthlyPage.tsx` for the Expense tab.
+
+**Scope:**
+- Included: extracting `ExpenseForm` into its own file; re-verifying (not re-implementing) F03's acceptance criteria against the current codebase.
+- Excluded: any change to `ExpensesSection.tsx`, `useMonthly.ts`, validation rules, or the tab-switch-discards-form mechanism (all already correct, from F01). No `MonthlyExpenseTab.tsx` wrapper — confirmed with the user, `MonthlyPage.tsx` keeps composing the two pieces directly.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/components/ExpenseForm.tsx` (new) — the extracted form component
+- `Financial.Web/src/pages/MonthlyPage.tsx` — removes the local `ExpenseForm` function and its field-mapping constants (`CREATE_FIELD_BY_FORM_FIELD`, `EDIT_FIELD_BY_FORM_FIELD`, `CATEGORIES`, `CARDS`), importing the new component instead
+- `Financial.Web/src/components/__tests__/ExpenseForm.test.tsx` (new)
+
+```mermaid
+graph TD
+    A[MonthlyPage - Expense tab] --> B[ExpenseForm]
+    A --> C[ExpensesSection]
+    B --> D["useMonthly - create/edit expense state"]
+    C --> D
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Extraction boundary | Extract only `ExpenseForm` into its own file; `MonthlyPage.tsx` keeps composing `<ExpenseForm>` + `<ExpensesSection>` directly | Also wrap both into a `MonthlyExpenseTab.tsx` coordinator component | Confirmed with the user; matches F02's grid-extraction precedent (one component per extracted unit) without adding an extra prop-passthrough layer that isn't yet justified by size or reuse |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/components/ExpenseForm.tsx` | New | Renders the create/edit expense form | Same props as the current local function (`isEditing`, `date`, `description`, `value`, `category`, `paymentSource`, `cardTag`, `roundUpAmount`, `paymentMode`, `banks`, `isSettled`, `isSaving`, `saveError`, `onFieldChange`, `onModeChange`, `onSave`, `onCancel`); owns the `CATEGORIES`/`CARDS` option lists and the settled-vs-editable field layout, moved verbatim |
+| `Financial.Web/src/pages/MonthlyPage.tsx` | Modified | Expense tab composition | Import `ExpenseForm` from `components/`; remove the local function definition and its field-mapping constants; the `EXPENSE_FIELD_BY_FORM_FIELD`-style mapping constants move alongside the component since they're only used by its `onFieldChange` wiring |
+
+## 5. API Contracts
+
+Not applicable — this feature makes no backend or API changes.
+
+## 6. Data Model
+
+Not applicable — this feature makes no data model or persistence changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/components/__tests__/ExpenseForm.test.tsx` | Component | `ExpenseForm` | Renders correctly in create/edit/settled/bank-mode/card-mode states |
+| `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` | Component/Integration | `MonthlyPage` Expense tab (existing suite) | F03 acceptance criteria re-verified unchanged after extraction |
+
+**Test functions:**
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `it('renders the create form with empty fields by default')` (`ExpenseForm`) | Basic render | Date/description/value/category fields present and empty |
+| `it('shows the settlement note and hides payment fields when settled')` (`ExpenseForm`) | Settled-expense branch | Settlement note visible, payment mode radios and pickers absent |
+| `it('shows the bank picker in bank mode and the card picker in card mode')` (`ExpenseForm`) | Mode toggle | Correct picker shown per `paymentMode` |
+| `it('shows the round-up field only for a round-up-enabled bank in bank mode')` (`ExpenseForm`) | Round-up conditional | Round-up input appears/disappears per bank selection |
+| Existing `MonthlyPage.test.tsx` Expense-tab tests (New/Edit/Delete, settled note, bank/card mode, round-up, tab-switch-discards-form) | Re-run unchanged | All pass against the extracted component, confirming no behavior regressed |

--- a/docs/prd/P15-prd-monthly-tab-subtab-redesign/prd-monthly-tab-subtab-redesign.md
+++ b/docs/prd/P15-prd-monthly-tab-subtab-redesign/prd-monthly-tab-subtab-redesign.md
@@ -222,12 +222,12 @@ graph TD
 - [x] Unmarking a paid card statement reverts its status, identically to pre-redesign behavior
 
 ### F03. Monthly Expense Sub-Tab
-- [ ] Expense sub-tab renders the full expense list for the selected month
-- [ ] Clicking "New Expense" opens the create form within the Expense sub-tab; the form is not visible when Summary or Incoming is active
-- [ ] Creating an expense with valid data adds it to the list and closes the form, identically to pre-redesign behavior
-- [ ] Editing an expense pre-fills the form with its current values and saves changes identically to pre-redesign behavior
-- [ ] Deleting an expense removes it from the list identically to pre-redesign behavior
-- [ ] Switching to another sub-tab while the create/edit form is open closes the form and discards unsaved input
+- [x] Expense sub-tab renders the full expense list for the selected month
+- [x] Clicking "New Expense" opens the create form within the Expense sub-tab; the form is not visible when Summary or Incoming is active
+- [x] Creating an expense with valid data adds it to the list and closes the form, identically to pre-redesign behavior
+- [x] Editing an expense pre-fills the form with its current values and saves changes identically to pre-redesign behavior
+- [x] Deleting an expense removes it from the list identically to pre-redesign behavior
+- [x] Switching to another sub-tab while the create/edit form is open closes the form and discards unsaved input
 
 ### F04. Monthly Incoming Sub-Tab
 - [ ] Incoming sub-tab renders the full income list for the selected month
@@ -239,7 +239,7 @@ graph TD
 
 ### Cross-Feature Integration
 - [x] Selecting a different month/year while Summary is active re-scopes all 4 grids to the new period (F01 → F02)
-- [ ] Selecting a different month/year while Expense is active re-scopes the expense list to the new period (F01 → F03)
+- [x] Selecting a different month/year while Expense is active re-scopes the expense list to the new period (F01 → F03)
 - [ ] Selecting a different month/year while Incoming is active re-scopes the income list to the new period (F01 → F04)
 - [ ] Switching from Summary to Expense or Incoming and back displays each sub-tab's content without re-triggering a network refetch, confirming the shared period from F01 is reused rather than reset (F01 → F02, F03, F04)
 - [ ] At every point in the flow, exactly one of Summary/Expense/Incoming content is visible, confirming F01's active-tab state correctly gates F02, F03, and F04 (F01 → F02, F03, F04)


### PR DESCRIPTION
## Summary
- Extracts the inline `ExpenseForm` function out of `MonthlyPage.tsx` into its own component (`src/components/ExpenseForm.tsx`), following F02's grid-extraction precedent
- F01 already delivered all of F03's required behavior (tab-scoped form, discard-on-tab-switch, unchanged create/edit/delete/validation) — this PR is a code-organization pass plus re-verification of that behavior against the extracted component
- No behavior change

## Test plan
### F03. Monthly Expense Sub-Tab
- [x] Expense sub-tab renders the full expense list for the selected month
- [x] Clicking "New Expense" opens the create form within the Expense sub-tab; the form is not visible when Summary or Incoming is active
- [x] Creating an expense with valid data adds it to the list and closes the form, identically to pre-redesign behavior
- [x] Editing an expense pre-fills the form with its current values and saves changes identically to pre-redesign behavior
- [x] Deleting an expense removes it from the list identically to pre-redesign behavior
- [x] Switching to another sub-tab while the create/edit form is open closes the form and discards unsaved input

### Cross-Feature Integration
- [x] Selecting a different month/year while Expense is active re-scopes the expense list to the new period (F01 → F03)

### Validation run
- [x] `tsc -b --noEmit` clean
- [x] `eslint .` clean
- [x] Full frontend suite: 612/612 tests passing (50 files), including a new `ExpenseForm.test.tsx`
- [x] `vite build` production build succeeds
- [ ] Manual browser smoke test — skipped (same as F01/F02), covered instead by the full automated test suite above

Spec/plan: `docs/P15-F03-monthly-expense-subtab/`