### PR TITLE
fix(investment): scope Broker/Portfolio transactions and credits to Active/Historic

### DIFF
--- a/Financial.Api/Controllers/CreditsController.cs
+++ b/Financial.Api/Controllers/CreditsController.cs
@@ -1,5 +1,6 @@
 using Financial.Investment.Application.DTOs;
 using Financial.Investment.Application.Interfaces;
+using Financial.Investment.Application.Validation;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Financial.Api.Controllers;
@@ -76,9 +77,9 @@ public sealed class CreditsController : ControllerBase
 
     [HttpGet("broker/{brokerName}")]
     [ProducesResponseType(typeof(IReadOnlyList<CreditDTO>), StatusCodes.Status200OK)]
-    public ActionResult<IReadOnlyList<CreditDTO>> GetCreditsByBroker(string brokerName)
+    public ActionResult<IReadOnlyList<CreditDTO>> GetCreditsByBroker(string brokerName, [FromQuery] string? scope)
     {
-        var credits = _creditQueryService.GetCreditsByBroker(brokerName);
+        var credits = _creditQueryService.GetCreditsByBroker(brokerName, InvestmentScopeParser.ParseOrDefault(scope));
         return Ok(credits);
     }
 
@@ -86,9 +87,10 @@ public sealed class CreditsController : ControllerBase
     [ProducesResponseType(typeof(IReadOnlyList<CreditDTO>), StatusCodes.Status200OK)]
     public ActionResult<IReadOnlyList<CreditDTO>> GetCreditsByPortfolio(
         string brokerName,
-        string portfolioName)
+        string portfolioName,
+        [FromQuery] string? scope)
     {
-        var credits = _creditQueryService.GetCreditsByPortfolio(brokerName, portfolioName);
+        var credits = _creditQueryService.GetCreditsByPortfolio(brokerName, portfolioName, InvestmentScopeParser.ParseOrDefault(scope));
         return Ok(credits);
     }
 }

--- a/Financial.Api/Controllers/TransactionsController.cs
+++ b/Financial.Api/Controllers/TransactionsController.cs
@@ -1,5 +1,6 @@
 using Financial.Investment.Application.DTOs;
 using Financial.Investment.Application.Interfaces;
+using Financial.Investment.Application.Validation;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Financial.Api.Controllers;
@@ -77,12 +78,12 @@ public sealed class TransactionsController : ControllerBase
     [HttpGet("broker/{brokerName}")]
     [ProducesResponseType(typeof(IReadOnlyList<TransactionSummaryItemDTO>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public ActionResult<IReadOnlyList<TransactionSummaryItemDTO>> GetTransactionsByBroker(string brokerName)
+    public ActionResult<IReadOnlyList<TransactionSummaryItemDTO>> GetTransactionsByBroker(string brokerName, [FromQuery] string? scope)
     {
         if (string.IsNullOrWhiteSpace(brokerName))
             return BadRequest();
 
-        var result = _transactionQueryService.GetTransactionsByBroker(brokerName);
+        var result = _transactionQueryService.GetTransactionsByBroker(brokerName, InvestmentScopeParser.ParseOrDefault(scope));
         return Ok(result);
     }
 
@@ -91,12 +92,13 @@ public sealed class TransactionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public ActionResult<IReadOnlyList<TransactionSummaryItemDTO>> GetTransactionsByPortfolio(
         string brokerName,
-        string portfolioName)
+        string portfolioName,
+        [FromQuery] string? scope)
     {
         if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
             return BadRequest();
 
-        var result = _transactionQueryService.GetTransactionsByPortfolio(brokerName, portfolioName);
+        var result = _transactionQueryService.GetTransactionsByPortfolio(brokerName, portfolioName, InvestmentScopeParser.ParseOrDefault(scope));
         return Ok(result);
     }
 }

--- a/Financial.App/ViewModels/AssetDetailsViewModel.cs
+++ b/Financial.App/ViewModels/AssetDetailsViewModel.cs
@@ -565,7 +565,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         {
             try
             {
-                var transactions = _transactionQueryService.GetTransactionsByBroker(brokerName);
+                var transactions = _transactionQueryService.GetTransactionsByBroker(brokerName, _scope);
                 if (token.IsCancellationRequested) return;
                 ApplyFetchedTransactions(transactions);
             }
@@ -589,7 +589,7 @@ public class AssetDetailsViewModel : ViewModelBase, IAssetDetailsViewModel
         {
             try
             {
-                var transactions = _transactionQueryService.GetTransactionsByPortfolio(brokerName, portfolioName);
+                var transactions = _transactionQueryService.GetTransactionsByPortfolio(brokerName, portfolioName, _scope);
                 if (token.IsCancellationRequested) return;
                 ApplyFetchedTransactions(transactions);
             }

--- a/Financial.App/ViewModels/MainNavigationViewModelBase.cs
+++ b/Financial.App/ViewModels/MainNavigationViewModelBase.cs
@@ -289,7 +289,7 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
         }
 
         var summary = _summaryService.GetPortfolioSummary(brokerName, portfolioName, _scope);
-        var credits = _creditQueryService.GetCreditsByPortfolio(brokerName, portfolioName);
+        var credits = _creditQueryService.GetCreditsByPortfolio(brokerName, portfolioName, _scope);
         var assetItems = _portfolioAssetSummaryService.GetPortfolioAssetsSummary(brokerName, portfolioName, _scope);
         AssetDetails.LoadPortfolioSummary(brokerName, portfolioName, summary, credits, assetItems);
         _ = AssetDetails.LoadPortfolioTransactions(brokerName, portfolioName);
@@ -305,7 +305,7 @@ public abstract class MainNavigationViewModelBase<TAssetDetailsViewModel> : View
         }
 
         var summary = _summaryService.GetBrokerSummary(brokerName, _scope);
-        var credits = _creditQueryService.GetCreditsByBroker(brokerName);
+        var credits = _creditQueryService.GetCreditsByBroker(brokerName, _scope);
         AssetDetails.LoadBrokerSummary(brokerName, summary, credits);
         _ = AssetDetails.LoadBrokerBreakdown(brokerName);
         _ = AssetDetails.LoadBrokerTransactions(brokerName);

--- a/Financial.Investment.Application/Interfaces/ICreditQueryService.cs
+++ b/Financial.Investment.Application/Interfaces/ICreditQueryService.cs
@@ -1,9 +1,10 @@
 using Financial.Investment.Application.DTOs;
+using Financial.Investment.Application.Enums;
 
 namespace Financial.Investment.Application.Interfaces;
 
 public interface ICreditQueryService
 {
-    IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName);
-    IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName);
+    IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName, InvestmentScope scope = InvestmentScope.Active);
+    IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active);
 }

