### PR TITLE
feat(P18-F04): scope investment accounts to the years they existed in

### DIFF
--- a/Financial.CashFlow.Application/Services/InvestmentSnapshotService.cs
+++ b/Financial.CashFlow.Application/Services/InvestmentSnapshotService.cs
@@ -1,6 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Domain.Rules;
 
 namespace Financial.CashFlow.Application.Services;
 
@@ -16,13 +17,16 @@ public sealed class InvestmentSnapshotService : IInvestmentSnapshotService
     public async Task<IReadOnlyList<InvestmentSnapshotDTO>> GetSnapshotsForMonthAsync(int year, int month)
     {
         var accounts = _repository.GetInvestmentAccounts().ToList();
+        var allSnapshots = _repository.GetInvestmentSnapshots().ToList();
+        var scopedAccounts = YearScopedInvestmentAccountResolver.ResolveForYear(accounts, allSnapshots, year, DateTime.Now.Year);
+        var scopedNames = scopedAccounts.Select(a => a.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        var existingSnapshots = _repository.GetInvestmentSnapshots()
-            .Where(s => s.Year == year && s.Month == month)
+        var existingSnapshots = allSnapshots
+            .Where(s => s.Year == year && s.Month == month && scopedNames.Contains(s.Account))
             .ToList();
 
         var created = false;
-        foreach (var account in accounts)
+        foreach (var account in scopedAccounts)
         {
             if (existingSnapshots.Any(s => s.Account == account.Name))
             {

--- a/Financial.CashFlow.Application/Services/YearlySummaryService.cs
+++ b/Financial.CashFlow.Application/Services/YearlySummaryService.cs
@@ -1,6 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Domain.Enums;
+using Financial.CashFlow.Domain.Rules;
 
 namespace Financial.CashFlow.Application.Services;
 
@@ -43,12 +44,16 @@ public sealed class YearlySummaryService : IYearlySummaryService
 
     public InvestmentDiffsYearlyDTO GetInvestmentDiffsForYear(int year)
     {
-        var valueByAccountAndMonth = _repository.GetInvestmentSnapshots()
+        var allSnapshots = _repository.GetInvestmentSnapshots().ToList();
+        var allAccounts = _repository.GetInvestmentAccounts().ToList();
+        var scopedAccounts = YearScopedInvestmentAccountResolver.ResolveForYear(allAccounts, allSnapshots, year, DateTime.Now.Year);
+
+        var valueByAccountAndMonth = allSnapshots
             .Where(s => s.Year == year)
             .GroupBy(s => (s.Account, s.Month))
             .ToDictionary(g => g.Key, g => g.First().Value);
 
-        var accounts = _repository.GetInvestmentAccounts()
+        var accounts = scopedAccounts
             .Select(account =>
             {
                 var monthlyValues = new decimal[MonthsInYear];

--- a/Financial.CashFlow.Domain/Rules/YearScopedInvestmentAccountResolver.cs
+++ b/Financial.CashFlow.Domain/Rules/YearScopedInvestmentAccountResolver.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using Financial.CashFlow.Domain.Entities;
+
+namespace Financial.CashFlow.Domain.Rules;
+
+/// <summary>
+/// Determines which investment accounts apply to a given year. For the current, in-progress
+/// year (or any later year), every active account applies, so a new month can still be tracked
+/// by hand before it's ever been imported. For any past year, an account applies only if it has
+/// at least one persisted snapshot that year - existence is derived purely from snapshot
+/// presence, which F03's explicit-zero-for-blank-months import guarantees is complete for every
+/// matched account-year, independent of the account's current active/disabled status.
+/// </summary>
+public static class YearScopedInvestmentAccountResolver
+{
+    public static IReadOnlyList<InvestmentAccount> ResolveForYear(
+        IReadOnlyCollection<InvestmentAccount> accounts,
+        IReadOnlyCollection<InvestmentSnapshot> snapshots,
+        int year,
+        int currentYear)
+    {
+        if (year >= currentYear)
+        {
+            return accounts.Where(a => a.IsActive).ToList();
+        }
+
+        var namesWithSnapshotsThatYear = snapshots
+            .Where(s => s.Year == year)
+            .Select(s => s.Account)
+            .ToHashSet(System.StringComparer.OrdinalIgnoreCase);
+
+        return accounts.Where(a => namesWithSnapshotsThatYear.Contains(a.Name)).ToList();
+    }
+}

--- a/Tests/Financial.CashFlow.Application.Tests/Services/InvestmentSnapshotServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/InvestmentSnapshotServiceTests.cs
@@ -8,6 +8,9 @@ namespace Financial.CashFlow.Application.Tests.Services;
 
 public class InvestmentSnapshotServiceTests
 {
+    private static readonly int CurrentYear = DateTime.Now.Year;
+    private static readonly int PastYear = CurrentYear - 5;
+
     [Fact]
     public void Constructor_WithNullRepository_Throws()
     {
@@ -21,7 +24,7 @@ public class InvestmentSnapshotServiceTests
         var repository = new StubCashFlowRepository();
         var service = new InvestmentSnapshotService(repository);
 
-        var result = await service.GetSnapshotsForMonthAsync(2026, 7);
+        var result = await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
 
         result.Should().HaveCount(11);
         result.Should().OnlyContain(s => s.Value == 0m);
@@ -34,7 +37,7 @@ public class InvestmentSnapshotServiceTests
         var repository = new StubCashFlowRepository();
         var service = new InvestmentSnapshotService(repository);
 
-        var result = await service.GetSnapshotsForMonthAsync(2026, 7);
+        var result = await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
 
         result.Where(s => s.IsLiability).Should().HaveCount(6);
         result.Should().ContainSingle(s => s.Account == "PlatinumVisa8003" && s.IsLiability);
@@ -48,8 +51,8 @@ public class InvestmentSnapshotServiceTests
         var repository = new StubCashFlowRepository();
         var service = new InvestmentSnapshotService(repository);
 
-        await service.GetSnapshotsForMonthAsync(2026, 7);
-        var result = await service.GetSnapshotsForMonthAsync(2026, 7);
+        await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
+        var result = await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
 
         result.Should().HaveCount(11);
         repository.Snapshots.Should().HaveCount(11);
@@ -57,12 +60,49 @@ public class InvestmentSnapshotServiceTests
     }
 
     [Fact]
+    public async Task GetSnapshotsForMonthAsync_CurrentYear_ExcludesDisabledAccounts()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Accounts.Add(InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false));
+        var service = new InvestmentSnapshotService(repository);
+
+        var result = await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
+
+        result.Should().HaveCount(11);
+        result.Should().NotContain(s => s.Account == "EverydaySaver");
+    }
+
+    [Fact]
+    public async Task GetSnapshotsForMonthAsync_PastYearWithNoExistingData_ReturnsEmptyNotAllAccounts()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new InvestmentSnapshotService(repository);
+
+        var result = await service.GetSnapshotsForMonthAsync(PastYear, 7);
+
+        result.Should().BeEmpty();
+        repository.Snapshots.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSnapshotsForMonthAsync_PastYearWithSomeAccountsPresent_ReturnsOnlyThose()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 7, 100m));
+        var service = new InvestmentSnapshotService(repository);
+
+        var result = await service.GetSnapshotsForMonthAsync(PastYear, 7);
+
+        result.Should().ContainSingle().Which.Account.Should().Be("ChaseSave");
+    }
+
+    [Fact]
     public async Task UpdateSnapshotValueAsync_UpdatesOnlyTheTargetedSnapshot()
     {
         var repository = new StubCashFlowRepository();
         var service = new InvestmentSnapshotService(repository);
-        await service.GetSnapshotsForMonthAsync(2026, 7);
-        await service.GetSnapshotsForMonthAsync(2026, 8);
+        await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
+        await service.GetSnapshotsForMonthAsync(CurrentYear, 8);
         var julySnapshot = repository.Snapshots.Single(s => s.Month == 7 && s.Account == "ChaseSave");
         var augustSnapshot = repository.Snapshots.Single(s => s.Month == 8 && s.Account == "ChaseSave");
         var otherAccountSnapshot = repository.Snapshots.Single(s => s.Month == 7 && s.Account == "PlatinumVisa8003");
@@ -79,7 +119,7 @@ public class InvestmentSnapshotServiceTests
     {
         var repository = new StubCashFlowRepository();
         var service = new InvestmentSnapshotService(repository);
-        await service.GetSnapshotsForMonthAsync(2026, 7);
+        await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
         var snapshot = repository.Snapshots.First();
 
         var act = async () => await service.UpdateSnapshotValueAsync(snapshot.Id, new UpdateInvestmentSnapshotValueDTO { Value = -1m });

--- a/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
@@ -8,6 +8,9 @@ namespace Financial.CashFlow.Application.Tests.Services;
 
 public class YearlySummaryServiceTests
 {
+    private static readonly int CurrentYear = DateTime.Now.Year;
+    private static readonly int PastYear = CurrentYear - 5;
+
     [Fact]
     public void Constructor_WithNullRepository_Throws()
     {
@@ -71,26 +74,61 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetInvestmentDiffsForYear_ReturnsAllElevenAccounts()
+    public void GetInvestmentDiffsForYear_CurrentYear_ReturnsAllElevenActiveAccounts()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
 
-        var result = service.GetInvestmentDiffsForYear(2026);
+        var result = service.GetInvestmentDiffsForYear(CurrentYear);
 
         result.Accounts.Should().HaveCount(repository.Accounts.Count);
+    }
+
+    [Fact]
+    public void GetInvestmentDiffsForYear_CurrentYear_ExcludesDisabledAccounts()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Accounts.Add(InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false));
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetInvestmentDiffsForYear(CurrentYear);
+
+        result.Accounts.Should().NotContain(a => a.Account == "EverydaySaver");
+    }
+
+    [Fact]
+    public void GetInvestmentDiffsForYear_PastYear_ReturnsOnlyAccountsPresentThatYear()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 100m));
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetInvestmentDiffsForYear(PastYear);
+
+        result.Accounts.Should().ContainSingle().Which.Account.Should().Be("ChaseSave");
+    }
+
+    [Fact]
+    public void GetInvestmentDiffsForYear_PastYearWithNoData_ReturnsNoAccounts()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetInvestmentDiffsForYear(PastYear);
+
+        result.Accounts.Should().BeEmpty();
     }
 
     [Fact]
     public void GetInvestmentDiffsForYear_MonthlyDiffsEqualThisMonthMinusPrevMonth()
     {
         var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", 2026, 1, 1000m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", 2026, 2, 1200m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", 2026, 3, 1100m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 1000m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 2, 1200m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 3, 1100m));
         var service = new YearlySummaryService(repository);
 
-        var result = service.GetInvestmentDiffsForYear(2026);
+        var result = service.GetInvestmentDiffsForYear(CurrentYear);
 
         var chaseSave = result.Accounts.Single(a => a.Account == "ChaseSave");
         chaseSave.MonthlyDiffs.Should().HaveCount(11);
@@ -102,10 +140,10 @@ public class YearlySummaryServiceTests
     public void GetInvestmentDiffsForYear_MissingSnapshotForAMonth_ContributesZero()
     {
         var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", 2026, 1, 500m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 500m));
         var service = new YearlySummaryService(repository);
 
-        var result = service.GetInvestmentDiffsForYear(2026);
+        var result = service.GetInvestmentDiffsForYear(CurrentYear);
 
         var chaseSave = result.Accounts.Single(a => a.Account == "ChaseSave");
         chaseSave.MonthlyValues[1].Should().Be(0m);
@@ -116,24 +154,37 @@ public class YearlySummaryServiceTests
     public void GetInvestmentDiffsForYear_NetPositionSubtractsLiabilitiesFromAssets()
     {
         var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", 2026, 1, 1000m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("PlatinumVisa8003", 2026, 1, 300m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 1000m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("PlatinumVisa8003", CurrentYear, 1, 300m));
         var service = new YearlySummaryService(repository);
 
-        var result = service.GetInvestmentDiffsForYear(2026);
+        var result = service.GetInvestmentDiffsForYear(CurrentYear);
 
         result.NetPosition.MonthlyValues[0].Should().Be(700m);
+    }
+
+    [Fact]
+    public void GetInvestmentDiffsForYear_NetPositionSumsOnlyScopedAccounts()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
+        // PlatinumVisa8003 has no snapshot in PastYear, so it's out of scope and must not contribute.
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetInvestmentDiffsForYear(PastYear);
+
+        result.NetPosition.MonthlyValues[0].Should().Be(1000m);
     }
 
     [Fact]
     public void GetInvestmentDiffsForYear_FullYearNetChangeEqualsDecemberMinusJanuary()
     {
         var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", 2026, 1, 1000m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", 2026, 12, 1800m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 1000m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 12, 1800m));
         var service = new YearlySummaryService(repository);
 
