### PR TITLE
feat(P17-F01): exclude the in-progress current month from historic averages

### DIFF
--- a/Financial.CashFlow.Application/Services/YearlySummaryService.cs
+++ b/Financial.CashFlow.Application/Services/YearlySummaryService.cs
@@ -309,7 +309,7 @@ public sealed class YearlySummaryService : IYearlySummaryService
     private Dictionary<int, List<IncomeAverageDTO>> GetAnnualAverageIncomeByGroupIncome(int year)
     {
         var monthlySumByIncomeSource = _repository.GetIncomes()
-            .Where(e => e.Date.Year <= year)
+            .Where(e => e.Date.Year <= year && e.Date < new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1))
             .GroupBy(e => new { e.Date.Year, e.Date.Month, IncomeGroup = GetIncomeGroup(e.IncomeSource) })
             .Select(g => new
             {
@@ -337,7 +337,7 @@ public sealed class YearlySummaryService : IYearlySummaryService
     private IList<CategoryAnnualAverageDTO> GetHistoricCategoriesAverageFromYear(int year)
     {
         var monthlySumByCategory = _repository.GetExpenses()
-            .Where(e => e.Date.Year <= year)
+            .Where(e => e.Date.Year <= year && e.Date < new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1))
             .GroupBy(e => (e.Date.Year, e.Date.Month, e.Category))
             .Select(g => new
             {

--- a/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
@@ -660,6 +660,53 @@ public class YearlySummaryServiceTests
         result[0].AnnualAverages.Select(a => a.Category).Should().Equal(expectedOrder);
     }
 
+    [Fact]
+    public void GetCategoryTotalsHistoricAverageFromYear_ExcludesInProgressCurrentMonthFromCurrentYearAverage()
+    {
+        var today = DateTime.UtcNow;
+        if (today.Month == 1)
+        {
+            // No completed month exists yet this year; that scenario is covered by the
+            // "omits current year entirely" test below instead.
+            return;
+        }
+
+        var repository = new StubCashFlowRepository();
+        var service = new YearlySummaryService(repository);
+        var currentYear = today.Year;
+        repository.Expenses.Add(Expense.Create(new DateOnly(currentYear, 1, 5), "Completed month", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(DateOnly.FromDateTime(today), "In-progress month", 9999m, Category.Mercado, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(currentYear, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        repository.Incomes.Add(Income.Create(DateOnly.FromDateTime(today), IncomeSource.Gleison, 9999m, 9999m, "Barclays"));
+
+        var result = service.GetCategoryTotalsHistoricAverageFromYear(currentYear);
+
+        var currentYearRow = result.Single(r => r.Year == currentYear);
+        // Only January's figures count; the in-progress current-month entries (9999) must be excluded entirely,
+        // not treated as a completed month with a low value.
+        currentYearRow.AnnualAverages.Single(a => a.Category == "Mercado").Average.Should().Be(100m);
+        currentYearRow.AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1000m);
+        currentYearRow.AnnualAverages.Single(a => a.Category == "Salary after taxes").Average.Should().Be(800m);
+    }
+
+    [Fact]
+    public void GetCategoryTotalsHistoricAverageFromYear_OmitsCurrentYearEntirelyWhenOnlyInProgressMonthIsRecorded()
+    {
+        var today = DateTime.UtcNow;
+        var repository = new StubCashFlowRepository();
+        var service = new YearlySummaryService(repository);
+        var currentYear = today.Year;
+        repository.Expenses.Add(Expense.Create(DateOnly.FromDateTime(today), "In-progress month", 9999m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(currentYear - 1, 12, 5), "Prior year", 50m, Category.Mercado, "Barclays", null));
+
+        var result = service.GetCategoryTotalsHistoricAverageFromYear(currentYear);
+
+        // The current year has no fully completed month yet, so it must not appear at all;
+        // the range starts at the previous year instead.
+        result.Should().NotContain(r => r.Year == currentYear);
+        result.Should().ContainSingle(r => r.Year == currentYear - 1);
+    }
+
     private sealed class StubCashFlowRepository : ICashFlowRepository
     {
         private static readonly (string Name, bool IsLiability)[] SeededAccounts =


### PR DESCRIPTION
## Summary
- `GetHistoricCategoriesAverageFromYear` and `GetAnnualAverageIncomeByGroupIncome` now filter out any expense/income dated on or after the first day of the current calendar month
- Since the filter is a plain chronological comparison, it naturally scopes to only the current year's in-progress month (no `year == currentYear` branch needed), and it also satisfies the January edge case for free: if the only recorded data for the current year is the in-progress month, that year produces zero grouped rows and is simply absent from the result — matching the PRD's "omit the current year entirely, range starts at the previous year" rule without any extra code
- Satisfies the two remaining Section 6/9 acceptance criteria for current-year handling that weren't covered by #263

## Test plan
- [x] `GetCategoryTotalsHistoricAverageFromYear_ExcludesInProgressCurrentMonthFromCurrentYearAverage` — completed January data plus an in-progress "today" entry (both expense and income); verifies only the completed month counts, self-skips only if run in January (covered instead by the next test)
- [x] `GetCategoryTotalsHistoricAverageFromYear_OmitsCurrentYearEntirelyWhenOnlyInProgressMonthIsRecorded` — month-agnostic, always runs; verifies the current year is fully absent from the result when its only data point is in-progress, while the prior year still appears
- [x] `dotnet test Tests/Financial.CashFlow.Application.Tests --filter "FullyQualifiedName~YearlySummaryServiceTests"` — 44/44 passing
- [x] `dotnet test Tests/Financial.Api.Tests --filter "FullyQualifiedName~YearlySummaryEndpointsTests"` — 4/4 passing (fixed 2026 seed dates in that test are all safely in the past relative to the current-month filter)
- [x] `dotnet build` — 0 errors (pre-existing unrelated warnings only)

Still outstanding on this PRD: the All-Years Average column and the frontend wiring itself — both tracked as the next steps, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P9h9D3DFkckJAyDktemTe