--- a/Financial.Investment.Application/Interfaces/ITransactionQueryService.cs
+++ b/Financial.Investment.Application/Interfaces/ITransactionQueryService.cs
@@ -1,9 +1,10 @@
 using Financial.Investment.Application.DTOs;
+using Financial.Investment.Application.Enums;
 
 namespace Financial.Investment.Application.Interfaces;
 
 public interface ITransactionQueryService
 {
-    IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName);
-    IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName);
+    IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName, InvestmentScope scope = InvestmentScope.Active);
+    IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active);
 }

--- a/Financial.Investment.Application/Services/CreditService.cs
+++ b/Financial.Investment.Application/Services/CreditService.cs
@@ -1,4 +1,5 @@
 using Financial.Investment.Application.DTOs;
+using Financial.Investment.Application.Enums;
 using Financial.Investment.Application.Interfaces;
 using Financial.Investment.Application.Validation;
 using Financial.Investment.Domain.Entities;
@@ -72,24 +73,24 @@ public sealed class CreditService : ICreditService, ICreditQueryService
             asset => asset.RemoveCredit(request.Id));
     }
 
-    public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName)
+    public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName, InvestmentScope scope = InvestmentScope.Active)
     {
         if (string.IsNullOrWhiteSpace(brokerName))
             return Array.Empty<CreditDTO>();
 
-        return _repository.GetAssetsByBroker(brokerName)
+        return _repository.GetAssetsByBroker(brokerName, scope)
             .SelectMany(asset => asset.Credits)
             .Select(NavigationMapper.MapCredit)
             .OrderByDescending(credit => credit.Date)
             .ToList();
     }
 
-    public IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName)
+    public IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active)
     {
         if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
             return Array.Empty<CreditDTO>();
 
-        return _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName)
+        return _repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName, scope)
             .SelectMany(asset => asset.Credits)
             .Select(NavigationMapper.MapCredit)
             .OrderByDescending(credit => credit.Date)

--- a/Financial.Investment.Application/Services/TransactionService.cs
+++ b/Financial.Investment.Application/Services/TransactionService.cs
@@ -1,4 +1,5 @@
 using Financial.Investment.Application.DTOs;
+using Financial.Investment.Application.Enums;
 using Financial.Investment.Application.Interfaces;
 using Financial.Investment.Application.Validation;
 using Financial.Investment.Domain.Entities;
@@ -72,20 +73,20 @@ public sealed class TransactionService : ITransactionService, ITransactionQueryS
             asset => asset.RemoveTransaction(request.Id));
     }
 
-    public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName)
+    public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName, InvestmentScope scope = InvestmentScope.Active)
     {
         if (string.IsNullOrWhiteSpace(brokerName))
             return Array.Empty<TransactionSummaryItemDTO>();
 
-        return MapAndSort(_repository.GetAssetsByBroker(brokerName));
+        return MapAndSort(_repository.GetAssetsByBroker(brokerName, scope));
     }
 
