### PR TITLE
feat(P17-F01): expose historic categories average via a single batch endpoint

### DIFF
--- a/Financial.Api/Controllers/YearlySummaryController.cs
+++ b/Financial.Api/Controllers/YearlySummaryController.cs
@@ -35,4 +35,11 @@ public sealed class YearlySummaryController : ControllerBase
     {
         return Ok(_yearlySummaryService.GetIncomeSummaryForYear(year));
     }
+
+    [HttpGet("{year:int}/historic-categories-averages")]
+    [ProducesResponseType(typeof(IReadOnlyList<CategoryAnnualAverageDTO>), StatusCodes.Status200OK)]
+    public ActionResult<IReadOnlyList<CategoryAnnualAverageDTO>> GetHistoricCategoriesAverages(int year)
+    {
+        return Ok(_yearlySummaryService.GetCategoryTotalsHistoricAverageFromYear(year));
+    }
 }

--- a/Financial.CashFlow.Application/Interfaces/IYearlySummaryService.cs
+++ b/Financial.CashFlow.Application/Interfaces/IYearlySummaryService.cs
@@ -7,6 +7,5 @@ public interface IYearlySummaryService
     IReadOnlyList<CategoryYearlyTotalDTO> GetCategoryTotalsForYear(int year);
     InvestmentDiffsYearlyDTO GetInvestmentDiffsForYear(int year);
     IncomeYearlySummaryDTO GetIncomeSummaryForYear(int year);
-    IReadOnlyList<CategoryAnnualAverageDTO> GetHistoricCategoriesAverageFromYear(int year);
-    IReadOnlyList<IncomeAnnualAverageDTO> GetHistoricIncomeAverageFromYear(int year);
+    IReadOnlyList<CategoryAnnualAverageDTO> GetCategoryTotalsHistoricAverageFromYear(int year);
 }

--- a/Financial.CashFlow.Application/Services/YearlySummaryService.cs
+++ b/Financial.CashFlow.Application/Services/YearlySummaryService.cs
@@ -162,7 +162,54 @@ public sealed class YearlySummaryService : IYearlySummaryService
         };
     }
 