-        var result = service.GetInvestmentDiffsForYear(2026);
+        var result = service.GetInvestmentDiffsForYear(CurrentYear);
 
         result.NetPosition.FullYearNetChange.Should().Be(800m);
     }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
@@ -109,6 +109,33 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
+    public void GetInvestmentDiffsForYear_2023_ReturnsExactlyTheNineAccountsConfirmedPresentThatYear()
+    {
+        // Mirrors PRD P18 F04's named acceptance criterion: Resumo2023 is confirmed (from the
+        // source spreadsheet inspection during PRD authoring) to contain exactly these 9 accounts.
+        var repository = new StubCashFlowRepository();
+        repository.Accounts.Add(InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false));
+        repository.Accounts.Add(InvestmentAccount.Create("HelpToBuyIsaGgs", isActive: false, isLiability: false));
+        repository.Accounts.Add(InvestmentAccount.Create("HelpToBuyIsaAacs", isActive: false, isLiability: false));
+        repository.Accounts.Add(InvestmentAccount.Create("ChipEasyAccess", isActive: false, isLiability: false));
+        string[] presentIn2023 =
+        [
+            "EverydaySaver", "BlueRewardsSaver", "PlatinumVisa8003", "PlatinumVisa6007",
+            "PaypalCredit", "HelpToBuyIsaGgs", "HelpToBuyIsaAacs", "ChipEasyAccess", "ChaseSave"
+        ];
+        foreach (var name in presentIn2023)
+        {
+            repository.Snapshots.Add(InvestmentSnapshot.Create(name, 2023, 1, 100m));
+        }
+        // Accounts NOT present in 2023 (e.g. opened later, like Trading212Invested) get no snapshot that year.
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetInvestmentDiffsForYear(2023);
+
+        result.Accounts.Select(a => a.Account).Should().BeEquivalentTo(presentIn2023);
+    }
+
+    [Fact]
     public void GetInvestmentDiffsForYear_PastYearWithNoData_ReturnsNoAccounts()
     {
         var repository = new StubCashFlowRepository();

--- a/Tests/Financial.CashFlow.Domain.Tests/Rules/YearScopedInvestmentAccountResolverTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Rules/YearScopedInvestmentAccountResolverTests.cs
@@ -1,0 +1,70 @@
+using Financial.CashFlow.Domain.Entities;
+using Financial.CashFlow.Domain.Rules;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Domain.Tests.Rules;
+
+public class YearScopedInvestmentAccountResolverTests
+{
+    [Fact]
+    public void ResolveForYear_CurrentYear_ReturnsOnlyActiveAccounts()
+    {
+        var active = InvestmentAccount.Create("ChaseSave", isActive: true, isLiability: false);
+        var disabled = InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false);
+        var accounts = new[] { active, disabled };
+        var snapshots = Array.Empty<InvestmentSnapshot>();
+
+        var result = YearScopedInvestmentAccountResolver.ResolveForYear(accounts, snapshots, year: 2026, currentYear: 2026);
+
+        result.Should().ContainSingle().Which.Should().Be(active);
+    }
+
+    [Fact]
+    public void ResolveForYear_PastYear_ReturnsOnlyAccountsWithASnapshotThatYear()
+    {
+        var withSnapshot = InvestmentAccount.Create("ChaseSave", isActive: true, isLiability: false);
+        var withoutSnapshot = InvestmentAccount.Create("Trading212Invested", isActive: true, isLiability: false);
+        var accounts = new[] { withSnapshot, withoutSnapshot };
+        var snapshots = new[] { InvestmentSnapshot.Create("ChaseSave", 2023, 5, 100m) };
+
+        var result = YearScopedInvestmentAccountResolver.ResolveForYear(accounts, snapshots, year: 2023, currentYear: 2026);
+
+        result.Should().ContainSingle().Which.Should().Be(withSnapshot);
+    }
+
+    [Fact]
+    public void ResolveForYear_PastYear_DisabledAccountWithSnapshotThatYear_StillIncluded()
+    {
+        var disabledButPresent = InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false);
+        var accounts = new[] { disabledButPresent };
+        var snapshots = new[] { InvestmentSnapshot.Create("EverydaySaver", 2020, 3, 50m) };
+
+        var result = YearScopedInvestmentAccountResolver.ResolveForYear(accounts, snapshots, year: 2020, currentYear: 2026);
+
+        result.Should().ContainSingle().Which.Should().Be(disabledButPresent);
+    }
+
+    [Fact]
+    public void ResolveForYear_PastYear_ActiveAccountWithNoSnapshotThatYear_IsExcluded()
+    {
+        var openedLater = InvestmentAccount.Create("Trading212Invested", isActive: true, isLiability: false);
+        var accounts = new[] { openedLater };
+        var snapshots = new[] { InvestmentSnapshot.Create("Trading212Invested", 2026, 1, 100m) };
+
+        var result = YearScopedInvestmentAccountResolver.ResolveForYear(accounts, snapshots, year: 2018, currentYear: 2026);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ResolveForYear_FutureYear_TreatedLikeCurrentYear()
+    {
+        var active = InvestmentAccount.Create("ChaseSave", isActive: true, isLiability: false);
+        var disabled = InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false);
+        var accounts = new[] { active, disabled };
+
+        var result = YearScopedInvestmentAccountResolver.ResolveForYear(accounts, Array.Empty<InvestmentSnapshot>(), year: 2027, currentYear: 2026);
+
+        result.Should().ContainSingle().Which.Should().Be(active);
+    }
+}

