### PR TITLE
feat(P17-F01): rename Historic Categories Average to Historic Summary Average

### DIFF
--- a/Financial.Api/Controllers/YearlySummaryController.cs
+++ b/Financial.Api/Controllers/YearlySummaryController.cs
@@ -36,10 +36,10 @@ public sealed class YearlySummaryController : ControllerBase
         return Ok(_yearlySummaryService.GetIncomeSummaryForYear(year));
     }
 
-    [HttpGet("{year:int}/historic-categories-averages")]
+    [HttpGet("{year:int}/historic-summary-averages")]
     [ProducesResponseType(typeof(IReadOnlyList<CategoryAnnualAverageDTO>), StatusCodes.Status200OK)]
-    public ActionResult<IReadOnlyList<CategoryAnnualAverageDTO>> GetHistoricCategoriesAverages(int year)
+    public ActionResult<IReadOnlyList<CategoryAnnualAverageDTO>> GetHistoricSummaryAverages(int year)
     {
-        return Ok(_yearlySummaryService.GetCategoryTotalsHistoricAverageFromYear(year));
+        return Ok(_yearlySummaryService.GetHistoricSummaryAverageFromYear(year));
     }
 }

--- a/Financial.CashFlow.Application/Interfaces/IYearlySummaryService.cs
+++ b/Financial.CashFlow.Application/Interfaces/IYearlySummaryService.cs
@@ -7,5 +7,5 @@ public interface IYearlySummaryService
     IReadOnlyList<CategoryYearlyTotalDTO> GetCategoryTotalsForYear(int year);
     InvestmentDiffsYearlyDTO GetInvestmentDiffsForYear(int year);
     IncomeYearlySummaryDTO GetIncomeSummaryForYear(int year);
-    IReadOnlyList<CategoryAnnualAverageDTO> GetCategoryTotalsHistoricAverageFromYear(int year);
+    IReadOnlyList<CategoryAnnualAverageDTO> GetHistoricSummaryAverageFromYear(int year);
 }

--- a/Financial.CashFlow.Application/Services/YearlySummaryService.cs
+++ b/Financial.CashFlow.Application/Services/YearlySummaryService.cs
@@ -161,7 +161,7 @@ public sealed class YearlySummaryService : IYearlySummaryService
         };
     }
 
-    public IReadOnlyList<CategoryAnnualAverageDTO> GetCategoryTotalsHistoricAverageFromYear(int year)
+    public IReadOnlyList<CategoryAnnualAverageDTO> GetHistoricSummaryAverageFromYear(int year)
     {
         var incomeAverages = GetHistoricIncomeAverageFromYear(year);
         var categoryAverages = GetHistoricCategoriesAverageFromYear(year);

--- a/Financial.Web/src/pages/YearlySummaryPage.tsx
+++ b/Financial.Web/src/pages/YearlySummaryPage.tsx
@@ -9,12 +9,12 @@ import './YearlySummaryPage.css'
 const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 const SPACER_COL_SPAN = MONTH_LABELS.length + 3
 
-type YearlySummaryTabId = 'categoryTotals' | 'investments' | 'historicCategoriesAverage'
+type YearlySummaryTabId = 'categoryTotals' | 'investments' | 'historicSummaryAverage'
 
 const TABS: { id: YearlySummaryTabId; label: string }[] = [
   { id: 'categoryTotals', label: 'Category Totals' },
   { id: 'investments', label: 'Investments' },
-  { id: 'historicCategoriesAverage', label: 'Historic Categories Average' },
+  { id: 'historicSummaryAverage', label: 'Historic Summary Average' },
 ]
 
 function YearlySummaryRow({
@@ -242,10 +242,10 @@ export default function YearlySummaryPage() {
             </section>
           )}
 
-          {activeTab === 'historicCategoriesAverage' && (
+          {activeTab === 'historicSummaryAverage' && (
             <section className="yearly-summary-page__section">
-              <h2>Historic Categories Average</h2>
-              <p>This is the historic categories average section.</p>
+              <h2>Historic Summary Average</h2>
+              <p>This is the historic summary average section.</p>
             </section>
           )}
         </div>

--- a/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/YearlySummaryPage.test.tsx
@@ -371,21 +371,21 @@ describe('YearlySummaryPage', () => {
     expect(screen.getByRole('button', { name: 'Investments' })).toHaveClass('yearly-summary-page__tab--active')
   })
 
-  it('shows only the Historic Categories Average placeholder after clicking Historic Categories Average', async () => {
+  it('shows only the Historic Summary Average placeholder after clicking Historic Summary Average', async () => {
     render(<YearlySummaryPage />)
 
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: 'Historic Categories Average' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Historic Summary Average' }))
 
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Historic Categories Average' })).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Historic Summary Average' })).toBeInTheDocument())
   })
 
-  it('does not affect the Category Totals tab content when viewing Historic Categories Average', async () => {
+  it('does not affect the Category Totals tab content when viewing Historic Summary Average', async () => {
     render(<YearlySummaryPage />)
 
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: 'Historic Categories Average' }))
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Historic Categories Average' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Historic Summary Average' }))
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Historic Summary Average' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Category Totals' }))
 
     await waitFor(() => expect(screen.getByRole('heading', { name: 'Category Totals' })).toBeInTheDocument())