-    public IReadOnlyList<IncomeAnnualAverageDTO> GetHistoricIncomeAverageFromYear(int year)
+    public IReadOnlyList<CategoryAnnualAverageDTO> GetCategoryTotalsHistoricAverageFromYear(int year)
+    {
+        var incomeAverages = GetHistoricIncomeAverageFromYear(year);
+        var categoryAverages = GetHistoricCategoriesAverageFromYear(year);
+        AddIncomeToFinalResult(incomeAverages, categoryAverages);
+        return [.. categoryAverages];
+    }
+
+    private static void AddIncomeToFinalResult(IList<IncomeAnnualAverageDTO> incomeAverages, 
+        IList<CategoryAnnualAverageDTO> categoryAverages)
+    {
+        foreach (var incomeAverage in incomeAverages)
+        {
+            var yearAverage = categoryAverages.FirstOrDefault(c => c.Year == incomeAverage.Year);
+            if (yearAverage is null)
+            {
+                yearAverage = new CategoryAnnualAverageDTO
+                {
+                    Year = incomeAverage.Year,
+                    AnnualAverages = new List<CategoryAverageDTO>()
+                };
+                categoryAverages.Add(yearAverage);
+            }
+
+            yearAverage.AnnualAverages.Insert(0, new CategoryAverageDTO
+            {
+                Category = "Salary",
+                Average = incomeAverage.SalaryAverage
+            });
+            yearAverage.AnnualAverages.Insert(1, new CategoryAverageDTO
+            {
+                Category = "Salary after taxes",
+                Average = incomeAverage.SalaryAfterTaxesAverage
+            });
+            yearAverage.AnnualAverages.Insert(2, new CategoryAverageDTO
+            {
+                Category = "Tax difference",
+                Average = incomeAverage.SalaryAverage - incomeAverage.SalaryAfterTaxesAverage
+            });
+            yearAverage.AnnualAverages.Insert(3, new CategoryAverageDTO
+            {
+                Category = "Dividendo/Juros",
+                Average = incomeAverage.DividendoJurosAverage
+            });
+        }
+    }
+
+    private IList<IncomeAnnualAverageDTO> GetHistoricIncomeAverageFromYear(int year)
     {
         Dictionary<int, List<IncomeAverageDTO>> averageIncome = GetAnnualAverageIncomeByGroupIncome(year);
         Dictionary<int, IncomeAnnualAverageDTO> result = BuildAnnualIncomeAverages(averageIncome);
@@ -236,7 +283,7 @@ public sealed class YearlySummaryService : IYearlySummaryService
             ? SalaryIncomeGroup
             : IncomeSource.DividendoJuros.ToString();
 
-    public IReadOnlyList<CategoryAnnualAverageDTO> GetHistoricCategoriesAverageFromYear(int year)
+    private IList<CategoryAnnualAverageDTO> GetHistoricCategoriesAverageFromYear(int year)
     {
         var monthlySumByCategory = _repository.GetExpenses()
             .Where(e => e.Date.Year <= year)

--- a/Tests/Financial.Api.Tests/YearlySummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/YearlySummaryEndpointsTests.cs
@@ -116,4 +116,82 @@ public class YearlySummaryEndpointsTests
         result.SalaryMonthly[3].Should().Be(0m);
         result.SalaryYearlyTotal.Should().Be(3600m);
     }
+
+    [Fact]
+    public async Task GetHistoricCategoriesAverages_MergesIncomeIntoMatchingYearAndOmitsItFromYearsWithoutIncome()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2025, 6, 5),
+            Description = "2025 groceries",
+            Value = 120m,
+            Category = "Mercado",
+            PaymentSource = "Barclays",
+            CardTag = null
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 1, 5),
+            Description = "January groceries",
+            Value = 100m,
+            Category = "Mercado",
+            PaymentSource = "Barclays",
+            CardTag = null
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 3, 5),
+            Description = "March groceries",
+            Value = 50m,
+            Category = "Mercado",
+            PaymentSource = "Barclays",
+            CardTag = null
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 1, 1),
+            IncomeSource = "Gleison",
+            GrossValue = 3200m,
+            NetValue = 2450m,
+            Bank = "Barclays"
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 1, 8),
+            IncomeSource = "Ariana",
+            GrossValue = 400m,
+            NetValue = 350m,
+            Bank = "Chase"
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 3, 1),
+            IncomeSource = "DividendoJuros",
+            GrossValue = null,
+            NetValue = 15.50m,
+            Bank = "Trading212"
+        });
+
+        var response = await client.GetAsync("/api/v1/financial/yearly-summary/2026/historic-categories-averages");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<List<CategoryAnnualAverageDTO>>();
+        result.Should().HaveCount(2);
+        result![0].Year.Should().Be(2026);
+        result[1].Year.Should().Be(2025);
+
+        // 2026: Mercado's two recorded months (Jan 100 + Mar 50) average to 75; income is combined
+        // (Gleison + Ariana) per month before averaging, over the single recorded month each.
+        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Mercado" && a.Average == 75m);
+        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Salary" && a.Average == 3600m);
+        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Salary after taxes" && a.Average == 2800m);
+        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Tax difference" && a.Average == 800m);
+        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Dividendo/Juros" && a.Average == 15.50m);
+
+        // 2025 has expenses but no income, so no income rows should be merged in for that year.
+        result[1].AnnualAverages.Should().ContainSingle(a => a.Category == "Mercado" && a.Average == 120m);
+        result[1].AnnualAverages.Should().NotContain(a => a.Category == "Salary");
+    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
@@ -455,34 +455,33 @@ public class YearlySummaryServiceTests
 
 
     [Fact]
-    public void GetHistoricCategoriesAverageFromYear_ReturnsEmptyList_WhenNoExpensesForSpecifiedYear()
+    public void GetCategoryTotalsHistoricAverageFromYear_ReturnsEmptyList_WhenNoExpensesForSpecifiedYear()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2027, 4, 5), "Should not be there", 1000m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Jan", 100m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetHistoricCategoriesAverageFromYear(2020);
+        var result = service.GetCategoryTotalsHistoricAverageFromYear(2020);
 
         result.Count.Should().Be(0);
     }
 
-
     [Fact]
-    public void GetHistoricCategoriesAverageFromYear_ReturnsYearsUpToAndIncludingSpecifiedYear()
+    public void GetCategoryTotalsHistoricAverageFromYear_ReturnsYearsUpToAndIncludingSpecifiedYear()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2027, 4, 5), "Should not be there", 1000m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Jan", 100m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetHistoricCategoriesAverageFromYear(2026);
-        
+        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+
         result.Count.Should().Be(1);
     }
 
     [Fact]