--- a/docs/P18-F04-year-scoped-investment-account-display/plan.md
+++ b/docs/P18-F04-year-scoped-investment-account-display/plan.md
@@ -1,0 +1,25 @@
+# Implementation Plan: F04. Year-Scoped Investment Account Display
+
+**Prerequisites:**
+- .NET 10 SDK (existing solution target)
+- F01, F02, F03 merged to main
+- No new NuGet packages, environment variables, or configuration files required
+- Branch `feat/P18-F04-year-scoped-investment-account-display`, already created from `main`
+
+### Stage 1: Domain Layer
+
+**1. Year-Scoped Account Resolver** - Add a pure business rule that, given the full account registry, all snapshots, a target year, and the current year, returns exactly the accounts applicable to that year: active accounts only for the current year, accounts with at least one snapshot that year for any past year.
+
+### Stage 2: Application Layer
+
+**2. Investment Snapshot Service** - Apply the resolver so a month's snapshot request only auto-creates zero-value rows for, and only returns, accounts that belong to the requested year, replacing the current unconditional all-accounts behavior.
+
+**3. Yearly Summary Service** - Apply the same resolver so a year's investment diff computation only builds rows for, and only sums net position over, accounts that belong to that year.
+
+### Stage 3: Test Suite Alignment
+
+**4. Domain Test Coverage** - Add unit tests for the resolver covering current-year (active-only), past-year (presence-only, independent of active status), and future-year (treated like current-year) cases.
+
+**5. Application Test Updates** - Update the snapshot service and yearly summary service test suites so their repository test doubles seed a mix of active and disabled accounts with varying snapshot years, and assert the year-scoped results.
+
+**6. Full Suite Verification** - Run the complete test suite to confirm the new scoping behaves correctly and nothing else regresses.