-    public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName)
+    public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active)
     {
         if (string.IsNullOrWhiteSpace(brokerName) || string.IsNullOrWhiteSpace(portfolioName))
             return Array.Empty<TransactionSummaryItemDTO>();
 
-        return MapAndSort(_repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName));
+        return MapAndSort(_repository.GetAssetsByBrokerPortfolio(brokerName, portfolioName, scope));
     }
 
     private static IReadOnlyList<TransactionSummaryItemDTO> MapAndSort(IEnumerable<Asset> assets)

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -61,13 +61,13 @@ export interface FinancialApiClient {
   getNavigationTree: (scope?: InvestmentScope) => Promise<TreeNodeDto>
   getBrokers: () => Promise<BrokerNodeDto[]>
   getAssetDetails: (brokerName: string, portfolioName: string, assetName: string, scope?: InvestmentScope) => Promise<AssetDetailsDto>
-  getCreditsByBroker: (brokerName: string) => Promise<CreditDto[]>
-  getCreditsByPortfolio: (brokerName: string, portfolioName: string) => Promise<CreditDto[]>
+  getCreditsByBroker: (brokerName: string, scope?: InvestmentScope) => Promise<CreditDto[]>
+  getCreditsByPortfolio: (brokerName: string, portfolioName: string, scope?: InvestmentScope) => Promise<CreditDto[]>
   getSummaryByBroker: (brokerName: string, scope?: InvestmentScope) => Promise<AggregatedSummaryDto>
   getSummaryByPortfolio: (brokerName: string, portfolioName: string, scope?: InvestmentScope) => Promise<AggregatedSummaryDto>
   getBrokerBreakdown: (brokerName: string, scope?: InvestmentScope) => Promise<PortfolioBreakdownItemDto[]>
-  getTransactionsByBroker: (brokerName: string) => Promise<TransactionSummaryItemDto[]>
-  getTransactionsByPortfolio: (brokerName: string, portfolioName: string) => Promise<TransactionSummaryItemDto[]>
+  getTransactionsByBroker: (brokerName: string, scope?: InvestmentScope) => Promise<TransactionSummaryItemDto[]>
+  getTransactionsByPortfolio: (brokerName: string, portfolioName: string, scope?: InvestmentScope) => Promise<TransactionSummaryItemDto[]>
   addTransaction: (request: TransactionCreateDto) => Promise<AssetDetailsDto>
   updateTransaction: (request: TransactionUpdateDto) => Promise<AssetDetailsDto>
   deleteTransaction: (request: TransactionDeleteDto) => Promise<AssetDetailsDto>
@@ -206,11 +206,11 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       request<AssetDetailsDto>(
         `/assets/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}/${encodeURIComponent(assetName)}${buildScopeQuery(scope)}`,
       ),
-    getCreditsByBroker: (brokerName) =>
-      request<CreditDto[]>(`/credits/broker/${encodeURIComponent(brokerName)}`),
-    getCreditsByPortfolio: (brokerName, portfolioName) =>
+    getCreditsByBroker: (brokerName, scope = 'active') =>
+      request<CreditDto[]>(`/credits/broker/${encodeURIComponent(brokerName)}${buildScopeQuery(scope)}`),
+    getCreditsByPortfolio: (brokerName, portfolioName, scope = 'active') =>
       request<CreditDto[]>(
-        `/credits/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}`,
+        `/credits/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}${buildScopeQuery(scope)}`,
       ),
     getSummaryByBroker: (brokerName, scope = 'active') =>
       request<AggregatedSummaryDto>(`/summary/broker/${encodeURIComponent(brokerName)}${buildScopeQuery(scope)}`),
@@ -220,11 +220,11 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       ),
     getBrokerBreakdown: (brokerName, scope = 'active') =>
       request<PortfolioBreakdownItemDto[]>(`/summary/broker/${encodeURIComponent(brokerName)}/breakdown${buildScopeQuery(scope)}`),
