### PR TITLE
feat(P16-F01): Yearly Summary tab navigation shell

### DIFF
--- a/Financial.Web/src/pages/YearlySummaryPage.css
+++ b/Financial.Web/src/pages/YearlySummaryPage.css
@@ -19,6 +19,33 @@
   width: 100px;
 }
 
+.yearly-summary-page__tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border, #e5e4e7);
+  flex-shrink: 0;
+}
+
+.yearly-summary-page__tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 8px 16px;
+  color: var(--text, #333);
+  margin-bottom: -1px;
+}
+
+.yearly-summary-page__tab:hover {
+  color: #007acc;
+}
+
+.yearly-summary-page__tab--active {
+  border-bottom-color: #007acc;
+  font-weight: 600;
+  color: #007acc;
+}
+
 .yearly-summary-page__content {
   flex: 1;
   min-height: 0;

--- a/Financial.Web/src/pages/YearlySummaryPage.tsx
+++ b/Financial.Web/src/pages/YearlySummaryPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import ErrorState from '../components/ErrorState'
 import LoadingState from '../components/LoadingState'
 import { useYearlySummary } from '../hooks/useYearlySummary'
@@ -6,8 +7,17 @@ import './YearlySummaryPage.css'
 
 const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
+type YearlySummaryTabId = 'categoryTotals' | 'investments'
+
+const TABS: { id: YearlySummaryTabId; label: string }[] = [
+  { id: 'categoryTotals', label: 'Category Totals' },
+  { id: 'investments', label: 'Investments' },
+]
+
 export default function YearlySummaryPage() {
   const { year, setYear, categoryTotals, investmentDiffs, incomeSummary, isLoading, error, retry } = useYearlySummary()
+
+  const [activeTab, setActiveTab] = useState<YearlySummaryTabId>('categoryTotals')
 
   return (
     <div className="yearly-summary-page">
@@ -21,45 +31,135 @@ export default function YearlySummaryPage() {
         />
       </div>
 
+      <div className="yearly-summary-page__tabs">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            className={`yearly-summary-page__tab${activeTab === tab.id ? ' yearly-summary-page__tab--active' : ''}`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
       {isLoading ? (
         <LoadingState />
       ) : error ? (
         <ErrorState message={error} onRetry={retry} />
       ) : (
         <div className="yearly-summary-page__content">
-          <section className="yearly-summary-page__section">
-            <h2>Category Totals</h2>
-            <table className="yearly-summary-page__table data-table">
-              <thead>
-                <tr>
-                  <th>Category</th>
-                  {MONTH_LABELS.map((m) => (
-                    <th key={m} className="data-table__col--numeric">
-                      {m}
-                    </th>
-                  ))}
-                  <th className="data-table__col--numeric">Yearly Total</th>
-                </tr>
-              </thead>
-              <tbody>
-                {categoryTotals.map((c) => (
-                  <tr key={c.category}>
-                    <td>{c.category}</td>
-                    {c.monthlyTotals.map((total, i) => (
-                      <td key={i} className="data-table__col--numeric">
-                        {formatN2(total)}
-                      </td>
+          {activeTab === 'categoryTotals' && (
+            <>
+              <section className="yearly-summary-page__section">
+                <h2>Category Totals</h2>
+                <table className="yearly-summary-page__table data-table">
+                  <thead>
+                    <tr>
+                      <th>Category</th>
+                      {MONTH_LABELS.map((m) => (
+                        <th key={m} className="data-table__col--numeric">
+                          {m}
+                        </th>
+                      ))}
+                      <th className="data-table__col--numeric">Yearly Total</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {categoryTotals.map((c) => (
+                      <tr key={c.category}>
+                        <td>{c.category}</td>
+                        {c.monthlyTotals.map((total, i) => (
+                          <td key={i} className="data-table__col--numeric">
+                            {formatN2(total)}
+                          </td>
+                        ))}
+                        <td className="data-table__col--numeric">
+                          <strong>{formatN2(c.yearlyTotal)}</strong>
+                        </td>
+                      </tr>
                     ))}
-                    <td className="data-table__col--numeric">
-                      <strong>{formatN2(c.yearlyTotal)}</strong>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </section>
+                  </tbody>
+                </table>
+              </section>
 
-          {investmentDiffs && (
+              {incomeSummary && (
+                <section className="yearly-summary-page__section">
+                  <h2>Income Summary</h2>
+                  <table className="yearly-summary-page__table data-table">
+                    <thead>
+                      <tr>
+                        <th />
+                        {MONTH_LABELS.map((m) => (
+                          <th key={m} className="data-table__col--numeric">
+                            {m}
+                          </th>
+                        ))}
+                        <th className="data-table__col--numeric">Yearly Total</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td colSpan={MONTH_LABELS.length + 2}>
+                          <strong>Income</strong>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Salary</td>
+                        {incomeSummary.salaryMonthly.map((v, i) => (
+                          <td key={i} className="data-table__col--numeric">
+                            {formatN2(v)}
+                          </td>
+                        ))}
+                        <td className="data-table__col--numeric">
+                          <strong>{formatN2(incomeSummary.salaryYearlyTotal)}</strong>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Salary after taxes</td>
+                        {incomeSummary.salaryAfterTaxesMonthly.map((v, i) => (
+                          <td key={i} className="data-table__col--numeric">
+                            {formatN2(v)}
+                          </td>
+                        ))}
+                        <td className="data-table__col--numeric">
+                          <strong>{formatN2(incomeSummary.salaryAfterTaxesYearlyTotal)}</strong>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>Tax difference</td>
+                        {incomeSummary.taxDifferenceMonthly.map((v, i) => (
+                          <td key={i} className="data-table__col--numeric">
+                            {formatN2(v)}
+                          </td>
+                        ))}
+                        <td className="data-table__col--numeric">
+                          <strong>{formatN2(incomeSummary.taxDifferenceYearlyTotal)}</strong>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td colSpan={MONTH_LABELS.length + 2} />
+                      </tr>
+                      <tr>
+                        <td>Dividendo/Juros</td>
+                        {incomeSummary.dividendoJurosMonthly.map((v, i) => (
+                          <td key={i} className="data-table__col--numeric">
+                            {formatN2(v)}
+                          </td>
+                        ))}
+                        <td className="data-table__col--numeric">
+                          <strong>{formatN2(incomeSummary.dividendoJurosYearlyTotal)}</strong>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </section>
+              )}
+            </>
+          )}
+
+          {activeTab === 'investments' && investmentDiffs && (
             <section className="yearly-summary-page__section">
               <h2>Investment Diffs</h2>
               <table className="yearly-summary-page__table data-table">
@@ -105,79 +205,6 @@ export default function YearlySummaryPage() {
                     ))}
                     <td className="data-table__col--numeric">
                       <strong>{formatN2(investmentDiffs.netPosition.fullYearNetChange)}</strong>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </section>
-          )}
-
-          {incomeSummary && (
-            <section className="yearly-summary-page__section">
-              <h2>Income Summary</h2>
-              <table className="yearly-summary-page__table data-table">
-                <thead>
-                  <tr>
-                    <th />
-                    {MONTH_LABELS.map((m) => (
-                      <th key={m} className="data-table__col--numeric">
-                        {m}
-                      </th>
-                    ))}
-                    <th className="data-table__col--numeric">Yearly Total</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td colSpan={MONTH_LABELS.length + 2}>
-                      <strong>Income</strong>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Salary</td>
-                    {incomeSummary.salaryMonthly.map((v, i) => (
-                      <td key={i} className="data-table__col--numeric">
-                        {formatN2(v)}
-                      </td>
-                    ))}
-                    <td className="data-table__col--numeric">
-                      <strong>{formatN2(incomeSummary.salaryYearlyTotal)}</strong>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Salary after taxes</td>
-                    {incomeSummary.salaryAfterTaxesMonthly.map((v, i) => (
-                      <td key={i} className="data-table__col--numeric">
-                        {formatN2(v)}
-                      </td>
-                    ))}
-                    <td className="data-table__col--numeric">
-                      <strong>{formatN2(incomeSummary.salaryAfterTaxesYearlyTotal)}</strong>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Tax difference</td>
-                    {incomeSummary.taxDifferenceMonthly.map((v, i) => (
-                      <td key={i} className="data-table__col--numeric">
-                        {formatN2(v)}
-                      </td>
-                    ))}
-                    <td className="data-table__col--numeric">
-                      <strong>{formatN2(incomeSummary.taxDifferenceYearlyTotal)}</strong>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td colSpan={MONTH_LABELS.length + 2} />
-                  </tr>
-                  <tr>
-                    <td>Dividendo/Juros</td>
-                    {incomeSummary.dividendoJurosMonthly.map((v, i) => (
-                      <td key={i} className="data-table__col--numeric">
-                        {formatN2(v)}
-                      </td>
-                    ))}
-                    <td className="data-table__col--numeric">
-                      <strong>{formatN2(incomeSummary.dividendoJurosYearlyTotal)}</strong>
                     </td>
                   </tr>
                 </tbody>

--- a/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import YearlySummaryPage from '../YearlySummaryPage'
 import type { FinancialApiClient } from '../../api/financialApiClient'
@@ -80,22 +80,39 @@ describe('YearlySummaryPage', () => {
     expect(screen.getByText('Network down')).toBeInTheDocument()
   })
 
+  it('shows the error/retry state regardless of the active tab', async () => {
+    getCategoryTotalsForYearMock.mockRejectedValue(new Error('Network down'))
+
+    render(<YearlySummaryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByText('Network down')).toBeInTheDocument()
+  })
+
+  it('defaults to the Category Totals tab on load', async () => {
+    render(<YearlySummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    expect(screen.getByRole('cell', { name: 'Mercado' })).toBeInTheDocument()
+    expect(screen.getByText('Income Summary')).toBeInTheDocument()
+    expect(screen.queryByText('Investment Diffs')).not.toBeInTheDocument()
+  })
+
+  it('marks Category Totals as the active tab button by default', async () => {
+    render(<YearlySummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Category Totals' })).toHaveClass('yearly-summary-page__tab--active')
+    expect(screen.getByRole('button', { name: 'Investments' })).not.toHaveClass('yearly-summary-page__tab--active')
+  })
+
   it('renders the category-totals table with monthly values and a yearly total column', async () => {
     render(<YearlySummaryPage />)
 
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
     expect(screen.getByRole('cell', { name: 'Mercado' })).toBeInTheDocument()
     expect(screen.getByText('1,860.00')).toBeInTheDocument()
-  })
-
-  it('renders the investment-diffs table with 11 monthly diff columns per account and the net position row', async () => {
-    render(<YearlySummaryPage />)
-
-    await waitFor(() => expect(screen.getByText('Investment Diffs')).toBeInTheDocument())
-    expect(screen.getByRole('cell', { name: 'ChaseSave' })).toBeInTheDocument()
-    expect(screen.getByText('PlatinumVisa8003 (liability)')).toBeInTheDocument()
-    expect(screen.getByText('Net Position')).toBeInTheDocument()
-    expect(screen.getByText('550.00')).toBeInTheDocument()
   })
 
   it('renders the income-summary table with the header row and the four data rows', async () => {
@@ -123,5 +140,58 @@ describe('YearlySummaryPage', () => {
 
     expect(screen.queryByText(/Lottery/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/Tithe/i)).not.toBeInTheDocument()
+  })
+
+  it('shows only the Investments tab content after clicking Investments', async () => {
+    render(<YearlySummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+
+    expect(screen.queryByText('Income Summary')).not.toBeInTheDocument()
+    expect(screen.queryByRole('cell', { name: 'Mercado' })).not.toBeInTheDocument()
+    expect(screen.getByText('Investment Diffs')).toBeInTheDocument()
+    expect(screen.getByRole('cell', { name: 'ChaseSave' })).toBeInTheDocument()
+    expect(screen.getByText('PlatinumVisa8003 (liability)')).toBeInTheDocument()
+    expect(screen.getByText('Net Position')).toBeInTheDocument()
+    expect(screen.getByText('550.00')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Investments' })).toHaveClass('yearly-summary-page__tab--active')
+  })
+
+  it('does not change the year picker value when switching tabs', async () => {
+    render(<YearlySummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    const yearInput = screen.getByLabelText('Year') as HTMLInputElement
+    const valueBefore = yearInput.value
+
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+
+    expect(yearInput.value).toBe(valueBefore)
+  })
+
+  it('does not refetch data when switching tabs', async () => {
+    render(<YearlySummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    const callCountBefore = getCategoryTotalsForYearMock.mock.calls.length
+
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Category Totals' }))
+
+    expect(getCategoryTotalsForYearMock.mock.calls.length).toBe(callCountBefore)
+  })
+
+  it('keeps the active tab unchanged when the year value changes', async () => {
+    render(<YearlySummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+    await waitFor(() => expect(screen.getByText('Investment Diffs')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByLabelText('Year'), { target: { value: '2027' } })
+
+    await waitFor(() => expect(screen.getByText('Investment Diffs')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Investments' })).toHaveClass('yearly-summary-page__tab--active')
   })
 })

--- a/docs/P16-F01-yearly-summary-navigation-shell/plan.md
+++ b/docs/P16-F01-yearly-summary-navigation-shell/plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan: Yearly Summary Navigation Shell
+
+**Prerequisites:**
+- None — this feature only touches existing frontend files (`Financial.Web/src/pages/YearlySummaryPage.tsx`, `YearlySummaryPage.css`, `pages/__tests__/YearlySummaryPage.test.tsx`); no new dependencies, environment variables, or configuration.
+
+### Stage 1: Tab Shell Foundation
+
+**1. Tab State and Type Definitions** - Add a `YearlySummaryTabId` union and a `TABS` array of `{id, label}` to `YearlySummaryPage.tsx`, plus `useState` for the active tab defaulting to Category Totals, following the same shape as `MonthlyPage.tsx`'s tab-state definitions.
+
+**2. Tab Button Row** - Render a row of tab buttons below the existing year picker header, each switching the active tab on click and visually reflecting which tab is currently active, reusing the button/active-class pattern already established by `MonthlyPage`.
+
+**3. Tab Bar Styling** - Add the CSS rules for the tab row and its active/inactive button states to `YearlySummaryPage.css`, visually matching the styling already defined for `MonthlyPage`'s tab bar.
+
+### Stage 2: Content Relocation and Test Coverage
+
+**4. Relocate Existing Content Behind Tab Guards** - Wrap the current Category Totals section and Income Summary section together in a conditional guarded by the Category Totals tab, and the current Investment Diffs section in a conditional guarded by the Investments tab, with no other change to their existing markup or behavior, so exactly one tab's content renders at a time.
+
+**5. Preserve Shared Loading/Error State** - Confirm the existing loading and error states keep rendering above/instead of the tab content regardless of which tab is active, since they reflect the one data fetch shared by both tabs.
+
+**6. Update Test Coverage** - Extend the Yearly Summary test suite with coverage for the default active tab, tab switching, active-tab visual state, and the independence of year selection from tab state, and add a tab-click step to the existing test that interacts with Investment Diffs content.

--- a/docs/P16-F01-yearly-summary-navigation-shell/spec.md
+++ b/docs/P16-F01-yearly-summary-navigation-shell/spec.md
@@ -1,0 +1,75 @@
+## 1. Technical Overview
+
+**What:** Add a local two-tab shell (Category Totals, Investments) to `YearlySummaryPage.tsx`, with the existing year picker relocated above the tab row so it applies to both tabs. The existing content — the Category Totals table, the Investment Diffs table, and the Income Summary table — is relocated as-is into a matching tab's conditional block (Category Totals + Income Summary under the "Category Totals" tab, Investment Diffs under the "Investments" tab), with no visual regrouping, merging, or column changes yet (that work belongs to F02/F03).
+
+**Why:** `MonthlyPage.tsx` already solved this exact shape of problem one PRD ago (P15-F01): a local `TabId` union, a `TABS` array, `useState` for the active tab, a button row, and conditional rendering, with matching CSS (`MonthlyPage.css:24-45`, classes `.monthly-page__tabs`/`__tab`/`__tab--active`). Reusing that now-twice-precedented pattern keeps tab-switching mechanics consistent across every page in the app instead of introducing a variant. Year state already lives entirely inside `useYearlySummary()` and is owned by `YearlySummaryPage.tsx` today, so no state needs to be lifted — it already sits at the right level to be shared across tabs once the tab row is added below it.
+
+**Scope:**
+- Included: `YearlySummaryTabId` type and `TABS` definition, `activeTab` state, tab button row, tab bar CSS, relocating the 3 existing content blocks (Category Totals section, Investment Diffs section, Income Summary section) behind tab guards, and updated/added tests for the tab mechanism itself.
+- Excluded: merging Income Summary rows into the Category Totals table and adding Resultado (R-D-Inv)/Total despesas/Average columns (F02); reshaping the Investments table to show full 12-month balances per account plus a Total row, Month Result row, and the three summary figures (F03). These features build on top of the tab guards this feature introduces, without changing the tab mechanism itself.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/pages/YearlySummaryPage.tsx` — gains tab state/types, the tab button row, and conditional guards around its 3 existing content blocks
+- `Financial.Web/src/pages/YearlySummaryPage.css` — gains the tab bar's visual styling
+- `Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx` — gains tab-mechanism tests; the existing Investment Diffs test gains a tab-click step (Category Totals and Income Summary stay visible under the default tab, so those two existing tests need no click step)
+
+```mermaid
+graph TD
+    A[Developer] --> B[YearlySummaryPage]
+    B --> C["useState(activeTab)"]
+    C --> D[Tab Button Row]
+    D --> C
+    B --> E["useYearlySummary() - year + data state"]
+    E --> F["Conditional block: Category Totals / Investments"]
+    C --> F
+    F --> G[Existing Category Totals / Investment Diffs / Income Summary tables - unchanged]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Active-tab state ownership | Local `useState<YearlySummaryTabId>` inside `YearlySummaryPage.tsx`, mirroring `MonthlyPage.tsx`'s `activeTab` pattern | URL search param (`?tab=investments`) for deep-linking | PRD Section 7 explicitly excludes deep-linking/persistence of the active tab; local state is simpler and matches the established precedent in this codebase |
+| F01 content scope | Relocate the 3 existing content blocks into their tab guard as-is (no merging/reshaping yet) | Ship F01 with empty/placeholder tab bodies and defer all content moves to F02/F03 | Keeps the app fully functional immediately after F01 merges, matching the approach already confirmed and used for P15-F01; F02/F03 diffs stay focused only on the specific transformation they own, with no rework of code F01 already moved |
+| Category Totals tab's initial content | Both the existing "Category Totals" section and the existing "Income Summary" section render under the Category Totals tab, stacked in their current order, unmerged | Put Income Summary under its own third tab temporarily | The PRD's final shape has Income Summary's rows folded into the Category Totals table (F02); grouping them under the same tab now, even before the merge, avoids a spurious third tab that would disappear again next PR |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/pages/YearlySummaryPage.tsx` | Modified | Hosts the year picker, tab bar, and per-tab content guards | Define `YearlySummaryTabId`/`TABS`; own `activeTab` state defaulting to `'categoryTotals'`; render the tab button row below the year picker; wrap the Category Totals + Income Summary sections in an `activeTab === 'categoryTotals'` guard and the Investment Diffs section in an `activeTab === 'investments'` guard; no change to `useYearlySummary()` usage or to the wrapped JSX itself |
+| `Financial.Web/src/pages/YearlySummaryPage.css` | Modified | Tab bar visual styling | Add `.yearly-summary-page__tabs`, `.yearly-summary-page__tab`, `.yearly-summary-page__tab--active`, matching the look already established by `.monthly-page__tabs`/`__tab`/`__tab--active` in `MonthlyPage.css:24-45` |
+| `Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx` | Modified | Cover the tab mechanism; keep existing coverage passing under the new structure | Add tests for default tab, tab switching, active-tab visual state, and year/tab-state independence; add a tab-click step before the existing Investment Diffs test |
+
+## 5. API Contracts
+
+Not applicable — this feature makes no backend or API changes. All three existing endpoints (`expense-categories`, `investment-diffs`, `income-summary`) are consumed exactly as today via `useYearlySummary()`.
+
+## 6. Data Model
+
+Not applicable — this feature makes no data model or persistence changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx` | Component | `YearlySummaryPage` tab shell | All 6 F01 acceptance criteria and the tab-related Cross-Feature Integration criteria covered |
+
+**Test functions:**
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `it('defaults to the Category Totals tab on load')` | Verifies F01 AC1 | Category Totals table and Income Summary table are visible on initial render; Investment Diffs table is not rendered |
+| `it('marks Category Totals as the active tab button by default')` | Verifies F01 AC1 | Category Totals tab button carries the active CSS class; Investments button does not |
+| `it('shows only the Investments tab content after clicking Investments')` | Verifies F01 AC2 | After clicking "Investments", the Category Totals and Income Summary tables are gone, the Investment Diffs table is visible |
+| `it('does not change the year picker value when switching tabs')` | Verifies F01 AC4 and the F01→F02/F03 Cross-Feature Integration criterion on shared year state | Year input value identical before and after a tab click |
+| `it('does not refetch data when switching tabs')` | Verifies F01 AC4 and the F01→F02/F03 Cross-Feature Integration criterion on avoiding redundant refetch | Mocked API client call counts (`getCategoryTotalsForYear`, `getInvestmentDiffsForYear`, `getIncomeSummaryForYear`) are unchanged across a tab switch |
+| `it('keeps the active tab unchanged when the year value changes')` | Verifies F01 AC5 | While Investments is active, changing the year input keeps Investments' content visible (does not revert to Category Totals) |
+| `it('shows the error/retry state regardless of the active tab')` | Verifies F01 AC6 | With the mocked API client rejecting, the error message and retry button render whether Category Totals or Investments was last active |
+| `it('renders the investment-diffs table with 11 monthly diff columns per account and the net position row')` (existing, modified) | Keeps existing F03-precursor coverage passing under the new structure | Add `fireEvent.click(screen.getByText('Investments'))` before the existing assertions; all prior assertions unchanged |

--- a/docs/prd/P16-prd-yearly-summary-subtab-redesign/prd-yearly-summary-subtab-redesign.md
+++ b/docs/prd/P16-prd-yearly-summary-subtab-redesign/prd-yearly-summary-subtab-redesign.md
@@ -188,12 +188,12 @@ graph TD
 ## 9. Acceptance Criteria
 
 ### F01. Yearly Summary Navigation Shell
-- [ ] Opening the Yearly Summary tab shows the year picker, the two sub-tab buttons (Category Totals, Investments), and Category Totals content by default
-- [ ] Exactly one sub-tab's content is visible/mounted at any time
-- [ ] Clicking a sub-tab button switches the visible content and marks that button as active
-- [ ] Switching sub-tabs does not change the year picker's value and does not trigger a new data fetch
-- [ ] Changing the year value refetches data and updates the currently active sub-tab's content without changing which sub-tab is active
-- [ ] If data loading fails, the error/retry state is shown regardless of the active sub-tab
+- [x] Opening the Yearly Summary tab shows the year picker, the two sub-tab buttons (Category Totals, Investments), and Category Totals content by default
+- [x] Exactly one sub-tab's content is visible/mounted at any time
+- [x] Clicking a sub-tab button switches the visible content and marks that button as active
+- [x] Switching sub-tabs does not change the year picker's value and does not trigger a new data fetch
+- [x] Changing the year value refetches data and updates the currently active sub-tab's content without changing which sub-tab is active
+- [x] If data loading fails, the error/retry state is shown regardless of the active sub-tab
 
 ### F02. Category Totals Sub-Tab
 - [ ] The table renders rows in the fixed order: Salary, Salary After Taxes, Tax Difference, Dividendo/Juros, the 14 categories in enum order, Resultado (R-D-Inv), Total despesas


### PR DESCRIPTION
## Summary
- Adds a Category Totals / Investments tab bar below the shared year picker in `YearlySummaryPage.tsx`, mirroring the P15 `MonthlyPage.tsx` tab pattern
- Relocates the existing Category Totals + Income Summary sections behind the Category Totals tab guard, and the existing Investment Diffs section behind the Investments tab guard — no markup/behavior changes to the relocated content itself
- Merging Income Summary into Category Totals (Resultado, Total despesas, Average column) and reshaping the Investments table (full monthly balances, Total/Month Result rows, extra summary figures) are deferred to F02/F03

## Acceptance criteria (PRD Section 9, F01)
- [x] Opening the Yearly Summary tab shows the year picker, the two sub-tab buttons (Category Totals, Investments), and Category Totals content by default
- [x] Exactly one sub-tab's content is visible/mounted at any time
- [x] Clicking a sub-tab button switches the visible content and marks that button as active
- [x] Switching sub-tabs does not change the year picker's value and does not trigger a new data fetch
- [x] Changing the year value refetches data and updates the currently active sub-tab's content without changing which sub-tab is active
- [x] If data loading fails, the error/retry state is shown regardless of the active sub-tab

## Test plan
- [x] `npx vitest run` — 623/623 tests pass (12 in `YearlySummaryPage.test.tsx`, including 8 new tab-mechanism tests)
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [ ] Manual browser smoke test (not run this pass — backend not spun up locally; CI's `browser-smoke-test` job covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P9h9D3DFkckJAyDktemTe