--- a/docs/P18-F04-year-scoped-investment-account-display/spec.md
+++ b/docs/P18-F04-year-scoped-investment-account-display/spec.md
@@ -1,0 +1,87 @@
+## 1. Technical Overview
+
+**What:** Introduce a shared, pure business rule that resolves which `InvestmentAccount`s apply to a given year — for a past year, only accounts with at least one persisted `InvestmentSnapshot` that year; for the current, in-progress year, every `IsActive` account regardless of snapshot presence — and apply it in both `InvestmentSnapshotService.GetSnapshotsForMonthAsync` and `YearlySummaryService.GetInvestmentDiffsForYear`, which today unconditionally return all 19 registry accounts for every year.
+
+**Why:** F01-F03 built the data (a persisted, disabled-capable registry; historical accounts recognized and populated with explicit per-month values for every year they existed). Nothing yet uses that data to change what's *displayed*. Today, both read paths call `_repository.GetInvestmentAccounts()` unfiltered, so every year — 2017 or 2026 — shows the same 19 accounts, which is the exact problem this whole PRD exists to fix. F04 is the feature that closes that gap.
+
+**Scope:**
+- Included: the year-scoping rule itself (as a pure, unit-testable Domain rule, not embedded logic in either service); applying it to both `InvestmentSnapshotService.GetSnapshotsForMonthAsync` (stops auto-creating zero-value rows for accounts that don't belong to the requested year) and `YearlySummaryService.GetInvestmentDiffsForYear` (stops returning a `InvestmentAccountYearlyDiffDTO` row, and stops including in `NetPosition`, for accounts that don't belong to the requested year).
+- Excluded: no API contract changes (`InvestmentSnapshotDTO`/`InvestmentAccountYearlyDiffDTO` shapes are unchanged — fewer/different *rows*, not new *fields*); no frontend changes (`InvestmentSnapshotsPage.tsx`/`YearlySummaryPage.tsx` already render whatever the API returns, with no hardcoded account count anywhere in the codebase or its tests — confirmed by search); F05's January prior-year-December carryover is untouched.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.CashFlow.Domain/Rules/YearScopedInvestmentAccountResolver.cs` (new)
+- `Financial.CashFlow.Application/Services/InvestmentSnapshotService.cs` (modified)
+- `Financial.CashFlow.Application/Services/YearlySummaryService.cs` (modified)
+
+```mermaid
+graph TD
+    A["InvestmentSnapshotService"] --> C["YearScopedInvestmentAccountResolver"]
+    B["YearlySummaryService"] --> C
+    C --> D["ICashFlowRepository.GetInvestmentAccounts()"]
+    C --> E["ICashFlowRepository.GetInvestmentSnapshots()"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|------------------|-------------------------|-----------|
+| Where the year-scoping rule lives | A new static Domain rule, `Financial.CashFlow.Domain.Rules.YearScopedInvestmentAccountResolver`, taking accounts + snapshots + target year + current year as plain arguments and returning the applicable accounts | Duplicate the filtering inline in each of the two services | Both services need the identical rule; duplicating it risks the two call sites drifting apart (e.g., one gets a year-boundary fix, the other doesn't). A Domain rule mirrors this codebase's existing pattern for shared, snapshot-independent business logic (`InvestmentAccountClassification` occupied this same location before F01 folded its concern into the entity) and is trivially unit-testable without a repository double. |
+| How "current year" reaches the rule | The rule is a pure function that takes `currentYear` as an explicit parameter; each service computes it via `DateTime.Now.Year` at the call site and passes it in | Have the rule call `DateTime.Now` itself | Keeps the rule deterministic and unit-testable for year-boundary cases (e.g., "is 2026 the current year or a past one") without needing to fake the system clock. `ControleMaeService` elsewhere in this codebase calls `DateTime.Now` directly inline for a simple future-date validation — that's fine for a one-line guard, but this rule's whole job is year-boundary logic, so it deserves to be exercised directly in tests rather than only indirectly through whichever year happens to be "today" when the test suite runs. |
+| Existence source for a past year | An account belongs to year Y (Y < current year) if and only if `GetInvestmentSnapshots()` contains at least one snapshot with `Account == account.Name && Year == Y` (any month) | Track an explicit `FirstActiveYear`/`LastActiveYear` range on the account | This is exactly what the PRD's F04 Capabilities specify and what F03 was built to guarantee (every matched account-year gets all 12 months, including explicit zeros) — presence-based existence needs no additional stored state and can't drift out of sync with the actual imported data. |
+| Filtering already-persisted snapshots that don't belong to the resolved year-scope | `InvestmentSnapshotService.GetSnapshotsForMonthAsync` filters its returned DTO list to only the resolved accounts, even though in practice `existingSnapshots` for a past year should already only contain scoped accounts (by construction, since scoping *is* presence) | Trust `existingSnapshots` as-is with no extra filter | Belt-and-suspenders for the one automated-loop-relevant edge case: a *disabled* account could theoretically still hold a snapshot for the *current* year if one was created before this feature shipped (e.g., during F01-F03 development/verification). The PRD's F04 AC is explicit that a disabled account must not appear in the current year's display "even though the same underlying store still holds their historical data" — filtering the return value, not just the auto-create loop, is what actually guarantees that for every code path, not just the happy path. |
+
+## 4. Component Overview
+
+**Backend — Domain (`Financial.CashFlow.Domain`):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|----------------------|
+| `Rules/YearScopedInvestmentAccountResolver.cs` | New | Year-existence business rule | `ResolveForYear(accounts, snapshots, year, currentYear)`: for `year >= currentYear`, returns accounts where `IsActive`; for `year < currentYear`, returns accounts with at least one snapshot in that year |
+
+**Backend — Application (`Financial.CashFlow.Application`):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|----------------------|
+| `Services/InvestmentSnapshotService.cs` | Modified | Snapshot read/update use case | `GetSnapshotsForMonthAsync` resolves the year-scoped account list via the new rule before auto-creating missing zero-value snapshots, and filters its returned DTOs to that same scoped list |
+| `Services/YearlySummaryService.cs` | Modified | Yearly investment diff computation | `GetInvestmentDiffsForYear` resolves the year-scoped account list via the new rule and builds `InvestmentAccountYearlyDiffDTO` rows (and the `NetPosition` sum) only over those accounts |
+
+No Infrastructure, Presentation, or frontend files change.
+
+## 5. API Contracts
+
+No request/response shape changes to either existing endpoint (`GET /api/v1/financial/investment-snapshots/{year}/{month}`, `GET` yearly-summary investments). Both return the same DTO shapes as before — just a year-dependent subset of rows instead of always all 19.
+
+## 6. Data Model
+
+No entity or JSON shape changes. This feature is purely a read-path filtering change.
+
+**Cross-Database Notes:** Not applicable — no relational database is used anywhere in this solution.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Tests/Financial.CashFlow.Domain.Tests/Rules/YearScopedInvestmentAccountResolverTests.cs` | Unit | `YearScopedInvestmentAccountResolver` | New: current-year (active-only), past-year (presence-only), and boundary cases |
+| `Tests/Financial.CashFlow.Application.Tests/Services/InvestmentSnapshotServiceTests.cs` | Unit | `InvestmentSnapshotService` | Updated: current-year requests still auto-create zero rows for active accounts only (not disabled ones); past-year requests only return/auto-create for accounts with existing snapshot presence that year |
+| `Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs` | Unit | `YearlySummaryService` | Updated: `GetInvestmentDiffsForYear` for a past year returns only accounts present that year; for the current year returns only active accounts; `NetPosition` reflects only the scoped accounts |
+
+**Key test functions:**
+
+| Test Function | Description | Assertions |
+|----------------|-------------|------------|
+| `ResolveForYear_CurrentYear_ReturnsOnlyActiveAccounts` (`YearScopedInvestmentAccountResolverTests`) | `year == currentYear`, mix of active/disabled accounts, no snapshots needed | Result contains only `IsActive` accounts |
+| `ResolveForYear_PastYear_ReturnsOnlyAccountsWithASnapshotThatYear` (`YearScopedInvestmentAccountResolverTests`) | `year < currentYear`, one account has a snapshot that year, another (even if active) does not | Result contains only the account with a snapshot that year |
+| `ResolveForYear_PastYear_DisabledAccountWithSnapshotThatYear_StillIncluded` (`YearScopedInvestmentAccountResolverTests`) | Disabled account, but has a snapshot for the requested past year | Included — past-year existence is presence-based, independent of `IsActive` |
+| `ResolveForYear_FutureYear_TreatedLikeCurrentYear` (`YearScopedInvestmentAccountResolverTests`) | `year > currentYear` | Same result as `year == currentYear` (active-only) |
+| `GetSnapshotsForMonthAsync_CurrentYear_OnlyCreatesZeroRowsForActiveAccounts` (`InvestmentSnapshotServiceTests`) | Repository seeded with a mix of active/disabled accounts | Returned DTOs and newly-created snapshots cover only active accounts |
+| `GetSnapshotsForMonthAsync_PastYearWithNoExistingData_ReturnsEmptyNotAllAccounts` (`InvestmentSnapshotServiceTests`) | Past year, no snapshots exist for it at all | Returns an empty list; no snapshots are fabricated for any account |
+| `GetSnapshotsForMonthAsync_PastYearWithSomeAccountsPresent_ReturnsOnlyThose` (`InvestmentSnapshotServiceTests`) | Past year, snapshots exist for 2 of several seeded accounts | Returns exactly those 2 accounts' rows |
+| `GetInvestmentDiffsForYear_PastYear_ReturnsOnlyAccountsPresentThatYear` (`YearlySummaryServiceTests`) | Past year, snapshots for a subset of accounts | `Accounts` contains only that subset |
+| `GetInvestmentDiffsForYear_CurrentYear_ExcludesDisabledAccounts` (`YearlySummaryServiceTests`) | Current year, mix of active/disabled accounts, some with stray snapshots | `Accounts` contains only active ones |
+| `GetInvestmentDiffsForYear_NetPositionSumsOnlyScopedAccounts` (`YearlySummaryServiceTests`) | Past year, one in-scope and one out-of-scope account with values | `NetPosition.MonthlyValues` reflects only the in-scope account |
+
+**Integration-level check:** Since the live data file hasn't been migrated by F01-F03 yet (verification throughout this feature loop has deliberately only run against copies — see F01-F03 PR notes), there's no production data yet to exercise this against end-to-end. Verification here is unit-test-only; the PR notes should reiterate that the user needs to run the import once (per F03's notes) before any of F01-F04's behavior is observable in the running app.

--- a/docs/prd/P18-prd-investment-account-lifecycle/prd-investment-account-lifecycle.md
+++ b/docs/prd/P18-prd-investment-account-lifecycle/prd-investment-account-lifecycle.md
@@ -246,10 +246,10 @@ graph TD
 - [x] If `Despesas.xlsx` is not found at the expected path, the command fails immediately with no snapshots written
 
 ### F04. Year-Scoped Investment Account Display
-- [ ] For year 2023, the Investment Snapshots page and the Yearly Summary Investments sub-tab show exactly the accounts confirmed present in Resumo2023 (Everyday Saver, Blue Rewards Saver, Platinum Visa 8003, Platinum Visa 6007, Paypal Credit, Help to Buy ISA GGS, Help to Buy ISA AACS, Chip Easy access, Chase Save) and no others
-- [ ] For the current calendar year, all 11 active registry accounts appear immediately, including any month with no snapshot yet (shown as zero), regardless of import status
-- [ ] A disabled account with historical data (e.g., Everyday Saver) does not appear in the current year's display
-- [ ] The Yearly Summary Investments sub-tab's Total/Net Position row for a past year sums only the accounts shown for that year
+- [x] For year 2023, the Investment Snapshots page and the Yearly Summary Investments sub-tab show exactly the accounts confirmed present in Resumo2023 (Everyday Saver, Blue Rewards Saver, Platinum Visa 8003, Platinum Visa 6007, Paypal Credit, Help to Buy ISA GGS, Help to Buy ISA AACS, Chip Easy access, Chase Save) and no others
+- [x] For the current calendar year, all 11 active registry accounts appear immediately, including any month with no snapshot yet (shown as zero), regardless of import status
+- [x] A disabled account with historical data (e.g., Everyday Saver) does not appear in the current year's display
+- [x] The Yearly Summary Investments sub-tab's Total/Net Position row for a past year sums only the accounts shown for that year
 
 ### F05. Prior-Year December Carryover for January
 - [ ] For year 2024, January's Month Result equals January 2024's net position minus December 2023's net position
@@ -260,5 +260,5 @@ graph TD
 ### Cross-Feature Integration
 - [x] Registry entries created by F01 are correctly consumed by F02 when seeding the 8 historical accounts and their aliases
 - [x] The seeded registry and alias-resolving importer produced by F02 are what F03's full re-import invokes across all 10 Resumo sheets
-- [ ] Snapshot data written by F03, together with F01's active-status flag, is what F04 queries to determine year-scoped account existence
+- [x] Snapshot data written by F03, together with F01's active-status flag, is what F04 queries to determine year-scoped account existence
 - [ ] The year-filtered account list and net position values produced by F04 are exactly what F05 consumes for its January diff calculation


### PR DESCRIPTION
## Summary
- Adds `YearScopedInvestmentAccountResolver` (Domain rule, pure function): for the current (or any later) year, only active accounts apply; for any past year, only accounts with at least one snapshot that year apply — independent of active status, so a disabled account's real history still shows for the years it existed.
- Applies it in both `InvestmentSnapshotService.GetSnapshotsForMonthAsync` (stops auto-creating zero rows for out-of-scope accounts and filters the returned list) and `YearlySummaryService.GetInvestmentDiffsForYear` (stops returning a diff row, and stops including in `NetPosition`, for out-of-scope accounts).
- This is the feature that finally makes F01-F03's data (registry with active/disabled flags, historical accounts recognized, full per-year snapshot presence) actually change what's *displayed* — until now every year showed all 19 accounts regardless of when they existed.

## Test plan
- [x] Full solution build — 0 errors
- [x] Full test suite — all 1396 tests pass across all 10 test projects
- [x] New `YearScopedInvestmentAccountResolverTests` (current/past/future year boundaries, disabled-but-present-in-past-year inclusion)
- [x] Extended `InvestmentSnapshotServiceTests`/`YearlySummaryServiceTests` for current-year disabled-account exclusion, past-year presence-only scoping, and net-position summing only over scoped accounts
- [x] Added a test that directly mirrors the PRD's named Resumo2023 scenario — seeds exactly the 9 accounts confirmed present that year and asserts the service returns exactly those, not the full registry
- [x] PRD P18 Section 9 F04 acceptance criteria (all 4) and the F03/F04 cross-feature integration criterion checked off

## Notes for review
- Existing tests that used a hardcoded `2026` were switched to a `DateTime.Now`-derived "current year" so they keep correctly exercising the current-year code path regardless of when the suite runs in the future — hardcoding 2026 would have silently started failing (or silently testing the wrong branch) once real time moves past it.
- No API contract or frontend changes — both endpoints return the same DTO shapes, just a year-dependent subset of rows. `InvestmentSnapshotsPage.tsx`/`YearlySummaryPage.tsx` already render whatever the API returns with no hardcoded account count anywhere (confirmed by search).
- As with F01-F03, this hasn't been run against the live data file — there's no real production data yet to see this working end-to-end until you run the import (per F03's notes).
- Builds on F01, F02, F03 (all merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P9h9D3DFkckJAyDktemTe