-    getTransactionsByBroker: (brokerName) =>
-      request<TransactionSummaryItemDto[]>(`/transactions/broker/${encodeURIComponent(brokerName)}`),
-    getTransactionsByPortfolio: (brokerName, portfolioName) =>
+    getTransactionsByBroker: (brokerName, scope = 'active') =>
+      request<TransactionSummaryItemDto[]>(`/transactions/broker/${encodeURIComponent(brokerName)}${buildScopeQuery(scope)}`),
+    getTransactionsByPortfolio: (brokerName, portfolioName, scope = 'active') =>
       request<TransactionSummaryItemDto[]>(
-        `/transactions/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}`,
+        `/transactions/portfolio/${encodeURIComponent(brokerName)}/${encodeURIComponent(portfolioName)}${buildScopeQuery(scope)}`,
       ),
     addTransaction: (requestBody) =>
       request<AssetDetailsDto>('/transactions', {

--- a/Financial.Web/src/hooks/useCredits.test.ts
+++ b/Financial.Web/src/hooks/useCredits.test.ts
@@ -139,7 +139,7 @@ describe('useCredits', () => {
     const { result } = renderHook(() => useCredits(), { wrapper })
     setNode(BROKER_NODE)
     await waitFor(() =>
-      expect(getCreditsByBrokerMock).toHaveBeenCalledWith('XPI'),
+      expect(getCreditsByBrokerMock).toHaveBeenCalledWith('XPI', 'active'),
     )
     await waitFor(() => expect(result.current.credits).toHaveLength(1))
   })
@@ -150,9 +150,29 @@ describe('useCredits', () => {
     const { result } = renderHook(() => useCredits(), { wrapper })
     setNode(PORTFOLIO_NODE)
     await waitFor(() =>
-      expect(getCreditsByPortfolioMock).toHaveBeenCalledWith('XPI', 'Acoes'),
+      expect(getCreditsByPortfolioMock).toHaveBeenCalledWith('XPI', 'Acoes', 'active'),
     )
     await waitFor(() => expect(result.current.credits).toHaveLength(1))
+  })
+
+  it('fetches_broker_credits_with_historic_scope', async () => {
+    getCreditsByBrokerMock.mockResolvedValue([CREDIT_A])
+    const { wrapper, setNode } = createSelectedNodeWrapper('historic')
+    renderHook(() => useCredits(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() =>
+      expect(getCreditsByBrokerMock).toHaveBeenCalledWith('XPI', 'historic'),
+    )
+  })
+
+  it('fetches_portfolio_credits_with_historic_scope', async () => {
+    getCreditsByPortfolioMock.mockResolvedValue([CREDIT_B])
+    const { wrapper, setNode } = createSelectedNodeWrapper('historic')
+    renderHook(() => useCredits(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() =>
+      expect(getCreditsByPortfolioMock).toHaveBeenCalledWith('XPI', 'Acoes', 'historic'),
+    )
   })
 
   it('resets_credits_when_node_is_null', async () => {

--- a/Financial.Web/src/hooks/useCredits.ts
+++ b/Financial.Web/src/hooks/useCredits.ts
@@ -275,7 +275,7 @@ export function useCredits(): CreditsData {
         })
     } else if (nodeType === 'Broker') {
       void apiClient
-        .getCreditsByBroker(brokerName)
+        .getCreditsByBroker(brokerName, scope)
         .then((result) => dispatch({ type: 'FETCH_SUCCESS', payload: result }))
         .catch((err: unknown) => {
           dispatch({
@@ -285,7 +285,7 @@ export function useCredits(): CreditsData {
         })
     } else if (nodeType === 'Portfolio' && portfolioName) {
       void apiClient
-        .getCreditsByPortfolio(brokerName, portfolioName)
+        .getCreditsByPortfolio(brokerName, portfolioName, scope)
         .then((result) => dispatch({ type: 'FETCH_SUCCESS', payload: result }))
         .catch((err: unknown) => {
           dispatch({

--- a/Financial.Web/src/hooks/useTransactions.test.ts
+++ b/Financial.Web/src/hooks/useTransactions.test.ts
@@ -363,7 +363,7 @@ describe('useTransactions', () => {
     const { wrapper, setNode } = createSelectedNodeWrapper()
     const { result } = renderHook(() => useTransactions(), { wrapper })
     setNode(BROKER_NODE)
-    await waitFor(() => expect(getTransactionsByBrokerMock).toHaveBeenCalledWith('XPI'))
+    await waitFor(() => expect(getTransactionsByBrokerMock).toHaveBeenCalledWith('XPI', 'active'))
     await waitFor(() => expect(result.current.chartData.length).toBeGreaterThan(0))
   })
 
@@ -373,9 +373,27 @@ describe('useTransactions', () => {
     const { result } = renderHook(() => useTransactions(), { wrapper })
     setNode(PORTFOLIO_NODE)
     await waitFor(() =>
-      expect(getTransactionsByPortfolioMock).toHaveBeenCalledWith('XPI', 'Acoes'),
+      expect(getTransactionsByPortfolioMock).toHaveBeenCalledWith('XPI', 'Acoes', 'active'),
     )
     await waitFor(() => expect(result.current.chartData.length).toBeGreaterThan(0))
+  })
+
+  it('fetches_broker_transactions_with_historic_scope', async () => {
+    getTransactionsByBrokerMock.mockResolvedValue([SUMMARY_ITEM_A])
+    const { wrapper, setNode } = createSelectedNodeWrapper('historic')
+    renderHook(() => useTransactions(), { wrapper })
+    setNode(BROKER_NODE)
+    await waitFor(() => expect(getTransactionsByBrokerMock).toHaveBeenCalledWith('XPI', 'historic'))
+  })
+
+  it('fetches_portfolio_transactions_with_historic_scope', async () => {
+    getTransactionsByPortfolioMock.mockResolvedValue([SUMMARY_ITEM_A])
+    const { wrapper, setNode } = createSelectedNodeWrapper('historic')
+    renderHook(() => useTransactions(), { wrapper })
+    setNode(PORTFOLIO_NODE)
+    await waitFor(() =>
+      expect(getTransactionsByPortfolioMock).toHaveBeenCalledWith('XPI', 'Acoes', 'historic'),
+    )
   })
 
   it('transactions_fetch_error_sets_error_state', async () => {

--- a/Financial.Web/src/hooks/useTransactions.ts
+++ b/Financial.Web/src/hooks/useTransactions.ts
@@ -281,7 +281,7 @@ export function useTransactions(): TransactionsData {
     } else if (nodeType === 'Broker') {
       dispatch({ type: 'FETCH_START', payload: { key } })
       void apiClient
-        .getTransactionsByBroker(brokerName)
+        .getTransactionsByBroker(brokerName, scope)
         .then((result) => dispatch({ type: 'FETCH_TRANSACTIONS_SUCCESS', payload: result }))
         .catch((err: unknown) => {
           dispatch({
@@ -292,7 +292,7 @@ export function useTransactions(): TransactionsData {
     } else if (nodeType === 'Portfolio' && portfolioName) {
       dispatch({ type: 'FETCH_START', payload: { key } })
       void apiClient
-        .getTransactionsByPortfolio(brokerName, portfolioName)
+        .getTransactionsByPortfolio(brokerName, portfolioName, scope)
         .then((result) => dispatch({ type: 'FETCH_TRANSACTIONS_SUCCESS', payload: result }))
         .catch((err: unknown) => {
           dispatch({

--- a/Tests/Financial.Api.Tests/Controllers/ControllerGuardClauseTests.cs
+++ b/Tests/Financial.Api.Tests/Controllers/ControllerGuardClauseTests.cs
@@ -122,7 +122,7 @@ public class ControllerGuardClauseTests
     {
         var controller = new TransactionsController(new StubTransactionService(), new StubTransactionQueryService());
 
-        var result = controller.GetTransactionsByBroker(" ");
+        var result = controller.GetTransactionsByBroker(" ", null);
 
         result.Result.Should().BeOfType<Microsoft.AspNetCore.Mvc.BadRequestResult>();
     }
@@ -132,7 +132,7 @@ public class ControllerGuardClauseTests
     {
         var controller = new TransactionsController(new StubTransactionService(), new StubTransactionQueryService());
 
-        var result = controller.GetTransactionsByPortfolio(" ", "Default");
+        var result = controller.GetTransactionsByPortfolio(" ", "Default", null);
 
         result.Result.Should().BeOfType<Microsoft.AspNetCore.Mvc.BadRequestResult>();
     }
@@ -142,7 +142,7 @@ public class ControllerGuardClauseTests
     {
         var controller = new TransactionsController(new StubTransactionService(), new StubTransactionQueryService());
 
-        var result = controller.GetTransactionsByPortfolio("XPI", " ");
+        var result = controller.GetTransactionsByPortfolio("XPI", " ", null);
 
         result.Result.Should().BeOfType<Microsoft.AspNetCore.Mvc.BadRequestResult>();
     }
@@ -267,8 +267,8 @@ public class ControllerGuardClauseTests
 
     private sealed class StubCreditQueryService : ICreditQueryService
     {
-        public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName) => throw new NotImplementedException();
-        public IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName) => throw new NotImplementedException();
+        public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
+        public IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
     }
 
     private sealed class StubCreditService : ICreditService
@@ -287,8 +287,8 @@ public class ControllerGuardClauseTests
 
     private sealed class StubTransactionQueryService : ITransactionQueryService
     {
-        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName) => throw new NotImplementedException();
-        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName) => throw new NotImplementedException();
+        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
+        public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active) => throw new NotImplementedException();
     }
 
     private sealed class StubDividendService : IDividendService

--- a/Tests/Financial.Api.Tests/CreditEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/CreditEndpointsTests.cs
@@ -193,4 +193,47 @@ public class CreditEndpointsTests
         asset.Should().NotBeNull();
         asset!.Credits.Should().NotContain(credit => credit.Id == creditId);
     }
+
+    [Fact]
+    public async Task GetCreditsByBroker_ScopeHistoric_ExcludesActiveAssetCredits()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        // CLOSEDASSET (Historic) has no credits, while the Active BCIA11 has two dividends
+        var response = await client.GetAsync("/api/v1/financial/credits/broker/XPI?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var credits = await response.Content.ReadFromJsonAsync<CreditDTO[]>();
+        credits.Should().NotBeNull();
+        credits.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCreditsByPortfolio_ScopeHistoric_ExcludesActivePortfolioCredits()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/credits/portfolio/XPI/Uncategorized?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var credits = await response.Content.ReadFromJsonAsync<CreditDTO[]>();
+        credits.Should().NotBeNull();
+        credits.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCreditsByPortfolio_DefaultScope_DoesNotReturnHistoricOnlyPortfolio()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/credits/portfolio/XPI/Uncategorized");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var credits = await response.Content.ReadFromJsonAsync<CreditDTO[]>();
+        credits.Should().NotBeNull();
+        credits.Should().BeEmpty();
+    }
 }

--- a/Tests/Financial.Api.Tests/TransactionEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/TransactionEndpointsTests.cs
@@ -236,4 +236,62 @@ public class TransactionEndpointsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    [Fact]
+    public async Task GetTransactionsByBroker_DefaultScope_ExcludesHistoricAssetTransactions()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/transactions/broker/XPI");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await response.Content.ReadFromJsonAsync<List<TransactionSummaryItemDTO>>();
+        items.Should().NotBeNull();
+        items!.Should().OnlyContain(i => i.AssetName == "BCIA11");
+    }
+
+    [Fact]
+    public async Task GetTransactionsByBroker_ScopeHistoric_ReturnsOnlyHistoricAssetTransactions()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/transactions/broker/XPI?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await response.Content.ReadFromJsonAsync<List<TransactionSummaryItemDTO>>();
+        items.Should().NotBeNull();
+        items!.Should().HaveCount(2);
+        items!.Should().OnlyContain(i => i.AssetName == "CLOSEDASSET");
+    }
+
+    [Fact]
+    public async Task GetTransactionsByPortfolio_ScopeHistoric_ReturnsOnlyHistoricPortfolioTransactions()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/transactions/portfolio/XPI/Uncategorized?scope=historic");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await response.Content.ReadFromJsonAsync<List<TransactionSummaryItemDTO>>();
+        items.Should().NotBeNull();
+        items!.Should().HaveCount(2);
+        items!.Should().OnlyContain(i => i.AssetName == "CLOSEDASSET");
+    }
+
+    [Fact]
+    public async Task GetTransactionsByPortfolio_DefaultScope_DoesNotReturnHistoricOnlyPortfolio()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/transactions/portfolio/XPI/Uncategorized");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await response.Content.ReadFromJsonAsync<List<TransactionSummaryItemDTO>>();
+        items.Should().NotBeNull();
+        items.Should().BeEmpty();
+    }
 }

--- a/Tests/Financial.Investment.Application.Tests/Services/CreditServiceTests.cs
+++ b/Tests/Financial.Investment.Application.Tests/Services/CreditServiceTests.cs
@@ -297,6 +297,30 @@ public class CreditServiceTests
         result.Should().BeEmpty();
     }
 
+    [Fact]
+    public void GetCreditsByBroker_DefaultsToActiveScope()
+    {
+        CreateService().GetCreditsByBroker("XPI");
+
+        _repository.LastBrokerScope.Should().Be(InvestmentScope.Active);
+    }
+
+    [Fact]
+    public void GetCreditsByBroker_ForwardsHistoricScopeToRepository()
+    {
+        CreateService().GetCreditsByBroker("XPI", InvestmentScope.Historic);
+
+        _repository.LastBrokerScope.Should().Be(InvestmentScope.Historic);
+    }
+
+    [Fact]
+    public void GetCreditsByPortfolio_ForwardsHistoricScopeToRepository()
+    {
+        CreateService().GetCreditsByPortfolio("XPI", "Default", InvestmentScope.Historic);
+
+        _repository.LastPortfolioScope.Should().Be(InvestmentScope.Historic);
+    }
+
     private CreditService CreateService() => new(_repository, new NavigationService(_repository));
 
     private static Asset MakeAsset(string name = "AAAA") =>
@@ -309,9 +333,21 @@ public class CreditServiceTests
         public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
         public IEnumerable<Broker> Brokers { get; set; } = [];
         public int SaveChangesCallCount { get; private set; }
+        public InvestmentScope? LastBrokerScope { get; private set; }
+        public InvestmentScope? LastPortfolioScope { get; private set; }
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastBrokerScope = scope;
+            return AssetsByBroker;
+        }
+
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastPortfolioScope = scope;
+            return AssetsByBrokerPortfolio;
+        }
+
         public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => Brokers;
         public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => Asset;
 

--- a/Tests/Financial.Investment.Application.Tests/Services/TransactionServiceQueryTests.cs
+++ b/Tests/Financial.Investment.Application.Tests/Services/TransactionServiceQueryTests.cs
@@ -126,6 +126,30 @@ public class TransactionServiceQueryTests
         result.Should().BeEmpty();
     }
 
+    [Fact]
+    public void GetTransactionsByBroker_DefaultsToActiveScope()
+    {
+        CreateService().GetTransactionsByBroker("XPI");
+
+        _repository.LastBrokerScope.Should().Be(InvestmentScope.Active);
+    }
+
+    [Fact]
+    public void GetTransactionsByBroker_ForwardsHistoricScopeToRepository()
+    {
+        CreateService().GetTransactionsByBroker("XPI", InvestmentScope.Historic);
+
+        _repository.LastBrokerScope.Should().Be(InvestmentScope.Historic);
+    }
+
+    [Fact]
+    public void GetTransactionsByPortfolio_ForwardsHistoricScopeToRepository()
+    {
+        CreateService().GetTransactionsByPortfolio("XPI", "Default", InvestmentScope.Historic);
+
+        _repository.LastPortfolioScope.Should().Be(InvestmentScope.Historic);
+    }
+
     [Theory]
     [InlineData(null, "Default")]
     [InlineData("", "Default")]
@@ -154,9 +178,21 @@ public class TransactionServiceQueryTests
         public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
         public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
         public IEnumerable<Broker> Brokers { get; set; } = [];
+        public InvestmentScope? LastBrokerScope { get; private set; }
+        public InvestmentScope? LastPortfolioScope { get; private set; }
 
-        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
+        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastBrokerScope = scope;
+            return AssetsByBroker;
+        }
+
+        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastPortfolioScope = scope;
+            return AssetsByBrokerPortfolio;
+        }
+
         public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => Brokers;
         public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
         public Task SaveChangesAsync() => Task.CompletedTask;

--- a/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelTransactionsChartTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/AssetDetailsViewModelTransactionsChartTests.cs
@@ -1,4 +1,5 @@
 using Financial.Investment.Application.DTOs;
+using Financial.Investment.Application.Enums;
 using Financial.Investment.Application.Interfaces;
 using Financial.Investment.Application.Services;
 using Financial.Presentation.App.Helpers;
@@ -11,7 +12,8 @@ public class AssetDetailsViewModelTransactionsChartTests
 {
     private static AssetDetailsViewModel BuildViewModel(
         IBrokerBreakdownService? brokerBreakdownService = null,
-        ITransactionQueryService? transactionQueryService = null)
+        ITransactionQueryService? transactionQueryService = null,
+        InvestmentScope scope = InvestmentScope.Active)
     {
         return new AssetDetailsViewModel(
             new StubTransactionService(),
@@ -20,7 +22,8 @@ public class AssetDetailsViewModelTransactionsChartTests
             brokerBreakdownService ?? new StubBrokerBreakdownService(),
             transactionQueryService ?? new StubTransactionQueryService(),
             new XirrCalculationService(),
-            new ProfitCalculationService());
+            new ProfitCalculationService(),
+            scope);
     }
 
     private static AssetDetailsDTO BuildAssetDetails(List<TransactionDTO> transactions) => new()
@@ -89,6 +92,39 @@ public class AssetDetailsViewModelTransactionsChartTests
 
         stub.LastPortfolioBrokerName.Should().Be("XPI");
         stub.LastPortfolioName.Should().Be("Acoes");
+    }
+
+    [Fact]
+    public async Task LoadBrokerTransactions_RequestsActiveScope()
+    {
+        var stub = new StubTransactionQueryService();
+        var vm = BuildViewModel(transactionQueryService: stub);
+
+        await vm.LoadBrokerTransactions("XPI");
+
+        stub.LastBrokerScope.Should().Be(InvestmentScope.Active);
+    }
+
+    [Fact]
+    public async Task LoadBrokerTransactions_HistoricScope_RequestsHistoricScope()
+    {
+        var stub = new StubTransactionQueryService();
+        var vm = BuildViewModel(transactionQueryService: stub, scope: InvestmentScope.Historic);
+
+        await vm.LoadBrokerTransactions("XPI");
+
+        stub.LastBrokerScope.Should().Be(InvestmentScope.Historic);
+    }
+
+    [Fact]
+    public async Task LoadPortfolioTransactions_HistoricScope_RequestsHistoricScope()
+    {
+        var stub = new StubTransactionQueryService();
+        var vm = BuildViewModel(transactionQueryService: stub, scope: InvestmentScope.Historic);
+
+        await vm.LoadPortfolioTransactions("XPI", "Acoes");
+
+        stub.LastPortfolioScope.Should().Be(InvestmentScope.Historic);
     }
 
     [Fact]

--- a/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/MainNavigationViewModelBaseTests.cs
@@ -137,6 +137,48 @@ public class MainNavigationViewModelBaseTests
     }
 
     [Fact]
+    public void SelectingBrokerNode_RequestsActiveScopeForCredits()
+    {
+        var summaryService = new StubSummaryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var creditQueryService = new StubCreditQueryService();
+        var vm = new TestableNavigationViewModel(summaryService, spy, creditQueryService: creditQueryService);
+
+        var brokerNode = BuildBrokerNode("XPI");
+        vm.SelectedNode = brokerNode;
+
+        creditQueryService.LastBrokerScope.Should().Be(InvestmentScope.Active);
+    }
+
+    [Fact]
+    public void SelectingBrokerNode_HistoricScope_RequestsHistoricScopeForCredits()
+    {
+        var summaryService = new StubSummaryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var creditQueryService = new StubCreditQueryService();
+        var vm = new TestableNavigationViewModel(summaryService, spy, scope: InvestmentScope.Historic, creditQueryService: creditQueryService);
+
+        var brokerNode = BuildBrokerNode("XPI");
+        vm.SelectedNode = brokerNode;
+
+        creditQueryService.LastBrokerScope.Should().Be(InvestmentScope.Historic);
+    }
+
+    [Fact]
+    public void SelectingPortfolioNode_HistoricScope_RequestsHistoricScopeForCredits()
+    {
+        var summaryService = new StubSummaryService();
+        var spy = new SpyAssetDetailsViewModel();
+        var creditQueryService = new StubCreditQueryService();
+        var vm = new TestableNavigationViewModel(summaryService, spy, scope: InvestmentScope.Historic, creditQueryService: creditQueryService);
+
+        var portfolioNode = BuildPortfolioNode("XPI", "FII");
+        vm.SelectedNode = portfolioNode;
+
+        creditQueryService.LastPortfolioScope.Should().Be(InvestmentScope.Historic);
+    }
+
+    [Fact]
     public void SelectingPortfolioNode_WhenMissingMetadata_ClearsDetails()
     {
         var summaryService = new StubSummaryService();
@@ -485,8 +527,9 @@ public class MainNavigationViewModelBaseTests
             SpyAssetDetailsViewModel spy,
             IPortfolioAssetSummaryService? portfolioAssetSummaryService = null,
             StubNavigationService? navigationService = null,
-            InvestmentScope scope = InvestmentScope.Active)
-            : this(navigationService ?? new StubNavigationService(), summaryService, spy, portfolioAssetSummaryService, scope)
+            InvestmentScope scope = InvestmentScope.Active,
+            ICreditQueryService? creditQueryService = null)
+            : this(navigationService ?? new StubNavigationService(), summaryService, spy, portfolioAssetSummaryService, scope, creditQueryService)
         {
         }
 
@@ -495,8 +538,9 @@ public class MainNavigationViewModelBaseTests
             ISummaryService summaryService,
             SpyAssetDetailsViewModel spy,
             IPortfolioAssetSummaryService? portfolioAssetSummaryService,
-            InvestmentScope scope)
-            : base(navigationService, new StubCreditQueryService(), summaryService, portfolioAssetSummaryService ?? new StubPortfolioAssetSummaryService(), spy, scope)
+            InvestmentScope scope,
+            ICreditQueryService? creditQueryService)
+            : base(navigationService, creditQueryService ?? new StubCreditQueryService(), summaryService, portfolioAssetSummaryService ?? new StubPortfolioAssetSummaryService(), spy, scope)
         {
             NavigationService = navigationService;
         }
