### PR TITLE
feat(P16-F03): Investments sub-tab reshape

### DIFF
--- a/Financial.Web/src/pages/YearlySummaryPage.css
+++ b/Financial.Web/src/pages/YearlySummaryPage.css
@@ -73,3 +73,25 @@
 .yearly-summary-page__emphasized-row {
   border-top: 2px solid var(--border, #ccc);
 }
+
+.yearly-summary-page__investment-totals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  margin-top: 16px;
+}
+
+.yearly-summary-page__investment-total {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.yearly-summary-page__investment-total span {
+  color: var(--text, #333);
+  font-size: 13px;
+}
+
+.yearly-summary-page__investment-total strong {
+  font-size: 16px;
+}

--- a/Financial.Web/src/pages/YearlySummaryPage.tsx
+++ b/Financial.Web/src/pages/YearlySummaryPage.tsx
@@ -46,6 +46,28 @@ function YearlySummaryRow({
   )
 }
 
+function InvestmentRow({
+  label,
+  monthlyValues,
+  emphasized = false,
+}: {
+  label: string
+  monthlyValues: (number | null)[]
+  emphasized?: boolean
+}) {
+  const cell = (content: ReactNode) => (emphasized ? <strong>{content}</strong> : content)
+  return (
+    <tr className={emphasized ? 'yearly-summary-page__emphasized-row' : undefined}>
+      <td>{cell(label)}</td>
+      {monthlyValues.map((v, i) => (
+        <td key={i} className="data-table__col--numeric">
+          {v === null ? null : cell(formatN2(v))}
+        </td>
+      ))}
+    </tr>
+  )
+}
+
 export default function YearlySummaryPage() {
   const {
     year,
@@ -173,54 +195,49 @@ export default function YearlySummaryPage() {
 
           {activeTab === 'investments' && investmentDiffs && (
             <section className="yearly-summary-page__section">
-              <h2>Investment Diffs</h2>
+              <h2>Investments</h2>
               <table className="yearly-summary-page__table data-table">
                 <thead>
                   <tr>
                     <th>Account</th>
-                    <th className="data-table__col--numeric">Jan</th>
-                    {MONTH_LABELS.slice(1).map((m) => (
+                    {MONTH_LABELS.map((m) => (
                       <th key={m} className="data-table__col--numeric">
-                        {m} Δ
+                        {m}
                       </th>
                     ))}
-                    <th className="data-table__col--numeric">Full Year Net Change</th>
                   </tr>
                 </thead>
                 <tbody>
                   {investmentDiffs.accounts.map((a) => (
-                    <tr key={a.account}>
-                      <td>
-                        {a.account}
-                        {a.isLiability ? ' (liability)' : ''}
-                      </td>
-                      <td className="data-table__col--numeric">{formatN2(a.monthlyValues[0])}</td>
-                      {a.monthlyDiffs.map((diff, i) => (
-                        <td key={i} className="data-table__col--numeric">
-                          {formatN2(diff)}
-                        </td>
-                      ))}
-                      <td className="data-table__col--numeric" />
-                    </tr>
+                    <InvestmentRow
+                      key={a.account}
+                      label={`${a.account}${a.isLiability ? ' (-)' : ''}`}
+                      monthlyValues={a.monthlyValues}
+                    />
                   ))}
-                  <tr className="yearly-summary-page__emphasized-row">
-                    <td>
-                      <strong>Net Position</strong>
-                    </td>
-                    <td className="data-table__col--numeric">
-                      <strong>{formatN2(investmentDiffs.netPosition.monthlyValues[0])}</strong>
-                    </td>
-                    {investmentDiffs.netPosition.monthlyDiffs.map((diff, i) => (
-                      <td key={i} className="data-table__col--numeric">
-                        <strong>{formatN2(diff)}</strong>
-                      </td>
-                    ))}
-                    <td className="data-table__col--numeric">
-                      <strong>{formatN2(investmentDiffs.netPosition.fullYearNetChange)}</strong>
-                    </td>
-                  </tr>
+                  <InvestmentRow label="Total" monthlyValues={investmentDiffs.netPosition.monthlyValues} emphasized />
+                  <InvestmentRow
+                    label="Month Result"
+                    monthlyValues={[null, ...investmentDiffs.netPosition.monthlyDiffs]}
+                    emphasized
+                  />
                 </tbody>
               </table>
+
+              <div className="yearly-summary-page__investment-totals">
+                <div className="yearly-summary-page__investment-total">
+                  <span>Year Progress</span>
+                  <strong>{formatN2(investmentDiffs.netPosition.fullYearNetChange)}</strong>
+                </div>
+                <div className="yearly-summary-page__investment-total">
+                  <span>Average Month Result</span>
+                  <strong>{formatN2(average(investmentDiffs.netPosition.monthlyDiffs))}</strong>
+                </div>
+                <div className="yearly-summary-page__investment-total">
+                  <span>Sum of Month Results</span>
+                  <strong>{formatN2(investmentDiffs.netPosition.monthlyDiffs.reduce((sum, v) => sum + v, 0))}</strong>
+                </div>
+              </div>
             </section>
           )}
         </div>

--- a/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
@@ -259,6 +259,40 @@ describe('YearlySummaryPage', () => {
     expect(screen.getByRole('cell', { name: 'Salary' })).toBeInTheDocument()
   })
 
+  it('re-scopes the account table, Total row, Month Result row, and summary figures when the year changes on the Investments tab', async () => {
+    render(<YearlySummaryPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'ChaseSave' })).toBeInTheDocument())
+
+    const nextYearInvestmentDiffs: InvestmentDiffsYearlyDto = {
+      accounts: [
+        {
+          account: 'ChipCashIsaGleison',
+          isLiability: false,
+          monthlyValues: new Array(12).fill(2000),
+          monthlyDiffs: new Array(11).fill(0),
+        },
+      ],
+      netPosition: {
+        monthlyValues: new Array(12).fill(2000),
+        monthlyDiffs: new Array(11).fill(0),
+        fullYearNetChange: 0,
+      },
+    }
+    getInvestmentDiffsForYearMock.mockResolvedValue(nextYearInvestmentDiffs)
+
+    fireEvent.change(screen.getByLabelText('Year'), { target: { value: '2027' } })
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'ChipCashIsaGleison' })).toBeInTheDocument())
+    expect(screen.queryByRole('cell', { name: 'ChaseSave' })).not.toBeInTheDocument()
+
+    const totalRow = screen.getByRole('cell', { name: 'Total' }).closest('tr')!
+    expect(within(totalRow).getAllByText('2,000.00').length).toBeGreaterThan(0)
+    const yearProgress = screen.getByText('Year Progress').closest('div')!
+    expect(within(yearProgress).getByText('0.00')).toBeInTheDocument()
+  })
+
   it('re-scopes the combined table, including Resultado and Total despesas, when the year changes', async () => {
     render(<YearlySummaryPage />)
 

--- a/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
@@ -96,7 +96,7 @@ describe('YearlySummaryPage', () => {
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
     expect(screen.getByRole('cell', { name: 'Mercado' })).toBeInTheDocument()
     expect(screen.getByRole('cell', { name: 'Salary' })).toBeInTheDocument()
-    expect(screen.queryByText('Investment Diffs')).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Investments' })).not.toBeInTheDocument()
   })
 
   it('marks Category Totals as the active tab button by default', async () => {
@@ -180,12 +180,83 @@ describe('YearlySummaryPage', () => {
 
     expect(screen.queryByRole('cell', { name: 'Salary' })).not.toBeInTheDocument()
     expect(screen.queryByRole('cell', { name: 'Mercado' })).not.toBeInTheDocument()
-    expect(screen.getByText('Investment Diffs')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Investments' })).toBeInTheDocument()
     expect(screen.getByRole('cell', { name: 'ChaseSave' })).toBeInTheDocument()
-    expect(screen.getByText('PlatinumVisa8003 (liability)')).toBeInTheDocument()
-    expect(screen.getByText('Net Position')).toBeInTheDocument()
-    expect(screen.getByText('550.00')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Investments' })).toHaveClass('yearly-summary-page__tab--active')
+  })
+
+  it('shows all 12 monthly balance values for each account', async () => {
+    render(<YearlySummaryPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'ChaseSave' })).toBeInTheDocument())
+
+    const chaseSaveRow = screen.getByRole('cell', { name: 'ChaseSave' }).closest('tr')!
+    for (const value of INVESTMENT_DIFFS.accounts[0].monthlyValues) {
+      expect(within(chaseSaveRow).getByText(value.toLocaleString(undefined, { minimumFractionDigits: 2 }))).toBeInTheDocument()
+    }
+  })
+
+  it('marks liability accounts with a (-) suffix and asset accounts without one', async () => {
+    render(<YearlySummaryPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+    await waitFor(() => expect(screen.getByText('PlatinumVisa8003 (-)')).toBeInTheDocument())
+    expect(screen.getByRole('cell', { name: 'ChaseSave' })).toBeInTheDocument()
+  })
+
+  it('renders a Total row matching the net position monthly values', async () => {
+    render(<YearlySummaryPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'Total' })).toBeInTheDocument())
+
+    const totalRow = screen.getByRole('cell', { name: 'Total' }).closest('tr')!
+    expect(totalRow).toHaveClass('yearly-summary-page__emphasized-row')
+    expect(within(totalRow).getByText('800.00')).toBeInTheDocument()
+    expect(within(totalRow).getByText('1,350.00')).toBeInTheDocument()
+  })
+
+  it('renders a Month Result row with a blank January cell and the net position diffs for Feb-Dec', async () => {
+    render(<YearlySummaryPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'Month Result' })).toBeInTheDocument())
+
+    const monthResultRow = screen.getByRole('cell', { name: 'Month Result' }).closest('tr')!
+    expect(monthResultRow).toHaveClass('yearly-summary-page__emphasized-row')
+    const cells = within(monthResultRow).getAllByRole('cell')
+    // cells[0] is the label; cells[1] is January, which must be blank
+    expect(cells[1].textContent).toBe('')
+    expect(within(monthResultRow).getAllByText('50.00').length).toBe(11)
+  })
+
+  it('shows Year Progress, Average Month Result, and Sum of Month Results, with Sum equal to Year Progress', async () => {
+    render(<YearlySummaryPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+    await waitFor(() => expect(screen.getByText('Year Progress')).toBeInTheDocument())
+
+    const yearProgress = screen.getByText('Year Progress').closest('div')!
+    expect(within(yearProgress).getByText('550.00')).toBeInTheDocument()
+
+    const averageMonthResult = screen.getByText('Average Month Result').closest('div')!
+    expect(within(averageMonthResult).getByText('50.00')).toBeInTheDocument()
+
+    const sumOfMonthResults = screen.getByText('Sum of Month Results').closest('div')!
+    expect(within(sumOfMonthResults).getByText('550.00')).toBeInTheDocument()
+  })
+
+  it('does not affect the Category Totals tab content when viewing Investments', async () => {
+    render(<YearlySummaryPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'Mercado' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'ChaseSave' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Category Totals' }))
+
+    expect(screen.getByRole('cell', { name: 'Mercado' })).toBeInTheDocument()
+    expect(screen.getByRole('cell', { name: 'Salary' })).toBeInTheDocument()
   })
 
   it('re-scopes the combined table, including Resultado and Total despesas, when the year changes', async () => {
@@ -238,11 +309,11 @@ describe('YearlySummaryPage', () => {
 
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
-    await waitFor(() => expect(screen.getByText('Investment Diffs')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Investments' })).toBeInTheDocument())
 
     fireEvent.change(screen.getByLabelText('Year'), { target: { value: '2027' } })
 
-    await waitFor(() => expect(screen.getByText('Investment Diffs')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Investments' })).toBeInTheDocument())
     expect(screen.getByRole('button', { name: 'Investments' })).toHaveClass('yearly-summary-page__tab--active')
   })
 })

--- a/docs/P16-F03-investments-subtab/plan.md
+++ b/docs/P16-F03-investments-subtab/plan.md
@@ -1,0 +1,19 @@
+# Implementation Plan: Investments Sub-Tab
+
+**Prerequisites:**
+- F01 (Yearly Summary Navigation Shell) merged to main — this feature reshapes content inside the Investments tab guard F01 introduced.
+- No new dependencies, environment variables, or configuration.
+
+### Stage 1: Reshaped Investments Table
+
+**1. Investment Row Component** - Add a local `InvestmentRow` component to `YearlySummaryPage.tsx` rendering a label plus 12 month cells, where a `null` value renders a blank cell (used for Month Result's January column) and an `emphasized` flag bolds the row.
+
+**2. Account Rows** - Replace the current Jan + 11-diff account rows with full 12-month balance rows using each account's existing `monthlyValues` array, changing the liability marker from `(liability)` to `(-)`.
+
+**3. Total and Month Result Rows** - Add a Total row (`netPosition.monthlyValues`) and a Month Result row (`netPosition.monthlyDiffs`, with a blank January cell), both emphasized, replacing the current single "Net Position" row.
+
+**4. Summary Figures** - Add a labeled block below the table showing Year Progress (`netPosition.fullYearNetChange`), Average Month Result (mean of `netPosition.monthlyDiffs`), and Sum of Month Results (sum of `netPosition.monthlyDiffs`), plus the CSS for that block.
+
+### Stage 2: Test Coverage
+
+**5. Update Investments Tab Test Coverage** - Replace the existing diff-table assertions with coverage for the 12-month account rows, the `(-)` suffix, the Total row, the Month Result row, and the three summary figures, and confirm the Category Totals tab and tab-switching behavior are unaffected by the reshape.

--- a/docs/P16-F03-investments-subtab/spec.md
+++ b/docs/P16-F03-investments-subtab/spec.md
@@ -1,0 +1,73 @@
+## 1. Technical Overview
+
+**What:** Replace the Investments tab's diff-only account table with a table showing each account's full 12-month balance history, followed by a Total row (net position per month) and a Month Result row (month-over-month change of the Total row), plus three summary figures below the table: Year Progress, Average Month Result, and Sum of Month Results.
+
+**Why:** Every number this feature needs already exists in `InvestmentDiffsYearlyDTO` — `InvestmentAccountYearlyDiffDTO.MonthlyValues` already carries all 12 months (today's UI only renders index 0), and `NetPositionYearlyDiffDTO` already has `MonthlyValues` (12), `MonthlyDiffs` (11), and `FullYearNetChange`. This is a pure UI reshape: no new API call, no new derived-value hook logic (unlike F02, this feature combines nothing across datasets — every figure is either already in `investmentDiffs` or a one-line reduction over its own `netPosition.monthlyDiffs`), consistent with PRD Section 7's "no API/DTO changes" scope.
+
+**Scope:**
+- Included: reshaped account rows (12 monthly balances instead of Jan + 11 diffs), the renamed Total row, the new Month Result row, the three summary figures, the `(-)` liability suffix (replacing the current `(liability)` text), and updated/added tests.
+- Excluded: any change to the Category Totals tab (F02, already shipped), any change to the three existing API endpoints, DTOs, or the `InvestmentAccountClassification` liability rule.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/pages/YearlySummaryPage.tsx` — Investments tab content replaced: new `InvestmentRow` component, reshaped table body, new summary-figures block
+- `Financial.Web/src/pages/YearlySummaryPage.css` — table header/columns adjust to 12 month columns (no Average/Yearly Total columns on this tab); new styles for the summary-figures block
+- `Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx` — all Investments-tab assertions updated for the new table shape; new tests for Month Result, Total, and the three summary figures
+
+```mermaid
+graph TD
+    A[YearlySummaryPage] --> B["useYearlySummary() - investmentDiffs (unchanged)"]
+    B --> C[11 InvestmentRow: account.monthlyValues]
+    B --> D["InvestmentRow: Total = netPosition.monthlyValues"]
+    B --> E["InvestmentRow: Month Result = [null, ...netPosition.monthlyDiffs]"]
+    B --> F["Summary figures: fullYearNetChange, average(monthlyDiffs), sum(monthlyDiffs)"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|----------------|----------------------|-----------|
+| Row rendering | A small local `InvestmentRow({ label, monthlyValues: (number \| null)[], emphasized })` component, reused for all 13 rows (11 accounts + Total + Month Result); `null` renders a blank cell (used for Month Result's January column) | Three separate hand-written `<tr>` blocks | Same row shape (label + 12 numeric cells) repeats 13 times; a single component avoids the duplication and keeps the "blank January cell" rule in one place, mirroring the F02 `YearlySummaryRow` precedent |
+| Average Month Result / Sum of Month Results computation | Computed inline in the page from `investmentDiffs.netPosition.monthlyDiffs` (`average()` from `Financial.Web/src/utils/math.ts`, plus a one-line `.reduce()` for the sum) | Add new fields to `useYearlySummary.ts` (as F02 did for Resultado/Total despesas) | Unlike F02's Resultado/Total despesas, these two figures reduce over a single already-fetched array with no cross-dataset combination — a hook round-trip would add indirection for a one-line computation used in exactly one place |
+| Liability marker | Change the existing `(liability)` suffix to `(-)`, matching the source spreadsheet's own notation for negative/liability accounts | Keep `(liability)` | PRD F03 Capabilities explicitly specifies the `(-)` suffix "matching the source spreadsheet's own notation" |
+| Sanity-check figure | Render "Sum of Month Results" even though it is always mathematically equal to "Year Progress" (telescoping sum) | Compute only one and label it twice | PRD F03 Capabilities explicitly calls for both to be shown together as a built-in cross-check, not deduplicated |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|---------------------|
+| `Financial.Web/src/pages/YearlySummaryPage.tsx` | Modified | Renders the reshaped Investments table and summary figures | New `InvestmentRow` component; table header shows `Account` + 12 month labels (no Average/Yearly Total columns); body renders 11 account rows (`monthlyValues` = full array, `(-)` suffix when `isLiability`), then the Total row (`emphasized`, `monthlyValues = netPosition.monthlyValues`), then the Month Result row (`emphasized`, `monthlyValues = [null, ...netPosition.monthlyDiffs]`); a summary block below the table renders Year Progress (`netPosition.fullYearNetChange`), Average Month Result (`average(netPosition.monthlyDiffs)`), and Sum of Month Results (`netPosition.monthlyDiffs.reduce(...)`) |
+| `Financial.Web/src/pages/YearlySummaryPage.css` | Modified | Styles the summary-figures block | Add `.yearly-summary-page__investment-totals` (flex row/wrap of labeled figures), reusing existing typography/spacing conventions from the page |
+| `Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx` | Modified | Covers the reshaped Investments tab | Existing Investments-tab test rewritten for 12-month account rows, `(-)` suffix, Total row, Month Result row; new tests for the three summary figures and the Sum-of-Month-Results/Year-Progress equality |
+
+## 5. API Contracts
+
+Not applicable — no endpoint or DTO changes. Every rendered figure comes from the existing `investment-diffs` endpoint response, already fetched by `useYearlySummary`.
+
+## 6. Data Model
+
+Not applicable — no persistence or entity changes.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|---------------|
+| `Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx` | Component | Reshaped Investments table | All 7 F03 acceptance criteria covered |
+
+**Test functions:**
+
+| Test Function | Description | Assertions |
+|---------------|-------------|------------|
+| `it('shows all 12 monthly balance values for each account')` | Verifies F03 AC1 | An account's row renders all 12 fixture values, not just January |
+| `it('marks liability accounts with a (-) suffix and asset accounts without one')` | Verifies F03 AC2 | Liability account cell text ends with `(-)`; asset account cell text does not |
+| `it('renders a Total row matching the net position monthly values')` | Verifies F03 AC3 | Total row's 12 cells equal `netPosition.monthlyValues` |
+| `it('renders a Month Result row with a blank January cell and the net position diffs for Feb-Dec')` | Verifies F03 AC4 | Month Result row's January cell is empty; Feb-Dec cells equal `netPosition.monthlyDiffs` |
+| `it('shows Year Progress equal to December minus January of the Total row')` | Verifies F03 AC5 | Year Progress figure equals `netPosition.fullYearNetChange` |
+| `it('shows Average Month Result as the mean of the 11 Month Result values')` | Verifies F03 AC6 | Average Month Result figure equals the arithmetic mean of `netPosition.monthlyDiffs` |
+| `it('shows Sum of Month Results equal to Year Progress')` | Verifies F03 AC7 | Sum of Month Results figure equals the sum of `netPosition.monthlyDiffs`, and that sum equals `fullYearNetChange` |
+| `it('does not affect the Category Totals tab content')` (Cross-Feature Integration, F01 → F03) | Confirms the reshape doesn't regress F01/F02 | Switching to Category Totals still shows the merged table unaffected; switching back to Investments re-shows the reshaped table with no refetch |

--- a/docs/prd/P16-prd-yearly-summary-subtab-redesign/prd-yearly-summary-subtab-redesign.md
+++ b/docs/prd/P16-prd-yearly-summary-subtab-redesign/prd-yearly-summary-subtab-redesign.md
@@ -204,16 +204,16 @@ graph TD
 - [x] Total despesas and Resultado rows render visually emphasized (bold), consistent with existing yearly-total styling
 
 ### F03. Investments Sub-Tab
-- [ ] Each of the 11 account rows shows all 12 monthly balance values (not just January)
-- [ ] Liability accounts (Platinum Visa 8003, Platinum Visa 6007, Chase Master 4023, Paypal credit, Reservas pessoais) display a "(-)" suffix; asset accounts do not
-- [ ] The Total row's 12 monthly values match the existing net position values for the same year
-- [ ] The Month Result row's 11 values (Feb–Dec) match the existing net position month-over-month diffs for the same year, and the Jan column under Month Result is empty
-- [ ] Year Progress equals December's Total minus January's Total
-- [ ] Average Month Result equals the arithmetic mean of the 11 Month Result values
-- [ ] Sum of Month Results equals the sum of the 11 Month Result values, and is numerically equal to Year Progress
+- [x] Each of the 11 account rows shows all 12 monthly balance values (not just January)
+- [x] Liability accounts (Platinum Visa 8003, Platinum Visa 6007, Chase Master 4023, Paypal credit, Reservas pessoais) display a "(-)" suffix; asset accounts do not
+- [x] The Total row's 12 monthly values match the existing net position values for the same year
+- [x] The Month Result row's 11 values (Feb–Dec) match the existing net position month-over-month diffs for the same year, and the Jan column under Month Result is empty
+- [x] Year Progress equals December's Total minus January's Total
+- [x] Average Month Result equals the arithmetic mean of the 11 Month Result values
+- [x] Sum of Month Results equals the sum of the 11 Month Result values, and is numerically equal to Year Progress
 
 ### Cross-Feature Integration
 - [x] Selecting a different year while Category Totals is active re-scopes the entire combined table, including Resultado and Total despesas, to the new year (F01 → F02)
-- [ ] Selecting a different year while Investments is active re-scopes the account table, Total row, Month Result row, and the three summary figures to the new year (F01 → F03)
-- [ ] Switching from Category Totals to Investments and back displays each sub-tab's content without re-triggering a network refetch, confirming the shared year from F01 is reused rather than reset (F01 → F02, F03)
-- [ ] At every point in the flow, exactly one of Category Totals/Investments content is visible, confirming F01's active-tab state correctly gates F02 and F03 (F01 → F02, F03)
+- [x] Selecting a different year while Investments is active re-scopes the account table, Total row, Month Result row, and the three summary figures to the new year (F01 → F03)
+- [x] Switching from Category Totals to Investments and back displays each sub-tab's content without re-triggering a network refetch, confirming the shared year from F01 is reused rather than reset (F01 → F02, F03)
+- [x] At every point in the flow, exactly one of Category Totals/Investments content is visible, confirming F01's active-tab state correctly gates F02 and F03 (F01 → F02, F03)


### PR DESCRIPTION
## Summary
- Reshapes the Investments tab: each of the 11 accounts now shows its full 12-month balance history (previously only January + 11 diffs)
- Replaces the single "Net Position" row with a Total row (net position per month) and a new Month Result row (month-over-month change, blank January cell)
- Adds three summary figures below the table: Year Progress, Average Month Result, Sum of Month Results (always numerically equal to Year Progress — shown together as a built-in cross-check)
- Liability accounts now show a `(-)` suffix (was `(liability)`), matching the source spreadsheet's notation
- No API/DTO changes — every figure comes from data `investment-diffs` already returns; `MonthlyValues`/`MonthlyDiffs`/`FullYearNetChange` were already present, just underused by the old UI

This is the last feature in the P16 PRD — the Yearly Summary tab redesign is complete after this merges.

## Acceptance criteria (PRD Section 9, F03 + remaining cross-feature)
- [x] Each account row shows all 12 monthly balances
- [x] Liability accounts show `(-)`, asset accounts don't
- [x] Total row matches net position monthly values
- [x] Month Result row has a blank Jan cell and matches net position diffs for Feb-Dec
- [x] Year Progress = Dec Total − Jan Total
- [x] Average Month Result = mean of the 11 Month Result values
- [x] Sum of Month Results = sum of the 11 values, numerically equal to Year Progress
- [x] All remaining Cross-Feature Integration criteria (F01→F02, F01→F03, F01→F02+F03) — now checked since F01/F02/F03 are all implemented

## Test plan
- [x] `npx vitest run` — 634/634 tests pass (21 in `YearlySummaryPage.test.tsx`)
- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [ ] Manual browser smoke test (not run this pass — backend not spun up locally; CI's `browser-smoke-test` job covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P9h9D3DFkckJAyDktemTe