### PR TITLE
fix(yearly-summary): include January and stop at current month in totals

### DIFF
--- a/Financial.CashFlow.Application/DTOs/NetPositionYearlyDiffDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/NetPositionYearlyDiffDTO.cs
@@ -5,10 +5,15 @@ namespace Financial.CashFlow.Application.DTOs;
 /// MonthlyValues index 0 = January. MonthlyDiffs index 0 = January minus the prior year's
 /// December net position (0 for an account not yet open that prior year, null if no prior-year
 /// data exists at all); indexes 1-11 = each month minus the previous month within the year.
+/// AverageMonthResult and SumOfMonthResults are computed over January through the year's last
+/// relevant month - December for a past year, or the current calendar month for the current
+/// year, so months that haven't happened yet don't drag the figures toward zero.
 /// </summary>
 public sealed class NetPositionYearlyDiffDTO
 {
     public required decimal[] MonthlyValues { get; init; }
     public required decimal?[] MonthlyDiffs { get; init; }
     public required decimal FullYearNetChange { get; init; }
+    public required decimal AverageMonthResult { get; init; }
+    public required decimal SumOfMonthResults { get; init; }
 }

--- a/Financial.CashFlow.Application/Services/YearlySummaryService.cs
+++ b/Financial.CashFlow.Application/Services/YearlySummaryService.cs
@@ -97,9 +97,9 @@ public sealed class YearlySummaryService : IYearlySummaryService
         var netPositionDiffs = ComputeDiffs(netPositionValues, netPositionJanuaryDiff);
 
         // A future month (beyond the current calendar month, for the current year) has no
-        // snapshot yet, so its value defaults to 0 and its diff would misrepresent a real drop.
-        // Average/Sum only consider months that have actually happened; December always counts
-        // for a past year.
+        // snapshot yet, so its value defaults to 0 and would misrepresent a real drop to zero.
+        // FullYearNetChange, Average, and Sum all stop at the year's last relevant month:
+        // December for a past year, or the current calendar month for the current year.
         var lastRelevantMonth = year >= DateTime.Now.Year ? Math.Min(DateTime.Now.Month, MonthsInYear) : MonthsInYear;
         var relevantDiffs = netPositionDiffs.Take(lastRelevantMonth).Where(d => d.HasValue).Select(d => d!.Value).ToList();
 
@@ -107,7 +107,7 @@ public sealed class YearlySummaryService : IYearlySummaryService
         {
             MonthlyValues = netPositionValues,
             MonthlyDiffs = netPositionDiffs,
-            FullYearNetChange = netPositionValues[MonthsInYear - 1] - netPositionValues[0],
+            FullYearNetChange = netPositionValues[lastRelevantMonth - 1] - netPositionValues[0],
             AverageMonthResult = relevantDiffs.Count > 0 ? relevantDiffs.Average() : 0m,
             SumOfMonthResults = relevantDiffs.Sum()
         };

--- a/Financial.CashFlow.Application/Services/YearlySummaryService.cs
+++ b/Financial.CashFlow.Application/Services/YearlySummaryService.cs
@@ -94,11 +94,22 @@ public sealed class YearlySummaryService : IYearlySummaryService
             ? accounts.Sum(a => (a.IsLiability ? -1 : 1) * a.MonthlyDiffs[0]!.Value)
             : null;
 
+        var netPositionDiffs = ComputeDiffs(netPositionValues, netPositionJanuaryDiff);
+
+        // A future month (beyond the current calendar month, for the current year) has no
+        // snapshot yet, so its value defaults to 0 and its diff would misrepresent a real drop.
+        // Average/Sum only consider months that have actually happened; December always counts
+        // for a past year.
+        var lastRelevantMonth = year >= DateTime.Now.Year ? Math.Min(DateTime.Now.Month, MonthsInYear) : MonthsInYear;
+        var relevantDiffs = netPositionDiffs.Take(lastRelevantMonth).Where(d => d.HasValue).Select(d => d!.Value).ToList();
+
         var netPosition = new NetPositionYearlyDiffDTO
         {
             MonthlyValues = netPositionValues,
-            MonthlyDiffs = ComputeDiffs(netPositionValues, netPositionJanuaryDiff),
-            FullYearNetChange = netPositionValues[MonthsInYear - 1] - netPositionValues[0]
+            MonthlyDiffs = netPositionDiffs,
+            FullYearNetChange = netPositionValues[MonthsInYear - 1] - netPositionValues[0],
+            AverageMonthResult = relevantDiffs.Count > 0 ? relevantDiffs.Average() : 0m,
+            SumOfMonthResults = relevantDiffs.Sum()
         };
 
         return new InvestmentDiffsYearlyDTO

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -465,6 +465,8 @@ export interface NetPositionYearlyDiffDto {
   monthlyValues: number[]
   monthlyDiffs: (number | null)[]
   fullYearNetChange: number
+  averageMonthResult: number
+  sumOfMonthResults: number
 }
 
 export interface InvestmentDiffsYearlyDto {

--- a/Financial.Web/src/hooks/useYearlySummary.test.ts
+++ b/Financial.Web/src/hooks/useYearlySummary.test.ts
@@ -35,6 +35,8 @@ const INVESTMENT_DIFFS: InvestmentDiffsYearlyDto = {
     monthlyValues: new Array(12).fill(1000),
     monthlyDiffs: new Array(12).fill(0),
     fullYearNetChange: 0,
+    averageMonthResult: 0,
+    sumOfMonthResults: 0,
   },
 }
 

