### PR TITLE
feat(P16-F02): Category Totals sub-tab merge

### DIFF
--- a/Financial.Web/src/hooks/useYearlySummary.test.ts
+++ b/Financial.Web/src/hooks/useYearlySummary.test.ts
@@ -97,4 +97,35 @@ describe('useYearlySummary', () => {
 
     await waitFor(() => expect(getCategoryTotalsForYearMock).toHaveBeenCalledTimes(2))
   })
+
+  it('computes total despesas as the sum of all category monthly totals', async () => {
+    const multiCategoryTotals: CategoryYearlyTotalDto[] = [
+      { category: 'Mercado', monthlyTotals: new Array(12).fill(100), yearlyTotal: 1200 },
+      { category: 'Investimento', monthlyTotals: new Array(12).fill(500), yearlyTotal: 6000 },
+      { category: 'Reserva', monthlyTotals: new Array(12).fill(50), yearlyTotal: 600 },
+    ]
+    getCategoryTotalsForYearMock.mockResolvedValue(multiCategoryTotals)
+
+    const { result } = renderHook(() => useYearlySummary())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.totalDespesasMonthly).toEqual(new Array(12).fill(650))
+    expect(result.current.totalDespesasYearlyTotal).toBe(7800)
+  })
+
+  it('computes resultado as net income minus every category except Investimento', async () => {
+    const multiCategoryTotals: CategoryYearlyTotalDto[] = [
+      { category: 'Mercado', monthlyTotals: new Array(12).fill(100), yearlyTotal: 1200 },
+      { category: 'Investimento', monthlyTotals: new Array(12).fill(500), yearlyTotal: 6000 },
+      { category: 'Reserva', monthlyTotals: new Array(12).fill(50), yearlyTotal: 600 },
+    ]
+    getCategoryTotalsForYearMock.mockResolvedValue(multiCategoryTotals)
+
+    const { result } = renderHook(() => useYearlySummary())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // resultado = salaryAfterTaxes (2450) + dividendoJuros (15.5) - totalDespesas (650) + investimento (500)
+    expect(result.current.resultadoMonthly).toEqual(new Array(12).fill(2315.5))
+    expect(result.current.resultadoYearlyTotal).toBeCloseTo(27786, 5)
+  })
 })

--- a/Financial.Web/src/hooks/useYearlySummary.ts
+++ b/Financial.Web/src/hooks/useYearlySummary.ts
@@ -59,12 +59,18 @@ function reducer(state: YearlySummaryState, action: YearlySummaryAction): Yearly
   }
 }
 