@@ -637,7 +681,19 @@ public class MainNavigationViewModelBaseTests
 
     private sealed class StubCreditQueryService : ICreditQueryService
     {
-        public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName) => [];
-        public IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName) => [];
+        public InvestmentScope? LastBrokerScope { get; private set; }
+        public InvestmentScope? LastPortfolioScope { get; private set; }
+
+        public IReadOnlyList<CreditDTO> GetCreditsByBroker(string brokerName, InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastBrokerScope = scope;
+            return [];
+        }
+
+        public IReadOnlyList<CreditDTO> GetCreditsByPortfolio(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active)
+        {
+            LastPortfolioScope = scope;
+            return [];
+        }
     }
 }

--- a/Tests/Financial.Presentation.Tests/ViewModels/TestStubs.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/TestStubs.cs
@@ -52,18 +52,22 @@ internal sealed class StubTransactionQueryService : ITransactionQueryService
     public string? LastBrokerName { get; private set; }
     public string? LastPortfolioBrokerName { get; private set; }
     public string? LastPortfolioName { get; private set; }
+    public InvestmentScope? LastBrokerScope { get; private set; }
+    public InvestmentScope? LastPortfolioScope { get; private set; }
 
-    public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName)
+    public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByBroker(string brokerName, InvestmentScope scope = InvestmentScope.Active)
     {
         LastBrokerName = brokerName;
+        LastBrokerScope = scope;
         if (ExceptionToThrow != null) throw ExceptionToThrow;
         return BrokerTransactions;
     }
 