--- a/Financial.Web/src/pages/YearlySummaryPage.tsx
+++ b/Financial.Web/src/pages/YearlySummaryPage.tsx
@@ -86,12 +86,6 @@ export default function YearlySummaryPage() {
 
   const [activeTab, setActiveTab] = useState<YearlySummaryTabId>('categoryTotals')
 
-  // Feb-Dec only, matching Year Progress's Dec-minus-Jan telescoping sum identity - including
-  // January (which diffs against the *prior* year's December) would break that relationship.
-  // Feb-Dec are never null (only January can be); the filter is just a type-safe narrowing.
-  const monthResults =
-    investmentDiffs?.netPosition.monthlyDiffs.slice(1).filter((v): v is number => v !== null) ?? []
-
   return (
     <div className="yearly-summary-page">
       <div className="yearly-summary-page__year-picker">
@@ -237,11 +231,11 @@ export default function YearlySummaryPage() {
                 </div>
                 <div className="yearly-summary-page__investment-total">
                   <span>Average Month Result</span>
-                  <strong>{formatN2(average(monthResults))}</strong>
+                  <strong>{formatN2(investmentDiffs.netPosition.averageMonthResult)}</strong>
                 </div>
                 <div className="yearly-summary-page__investment-total">
                   <span>Sum of Month Results</span>
-                  <strong>{formatN2(monthResults.reduce((sum, v) => sum + v, 0))}</strong>
+                  <strong>{formatN2(investmentDiffs.netPosition.sumOfMonthResults)}</strong>
                 </div>
               </div>
             </section>

--- a/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
@@ -43,6 +43,8 @@ const INVESTMENT_DIFFS: InvestmentDiffsYearlyDto = {
     monthlyValues: [800, 850, 900, 950, 1000, 1050, 1100, 1150, 1200, 1250, 1300, 1350],
     monthlyDiffs: [75, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50],
     fullYearNetChange: 550,
+    averageMonthResult: 52.08,
+    sumOfMonthResults: 625,
   },
 }
 
@@ -247,7 +249,7 @@ describe('YearlySummaryPage', () => {
     expect(within(monthResultRow).getAllByText('50.00').length).toBe(11)
   })
 
-  it('shows Year Progress, Average Month Result, and Sum of Month Results, with Sum equal to Year Progress', async () => {
+  it('shows Year Progress, Average Month Result, and Sum of Month Results as returned by the API', async () => {
     render(<YearlySummaryPage />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
@@ -257,10 +259,10 @@ describe('YearlySummaryPage', () => {
     expect(within(yearProgress).getByText('550.00')).toBeInTheDocument()
 
     const averageMonthResult = screen.getByText('Average Month Result').closest('div')!
-    expect(within(averageMonthResult).getByText('50.00')).toBeInTheDocument()
+    expect(within(averageMonthResult).getByText('52.08')).toBeInTheDocument()
 
     const sumOfMonthResults = screen.getByText('Sum of Month Results').closest('div')!
-    expect(within(sumOfMonthResults).getByText('550.00')).toBeInTheDocument()
+    expect(within(sumOfMonthResults).getByText('625.00')).toBeInTheDocument()
   })
 
   it('does not affect the Category Totals tab content when viewing Investments', async () => {
@@ -294,6 +296,8 @@ describe('YearlySummaryPage', () => {
         monthlyValues: new Array(12).fill(2000),
         monthlyDiffs: new Array(12).fill(0),
         fullYearNetChange: 0,
+        averageMonthResult: 0,
+        sumOfMonthResults: 0,
       },
     }
     getInvestmentDiffsForYearMock.mockResolvedValue(nextYearInvestmentDiffs)

--- a/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
@@ -277,6 +277,49 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
+    public void GetInvestmentDiffsForYear_PastYear_AverageAndSumIncludeAllTwelveMonthsIncludingJanuary()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear - 1, 12, 800m));
+        var value = 900m;
+        for (var month = 1; month <= 12; month++)
+        {
+            repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, month, value));
+            value += 50m;
+        }
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetInvestmentDiffsForYear(PastYear);
+
+        // January diff = 900 - 800 = 100; the remaining 11 months each diff by 50.
+        result.NetPosition.SumOfMonthResults.Should().Be(650m);
+        result.NetPosition.AverageMonthResult.Should().BeApproximately(650m / 12m, 0.0001m);
+    }
+
+    [Fact]
+    public void GetInvestmentDiffsForYear_CurrentYear_AverageAndSumOnlyIncludeMonthsThroughTheCurrentMonth()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear - 1, 12, 500m));
+        var currentMonth = DateTime.Now.Month;
+        var value = 600m;
+        for (var month = 1; month <= currentMonth; month++)
+        {
+            repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, month, value));
+            value += 50m;
+        }
+        // No snapshots for any month after the current one - they must not contribute a fake
+        // "dropped to zero" diff to the totals.
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetInvestmentDiffsForYear(CurrentYear);
+
+        var expectedSum = 100m + 50m * (currentMonth - 1);
+        result.NetPosition.SumOfMonthResults.Should().Be(expectedSum);
+        result.NetPosition.AverageMonthResult.Should().BeApproximately(expectedSum / currentMonth, 0.0001m);
+    }
+
+    [Fact]
     public void GetIncomeSummaryForYear_SalaryRowSumsGleisonAndArianaGrossValuesPerMonth()
     {
         var repository = new StubCashFlowRepository();

--- a/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
@@ -264,16 +264,39 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetInvestmentDiffsForYear_FullYearNetChangeEqualsDecemberMinusJanuary()
+    public void GetInvestmentDiffsForYear_PastYear_FullYearNetChangeEqualsDecemberMinusJanuary()
     {
         var repository = new StubCashFlowRepository();
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 12, 1800m));
+        var service = new YearlySummaryService(repository);
+
+        var result = service.GetInvestmentDiffsForYear(PastYear);
+
+        result.NetPosition.FullYearNetChange.Should().Be(800m);
+    }
+
+    [Fact]
+    public void GetInvestmentDiffsForYear_CurrentYear_FullYearNetChangeUsesCurrentMonthNotDecember()
+    {
+        var repository = new StubCashFlowRepository();
+        var currentMonth = DateTime.Now.Month;
         repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 1000m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 12, 1800m));