--- a/Tests/Financial.Api.Tests/YearlySummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/YearlySummaryEndpointsTests.cs
@@ -118,7 +118,7 @@ public class YearlySummaryEndpointsTests
     }
 
     [Fact]
-    public async Task GetHistoricCategoriesAverages_MergesIncomeIntoMatchingYearAndOmitsItFromYearsWithoutIncome()
+    public async Task GetHistoricSummaryAverages_MergesIncomeIntoMatchingYearAndOmitsItFromYearsWithoutIncome()
     {
         await using var factory = new ApiTestFactory();
         using var client = factory.CreateClient();
@@ -174,7 +174,7 @@ public class YearlySummaryEndpointsTests
             Bank = "Trading212"
         });
 
-        var response = await client.GetAsync("/api/v1/financial/yearly-summary/2026/historic-categories-averages");
+        var response = await client.GetAsync("/api/v1/financial/yearly-summary/2026/historic-summary-averages");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var result = await response.Content.ReadFromJsonAsync<List<CategoryAnnualAverageDTO>>();

--- a/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/YearlySummaryServiceTests.cs
@@ -455,33 +455,33 @@ public class YearlySummaryServiceTests
 
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_ReturnsEmptyList_WhenNoExpensesForSpecifiedYear()
+    public void GetHistoricSummaryAverageFromYear_ReturnsEmptyList_WhenNoExpensesForSpecifiedYear()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2027, 4, 5), "Should not be there", 1000m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Jan", 100m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2020);
+        var result = service.GetHistoricSummaryAverageFromYear(2020);
 
         result.Count.Should().Be(0);
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_ReturnsYearsUpToAndIncludingSpecifiedYear()
+    public void GetHistoricSummaryAverageFromYear_ReturnsYearsUpToAndIncludingSpecifiedYear()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2027, 4, 5), "Should not be there", 1000m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Jan", 100m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(2026);
 
         result.Count.Should().Be(1);
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_ReturnsTheYearsInOrderDescending()
+    public void GetHistoricSummaryAverageFromYear_ReturnsTheYearsInOrderDescending()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -492,7 +492,7 @@ public class YearlySummaryServiceTests
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 6, 5), "Jun", 120m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2023, 3, 5), "Mar", 52m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(2026);
 
         result[0].Year.Should().Be(2026);
         result[1].Year.Should().Be(2025);
@@ -500,7 +500,7 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_AveragesCategoryValuesPerMonthNotPerTransaction()
+    public void GetHistoricSummaryAverageFromYear_AveragesCategoryValuesPerMonthNotPerTransaction()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -508,7 +508,7 @@ public class YearlySummaryServiceTests
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 20), "Jan second", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 2, 10), "Feb", 400m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(2026);
 
         var mercadoAverage = result[0].AnnualAverages.Single(a => a.Category == nameof(Category.Mercado)).Average;
 
@@ -517,7 +517,7 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_MergesIncomeAveragesIntoMatchingYearsInDescendingOrder()
+    public void GetHistoricSummaryAverageFromYear_MergesIncomeAveragesIntoMatchingYearsInDescendingOrder()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -530,7 +530,7 @@ public class YearlySummaryServiceTests
         repository.Incomes.Add(Income.Create(new DateOnly(2025, 4, 5), IncomeSource.Gleison, 1200m, 1200m, "Barclays"));
         repository.Incomes.Add(Income.Create(new DateOnly(2023, 4, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(2026);
 
         result.Count.Should().Be(3);
         result[0].Year.Should().Be(2026);
@@ -542,7 +542,7 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_AveragesIncomePerMonthNotPerTransaction()
+    public void GetHistoricSummaryAverageFromYear_AveragesIncomePerMonthNotPerTransaction()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -550,7 +550,7 @@ public class YearlySummaryServiceTests
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 20), IncomeSource.Gleison, 500m, 400m, "Barclays"));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 2, 5), IncomeSource.Gleison, 3000m, 2400m, "Barclays"));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(2026);
 
         // Per-month gross: Jan total 1500 + Feb total 3000 → avg over 2 months = 2250
         result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(2250m);