-    public void GetHistoricCategoriesAverageFromYear_ReturnsTheYearsInOrderDescending()
+    public void GetCategoryTotalsHistoricAverageFromYear_ReturnsTheYearsInOrderDescending()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -493,7 +492,7 @@ public class YearlySummaryServiceTests
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 6, 5), "Jun", 120m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2023, 3, 5), "Mar", 52m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetHistoricCategoriesAverageFromYear(2026);
+        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
 
         result[0].Year.Should().Be(2026);
         result[1].Year.Should().Be(2025);
@@ -501,7 +500,7 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetHistoricCategoriesAverageFromYear_AveragesPerMonthNotPerTransaction()
+    public void GetCategoryTotalsHistoricAverageFromYear_AveragesCategoryValuesPerMonthNotPerTransaction()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -509,7 +508,7 @@ public class YearlySummaryServiceTests
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 20), "Jan second", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 2, 10), "Feb", 400m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetHistoricCategoriesAverageFromYear(2026);
+        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
 
         var mercadoAverage = result[0].AnnualAverages.Single(a => a.Category == nameof(Category.Mercado)).Average;
 
@@ -518,52 +517,32 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetHistoricIncomeAverageFromYear_ReturnsEmptyList_WhenNoIncomesForSpecifiedYear()
+    public void GetCategoryTotalsHistoricAverageFromYear_MergesIncomeAveragesIntoMatchingYearsInDescendingOrder()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
-        repository.Incomes.Add(Income.Create(new DateOnly(2027, 4, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 100m, 100m, "Barclays"));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2027, 4, 5), "Should not be there", 10m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 4, 5), "2026", 10m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2025, 4, 5), "2025", 10m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2023, 4, 5), "2023", 10m, Category.Mercado, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(2027, 4, 5), IncomeSource.Gleison, 9999m, 9999m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 4, 5), IncomeSource.Gleison, 1500m, 1500m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2025, 4, 5), IncomeSource.Gleison, 1200m, 1200m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2023, 4, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
 
-        var result = service.GetHistoricIncomeAverageFromYear(2020);
+        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
 
-        result.Count.Should().Be(0);
-    }
-
-    [Fact]
-    public void GetHistoricIncomeAverageFromYear_ReturnsYearsUpToAndIncludingSpecifiedYear()
-    {
-        var repository = new StubCashFlowRepository();
-        var service = new YearlySummaryService(repository);
-        repository.Incomes.Add(Income.Create(new DateOnly(2027, 4, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 100m, 100m, "Barclays"));
-
-        var result = service.GetHistoricIncomeAverageFromYear(2026);
-
-        result.Count.Should().Be(1);
-    }
-
-    [Fact]
-    public void GetHistoricIncomeAverageFromYear_ReturnsTheYearsInOrderDescending()
-    {
-        var repository = new StubCashFlowRepository();
-        var service = new YearlySummaryService(repository);
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 100m, 100m, "Barclays" ));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 5), IncomeSource.Gleison, 50m, 50m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 12, 5), IncomeSource.Gleison, 25m, 25m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 12, 5), IncomeSource.Gleison, 55m, 55m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2025, 6, 5), IncomeSource.Gleison, 120m, 120m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2023, 3, 5), IncomeSource.Gleison, 52m, 52m, "Barclays"));
-
-        var result = service.GetHistoricIncomeAverageFromYear(2026);
-
+        result.Count.Should().Be(3);
         result[0].Year.Should().Be(2026);
         result[1].Year.Should().Be(2025);
         result[2].Year.Should().Be(2023);
+        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1500m);
+        result[1].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1200m);
+        result[2].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1000m);
     }
 
     [Fact]
-    public void GetHistoricIncomeAverageFromYear_AveragesPerMonthNotPerTransaction()
+    public void GetCategoryTotalsHistoricAverageFromYear_AveragesIncomePerMonthNotPerTransaction()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -571,17 +550,17 @@ public class YearlySummaryServiceTests
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 20), IncomeSource.Gleison, 500m, 400m, "Barclays"));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 2, 5), IncomeSource.Gleison, 3000m, 2400m, "Barclays"));
 
-        var result = service.GetHistoricIncomeAverageFromYear(2026);
+        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
 
         // Per-month gross: Jan total 1500 + Feb total 3000 → avg over 2 months = 2250
-        result[0].SalaryAverage.Should().Be(2250m);
+        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(2250m);
 
         // Per-month net: Jan total 1200 + Feb total 2400 → avg over 2 months = 1800
