### PR TITLE
fix(cashflow-import): treat column E "X"/"x" as a credit-card marker, not a Barclays payment

### DIFF
--- a/Integrations/CashFlowSpreadsheetImport/SheetImporters/MonthlyExpenseSheetImporter.cs
+++ b/Integrations/CashFlowSpreadsheetImport/SheetImporters/MonthlyExpenseSheetImporter.cs
@@ -13,12 +13,15 @@ namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowSpreadsheetImpo
 /// used, so no <see cref="Expense.CardTag"/> is set for them (see F10's spec.md). For the months
 /// listed in <see cref="MonthsWithFixedCardSections"/>, the source spreadsheet instead groups
 /// card charges into sections that each start at a known row number (see
-/// <see cref="CardSectionStartRows"/>), so rows in those months are tagged by row position - but
-/// only when column E has no explicit "T"/"C" payment-source tag, which still takes precedence
-/// when present (column E never identifies a card; an explicit tag means the row was paid
-/// directly from that bank). A row that does resolve a card tag imports as an unsettled
-/// credit card charge - <see cref="Expense.PaymentSource"/> stays null - and settlement is
-/// applied afterward in-app by marking the card statement paid, never inferred by the import.
+/// <see cref="CardSectionStartRows"/>), so rows in those months are tagged by row position when
+/// column E is blank or carries the "X"/"x" credit-card marker - "X" confirms the row belongs to
+/// the card section it falls in, it never names a specific card. An explicit "T"/"C" tag still
+/// takes precedence over row position (it means the row was paid directly from that bank, not a
+/// card). A row that does resolve a card tag imports as an unsettled credit card charge -
+/// <see cref="Expense.PaymentSource"/> stays null - and settlement is applied afterward in-app by
+/// marking the card statement paid, never inferred by the import. If "X" can't be matched to a
+/// card section (row/month falls outside every known section), the row is flagged and skipped
+/// rather than defaulting to the Barclays bank payment source blank rows fall back to.
 /// </summary>
 public static class MonthlyExpenseSheetImporter
 {
@@ -98,6 +101,15 @@ public static class MonthlyExpenseSheetImporter
             var description = sheet.Cell(row, descriptionColumn).GetString();
             var rawPaymentSourceTag = sheet.Cell(row, PaymentSourceColumn).GetString();
             var cardTag = ResolveCardTag(row, year, month, rawPaymentSourceTag);
+
+            if (cardTag is null && IsCreditCardMarker(rawPaymentSourceTag))
+            {
+                report.RowFlagged(
+                    sheet.Name, row, "PaymentSource", rawPaymentSourceTag,
+                    "Credit card marker (\"X\") could not be matched to a card section - expense not imported");
+                continue;
+            }
+
             string? paymentSource = cardTag is null ? ResolvePaymentSource(rawPaymentSourceTag) : null;
 
             expenses.Add(Expense.Create(date, description, value.Value, category, paymentSource, cardTag));
@@ -135,7 +147,8 @@ public static class MonthlyExpenseSheetImporter
 
     private static CreditCard? ResolveCardTag(int row, int year, int month, string? rawPaymentSourceTag)
     {
-        if (!string.IsNullOrWhiteSpace(rawPaymentSourceTag))
+        var isCardSectionEligible = string.IsNullOrWhiteSpace(rawPaymentSourceTag) || IsCreditCardMarker(rawPaymentSourceTag);
+        if (!isCardSectionEligible)
         {
             return null;
         }
@@ -156,4 +169,7 @@ public static class MonthlyExpenseSheetImporter
 
         return cardTag;
     }
+
+    private static bool IsCreditCardMarker(string? tag) =>
+        string.Equals(tag?.Trim(), "X", StringComparison.OrdinalIgnoreCase);
 }

--- a/Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/MonthlyExpenseSheetImporterTests.cs
+++ b/Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/MonthlyExpenseSheetImporterTests.cs
@@ -262,6 +262,61 @@ public class MonthlyExpenseSheetImporterTests
         expenses.Should().ContainSingle().Which.CardTag.Should().BeNull();
     }
 