@@ -560,7 +560,7 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_SumsIncomeSourcesPerMonthBeforeAveragingWhenActiveMonthsDiffer()
+    public void GetHistoricSummaryAverageFromYear_SumsIncomeSourcesPerMonthBeforeAveragingWhenActiveMonthsDiffer()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -569,20 +569,20 @@ public class YearlySummaryServiceTests
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Ariana, 500m, 500m, "Barclays"));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(2026);
 
         // Combined per-month salary: Jan 1500, Feb 1000, Mar 1000 → avg over 3 months = 1166.67
         result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1166.67m);
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_IncludesYearsWithIncomeButNoExpenses()
+    public void GetHistoricSummaryAverageFromYear_IncludesYearsWithIncomeButNoExpenses()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(2026);
 
         result.Count.Should().Be(1);
         result[0].Year.Should().Be(2026);
@@ -591,7 +591,7 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_ComputesTotalDespesasAsSumOfCategoryRowsOnly()
+    public void GetHistoricSummaryAverageFromYear_ComputesTotalDespesasAsSumOfCategoryRowsOnly()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -600,7 +600,7 @@ public class YearlySummaryServiceTests
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.DividendoJuros, null, 20m, "Barclays"));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(2026);
 
         // Total despesas must be the sum of the 14 expense category rows only (Mercado 100 + Investimento 30 = 130),
         // never the income rows (Salary/Salary after taxes/Tax difference/Dividendo/Juros) merged in ahead of them.
@@ -608,7 +608,7 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_ComputesResultadoFromSalaryAfterTaxesTotalDespesasAndInvestimentoExcludingDividendoJuros()
+    public void GetHistoricSummaryAverageFromYear_ComputesResultadoFromSalaryAfterTaxesTotalDespesasAndInvestimentoExcludingDividendoJuros()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -619,20 +619,20 @@ public class YearlySummaryServiceTests
         // Resultado excludes Dividendo/Juros entirely, so this income must NOT affect the expected value.
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.DividendoJuros, null, 20m, "Barclays"));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(2026);
 
         // Resultado (R-D-Inv) = SalaryAfterTaxes(800) - TotalDespesas(130) + Investimento(30) = 700
         result[0].AnnualAverages.Single(a => a.Category == "Resultado (R-D-Inv)").Average.Should().Be(700m);
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_ZeroFillsCategoriesWithNoExpensesThatYear()
+    public void GetHistoricSummaryAverageFromYear_ZeroFillsCategoriesWithNoExpensesThatYear()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(2026);
 
         // Every one of the 14 Category enum values must appear, even with zero recorded expenses that year.
         foreach (var category in Enum.GetValues<Category>())
@@ -643,7 +643,7 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_RowOrderMatchesCategoryTotalsFixedOrder()
+    public void GetHistoricSummaryAverageFromYear_RowOrderMatchesCategoryTotalsFixedOrder()
     {
         var repository = new StubCashFlowRepository();
         var service = new YearlySummaryService(repository);
@@ -651,7 +651,7 @@ public class YearlySummaryServiceTests
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.DividendoJuros, null, 20m, "Barclays"));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(2026);
 
         var expectedOrder = new List<string> { "Salary", "Salary after taxes", "Tax difference", "Dividendo/Juros" }
             .Concat(Enum.GetValues<Category>().Select(c => c.ToString()))