+const INVESTIMENTO_CATEGORY = 'Investimento'
+
 export interface YearlySummaryData {
   year: number
   setYear: (year: number) => void
   categoryTotals: CategoryYearlyTotalDto[]
   investmentDiffs: InvestmentDiffsYearlyDto | null
   incomeSummary: IncomeYearlySummaryDto | null
+  totalDespesasMonthly: number[]
+  totalDespesasYearlyTotal: number
+  resultadoMonthly: number[]
+  resultadoYearlyTotal: number
   isLoading: boolean
   error: string | null
   retry: () => void
@@ -99,12 +105,45 @@ export function useYearlySummary(): YearlySummaryData {
 
   const retry = useCallback(() => dispatch({ type: 'RETRY' }), [])
 
+  const totalDespesasMonthly = useMemo(
+    () =>
+      state.categoryTotals.length === 0
+        ? []
+        : Array.from({ length: 12 }, (_, month) =>
+            state.categoryTotals.reduce((sum, c) => sum + c.monthlyTotals[month], 0),
+          ),
+    [state.categoryTotals],
+  )
+
+  const totalDespesasYearlyTotal = useMemo(
+    () => totalDespesasMonthly.reduce((sum, v) => sum + v, 0),
+    [totalDespesasMonthly],
+  )
+
+  const resultadoMonthly = useMemo(() => {
+    if (!state.incomeSummary || totalDespesasMonthly.length === 0) return []
+    const investimento = state.categoryTotals.find((c) => c.category === INVESTIMENTO_CATEGORY)
+    return totalDespesasMonthly.map(
+      (totalDespesas, month) =>
+        state.incomeSummary!.salaryAfterTaxesMonthly[month] +
+        state.incomeSummary!.dividendoJurosMonthly[month] -
+        totalDespesas +
+        (investimento?.monthlyTotals[month] ?? 0),
+    )
+  }, [state.incomeSummary, state.categoryTotals, totalDespesasMonthly])
+
+  const resultadoYearlyTotal = useMemo(() => resultadoMonthly.reduce((sum, v) => sum + v, 0), [resultadoMonthly])
+
   return {
     year: state.year,
     setYear,
     categoryTotals: state.categoryTotals,
     investmentDiffs: state.investmentDiffs,
     incomeSummary: state.incomeSummary,
+    totalDespesasMonthly,
+    totalDespesasYearlyTotal,
+    resultadoMonthly,
+    resultadoYearlyTotal,
     isLoading: state.isLoading,
     error: state.error,
     retry,

--- a/Financial.Web/src/pages/YearlySummaryPage.css
+++ b/Financial.Web/src/pages/YearlySummaryPage.css
@@ -70,6 +70,6 @@
   min-width: 900px;
 }
 
-.yearly-summary-page__net-position-row {
+.yearly-summary-page__emphasized-row {
   border-top: 2px solid var(--border, #ccc);
 }

--- a/Financial.Web/src/pages/YearlySummaryPage.tsx
+++ b/Financial.Web/src/pages/YearlySummaryPage.tsx
@@ -1,11 +1,13 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import ErrorState from '../components/ErrorState'
 import LoadingState from '../components/LoadingState'
 import { useYearlySummary } from '../hooks/useYearlySummary'
 import { formatN2 } from '../utils/formatters'
+import { average } from '../utils/math'
 import './YearlySummaryPage.css'
 
 const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const SPACER_COL_SPAN = MONTH_LABELS.length + 3
 
 type YearlySummaryTabId = 'categoryTotals' | 'investments'
 
@@ -14,8 +16,51 @@ const TABS: { id: YearlySummaryTabId; label: string }[] = [
   { id: 'investments', label: 'Investments' },
 ]
 
+function YearlySummaryRow({
+  label,
+  monthlyValues,
+  yearlyTotal,
+  emphasized = false,
+}: {
+  label: string
+  monthlyValues: number[]
+  yearlyTotal: number
+  emphasized?: boolean
+}) {
+  const cell = (content: ReactNode) => (emphasized ? <strong>{content}</strong> : content)
+  return (
+    <tr className={emphasized ? 'yearly-summary-page__emphasized-row' : undefined}>
+      <td>{cell(label)}</td>
+      {monthlyValues.map((v, i) => (
+        <td key={i} className="data-table__col--numeric">
+          {cell(formatN2(v))}
+        </td>
+      ))}
+      <td className="data-table__col--numeric">
+        <strong>{formatN2(average(monthlyValues))}</strong>
+      </td>
+      <td className="data-table__col--numeric">
+        <strong>{formatN2(yearlyTotal)}</strong>
+      </td>
+    </tr>
+  )
+}
+
 export default function YearlySummaryPage() {
-  const { year, setYear, categoryTotals, investmentDiffs, incomeSummary, isLoading, error, retry } = useYearlySummary()
+  const {
+    year,
+    setYear,
+    categoryTotals,
+    investmentDiffs,
+    incomeSummary,
+    totalDespesasMonthly,
+    totalDespesasYearlyTotal,
+    resultadoMonthly,
+    resultadoYearlyTotal,
+    isLoading,
+    error,
+    retry,
+  } = useYearlySummary()
 
   const [activeTab, setActiveTab] = useState<YearlySummaryTabId>('categoryTotals')
 
@@ -51,112 +96,79 @@ export default function YearlySummaryPage() {
       ) : (
         <div className="yearly-summary-page__content">
           {activeTab === 'categoryTotals' && (
-            <>
-              <section className="yearly-summary-page__section">
-                <h2>Category Totals</h2>
-                <table className="yearly-summary-page__table data-table">
-                  <thead>
-                    <tr>
-                      <th>Category</th>
-                      {MONTH_LABELS.map((m) => (
-                        <th key={m} className="data-table__col--numeric">
-                          {m}
-                        </th>
-                      ))}
-                      <th className="data-table__col--numeric">Yearly Total</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {categoryTotals.map((c) => (
-                      <tr key={c.category}>
-                        <td>{c.category}</td>
-                        {c.monthlyTotals.map((total, i) => (
-                          <td key={i} className="data-table__col--numeric">
-                            {formatN2(total)}
-                          </td>
-                        ))}
-                        <td className="data-table__col--numeric">
-                          <strong>{formatN2(c.yearlyTotal)}</strong>
-                        </td>
-                      </tr>
+            <section className="yearly-summary-page__section">
+              <h2>Category Totals</h2>
+              <table className="yearly-summary-page__table data-table">
+                <thead>
+                  <tr>
+                    <th />
+                    {MONTH_LABELS.map((m) => (
+                      <th key={m} className="data-table__col--numeric">
+                        {m}
+                      </th>
                     ))}
-                  </tbody>
-                </table>
-              </section>
+                    <th className="data-table__col--numeric">Average</th>
+                    <th className="data-table__col--numeric">Yearly Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {incomeSummary && (
+                    <>
+                      <YearlySummaryRow
+                        label="Salary"
+                        monthlyValues={incomeSummary.salaryMonthly}
+                        yearlyTotal={incomeSummary.salaryYearlyTotal}
+                      />
+                      <YearlySummaryRow
+                        label="Salary after taxes"
+                        monthlyValues={incomeSummary.salaryAfterTaxesMonthly}
+                        yearlyTotal={incomeSummary.salaryAfterTaxesYearlyTotal}
+                      />
+                      <YearlySummaryRow
+                        label="Tax difference"
+                        monthlyValues={incomeSummary.taxDifferenceMonthly}
+                        yearlyTotal={incomeSummary.taxDifferenceYearlyTotal}
+                      />
+                      <tr>
+                        <td colSpan={SPACER_COL_SPAN} />
+                      </tr>
+                      <YearlySummaryRow
+                        label="Dividendo/Juros"
+                        monthlyValues={incomeSummary.dividendoJurosMonthly}
+                        yearlyTotal={incomeSummary.dividendoJurosYearlyTotal}
+                      />
+                    </>
+                  )}
 
-              {incomeSummary && (
-                <section className="yearly-summary-page__section">
-                  <h2>Income Summary</h2>
-                  <table className="yearly-summary-page__table data-table">
-                    <thead>
-                      <tr>
-                        <th />
-                        {MONTH_LABELS.map((m) => (
-                          <th key={m} className="data-table__col--numeric">
-                            {m}
-                          </th>
-                        ))}
-                        <th className="data-table__col--numeric">Yearly Total</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td colSpan={MONTH_LABELS.length + 2}>
-                          <strong>Income</strong>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>Salary</td>
-                        {incomeSummary.salaryMonthly.map((v, i) => (
-                          <td key={i} className="data-table__col--numeric">
-                            {formatN2(v)}
-                          </td>
-                        ))}
-                        <td className="data-table__col--numeric">
-                          <strong>{formatN2(incomeSummary.salaryYearlyTotal)}</strong>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>Salary after taxes</td>
-                        {incomeSummary.salaryAfterTaxesMonthly.map((v, i) => (
-                          <td key={i} className="data-table__col--numeric">
-                            {formatN2(v)}
-                          </td>
-                        ))}
-                        <td className="data-table__col--numeric">
-                          <strong>{formatN2(incomeSummary.salaryAfterTaxesYearlyTotal)}</strong>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>Tax difference</td>
-                        {incomeSummary.taxDifferenceMonthly.map((v, i) => (
-                          <td key={i} className="data-table__col--numeric">
-                            {formatN2(v)}
-                          </td>
-                        ))}
-                        <td className="data-table__col--numeric">
-                          <strong>{formatN2(incomeSummary.taxDifferenceYearlyTotal)}</strong>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td colSpan={MONTH_LABELS.length + 2} />
-                      </tr>
-                      <tr>
-                        <td>Dividendo/Juros</td>
-                        {incomeSummary.dividendoJurosMonthly.map((v, i) => (
-                          <td key={i} className="data-table__col--numeric">
-                            {formatN2(v)}
-                          </td>
-                        ))}
-                        <td className="data-table__col--numeric">
-                          <strong>{formatN2(incomeSummary.dividendoJurosYearlyTotal)}</strong>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </section>
-              )}
-            </>
+                  <tr>
+                    <td colSpan={SPACER_COL_SPAN} />
+                  </tr>
+
+                  {categoryTotals.map((c) => (
+                    <YearlySummaryRow key={c.category} label={c.category} monthlyValues={c.monthlyTotals} yearlyTotal={c.yearlyTotal} />
+                  ))}
+
+                  <tr>
+                    <td colSpan={SPACER_COL_SPAN} />
+                  </tr>
+
+                  {incomeSummary && (
+                    <YearlySummaryRow
+                      label="Resultado (R-D-Inv)"
+                      monthlyValues={resultadoMonthly}
+                      yearlyTotal={resultadoYearlyTotal}
+                      emphasized
+                    />
+                  )}
+                  <YearlySummaryRow
+                    label="Total despesas"
+                    monthlyValues={totalDespesasMonthly}
+                    yearlyTotal={totalDespesasYearlyTotal}
+                    emphasized
+                  />
+                </tbody>
+              </table>
+            </section>
           )}
 
           {activeTab === 'investments' && investmentDiffs && (
@@ -191,7 +203,7 @@ export default function YearlySummaryPage() {
                       <td className="data-table__col--numeric" />
                     </tr>
                   ))}
-                  <tr className="yearly-summary-page__net-position-row">
+                  <tr className="yearly-summary-page__emphasized-row">
                     <td>
                       <strong>Net Position</strong>
                     </td>

--- a/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
@@ -95,7 +95,7 @@ describe('YearlySummaryPage', () => {
 
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
     expect(screen.getByRole('cell', { name: 'Mercado' })).toBeInTheDocument()
-    expect(screen.getByText('Income Summary')).toBeInTheDocument()
+    expect(screen.getByRole('cell', { name: 'Salary' })).toBeInTheDocument()
     expect(screen.queryByText('Investment Diffs')).not.toBeInTheDocument()
   })
 
@@ -107,39 +107,69 @@ describe('YearlySummaryPage', () => {
     expect(screen.getByRole('button', { name: 'Investments' })).not.toHaveClass('yearly-summary-page__tab--active')
   })
 
-  it('renders the category-totals table with monthly values and a yearly total column', async () => {
+  it('renders the combined table in the fixed row order', async () => {
     render(<YearlySummaryPage />)
 
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
-    expect(screen.getByRole('cell', { name: 'Mercado' })).toBeInTheDocument()
-    expect(screen.getByText('1,860.00')).toBeInTheDocument()
+    const rowLabels = screen
+      .getAllByRole('row')
+      .map((row) => row.querySelector('td')?.textContent ?? '')
+      .filter((label) => label !== '')
+
+    expect(rowLabels).toEqual([
+      'Salary',
+      'Salary after taxes',
+      'Tax difference',
+      'Dividendo/Juros',
+      'Mercado',
+      'Resultado (R-D-Inv)',
+      'Total despesas',
+    ])
   })
 
-  it('renders the income-summary table with the header row and the four data rows', async () => {
+  it('renders Salary/Dividendo rows and category rows in the same table (no standalone Income Summary section)', async () => {
     render(<YearlySummaryPage />)
 
-    await waitFor(() => expect(screen.getByText('Income Summary')).toBeInTheDocument())
-    const incomeSection = screen.getByText('Income Summary').closest('section')!
-    expect(within(incomeSection).getByText('Income')).toBeInTheDocument()
-    expect(within(incomeSection).getByRole('cell', { name: 'Salary' })).toBeInTheDocument()
-    expect(within(incomeSection).getByRole('cell', { name: 'Salary after taxes' })).toBeInTheDocument()
-    expect(within(incomeSection).getByRole('cell', { name: 'Tax difference' })).toBeInTheDocument()
-    expect(within(incomeSection).getByRole('cell', { name: 'Dividendo/Juros' })).toBeInTheDocument()
-    expect(within(incomeSection).getByText('38,800.00')).toBeInTheDocument()
-    expect(within(incomeSection).getByText('9,450.00')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    expect(screen.queryByText('Income Summary')).not.toBeInTheDocument()
+
+    const salaryCell = screen.getByRole('cell', { name: 'Salary' })
+    const mercadoCell = screen.getByRole('cell', { name: 'Mercado' })
+    expect(salaryCell.closest('table')).toBe(mercadoCell.closest('table'))
+    expect(within(salaryCell.closest('tr')!).getByText('38,800.00')).toBeInTheDocument()
+    const taxDifferenceRow = screen.getByRole('cell', { name: 'Tax difference' }).closest('tr')!
+    expect(within(taxDifferenceRow).getByText('9,450.00')).toBeInTheDocument()
   })
 
-  it('renders row 5 of the income-summary table blank, and shows no Lottery, tithe, or tithe-balance content anywhere', async () => {
+  it('shows an Average column between the Dec and Yearly Total columns for every row', async () => {
     render(<YearlySummaryPage />)
 
-    await waitFor(() => expect(screen.getByText('Income Summary')).toBeInTheDocument())
-    const incomeSection = screen.getByText('Income Summary').closest('section')!
-    const rows = within(incomeSection).getAllByRole('row')
-    const blankRow = rows[5]
-    expect(blankRow.textContent).toBe('')
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    const headerCells = screen.getAllByRole('columnheader').map((th) => th.textContent)
+    const decIndex = headerCells.indexOf('Dec')
+    const averageIndex = headerCells.indexOf('Average')
+    const yearlyTotalIndex = headerCells.indexOf('Yearly Total')
+    expect(averageIndex).toBe(decIndex + 1)
+    expect(yearlyTotalIndex).toBe(averageIndex + 1)
 
-    expect(screen.queryByText(/Lottery/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/Tithe/i)).not.toBeInTheDocument()
+    // Mercado average = 1860 / 12 = 155.00
+    const mercadoRow = screen.getByRole('cell', { name: 'Mercado' }).closest('tr')!
+    expect(within(mercadoRow).getByText('155.00')).toBeInTheDocument()
+  })
+
+  it('computes Resultado and Total despesas from already-fetched data and renders them with emphasized styling', async () => {
+    render(<YearlySummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    // Total despesas yearly total = sum of Mercado's monthly totals = 1,860.00
+    const totalDespesasRow = screen.getByRole('cell', { name: 'Total despesas' }).closest('tr')!
+    expect(totalDespesasRow).toHaveClass('yearly-summary-page__emphasized-row')
+    expect(within(totalDespesasRow).getByText('1,860.00')).toBeInTheDocument()
+
+    // Resultado yearly total = sum(salaryAfterTaxesMonthly)=29,600 + sum(dividendoJurosMonthly)=20 - totalDespesasYearlyTotal=1,860 + 0 (no Investimento category) = 27,760
+    const resultadoRow = screen.getByRole('cell', { name: 'Resultado (R-D-Inv)' }).closest('tr')!
+    expect(resultadoRow).toHaveClass('yearly-summary-page__emphasized-row')
+    expect(within(resultadoRow).getByText('27,760.00')).toBeInTheDocument()
   })
 
   it('shows only the Investments tab content after clicking Investments', async () => {
@@ -148,7 +178,7 @@ describe('YearlySummaryPage', () => {
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
 
-    expect(screen.queryByText('Income Summary')).not.toBeInTheDocument()
+    expect(screen.queryByRole('cell', { name: 'Salary' })).not.toBeInTheDocument()
     expect(screen.queryByRole('cell', { name: 'Mercado' })).not.toBeInTheDocument()
     expect(screen.getByText('Investment Diffs')).toBeInTheDocument()
     expect(screen.getByRole('cell', { name: 'ChaseSave' })).toBeInTheDocument()

--- a/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
@@ -188,6 +188,27 @@ describe('YearlySummaryPage', () => {
     expect(screen.getByRole('button', { name: 'Investments' })).toHaveClass('yearly-summary-page__tab--active')
   })
 
+  it('re-scopes the combined table, including Resultado and Total despesas, when the year changes', async () => {
+    render(<YearlySummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    expect(screen.getByRole('cell', { name: 'Mercado' })).toBeInTheDocument()
+
+    const nextYearCategoryTotals: CategoryYearlyTotalDto[] = [
+      { category: 'Carro', monthlyTotals: new Array(12).fill(50), yearlyTotal: 600 },
+    ]
+    getCategoryTotalsForYearMock.mockResolvedValue(nextYearCategoryTotals)
+
+    fireEvent.change(screen.getByLabelText('Year'), { target: { value: '2027' } })
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'Carro' })).toBeInTheDocument())
+    expect(screen.queryByRole('cell', { name: 'Mercado' })).not.toBeInTheDocument()
+
+    // Total despesas yearly total now sums only Carro = 600.00
+    const totalDespesasRow = screen.getByRole('cell', { name: 'Total despesas' }).closest('tr')!
+    expect(within(totalDespesasRow).getByText('600.00')).toBeInTheDocument()
+  })
+
   it('does not change the year picker value when switching tabs', async () => {
     render(<YearlySummaryPage />)
 

--- a/Financial.Web/src/utils/math.ts
+++ b/Financial.Web/src/utils/math.ts
@@ -1,0 +1,3 @@
+export function average(values: number[]): number {
+  return values.reduce((sum, v) => sum + v, 0) / values.length
+}

--- a/docs/P16-F02-category-totals-subtab/plan.md
+++ b/docs/P16-F02-category-totals-subtab/plan.md
@@ -1,0 +1,25 @@
+# Implementation Plan: Category Totals Sub-Tab
+
+**Prerequisites:**
+- F01 (Yearly Summary Navigation Shell) merged to main — this feature builds inside the Category Totals tab guard F01 introduced.
+- No new dependencies, environment variables, or configuration.
+
+### Stage 1: Derived Data Layer
+
+**1. Average Utility** - Add `Financial.Web/src/utils/math.ts` exporting `average(values: number[]): number`, computing the arithmetic mean using the array's own length (no hardcoded month count).
+
+**2. Total Despesas and Resultado in the Hook** - Extend `useYearlySummary.ts` with memoized `totalDespesasMonthly`/`totalDespesasYearlyTotal` (sum of all fetched categories' monthly totals) and `resultadoMonthly`/`resultadoYearlyTotal` (net income minus every category except Investimento, per the PRD formula), derived from the already-fetched `categoryTotals` and `incomeSummary`.
+
+**3. Hook Test Coverage** - Add test cases to `useYearlySummary.test.ts` verifying both derived value sets against a multi-category fixture that includes `Investimento`.
+
+### Stage 2: Merged Category Totals Table
+
+**4. Combine Category Totals and Income Summary** - Replace the Category Totals tab's two separate `<section>` blocks with one, rendering a single table whose rows follow the fixed order: Salary, Salary After Taxes, Tax Difference, spacer, Dividendo/Juros, spacer, the 14 category rows, spacer, Resultado (R-D-Inv), Total despesas.
+
+**5. Average Column** - Add an Average `<th>`/`<td>` to every row in the merged table, positioned between the Dec column and the Yearly Total column, using the new `average()` utility.
+
+**6. Emphasis Styling** - Rename `.yearly-summary-page__net-position-row` to `.yearly-summary-page__emphasized-row` in `YearlySummaryPage.css` (and its one existing usage on the Investments tab's Net Position row), then apply the same class to the new Resultado and Total despesas rows.
+
+### Stage 3: Test Coverage
+
+**7. Update Page Test Coverage** - Replace the existing separate Category Totals / Income Summary test expectations with coverage for the merged table's row order, the Average column, Resultado, Total despesas, and the emphasized-row styling, and confirm the Investments tab and tab-switching behavior from F01 are unaffected by the merge.

--- a/docs/P16-F02-category-totals-subtab/spec.md
+++ b/docs/P16-F02-category-totals-subtab/spec.md
@@ -1,0 +1,83 @@
+## 1. Technical Overview
+
+**What:** Merge the Category Totals tab's two existing tables (Category Totals + Income Summary) into one combined table with a fixed row order — Salary, Salary After Taxes, Tax Difference, Dividendo/Juros, the 14 expense categories, Resultado (R-D-Inv), Total despesas — and add an Average column between the Dec column and the Yearly Total column on every row. Two new derived rows (Total despesas, Resultado) are computed client-side from data the app already fetches; no API or backend change.
+
+**Why:** The PRD's formulas are fully specified (Total despesas = sum of all 14 categories per month; Resultado = Salary After Taxes + Dividendo/Juros − Total despesas + Investimento per month), and this codebase already has a precedent for exactly this kind of client-side aggregation: `useMonthly.ts` computes `categoryTotalsSum`, `bankTotalsSum`, `roundUpTotalsSum`, and `totalIncoming` via `.reduce()` inside the hook rather than in a new backend service. Following that precedent keeps this a genuinely UI-only change (per PRD Section 7) and avoids introducing an Application-layer service for arithmetic that's already fully derivable from data the three existing endpoints return.
+
+**Scope:**
+- Included: `average()` utility, `totalDespesasMonthly`/`totalDespesasYearlyTotal`/`resultadoMonthly`/`resultadoYearlyTotal` derived values in `useYearlySummary.ts`, the merged single-table UI under the Category Totals tab guard (introduced by F01), an Average column on every row, removal of the now-redundant standalone Income Summary section, and updated/added tests.
+- Excluded: any change to the Investments tab (F03), any change to the three existing API endpoints or their DTOs, any change to the `Category`/`IncomeSource` enums.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/utils/math.ts` (new) — generic numeric helper, separate from `formatters.ts`'s string-formatting responsibility
+- `Financial.Web/src/hooks/useYearlySummary.ts` — gains memoized `totalDespesasMonthly`, `totalDespesasYearlyTotal`, `resultadoMonthly`, `resultadoYearlyTotal`, derived from the already-fetched `categoryTotals` and `incomeSummary`
+- `Financial.Web/src/pages/YearlySummaryPage.tsx` — Category Totals tab content restructured into one table; Income Summary's separate `<section>` is removed, its rows folded into the same table; every row gains an Average cell
+- `Financial.Web/src/pages/YearlySummaryPage.css` — generalizes the existing bordered-emphasis row style (currently named for "Net Position" only) so it also applies to the new Resultado and Total despesas rows
+- `Financial.Web/src/hooks/useYearlySummary.test.ts` — gains coverage for the two new derived value sets
+- `Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx` — Category Totals tests updated for the merged table; new tests for Resultado, Total despesas, and the Average column
+
+```mermaid
+graph TD
+    A[YearlySummaryPage] --> B["useYearlySummary()"]
+    B --> C[categoryTotals, incomeSummary - fetched]
+    C --> D["useMemo: totalDespesasMonthly/YearlyTotal"]
+    C --> E["useMemo: resultadoMonthly/YearlyTotal (uses D)"]
+    D --> F[Category Totals table]
+    E --> F
+    B --> F
+    F --> G["average() per row - Financial.Web/src/utils/math.ts"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Where Total despesas / Resultado are computed | Inside `useYearlySummary.ts`, via `useMemo` over the already-fetched `categoryTotals`/`incomeSummary` | A new Application-layer `YearlySummaryService` method returning the derived rows from the backend | PRD Section 7 explicitly scopes this as UI-only with no API changes; the codebase's own `useMonthly.ts` precedent already does equivalent client-side reduction for on-screen totals, so a new backend round-trip would be inconsistent with established practice here and unnecessary for a personal single-user tool |
+| Average formula | `average(values) = sum(values) / values.length`, applied uniformly to every row's 12 monthly values | Reuse each row's existing `yearlyTotal / 12` | Using `values.length` instead of a hardcoded `12` avoids a magic number and keeps the helper correct if a row's monthly array shape ever changes; mathematically identical result for existing 12-month rows |
+| New file for `average()` | `Financial.Web/src/utils/math.ts` (new file) | Add `average()` to the existing `formatters.ts` | `formatters.ts`'s current responsibility is string formatting (`Intl.NumberFormat`-based); `average()` is a numeric computation, not a formatter — keeping them apart follows the single-responsibility convention already visible in this file (each exported function has one narrow job) |
+| Row-grouping visual separators | Reuse the existing empty spacer `<tr><td colSpan={...} /></tr>` row already used once (between Tax Difference and Dividendo/Juros) for the two additional separators (before the first category row, before Resultado) | Add a text label or heading between groups | PRD F02 Experience explicitly calls for "no text labels... visually distinguishable" via spacer rows, matching the one spacer already in the current markup |
+| Emphasis styling for Resultado/Total despesas | Generalize the existing `.yearly-summary-page__net-position-row` CSS class (top border + bold, currently used only by the Investment Diffs "Net Position" row) into a stack-agnostic `.yearly-summary-page__emphasized-row` name, applied to 3 rows total (Net Position stays on the Investments tab, Resultado and Total despesas join on the Category Totals tab) | Add a second, separately-named class with identical rules | One shared class matches the "reuse existing patterns" principle and avoids duplicate CSS; renaming (not duplicating) keeps a single source of truth for this visual treatment |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/utils/math.ts` | New | Generic numeric helpers usable across pages | Export `average(values: number[]): number` |
+| `Financial.Web/src/hooks/useYearlySummary.ts` | Modified | Adds derived yearly figures on top of the existing fetched data | `useMemo`-compute `totalDespesasMonthly: number[]` (sum of all `categoryTotals[i].monthlyTotals[m]` per month), `totalDespesasYearlyTotal: number` (sum of that array), `resultadoMonthly: number[]` (`incomeSummary.salaryAfterTaxesMonthly[m] + incomeSummary.dividendoJurosMonthly[m] - totalDespesasMonthly[m] + investimento.monthlyTotals[m]`, where `investimento` is the `categoryTotals` entry whose `category === 'Investimento'`), `resultadoYearlyTotal: number`; returns `[]`/`0` before `categoryTotals`/`incomeSummary` have loaded |
+| `Financial.Web/src/pages/YearlySummaryPage.tsx` | Modified | Renders the merged Category Totals table | Single `<table>` under the Category Totals tab guard with rows in order: Salary, Salary After Taxes, Tax Difference, spacer, Dividendo/Juros, spacer, 14 category rows, spacer, Resultado, Total despesas; every row renders an Average cell (`average(row's monthly array)`) between the Dec cell and the Yearly Total cell; Resultado and Total despesas rows use the emphasized-row class |
+| `Financial.Web/src/pages/YearlySummaryPage.css` | Modified | Renames/generalizes the emphasis row class | `.yearly-summary-page__net-position-row` → `.yearly-summary-page__emphasized-row`, same declarations, referenced by both tabs' bold summary rows |
+| `Financial.Web/src/hooks/useYearlySummary.test.ts` | Modified | Covers the two new derived value sets | New test cases for `totalDespesasMonthly`/`totalDespesasYearlyTotal` and `resultadoMonthly`/`resultadoYearlyTotal` against a fixture with several categories including `Investimento` |
+| `Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx` | Modified | Covers the merged table structure | Existing Category Totals / Income Summary tests updated to expect one combined table; new tests for row order, the Average column, Resultado, and Total despesas values |
+
+## 5. API Contracts
+
+Not applicable — no endpoint or DTO changes. `totalDespesasMonthly`, `resultadoMonthly`, and every row's Average are computed entirely client-side from the three existing endpoints' responses.
+
+## 6. Data Model
+
+Not applicable — no persistence or entity changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/hooks/useYearlySummary.test.ts` | Hook | Derived Total despesas / Resultado computation | Correct sums/formula across a multi-category fixture, including the Investimento add-back |
+| `Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx` | Component | Merged Category Totals table | All 6 F02 acceptance criteria covered |
+
+**Test functions:**
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `it('computes total despesas as the sum of all category monthly totals')` | Verifies F02 AC3 | `totalDespesasMonthly[m]` equals the sum of every fixture category's `monthlyTotals[m]`, for a fixture including `Investimento` and `Reserva` |
+| `it('computes resultado as net income minus every category except Investimento')` | Verifies F02 AC4 | `resultadoMonthly[m]` equals `salaryAfterTaxesMonthly[m] + dividendoJurosMonthly[m] - totalDespesasMonthly[m] + investimento.monthlyTotals[m]` for the same fixture |
+| `it('renders the combined table in the fixed row order')` | Verifies F02 AC1 | Row labels appear top-to-bottom in order: Salary, Salary after taxes, Tax difference, Dividendo/Juros, each fixture category, Resultado (R-D-Inv), Total despesas |
+| `it('renders no standalone Income Summary section')` | Verifies F02 AC1/AC2 (merge) | `screen.queryByText('Income Summary')` is not present; Salary/Dividendo rows render inside the same `<table>` element as the category rows |
+| `it('shows an Average column between the Dec and Yearly Total columns for every row')` | Verifies F02 AC5 | Header row has `Average` immediately before `Yearly Total`; a sampled row's Average cell equals the arithmetic mean of its 12 monthly cells |
+| `it('renders Resultado and Total despesas with emphasized styling')` | Verifies F02 AC6 | Both rows carry the `yearly-summary-page__emphasized-row` class |
+| `it('does not affect the Investments tab content')` (Cross-Feature Integration, F01 → F02) | Verifies year/tab-sharing still holds after the table merge | Switching to Investments still shows the (unchanged) Investment Diffs table; switching back still shows Category Totals with no refetch |

--- a/docs/prd/P16-prd-yearly-summary-subtab-redesign/prd-yearly-summary-subtab-redesign.md
+++ b/docs/prd/P16-prd-yearly-summary-subtab-redesign/prd-yearly-summary-subtab-redesign.md
@@ -196,12 +196,12 @@ graph TD
 - [x] If data loading fails, the error/retry state is shown regardless of the active sub-tab
 
 ### F02. Category Totals Sub-Tab
-- [ ] The table renders rows in the fixed order: Salary, Salary After Taxes, Tax Difference, Dividendo/Juros, the 14 categories in enum order, Resultado (R-D-Inv), Total despesas
-- [ ] Salary, Salary After Taxes, Tax Difference, Dividendo/Juros, and each category row's monthly and yearly-total values match the values shown before the redesign for the same year
-- [ ] Total despesas for each month equals the sum of that month's 14 category values, including Investimento and Reserva
-- [ ] Resultado (R-D-Inv) for each month equals Salary After Taxes + Dividendo/Juros − Total despesas + Investimento for that month
-- [ ] Every row displays an Average column equal to the arithmetic mean of its 12 monthly values, positioned between the Dec column and the Yearly Total column
-- [ ] Total despesas and Resultado rows render visually emphasized (bold), consistent with existing yearly-total styling
+- [x] The table renders rows in the fixed order: Salary, Salary After Taxes, Tax Difference, Dividendo/Juros, the 14 categories in enum order, Resultado (R-D-Inv), Total despesas
+- [x] Salary, Salary After Taxes, Tax Difference, Dividendo/Juros, and each category row's monthly and yearly-total values match the values shown before the redesign for the same year
+- [x] Total despesas for each month equals the sum of that month's 14 category values, including Investimento and Reserva
+- [x] Resultado (R-D-Inv) for each month equals Salary After Taxes + Dividendo/Juros − Total despesas + Investimento for that month
+- [x] Every row displays an Average column equal to the arithmetic mean of its 12 monthly values, positioned between the Dec column and the Yearly Total column
+- [x] Total despesas and Resultado rows render visually emphasized (bold), consistent with existing yearly-total styling
 
 ### F03. Investments Sub-Tab
 - [ ] Each of the 11 account rows shows all 12 monthly balance values (not just January)
@@ -213,7 +213,7 @@ graph TD
 - [ ] Sum of Month Results equals the sum of the 11 Month Result values, and is numerically equal to Year Progress
 
 ### Cross-Feature Integration
-- [ ] Selecting a different year while Category Totals is active re-scopes the entire combined table, including Resultado and Total despesas, to the new year (F01 → F02)
+- [x] Selecting a different year while Category Totals is active re-scopes the entire combined table, including Resultado and Total despesas, to the new year (F01 → F02)
 - [ ] Selecting a different year while Investments is active re-scopes the account table, Total row, Month Result row, and the three summary figures to the new year (F01 → F03)
 - [ ] Switching from Category Totals to Investments and back displays each sub-tab's content without re-triggering a network refetch, confirming the shared year from F01 is reused rather than reset (F01 → F02, F03)
 - [ ] At every point in the flow, exactly one of Category Totals/Investments content is visible, confirming F01's active-tab state correctly gates F02 and F03 (F01 → F02, F03)


### PR DESCRIPTION
## Summary
- Merges the Category Totals tab's two tables (Category Totals + Income Summary) into one, in fixed row order: Salary, Salary After Taxes, Tax Difference, Dividendo/Juros, the 14 categories, Resultado (R-D-Inv), Total despesas
- Adds two new derived value sets computed client-side in `useYearlySummary.ts` (mirroring the existing `useMonthly.ts` `.reduce()` aggregation precedent — no backend/API changes): `totalDespesasMonthly`/`YearlyTotal` (sum of all 14 categories) and `resultadoMonthly`/`YearlyTotal` (net income minus every category except Investimento)
- Adds an Average column between Dec and Yearly Total on every row via a shared `YearlySummaryRow` component and a new `average()` utility
- Generalizes the "Net Position" emphasis CSS class to `yearly-summary-page__emphasized-row`, now also applied to Resultado and Total despesas

## Acceptance criteria (PRD Section 9, F02 + cross-feature)
- [x] Table renders rows in the fixed order (Salary, Salary After Taxes, Tax Difference, Dividendo/Juros, 14 categories, Resultado, Total despesas)
- [x] Existing Salary/category values unchanged from before the redesign
- [x] Total despesas = sum of all 14 categories per month, including Investimento and Reserva
- [x] Resultado (R-D-Inv) = Salary After Taxes + Dividendo/Juros − Total despesas + Investimento
- [x] Average column between Dec and Yearly Total on every row
- [x] Resultado and Total despesas render with emphasized (bold) styling
- [x] Cross-feature (F01→F02): changing year re-scopes the combined table including Resultado/Total despesas

## Test plan
- [x] `npx vitest run` — 627/627 tests pass (14 in `YearlySummaryPage.test.tsx`, 6 in `useYearlySummary.test.ts`)
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [ ] Manual browser smoke test (not run this pass — backend not spun up locally; CI's `browser-smoke-test` job covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P9h9D3DFkckJAyDktemTe