-    public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName)
+    public IReadOnlyList<TransactionSummaryItemDTO> GetTransactionsByPortfolio(string brokerName, string portfolioName, InvestmentScope scope = InvestmentScope.Active)
     {
         LastPortfolioBrokerName = brokerName;
         LastPortfolioName = portfolioName;
+        LastPortfolioScope = scope;
         if (ExceptionToThrow != null) throw ExceptionToThrow;
         return PortfolioTransactions;
     }


### PR DESCRIPTION
## Summary
- Transactions and Credits for a selected Broker or Portfolio were global to Active vs Historic: they used the broker/portfolio *name* correctly but always resolved against the **Active** broker tree, silently ignoring the requested scope. Viewing a Historic broker/portfolio's Transactions/Credits tab could show the wrong data (or nothing) instead of that broker/portfolio's own historic records.
- Root cause: `ITransactionQueryService`/`ICreditQueryService` (and their `TransactionService`/`CreditService` implementations, controllers, Web API client/hooks, and WPF view models) never threaded the existing `InvestmentScope` (Active/Historic) parameter through — unlike `ISummaryService`/`SummaryController`, which already did this correctly.
- Fix mirrors the existing, working `Summary` pattern end-to-end:
  - `ITransactionQueryService` / `ICreditQueryService`: added `InvestmentScope scope = InvestmentScope.Active` parameter.
  - `TransactionService` / `CreditService`: forward `scope` to `IRepository.GetAssetsByBroker`/`GetAssetsByBrokerPortfolio` (Infrastructure already supported scope — no change needed there).
  - `TransactionsController` / `CreditsController`: accept `[FromQuery] string? scope`, parsed via the existing `InvestmentScopeParser`.
  - Web (`financialApiClient.ts`, `useTransactions.ts`, `useCredits.ts`): the `scope` already read from `SelectedNodeContext` is now passed to the Broker/Portfolio API calls (it was already correctly passed for the Asset-level call).
  - WPF (`AssetDetailsViewModel`, `MainNavigationViewModelBase`): the existing `_scope` field is now passed to the Broker/Portfolio transaction/credit query calls.
- No Domain or Infrastructure changes were required.

## Test plan
- [x] Unit tests (Application): `TransactionServiceQueryTests`, `CreditServiceTests` — verify the requested scope is forwarded to the repository (defaults to Active, forwards Historic).
- [x] Integration tests (API): `TransactionEndpointsTests`, `CreditEndpointsTests` — new tests using the fixture's `XPI` broker (which has different assets Active vs Historic) prove `?scope=historic` returns only the historic asset's records and default/`active` excludes them.
- [x] WPF tests: `AssetDetailsViewModelTransactionsChartTests`, `MainNavigationViewModelBaseTests` — verify `_scope` reaches the transaction/credit query services for both Broker and Portfolio selection.
- [x] Web tests: `useTransactions.test.ts`, `useCredits.test.ts` — updated/added assertions that `scope` is passed to `getTransactionsByBroker/Portfolio` and `getCreditsByBroker/Portfolio`.
- [x] Full suites green: 257 Application, 187 API, 160 Infrastructure, 236 Presentation (WPF), 643 frontend (vitest); `tsc -b --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)