+    [Theory]
+    [InlineData("X")]
+    [InlineData("x")]
+    [InlineData(" X ")]
+    public void Import_FixedCardSectionMonth_CreditCardMarkerTag_SetsCardTagByRowPositionNotBarclays(string tag)
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Jul2026");
+        WriteExpenseRow(sheet, row: 150, paymentSourceTag: tag);
+
+        var report = new ImportReport();
+
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, report);
+
+        var expense = expenses.Should().ContainSingle().Which;
+        expense.CardTag.Should().Be(CreditCard.BarclaysPlatinumVisa6007);
+        expense.PaymentSource.Should().BeNull();
+        expense.PaymentStatus.Should().Be(ExpensePaymentStatus.CreditCardCharge);
+        report.RowIssues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Import_FixedCardSectionMonth_CreditCardMarkerTagOutsideAnyCardSection_FlagsRowAndDoesNotImportAsBarclays()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Jul2026");
+        // Row 50 is before the first card section (BarclaysPlatinumVisa8003StartRow = 129), so an
+        // "X" here can't be matched to any card - it must not silently fall back to Barclays.
+        WriteExpenseRow(sheet, row: 50, paymentSourceTag: "X");
+
+        var report = new ImportReport();
+
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, report);
+
+        expenses.Should().BeEmpty();
+        report.RowIssues.Should().ContainSingle(i => i.SheetName == "Jul2026" && i.RawValue == "X");
+    }
+
+    [Theory]
+    [InlineData(2017, 10)]
+    [InlineData(2026, 9)]
+    public void Import_MonthOutsideFixedCardSectionScope_CreditCardMarkerTag_FlagsRowAndDoesNotImportAsBarclays(int year, int month)
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet($"Sheet{year}{month}");
+        WriteExpenseRow(sheet, row: 129, paymentSourceTag: "X");
+
+        var report = new ImportReport();
+
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, year, month, report);
+
+        expenses.Should().BeEmpty();
+        report.RowIssues.Should().ContainSingle(i => i.RawValue == "X");
+    }
+
     private static void WriteExpenseRow(IXLWorksheet sheet, int row, string? paymentSourceTag)
     {
         sheet.Cell(1, 1).Value = "Dia";


### PR DESCRIPTION
## Summary
- In `MonthlyExpenseSheetImporter`, any non-blank column-E tag bailed out of card-tag resolution (`ResolveCardTag`) and fell through to `ResolvePaymentSource`'s default case, so an `"X"`/`"x"` marker was silently imported as an immediate **Barclays** bank payment instead of an unsettled credit-card charge.
- Fix: `"X"`/`"x"` (case-insensitive) is now treated the same as a blank column-E cell for card-tag resolution — it resolves the specific card by the row's position within the known fixed card sections (`BarclaysPlatinumVisa8003`/`6007`, `ChaseMaster4023`, `BaAmex`), exactly like blank already does. An explicit `"T"`/`"C"` tag still takes precedence and means a direct bank payment, unaffected by this change.
- Safety net: if `"X"` can't be matched to any card section (row/month outside the known fixed sections), the row is flagged and skipped — same pattern already used for an unrecognized category — rather than silently defaulting to Barclays.
- No Domain changes: `CreditCard`/`Expense` were untouched; this is purely an Infrastructure-layer parsing fix.

## Test plan
- [x] New tests in `MonthlyExpenseSheetImporterTests`:
  - `"X"`/`"x"`/`" X "` in a known card-section row resolves the correct `CreditCard`, `PaymentSource` stays null, and `PaymentStatus` is `CreditCardCharge` (not Barclays).
  - `"X"` outside any card section (row before the first section, or a month without fixed sections) is flagged and the expense is skipped, never defaulting to Barclays.
- [x] Full suite green: 138/138 in `Financial.CashFlowSpreadsheetImport.Tests`, including all pre-existing blank/"T"/"C" and fixed-section-precedence tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)