### PR TITLE
feat(P15-F04): Monthly incoming sub-tab component extraction

### DIFF
--- a/Financial.Web/src/components/IncomeForm.tsx
+++ b/Financial.Web/src/components/IncomeForm.tsx
@@ -1,0 +1,109 @@
+import type { BankDto } from '../api/types'
+import { INCOME_SOURCES_WITH_GROSS_VALUE } from '../hooks/useMonthly'
+
+export type IncomeFormField = 'date' | 'incomeSource' | 'grossValue' | 'netValue' | 'bank'
+
+const INCOME_SOURCES = ['Gleison', 'Ariana', 'Lottery', 'DividendoJuros']
+
+interface IncomeFormProps {
+  isEditing: boolean
+  date: string
+  incomeSource: string
+  grossValue: string
+  netValue: string
+  bank: string
+  banks: BankDto[]
+  isSaving: boolean
+  saveError: string | null
+  onFieldChange: (field: IncomeFormField, value: string) => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+export default function IncomeForm({
+  isEditing,
+  date,
+  incomeSource,
+  grossValue,
+  netValue,
+  bank,
+  banks,
+  isSaving,
+  saveError,
+  onFieldChange,
+  onSave,
+  onCancel,
+}: IncomeFormProps) {
+  const showGrossValueField = INCOME_SOURCES_WITH_GROSS_VALUE.includes(incomeSource)
+  return (
+    <div className="monthly-page__form-panel">
+      <p className="monthly-page__form-title">{isEditing ? 'Edit Income' : 'New Income'}</p>
+      <div className="monthly-page__form">
+        <div className="monthly-page__form-field">
+          <label htmlFor="income-date">Date</label>
+          <input
+            id="income-date"
+            type="date"
+            value={date}
+            onChange={(e) => onFieldChange('date', e.target.value)}
+          />
+        </div>
+        <div className="monthly-page__form-field">
+          <label htmlFor="income-source">Source</label>
+          <select
+            id="income-source"
+            value={incomeSource}
+            onChange={(e) => onFieldChange('incomeSource', e.target.value)}
+          >
+            {INCOME_SOURCES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+        {showGrossValueField && (
+          <div className="monthly-page__form-field">
+            <label htmlFor="income-gross-value">Gross Value</label>
+            <input
+              id="income-gross-value"
+              type="number"
+              step="0.01"
+              value={grossValue}
+              onChange={(e) => onFieldChange('grossValue', e.target.value)}
+            />
+          </div>
+        )}
+        <div className="monthly-page__form-field">
+          <label htmlFor="income-net-value">Net Value</label>
+          <input
+            id="income-net-value"
+            type="number"
+            step="0.01"
+            value={netValue}
+            onChange={(e) => onFieldChange('netValue', e.target.value)}
+          />
+        </div>
+        <div className="monthly-page__form-field">
+          <label htmlFor="income-bank">Bank</label>
+          <select id="income-bank" value={bank} onChange={(e) => onFieldChange('bank', e.target.value)}>
+            {banks.map((b) => (
+              <option key={b.name} value={b.name}>
+                {b.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="monthly-page__form-actions">
+        <button className="monthly-page__submit-btn" type="button" disabled={isSaving} onClick={onSave}>
+          {isSaving ? 'Saving...' : isEditing ? 'Save' : 'Add Income'}
+        </button>
+        <button className="monthly-page__cancel-btn" type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+      {saveError && <p className="monthly-page__error">{saveError}</p>}
+    </div>
+  )
+}

--- a/Financial.Web/src/components/__tests__/IncomeForm.test.tsx
+++ b/Financial.Web/src/components/__tests__/IncomeForm.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import IncomeForm from '../IncomeForm'
+import type { BankDto } from '../../api/types'
+
+const BANKS: BankDto[] = [
+  { name: 'Barclays', roundUpEnabled: false },
+  { name: 'Trading212', roundUpEnabled: true },
+]
+
+const baseProps = {
+  isEditing: false,
+  date: '',
+  incomeSource: 'Gleison',
+  grossValue: '',
+  netValue: '',
+  bank: 'Barclays',
+  banks: BANKS,
+  isSaving: false,
+  saveError: null,
+  onFieldChange: vi.fn(),
+  onSave: vi.fn(),
+  onCancel: vi.fn(),
+}
+
+describe('IncomeForm', () => {
+  it('renders the create form with empty date/net-value fields', () => {
+    render(<IncomeForm {...baseProps} />)
+
+    expect(screen.getByText('New Income')).toBeInTheDocument()
+    expect(screen.getByLabelText('Date')).toHaveValue('')
+    expect(screen.getByLabelText('Net Value')).toHaveValue(null)
+    expect(screen.getByRole('button', { name: 'Add Income' })).toBeInTheDocument()
+  })
+
+  it('shows the gross value field only for sources that require it', () => {
+    const { rerender } = render(<IncomeForm {...baseProps} incomeSource="Gleison" />)
+    expect(screen.getByLabelText('Gross Value')).toBeInTheDocument()
+
+    rerender(<IncomeForm {...baseProps} incomeSource="Ariana" />)
+    expect(screen.getByLabelText('Gross Value')).toBeInTheDocument()
+
+    rerender(<IncomeForm {...baseProps} incomeSource="Lottery" />)
+    expect(screen.queryByLabelText('Gross Value')).not.toBeInTheDocument()
+
+    rerender(<IncomeForm {...baseProps} incomeSource="DividendoJuros" />)
+    expect(screen.queryByLabelText('Gross Value')).not.toBeInTheDocument()
+  })
+
+  it('calls onSave and onCancel', () => {
+    const onSave = vi.fn()
+    const onCancel = vi.fn()
+    render(<IncomeForm {...baseProps} onSave={onSave} onCancel={onCancel} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Income' }))
+    expect(onSave).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('shows Edit Income and Save when editing', () => {
+    render(<IncomeForm {...baseProps} isEditing />)
+
+    expect(screen.getByText('Edit Income')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  })
+})

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -5,18 +5,17 @@ import CategoryTotalsGrid from '../components/CategoryTotalsGrid'
 import ErrorState from '../components/ErrorState'
 import ExpenseForm, { type ExpenseFormField } from '../components/ExpenseForm'
 import ExpensesSection from '../components/ExpensesSection'
+import IncomeForm, { type IncomeFormField } from '../components/IncomeForm'
 import IncomeSection from '../components/IncomeSection'
 import IncomingGrid from '../components/IncomingGrid'
 import LoadingState from '../components/LoadingState'
 import {
   useMonthly,
-  INCOME_SOURCES_WITH_GROSS_VALUE,
   type CreateFormField,
   type CreateIncomeField,
   type EditField,
   type EditIncomeField,
 } from '../hooks/useMonthly'
-import type { BankDto } from '../api/types'
 import './MonthlyPage.css'
 
 type MonthlyTabId = 'summary' | 'expense' | 'incoming'
@@ -47,10 +46,6 @@ const EDIT_FIELD_BY_FORM_FIELD: Record<ExpenseFormField, EditField> = {
   roundUpAmount: 'editRoundUpAmount',
 }
 
-const INCOME_SOURCES = ['Gleison', 'Ariana', 'Lottery', 'DividendoJuros']
-
-type IncomeFormField = 'date' | 'incomeSource' | 'grossValue' | 'netValue' | 'bank'
-
 const CREATE_INCOME_FIELD_BY_FORM_FIELD: Record<IncomeFormField, CreateIncomeField> = {
   date: 'createIncomeDate',
   incomeSource: 'createIncomeSource',
@@ -65,109 +60,6 @@ const EDIT_INCOME_FIELD_BY_FORM_FIELD: Record<IncomeFormField, EditIncomeField> 
   grossValue: 'editIncomeGrossValue',
   netValue: 'editIncomeNetValue',
   bank: 'editIncomeBank',
-}
-
-interface IncomeFormProps {
-  isEditing: boolean
-  date: string
-  incomeSource: string
-  grossValue: string
-  netValue: string
-  bank: string
-  banks: BankDto[]
-  isSaving: boolean
-  saveError: string | null
-  onFieldChange: (field: IncomeFormField, value: string) => void
-  onSave: () => void
-  onCancel: () => void
-}
-
-function IncomeForm({
-  isEditing,
-  date,
-  incomeSource,
-  grossValue,
-  netValue,
-  bank,
-  banks,
-  isSaving,
-  saveError,
-  onFieldChange,
-  onSave,
-  onCancel,
-}: IncomeFormProps) {
-  const showGrossValueField = INCOME_SOURCES_WITH_GROSS_VALUE.includes(incomeSource)
-  return (
-    <div className="monthly-page__form-panel">
-      <p className="monthly-page__form-title">{isEditing ? 'Edit Income' : 'New Income'}</p>
-      <div className="monthly-page__form">
-        <div className="monthly-page__form-field">
-          <label htmlFor="income-date">Date</label>
-          <input
-            id="income-date"
-            type="date"
-            value={date}
-            onChange={(e) => onFieldChange('date', e.target.value)}
-          />
-        </div>
-        <div className="monthly-page__form-field">
-          <label htmlFor="income-source">Source</label>
-          <select
-            id="income-source"
-            value={incomeSource}
-            onChange={(e) => onFieldChange('incomeSource', e.target.value)}
-          >
-            {INCOME_SOURCES.map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-        </div>
-        {showGrossValueField && (
-          <div className="monthly-page__form-field">
-            <label htmlFor="income-gross-value">Gross Value</label>
-            <input
-              id="income-gross-value"
-              type="number"
-              step="0.01"
-              value={grossValue}
-              onChange={(e) => onFieldChange('grossValue', e.target.value)}
-            />
-          </div>
-        )}
-        <div className="monthly-page__form-field">
-          <label htmlFor="income-net-value">Net Value</label>
-          <input
-            id="income-net-value"
-            type="number"
-            step="0.01"
-            value={netValue}
-            onChange={(e) => onFieldChange('netValue', e.target.value)}
-          />
-        </div>
-        <div className="monthly-page__form-field">
-          <label htmlFor="income-bank">Bank</label>
-          <select id="income-bank" value={bank} onChange={(e) => onFieldChange('bank', e.target.value)}>
-            {banks.map((b) => (
-              <option key={b.name} value={b.name}>
-                {b.name}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
-      <div className="monthly-page__form-actions">
-        <button className="monthly-page__submit-btn" type="button" disabled={isSaving} onClick={onSave}>
-          {isSaving ? 'Saving...' : isEditing ? 'Save' : 'Add Income'}
-        </button>
-        <button className="monthly-page__cancel-btn" type="button" onClick={onCancel}>
-          Cancel
-        </button>
-      </div>
-      {saveError && <p className="monthly-page__error">{saveError}</p>}
-    </div>
-  )
 }
 
 export default function MonthlyPage() {

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -473,6 +473,22 @@ describe('MonthlyPage', () => {
     expect(incomeSection.getByText('2,450.00')).toBeInTheDocument()
   })
 
+  it('re-scopes the income list when the month/year value changes while Incoming is active', async () => {
+    render(<MonthlyPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
+
+    await waitFor(() => expect(screen.getByText('Gleison')).toBeInTheDocument())
+
+    getIncomesByMonthMock.mockResolvedValue([
+      { id: 'i3', date: '2026-08-01', incomeSource: 'Lottery', grossValue: null, netValue: 75, bank: 'Barclays' },
+    ])
+
+    fireEvent.change(screen.getByLabelText('Month'), { target: { value: '2026-08' } })
+
+    await waitFor(() => expect(screen.getByText('Lottery')).toBeInTheDocument())
+    expect(screen.queryByText('Gleison')).not.toBeInTheDocument()
+  })
+
   it('shows the add-income form only after New Income is clicked, and submits a new income entry', async () => {
     createIncomeMock.mockResolvedValue({ ...INCOMES[0], id: 'i2' })
     render(<MonthlyPage />)

--- a/docs/P15-F04-monthly-incoming-subtab/plan.md
+++ b/docs/P15-F04-monthly-incoming-subtab/plan.md
@@ -1,0 +1,16 @@
+# Implementation Plan: Monthly Incoming Sub-Tab
+
+**Prerequisites:**
+- F01 (Monthly Tab Navigation Shell) merged — this feature only extracts a component F01 already scoped correctly to the Incoming tab.
+
+### Stage 1: Extract the Income Form Component
+
+**1. IncomeForm Component** - Move the `IncomeForm` local function, its option list (`INCOME_SOURCES`), and its field-mapping constants out of `MonthlyPage.tsx` into their own file, with no change to props, markup, or behavior.
+
+**2. Wire MonthlyPage to the Extracted Component** - Update `MonthlyPage.tsx`'s Incoming tab block to import and render the extracted `IncomeForm`, removing the now-unused local definitions.
+
+### Stage 2: Test Coverage
+
+**3. Add IncomeForm Component Tests** - Add a dedicated test file covering the form's create/edit and gross-value-conditional rendering branches in isolation.
+
+**4. Re-verify Incoming Tab Behavior** - Re-run the existing Incoming-tab tests in `MonthlyPage.test.tsx` to confirm New/Edit/Delete, the gross-value toggle, validation errors, and tab-switch form discarding all still pass unchanged against the extracted component.

--- a/docs/P15-F04-monthly-incoming-subtab/spec.md
+++ b/docs/P15-F04-monthly-incoming-subtab/spec.md
@@ -1,0 +1,65 @@
+## 1. Technical Overview
+
+**What:** Extract the `IncomeForm` local function (currently defined inline in `MonthlyPage.tsx`) into its own component under `src/components/`, with no change to its props, markup, or behavior. `MonthlyPage.tsx` continues composing `<IncomeForm>` + `<IncomeSection>` directly inside the Incoming tab guard.
+
+**Why:** F01 already relocated the full income list and create/edit form into the Incoming tab guard and already implements every behavior this feature's PRD entry describes — tab-scoped form visibility, discarding an open form on tab switch (via `handleTabClick`'s `cancelEditIncome`/`cancelCreateIncomeForm` calls), and unchanged create/edit/delete/validation flows. This feature's only remaining work is code organization, mirroring F03's `ExpenseForm` extraction for the last piece of UI still inlined in `MonthlyPage.tsx`.
+
+**Scope:**
+- Included: extracting `IncomeForm` into its own file; re-verifying (not re-implementing) F04's acceptance criteria against the current codebase.
+- Excluded: any change to `IncomeSection.tsx`, `useMonthly.ts`, validation rules, or the tab-switch-discards-form mechanism (all already correct, from F01). No `MonthlyIncomingTab.tsx` wrapper, matching F03's precedent — `MonthlyPage.tsx` keeps composing the two pieces directly.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/components/IncomeForm.tsx` (new) — the extracted form component
+- `Financial.Web/src/pages/MonthlyPage.tsx` — removes the local `IncomeForm` function and its field-mapping constants (`CREATE_INCOME_FIELD_BY_FORM_FIELD`, `EDIT_INCOME_FIELD_BY_FORM_FIELD`, `INCOME_SOURCES`), importing the new component instead
+- `Financial.Web/src/components/__tests__/IncomeForm.test.tsx` (new)
+
+```mermaid
+graph TD
+    A[MonthlyPage - Incoming tab] --> B[IncomeForm]
+    A --> C[IncomeSection]
+    B --> D["useMonthly - create/edit income state"]
+    C --> D
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Extraction boundary | Extract only `IncomeForm` into its own file; `MonthlyPage.tsx` keeps composing `<IncomeForm>` + `<IncomeSection>` directly | Also wrap both into a `MonthlyIncomingTab.tsx` coordinator component | Matches the precedent already established by F03's `ExpenseForm` extraction — same decision, applied symmetrically, no new pattern introduced |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/components/IncomeForm.tsx` | New | Renders the create/edit income form | Same props as the current local function (`isEditing`, `date`, `incomeSource`, `grossValue`, `netValue`, `bank`, `banks`, `isSaving`, `saveError`, `onFieldChange`, `onSave`, `onCancel`); owns the `INCOME_SOURCES` option list and the conditional gross-value field, moved verbatim |
+| `Financial.Web/src/pages/MonthlyPage.tsx` | Modified | Incoming tab composition | Import `IncomeForm` from `components/`; remove the local function definition and its field-mapping constants |
+
+## 5. API Contracts
+
+Not applicable — this feature makes no backend or API changes.
+
+## 6. Data Model
+
+Not applicable — this feature makes no data model or persistence changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/components/__tests__/IncomeForm.test.tsx` | Component | `IncomeForm` | Renders correctly in create/edit and gross-value-conditional states |
+| `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` | Component/Integration | `MonthlyPage` Incoming tab (existing suite) | F04 acceptance criteria re-verified unchanged after extraction |
+
+**Test functions:**
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `it('renders the create form with empty fields by default')` (`IncomeForm`) | Basic render | Date/source/net-value fields present and empty |
+| `it('shows the gross value field only for sources that require it')` (`IncomeForm`) | Conditional field | Gross value field present for Gleison/Ariana, absent for Lottery/DividendoJuros |
+| `it('calls onSave and onCancel')` (`IncomeForm`) | Interaction | Save/Cancel buttons invoke their handlers |
+| Existing `MonthlyPage.test.tsx` Incoming-tab tests (New/Edit/Delete, gross-value toggle, validation error, tab-switch-discards-form) | Re-run unchanged | All pass against the extracted component, confirming no behavior regressed |

--- a/docs/prd/P15-prd-monthly-tab-subtab-redesign/prd-monthly-tab-subtab-redesign.md
+++ b/docs/prd/P15-prd-monthly-tab-subtab-redesign/prd-monthly-tab-subtab-redesign.md
@@ -230,16 +230,16 @@ graph TD
 - [x] Switching to another sub-tab while the create/edit form is open closes the form and discards unsaved input
 
 ### F04. Monthly Incoming Sub-Tab
-- [ ] Incoming sub-tab renders the full income list for the selected month
-- [ ] Clicking "New Income" opens the create form within the Incoming sub-tab; the form is not visible when Summary or Expense is active
-- [ ] Creating an income entry with valid data adds it to the list and closes the form, identically to pre-redesign behavior
-- [ ] Editing an income entry pre-fills the form with its current values and saves changes identically to pre-redesign behavior
-- [ ] Deleting an income entry removes it from the list identically to pre-redesign behavior
-- [ ] Switching to another sub-tab while the create/edit form is open closes the form and discards unsaved input
+- [x] Incoming sub-tab renders the full income list for the selected month
+- [x] Clicking "New Income" opens the create form within the Incoming sub-tab; the form is not visible when Summary or Expense is active
+- [x] Creating an income entry with valid data adds it to the list and closes the form, identically to pre-redesign behavior
+- [x] Editing an income entry pre-fills the form with its current values and saves changes identically to pre-redesign behavior
+- [x] Deleting an income entry removes it from the list identically to pre-redesign behavior
+- [x] Switching to another sub-tab while the create/edit form is open closes the form and discards unsaved input
 
 ### Cross-Feature Integration
 - [x] Selecting a different month/year while Summary is active re-scopes all 4 grids to the new period (F01 → F02)
 - [x] Selecting a different month/year while Expense is active re-scopes the expense list to the new period (F01 → F03)
-- [ ] Selecting a different month/year while Incoming is active re-scopes the income list to the new period (F01 → F04)
-- [ ] Switching from Summary to Expense or Incoming and back displays each sub-tab's content without re-triggering a network refetch, confirming the shared period from F01 is reused rather than reset (F01 → F02, F03, F04)
-- [ ] At every point in the flow, exactly one of Summary/Expense/Incoming content is visible, confirming F01's active-tab state correctly gates F02, F03, and F04 (F01 → F02, F03, F04)
+- [x] Selecting a different month/year while Incoming is active re-scopes the income list to the new period (F01 → F04)
+- [x] Switching from Summary to Expense or Incoming and back displays each sub-tab's content without re-triggering a network refetch, confirming the shared period from F01 is reused rather than reset (F01 → F02, F03, F04)
+- [x] At every point in the flow, exactly one of Summary/Expense/Incoming content is visible, confirming F01's active-tab state correctly gates F02, F03, and F04 (F01 → F02, F03, F04)


### PR DESCRIPTION
## Summary
- Extracts the inline `IncomeForm` function out of `MonthlyPage.tsx` into its own component (`src/components/IncomeForm.tsx`), mirroring F03's `ExpenseForm` extraction
- F01 already delivered all of F04's required behavior — this PR is a code-organization pass plus re-verification of that behavior against the extracted component
- No behavior change
- **This is the last feature of P15** — all 4 features (F01-F04) and all 5 Cross-Feature Integration criteria are now complete

## Test plan
### F04. Monthly Incoming Sub-Tab
- [x] Incoming sub-tab renders the full income list for the selected month
- [x] Clicking "New Income" opens the create form within the Incoming sub-tab; the form is not visible when Summary or Expense is active
- [x] Creating an income entry with valid data adds it to the list and closes the form, identically to pre-redesign behavior
- [x] Editing an income entry pre-fills the form with its current values and saves changes identically to pre-redesign behavior
- [x] Deleting an income entry removes it from the list identically to pre-redesign behavior
- [x] Switching to another sub-tab while the create/edit form is open closes the form and discards unsaved input

### Cross-Feature Integration (all now complete)
- [x] Selecting a different month/year while Summary is active re-scopes all 4 grids to the new period (F01 → F02)
- [x] Selecting a different month/year while Expense is active re-scopes the expense list to the new period (F01 → F03)
- [x] Selecting a different month/year while Incoming is active re-scopes the income list to the new period (F01 → F04)
- [x] Switching from Summary to Expense or Incoming and back displays each sub-tab's content without re-triggering a network refetch, confirming the shared period from F01 is reused rather than reset (F01 → F02, F03, F04)
- [x] At every point in the flow, exactly one of Summary/Expense/Incoming content is visible, confirming F01's active-tab state correctly gates F02, F03, and F04 (F01 → F02, F03, F04)

### Validation run
- [x] `tsc -b --noEmit` clean
- [x] `eslint .` clean
- [x] Full frontend suite: 617/617 tests passing (51 files), including a new `IncomeForm.test.tsx`
- [x] `vite build` production build succeeds
- [ ] Manual browser smoke test — skipped (same as F01-F03), covered instead by the full automated test suite above

Spec/plan: `docs/P15-F04-monthly-incoming-subtab/`