-        result[0].SalaryAfterTaxesAverage.Should().Be(1800m);
+        result[0].AnnualAverages.Single(a => a.Category == "Salary after taxes").Average.Should().Be(1800m);
     }
 
     [Fact]
-    public void GetHistoricIncomeAverageFromYear_SumsSourcesPerMonthBeforeAveragingWhenActiveMonthsDiffer()
+    public void GetCategoryTotalsHistoricAverageFromYear_SumsIncomeSourcesPerMonthBeforeAveragingWhenActiveMonthsDiffer()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -590,10 +569,25 @@ public class YearlySummaryServiceTests
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Ariana, 500m, 500m, "Barclays"));
 
-        var result = service.GetHistoricIncomeAverageFromYear(2026);
+        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
 
         // Combined per-month salary: Jan 1500, Feb 1000, Mar 1000 → avg over 3 months = 1166.67
-        result[0].SalaryAverage.Should().Be(1166.67m);
+        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1166.67m);
+    }
+
+    [Fact]
+    public void GetCategoryTotalsHistoricAverageFromYear_IncludesYearsWithIncomeButNoExpenses()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new YearlySummaryService(repository);
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+
+        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+
+        result.Count.Should().Be(1);
+        result[0].Year.Should().Be(2026);
+        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1000m);
+        result[0].AnnualAverages.Single(a => a.Category == "Salary after taxes").Average.Should().Be(800m);
     }
 
     private sealed class StubCashFlowRepository : ICashFlowRepository


### PR DESCRIPTION
## Summary
- Adds `GET /yearly-summary/{year}/historic-categories-averages`, the single batch endpoint the [P17](docs/prd/P17-prd-yearly-summary-historical-averages-subtab/prd-yearly-summary-historical-averages-subtab.md) PRD requires ("exactly one network request... regardless of how many year columns are displayed")
- New `IYearlySummaryService.GetCategoryTotalsHistoricAverageFromYear(int year)` composes the previously separate category and income historic-average computations (now `private` — no longer part of the public interface, since nothing outside this method needs them independently) into one merged, per-year result
- Merged rows: Salary, Salary after taxes, Tax difference, Dividendo/Juros inserted ahead of the category rows, matching Category Totals' existing row shape/order
- **Fixes a real bug found while doing this**: a year with income but zero expenses was computed correctly but then silently dropped from the result (the merge only mutated a local variable, never added it back to the list) — now fixed and covered

## Test plan
- [x] `GetCategoryTotalsHistoricAverageFromYear_ReturnsEmptyList_WhenNoExpensesForSpecifiedYear`
- [x] `GetCategoryTotalsHistoricAverageFromYear_ReturnsYearsUpToAndIncludingSpecifiedYear`
- [x] `GetCategoryTotalsHistoricAverageFromYear_ReturnsTheYearsInOrderDescending`
- [x] `GetCategoryTotalsHistoricAverageFromYear_AveragesCategoryValuesPerMonthNotPerTransaction`
- [x] `GetCategoryTotalsHistoricAverageFromYear_MergesIncomeAveragesIntoMatchingYearsInDescendingOrder`
- [x] `GetCategoryTotalsHistoricAverageFromYear_AveragesIncomePerMonthNotPerTransaction`
- [x] `GetCategoryTotalsHistoricAverageFromYear_SumsIncomeSourcesPerMonthBeforeAveragingWhenActiveMonthsDiffer`
- [x] `GetCategoryTotalsHistoricAverageFromYear_IncludesYearsWithIncomeButNoExpenses` — regression test for the merge bug fix
- [x] `GetHistoricCategoriesAverages_MergesIncomeIntoMatchingYearAndOmitsItFromYearsWithoutIncome` — new API-level integration test (controller → service → merge), also verifies the flip side of the bug fix (a year with expenses but no income gets no spurious income rows)
- [x] `dotnet test Tests/Financial.CashFlow.Application.Tests --filter "FullyQualifiedName~YearlySummaryServiceTests"` — 38/38 passing
- [x] `dotnet test Tests/Financial.Api.Tests` — 180/180 passing
- [x] `dotnet build` — 0 errors (pre-existing unrelated warnings only)

Does not yet cover: the current-year exclusion rule (excluding the in-progress month) or zero-filling all 14 categories for years with partial data — tracked as follow-up work on this PRD, not part of this endpoint-wiring step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P9h9D3DFkckJAyDktemTe