@@ -661,7 +661,7 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_ExcludesInProgressCurrentMonthFromCurrentYearAverage()
+    public void GetHistoricSummaryAverageFromYear_ExcludesInProgressCurrentMonthFromCurrentYearAverage()
     {
         var today = DateTime.UtcNow;
         if (today.Month == 1)
@@ -679,7 +679,7 @@ public class YearlySummaryServiceTests
         repository.Incomes.Add(Income.Create(new DateOnly(currentYear, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
         repository.Incomes.Add(Income.Create(DateOnly.FromDateTime(today), IncomeSource.Gleison, 9999m, 9999m, "Barclays"));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(currentYear);
+        var result = service.GetHistoricSummaryAverageFromYear(currentYear);
 
         var currentYearRow = result.Single(r => r.Year == currentYear);
         // Only January's figures count; the in-progress current-month entries (9999) must be excluded entirely,
@@ -690,7 +690,7 @@ public class YearlySummaryServiceTests
     }
 
     [Fact]
-    public void GetCategoryTotalsHistoricAverageFromYear_OmitsCurrentYearEntirelyWhenOnlyInProgressMonthIsRecorded()
+    public void GetHistoricSummaryAverageFromYear_OmitsCurrentYearEntirelyWhenOnlyInProgressMonthIsRecorded()
     {
         var today = DateTime.UtcNow;
         var repository = new StubCashFlowRepository();
@@ -699,7 +699,7 @@ public class YearlySummaryServiceTests
         repository.Expenses.Add(Expense.Create(DateOnly.FromDateTime(today), "In-progress month", 9999m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(currentYear - 1, 12, 5), "Prior year", 50m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetCategoryTotalsHistoricAverageFromYear(currentYear);
+        var result = service.GetHistoricSummaryAverageFromYear(currentYear);
 
         // The current year has no fully completed month yet, so it must not appear at all;
         // the range starts at the previous year instead.

--- a/docs/prd/P17-prd-yearly-summary-historical-averages-subtab/prd-yearly-summary-historical-averages-subtab.md
+++ b/docs/prd/P17-prd-yearly-summary-historical-averages-subtab/prd-yearly-summary-historical-averages-subtab.md
@@ -4,7 +4,7 @@
 
 Yearly Summary Historical Averages Sub-Tab adds a third view to `Financial.CashFlow`'s Yearly Summary tab, alongside the existing Category Totals and Investments sub-tabs. It is used by the same single developer-maintainer that all prior CashFlow features serve. Today, seeing how a category or income line has trended across past years requires opening each year's `Resumo/xxxx` spreadsheet tab individually and comparing figures by hand — there is no in-app way to see multiple years side by side. This feature closes that gap by reproducing the spreadsheet's `Q1:Y25`-style historical block directly in the app: one column per year, one row per category/income line, each cell holding that line's yearly average.
 
-At a high level, the new "Historical Categories Averages" sub-tab shares the same year picker as Category Totals and Investments. It shows the exact same row set as Category Totals (income lines, the 14 expense categories, Resultado, Total despesas), but instead of 12 month columns it shows one column per calendar year — starting at the selected year and going backward to the earliest year with any recorded data. Every year's value is computed server-side in a single batch request, so opening the sub-tab never issues one network call per year.
+At a high level, the new "Historical Summary Averages" sub-tab shares the same year picker as Category Totals and Investments. It shows the exact same row set as Category Totals (income lines, the 14 expense categories, Resultado, Total despesas), but instead of 12 month columns it shows one column per calendar year — starting at the selected year and going backward to the earliest year with any recorded data. Every year's value is computed server-side in a single batch request, so opening the sub-tab never issues one network call per year.
 
 ## 2. Problem and Opportunity
 
@@ -59,7 +59,7 @@ At a high level, the new "Historical Categories Averages" sub-tab shares the sam
 ## 5. User Stories
 
 ### F01. Historical Averages Sub-Tab
-- As the developer, I want a third "Historical Categories Averages" sub-tab next to Category Totals and Investments so that I can review year-over-year trends without leaving the Yearly Summary tab
+- As the developer, I want a third "Historical Summary Averages" sub-tab next to Category Totals and Investments so that I can review year-over-year trends without leaving the Yearly Summary tab
 - As the developer, I want the same shared year picker to control this sub-tab so that I never have to re-select the year separately from the other two sub-tabs
 - As the developer, I want the same rows as Category Totals (Salary, Salary After Taxes, Tax Difference, Dividendo/Juros, the 14 expense categories, Resultado, Total despesas) so that the historical view lines up with the single-year view I already know
 - As the developer, I want one column per year, starting at the selected year and going backward to the earliest year with any data, so that I see the full available history at a glance
@@ -73,7 +73,7 @@ At a high level, the new "Historical Categories Averages" sub-tab shares the sam
 ### F01. Historical Averages Sub-Tab
 
 **Capabilities:**
-- Adds a third sub-tab, "Historical Categories Averages", after "Investments" on the existing Yearly Summary tab shell; selecting it never resets the shared year picker and never affects the other two sub-tabs' loaded data
+- Adds a third sub-tab, "Historical Summary Averages", after "Investments" on the existing Yearly Summary tab shell; selecting it never resets the shared year picker and never affects the other two sub-tabs' loaded data
 - Row set and order identical to Category Totals: Salary, Salary After Taxes, Tax Difference, Dividendo/Juros, then the 14 `Category` enum rows in declaration order (Ariana, Carro, Casa, Estudo, Extras, Familia, Gleison, Mercado, Samuel, Saude, Viagem, Dizimo, Investimento, Reserva), then Resultado (R-D-Inv), then Total despesas — using the same monthly value definitions established for Category Totals (Total despesas = sum of the 14 categories), with one deliberate exception: this sub-tab's Resultado = Salary After Taxes − Total despesas + Investimento, excluding Dividendo/Juros. This differs intentionally from Category Totals' own Resultado (which does include Dividendo/Juros) — a conscious divergence for the historic-average view, not an oversight
 - Column set: one column per calendar year, ordered left to right starting at the selected year and decreasing by one each column, continuing down to the earliest year for which at least one row has at least one recorded month; any year within that span with zero recorded data across every row is omitted entirely (no blank filler column)
 - Each year's cell value = arithmetic mean of that row's recorded monthly values for that year (partial years average over however many months are actually recorded, consistent with the existing per-row Average column behavior on Category Totals)
@@ -83,7 +83,7 @@ At a high level, the new "Historical Categories Averages" sub-tab shares the sam
 - All monthly and yearly figures use the existing 2-decimal numeric formatting (`formatN2`) used throughout the Yearly Summary tab today
 
 **Experience:**
-- Clicking "Historical Categories Averages" swaps the visible content exactly like switching between Category Totals and Investments; the tab is highlighted as active and the shared year picker remains unchanged
+- Clicking "Historical Summary Averages" swaps the visible content exactly like switching between Category Totals and Investments; the tab is highlighted as active and the shared year picker remains unchanged
 - Because this sub-tab's data is not already fetched by the other two sub-tabs, a loading indicator shows on first visit (and on every year change) while the batch request completes, independent of whether Category Totals/Investments data is cached
 - The table scrolls horizontally when the year range exceeds the viewport width, consistent with how the existing month-column tables behave on narrow viewports
 - A visual separator (blank spacer row) appears between Dividendo/Juros and the first category row, and again before Resultado, mirroring Category Totals' grouping convention
@@ -133,7 +133,7 @@ graph TD
 ## 9. Acceptance Criteria
 
 ### F01. Historical Averages Sub-Tab
-- [ ] The Yearly Summary tab shows a third sub-tab, "Historical Categories Averages", after Investments, sharing the same year picker as the other two sub-tabs
+- [ ] The Yearly Summary tab shows a third sub-tab, "Historical Summary Averages", after Investments, sharing the same year picker as the other two sub-tabs
 - [ ] The table's rows match Category Totals exactly, in the same fixed order: Salary, Salary After Taxes, Tax Difference, Dividendo/Juros, the 14 categories in enum order, Resultado (R-D-Inv), Total despesas
 - [ ] The leftmost year column equals the currently selected year; each subsequent column decreases by one year, down to the earliest year with any recorded data across any row
 - [ ] Any year in that span with zero recorded data in every row is omitted from the column set entirely


### PR DESCRIPTION
## Summary
Renames the sub-tab from "Historic Categories Average" to "Historic Summary Average" throughout the stack, per product decision.

- **Frontend**: tab id (`historicCategoriesAverage` -> `historicSummaryAverage`), label, heading, placeholder text, and all test descriptions/selectors in `YearlySummaryPage.tsx`/`.test.tsx`
- **API**: route `/yearly-summary/{year}/historic-categories-averages` -> `/historic-summary-averages`, controller action `GetHistoricCategoriesAverages` -> `GetHistoricSummaryAverages`
- **Application**: `IYearlySummaryService.GetCategoryTotalsHistoricAverageFromYear` -> `GetHistoricSummaryAverageFromYear` (interface + implementation), all Application/API test method names and call sites updated to match
- **PRD**: all 5 "Historical Categories Averages" mentions updated to "Historical Summary Averages"
- **Deliberately left unchanged**: the private `GetHistoricCategoriesAverageFromYear` helper inside `YearlySummaryService` — it only computes the 14 category rows, not the full merged summary, so keeping "Categories" in its name is accurate, not stale

## Test plan
- [x] `dotnet build` — 0 errors (pre-existing unrelated warnings only)
- [x] `dotnet test Tests/Financial.CashFlow.Application.Tests --filter "FullyQualifiedName~YearlySummaryServiceTests"` — 44/44 passing
- [x] `dotnet test Tests/Financial.Api.Tests --filter "FullyQualifiedName~YearlySummaryEndpointsTests"` — 4/4 passing
- [x] `npx vitest run src/pages/__tests__/YearlySummaryPage.test.tsx` — 24/24 passing
- [x] `npx tsc -b --noEmit` — clean
- [x] Repo-wide grep confirms no remaining "Categories Average" references outside the intentionally-kept private helper

Not merging — holding for your review/approval per your instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P9h9D3DFkckJAyDktemTe