+        if (currentMonth != 1)
+        {
+            repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, currentMonth, 1300m));
+        }
+        if (currentMonth != 12)
+        {
+            // A December value exists but must NOT be used - it hasn't happened yet this year.
+            repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 12, 9999m));
+        }
         var service = new YearlySummaryService(repository);
 
         var result = service.GetInvestmentDiffsForYear(CurrentYear);
 
-        result.NetPosition.FullYearNetChange.Should().Be(800m);
+        var expected = currentMonth == 1 ? 0m : 300m;
+        result.NetPosition.FullYearNetChange.Should().Be(expected);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Bug report from live testing after F05 merged, covering three related issues on the Yearly Summary Investments tab.

1. **Average Month Result / Sum of Month Results excluding January** — both figures still only looked at the Feb-Dec diffs, from before F05 gave January a real value. Confirmed against 2023: average should be 523.31 (12-month average including January's -105.18), was showing 580.44 (Feb-Dec only).
2. **Average / Sum including not-yet-happened future months for the current year** — for 2026 (today: July), months Aug-Dec have no snapshot yet, default to 0, and their "diff" computed as `0 - July's real value` is a large fake negative swing that dragged both figures down.
3. **Year Progress using December for the current year** — for 2026, Year Progress should be (current month's total) − (January's total), not (December's total) − (January's total), since December hasn't happened yet and defaults to 0.

## Fix
- `NetPositionYearlyDiffDTO` gains two backend-computed fields: `AverageMonthResult` and `SumOfMonthResults`.
- All three figures (`FullYearNetChange`, `AverageMonthResult`, `SumOfMonthResults`) are now computed over January through the year's *last relevant month* — December for a past year (unchanged there), or the current calendar month for the current year.
- Frontend renders `AverageMonthResult`/`SumOfMonthResults` directly from the API instead of deriving them client-side from a Feb-Dec slice (which is where the January exclusion was happening).

## Test plan
- [x] Full backend suite — all 1409 tests pass
- [x] Full frontend suite — all 51 test files / 635 tests pass
- [x] TypeScript type-checks clean
- [x] New backend tests: a past year's totals include all 12 months (verified against synthetic data matching the 2023 report's shape); the current year's totals stop at the current calendar month, ignoring unseeded future months; a dedicated test proves Year Progress uses the current month even when a (should-be-ignored) December snapshot exists
- [x] Updated the frontend test that asserted "Sum of Month Results always equals Year Progress" — that identity no longer holds once January uses a different year's baseline (Dec(year) − Dec(year−1) ≠ Dec(year) − Jan(year)), so it now just asserts the API-returned values directly

## Notes for review
- This doesn't touch the live data file — same as the whole P18 loop, verified via the test suites only.