### PR TITLE
fix(cashflow): Annual Summary average excludes zero months and open-year in-progress month

### DIFF
--- a/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
+++ b/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
@@ -308,25 +308,38 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
 
     private Dictionary<int, List<IncomeAverageDTO>> GetAnnualAverageIncomeByGroupIncome(int year)
     {
-        var monthlySumByIncomeSource = _repository.GetIncomes()
+        var relevantIncomes = _repository.GetIncomes()
             .Where(e => e.Date.Year <= year && e.Date < new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1))
-            .GroupBy(e => new { e.Date.Year, e.Date.Month, IncomeGroup = GetIncomeGroup(e.IncomeSource) })
-            .Select(g => new
+            .ToList();
+
+        return relevantIncomes
+            .Select(e => e.Date.Year)
+            .Distinct()
+            .ToDictionary(incomeYear => incomeYear, incomeYear =>
             {
-                Key = (g.Key.Year, g.Key.Month, g.Key.IncomeGroup),
-                GrossSumValue = g.Sum(e => e.GrossValue ?? 0m),
-                NetSumValue = g.Sum(e => e.NetValue)
-            }).ToList();
-        var averageExpenseByYear = monthlySumByIncomeSource
-            .GroupBy(e => e.Key.Year)
-            .ToDictionary(g => g.Key, g => g.GroupBy(e => e.Key.IncomeGroup)
-                .Select(a => new IncomeAverageDTO
-                {
-                    IncomeGroup = a.Key,
-                    GrossAverageValue = Math.Round(a.Average(e => e.GrossSumValue), AverageDecimalPlaces),
-                    NetAverageValue = Math.Round(a.Average(e => e.NetSumValue), AverageDecimalPlaces)
-                }).ToList());
-        return averageExpenseByYear;
+                var monthsToAverage = GetMonthsToAverage(incomeYear);
+                return relevantIncomes
+                    .Where(e => e.Date.Year == incomeYear)
+                    .GroupBy(e => GetIncomeGroup(e.IncomeSource))
+                    .Select(incomeGroup =>
+                    {
+                        var grossMonthly = new decimal[MonthsInYear];
+                        var netMonthly = new decimal[MonthsInYear];
+                        foreach (var income in incomeGroup)
+                        {
+                            grossMonthly[income.Date.Month - 1] += income.GrossValue ?? 0m;
+                            netMonthly[income.Date.Month - 1] += income.NetValue;
+                        }
+
+                        return new IncomeAverageDTO
+                        {
+                            IncomeGroup = incomeGroup.Key,
+                            GrossAverageValue = Math.Round(AverageOverMonths(grossMonthly, monthsToAverage), AverageDecimalPlaces),
+                            NetAverageValue = Math.Round(AverageOverMonths(netMonthly, monthsToAverage), AverageDecimalPlaces)
+                        };
+                    })
+                    .ToList();
+            });
     }
 
     private static string GetIncomeGroup(IncomeSource incomeSource) =>
@@ -336,32 +349,55 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
 
     private IList<CategoryAnnualAverageDTO> GetHistoricCategoriesAverageFromYear(int year)
     {
-        var monthlySumByCategory = _repository.GetExpenses()
+        var relevantExpenses = _repository.GetExpenses()
             .Where(e => e.Date.Year <= year && e.Date < new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1))
-            .GroupBy(e => (e.Date.Year, e.Date.Month, e.Category))
-            .Select(g => new
+            .ToList();
+
+        return relevantExpenses
+            .Select(e => e.Date.Year)
+            .Distinct()
+            .OrderByDescending(expenseYear => expenseYear)
+            .Select(expenseYear =>
             {
-                Key = (g.Key.Year, g.Key.Month, g.Key.Category),
-                Sum = g.Sum(e => e.Value)
-            });
-        var averageExpenseByYear = monthlySumByCategory
-            .GroupBy(g => g.Key.Year)
-            .Select(yearGroup => new CategoryAnnualAverageDTO
-            {
-                Year = yearGroup.Key,
-                AnnualAverages =
-                [
-                    .. yearGroup
-                    .GroupBy(g => g.Key.Category)
-                    .Select(categoryGroup => new CategoryAverageDTO
-                    {
-                        Category = categoryGroup.Key.ToString(),
-                        Average = Math.Round(categoryGroup.Average(monthGroup => monthGroup.Sum), AverageDecimalPlaces)
-                    })
-                ]
-            });
-        return [.. averageExpenseByYear.OrderByDescending(a => a.Year)];
+                var monthsToAverage = GetMonthsToAverage(expenseYear);
+                return new CategoryAnnualAverageDTO
+                {
+                    Year = expenseYear,
+                    AnnualAverages = relevantExpenses
+                        .Where(e => e.Date.Year == expenseYear)
+                        .GroupBy(e => e.Category)
+                        .Select(categoryGroup =>
+                        {
+                            var monthlyTotals = new decimal[MonthsInYear];
+                            foreach (var expense in categoryGroup)
+                            {
+                                monthlyTotals[expense.Date.Month - 1] += expense.Value;
+                            }
+
+                            return new CategoryAverageDTO
+                            {
+                                Category = categoryGroup.Key.ToString(),
+                                Average = Math.Round(AverageOverMonths(monthlyTotals, monthsToAverage), AverageDecimalPlaces)
+                            };
+                        })
+                        .ToList()
+                };
+            })
+            .ToList();
     }
+
+    // A closed/past year always averages over all 12 calendar months - a month with no recorded
+    // movement still counts as a real elapsed month, matching the source spreadsheet's own
+    // AVERAGE(B:M) over always-filled cells. The current calendar year instead only averages over
+    // its fully completed months (current month - 1): the in-progress month is excluded entirely
+    // (never treated as a completed zero month), and a future year has no completed months at all.
+    private static int GetMonthsToAverage(int year) =>
+        year < DateTime.Now.Year ? MonthsInYear
+        : year == DateTime.Now.Year ? DateTime.Now.Month - 1
+        : 0;
+
+    private static decimal AverageOverMonths(decimal[] monthlyTotals, int monthsToAverage) =>
+        monthsToAverage == 0 ? 0m : monthlyTotals.Take(monthsToAverage).Sum() / monthsToAverage;
 
     private static decimal?[] ComputeDiffs(decimal[] monthlyValues, decimal? januaryDiff)
     {

--- a/Financial.Web/src/pages/AnnualSummaryPage.tsx
+++ b/Financial.Web/src/pages/AnnualSummaryPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, type ReactNode } from 'react'
+import { Fragment, useMemo, useState, type ReactNode } from 'react'
 import ErrorState from '../components/ErrorState'
 import LoadingState from '../components/LoadingState'
 import { useAnnualSummary } from '../hooks/useAnnualSummary'
@@ -21,11 +21,13 @@ function AnnualSummaryRow({
   label,
   monthlyValues,
   annualTotal,
+  monthsElapsed,
   emphasized = false,
 }: {
   label: string
   monthlyValues: number[]
   annualTotal: number
+  monthsElapsed?: number
   emphasized?: boolean
 }) {
   const cell = (content: ReactNode) => (emphasized ? <strong>{content}</strong> : content)
@@ -38,13 +40,20 @@ function AnnualSummaryRow({
         </td>
       ))}
       <td className="data-table__col--numeric">
-        <strong>{formatN2(average(monthlyValues))}</strong>
+        <strong>{formatN2(average(monthlyValues, monthsElapsed))}</strong>
       </td>
       <td className="data-table__col--numeric">
         <strong>{formatN2(annualTotal)}</strong>
       </td>
     </tr>
   )
+}
+
+function getMonthsElapsed(year: number): number | undefined {
+  const now = new Date()
+  if (year < now.getFullYear()) return undefined
+  if (year > now.getFullYear()) return 0
+  return now.getMonth()
 }
 
 
@@ -89,6 +98,7 @@ export default function AnnualSummaryPage() {
   } = useAnnualSummary()
 
   const [activeTab, setActiveTab] = useState<AnnualSummaryTabId>('categoryTotals')
+  const monthsElapsed = useMemo(() => getMonthsElapsed(year), [year])
   const HISTORIC_SUMMARY_AVERAGE_SPACER_AFTER = new Set(['Tax difference', 'Dividendo/Juros', 'Reserva'])
   const HISTORIC_SUMMARY_AVERAGE_EMPHASIZED = new Set(['Resultado (R-D-Inv)', 'Total despesas'])
 
@@ -146,16 +156,19 @@ export default function AnnualSummaryPage() {
                         label="Salary"
                         monthlyValues={incomeSummary.salaryMonthly}
                         annualTotal={incomeSummary.salaryAnnualTotal}
+                        monthsElapsed={monthsElapsed}
                       />
                       <AnnualSummaryRow
                         label="Salary after taxes"
                         monthlyValues={incomeSummary.salaryAfterTaxesMonthly}
                         annualTotal={incomeSummary.salaryAfterTaxesAnnualTotal}
+                        monthsElapsed={monthsElapsed}
                       />
                       <AnnualSummaryRow
                         label="Tax difference"
                         monthlyValues={incomeSummary.taxDifferenceMonthly}
                         annualTotal={incomeSummary.taxDifferenceAnnualTotal}
+                        monthsElapsed={monthsElapsed}
                       />
                       <tr>
                         <td colSpan={SPACER_COL_SPAN} />
@@ -164,6 +177,7 @@ export default function AnnualSummaryPage() {
                         label="Dividendo/Juros"
                         monthlyValues={incomeSummary.dividendoJurosMonthly}
                         annualTotal={incomeSummary.dividendoJurosAnnualTotal}
+                        monthsElapsed={monthsElapsed}
                       />
                     </>
                   )}
@@ -173,7 +187,13 @@ export default function AnnualSummaryPage() {
                   </tr>
 
                   {categoryTotals.map((c) => (
-                    <AnnualSummaryRow key={c.category} label={c.category} monthlyValues={c.monthlyTotals} annualTotal={c.annualTotal} />
+                    <AnnualSummaryRow
+                      key={c.category}
+                      label={c.category}
+                      monthlyValues={c.monthlyTotals}
+                      annualTotal={c.annualTotal}
+                      monthsElapsed={monthsElapsed}
+                    />
                   ))}
 
                   <tr>
@@ -185,6 +205,7 @@ export default function AnnualSummaryPage() {
                       label="Resultado (R-D-Inv)"
                       monthlyValues={resultadoMonthly}
                       annualTotal={resultadoAnnualTotal}
+                      monthsElapsed={monthsElapsed}
                       emphasized
                     />
                   )}
@@ -192,6 +213,7 @@ export default function AnnualSummaryPage() {
                     label="Total despesas"
                     monthlyValues={totalDespesasMonthly}
                     annualTotal={totalDespesasAnnualTotal}
+                    monthsElapsed={monthsElapsed}
                     emphasized
                   />
                 </tbody>

--- a/Financial.Web/src/pages/__tests__/AnnualSummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/AnnualSummaryPage.test.tsx
@@ -194,7 +194,7 @@ describe('AnnualSummaryPage', () => {
     })
   })
 
-  it('excludes zero-value months from the Average for a past year, for both category and income rows', async () => {
+  it('divides the Average by 12 for a past year even when some months are 0, for both category and income rows', async () => {
     getCategoryTotalsForYearMock.mockResolvedValue([
       { category: 'Mercado', monthlyTotals: [100, 100, 100, 100, 0, 0, 0, 0, 0, 0, 0, 0], annualTotal: 400 },
     ])
@@ -203,20 +203,20 @@ describe('AnnualSummaryPage', () => {
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
     fireEvent.change(screen.getByLabelText('Year'), { target: { value: '2020' } })
 
-    // Mercado: 400 / 4 non-zero months = 100.00 (not 400 / 12 = 33.33). The Average column is the
-    // second-to-last cell (last is Annual Total); several monthly cells also happen to read "100.00"
-    // so the column is located by position rather than by text.
+    // Mercado: 400 / 12 calendar months = 33.33 (not / 4 non-zero months = 100.00). The Average
+    // column is the second-to-last cell (last is Annual Total); several monthly cells also happen
+    // to read "100.00" so the column is located by position rather than by text.
     await waitFor(() => {
       const mercadoRow = screen.getByRole('cell', { name: 'Mercado' }).closest('tr')!
       const cells = within(mercadoRow).getAllByRole('cell')
-      expect(cells[cells.length - 2].textContent).toBe('100.00')
+      expect(cells[cells.length - 2].textContent).toBe('33.33')
     })
 
     // Dividendo/Juros (from the shared INCOME_SUMMARY fixture): [0,0,15.5,0,0,0,0,0,0,0,0,4.5]
-    // sums to 20 over 2 non-zero months = 10.00 (not 20 / 12 = 1.67)
+    // sums to 20 over 12 calendar months = 1.67 (not / 2 non-zero months = 10.00)
     const dividendoRow = screen.getByRole('cell', { name: 'Dividendo/Juros' }).closest('tr')!
     const dividendoCells = within(dividendoRow).getAllByRole('cell')
-    expect(dividendoCells[dividendoCells.length - 2].textContent).toBe('10.00')
+    expect(dividendoCells[dividendoCells.length - 2].textContent).toBe('1.67')
   })
 
   it('averages the current (open) year over only the completed months, ignoring the in-progress month and any zero completed months', async () => {

--- a/Financial.Web/src/pages/__tests__/AnnualSummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/AnnualSummaryPage.test.tsx
@@ -186,9 +186,66 @@ describe('AnnualSummaryPage', () => {
     expect(averageIndex).toBe(decIndex + 1)
     expect(annualTotalIndex).toBe(averageIndex + 1)
 
-    // Mercado average = 1860 / 12 = 155.00
-    const mercadoRow = screen.getByRole('cell', { name: 'Mercado' }).closest('tr')!
-    expect(within(mercadoRow).getByText('155.00')).toBeInTheDocument()
+    // A past (fully closed) year with all 12 months non-zero: Mercado average = 1860 / 12 = 155.00
+    fireEvent.change(screen.getByLabelText('Year'), { target: { value: '2020' } })
+    await waitFor(() => {
+      const mercadoRow = screen.getByRole('cell', { name: 'Mercado' }).closest('tr')!
+      expect(within(mercadoRow).getByText('155.00')).toBeInTheDocument()
+    })
+  })
+
+  it('excludes zero-value months from the Average for a past year, for both category and income rows', async () => {
+    getCategoryTotalsForYearMock.mockResolvedValue([
+      { category: 'Mercado', monthlyTotals: [100, 100, 100, 100, 0, 0, 0, 0, 0, 0, 0, 0], annualTotal: 400 },
+    ])
+    render(<AnnualSummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    fireEvent.change(screen.getByLabelText('Year'), { target: { value: '2020' } })
+
+    // Mercado: 400 / 4 non-zero months = 100.00 (not 400 / 12 = 33.33). The Average column is the
+    // second-to-last cell (last is Annual Total); several monthly cells also happen to read "100.00"
+    // so the column is located by position rather than by text.
+    await waitFor(() => {
+      const mercadoRow = screen.getByRole('cell', { name: 'Mercado' }).closest('tr')!
+      const cells = within(mercadoRow).getAllByRole('cell')
+      expect(cells[cells.length - 2].textContent).toBe('100.00')
+    })
+
+    // Dividendo/Juros (from the shared INCOME_SUMMARY fixture): [0,0,15.5,0,0,0,0,0,0,0,0,4.5]
+    // sums to 20 over 2 non-zero months = 10.00 (not 20 / 12 = 1.67)
+    const dividendoRow = screen.getByRole('cell', { name: 'Dividendo/Juros' }).closest('tr')!
+    const dividendoCells = within(dividendoRow).getAllByRole('cell')
+    expect(dividendoCells[dividendoCells.length - 2].textContent).toBe('10.00')
+  })
+
+  it('averages the current (open) year over only the completed months, ignoring the in-progress month and any zero completed months', async () => {
+    const now = new Date()
+    const currentYear = now.getFullYear()
+    const monthsElapsed = now.getMonth()
+
+    // First `monthsElapsed` entries are completed months (one deliberately 0 - still counted, unlike
+    // a past year where a 0 month would be excluded); everything from index `monthsElapsed` onward
+    // (the in-progress current month and any real future months) must be ignored entirely.
+    const monthlyTotals: number[] = Array.from({ length: 12 }, (_, i) =>
+      i >= monthsElapsed ? 9999 : i === 0 ? 0 : 100,
+    )
+    const expectedSum = monthlyTotals.slice(0, monthsElapsed).reduce((a, b) => a + b, 0)
+    const expectedAverage = monthsElapsed === 0 ? 0 : expectedSum / monthsElapsed
+
+    getCategoryTotalsForYearMock.mockResolvedValue([
+      { category: 'Mercado', monthlyTotals, annualTotal: monthlyTotals.reduce((a, b) => a + b, 0) },
+    ])
+    render(<AnnualSummaryPage />)
+
+    await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
+    fireEvent.change(screen.getByLabelText('Year'), { target: { value: String(currentYear) } })
+
+    await waitFor(() => {
+      const mercadoRow = screen.getByRole('cell', { name: 'Mercado' }).closest('tr')!
+      const cells = within(mercadoRow).getAllByRole('cell')
+      expect(cells[cells.length - 2].textContent).toBe(expectedAverage.toFixed(2))
+    })
   })
 
   it('computes Resultado and Total despesas from already-fetched data and renders them with emphasized styling', async () => {

--- a/Financial.Web/src/utils/math.test.ts
+++ b/Financial.Web/src/utils/math.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from 'vitest'
 import { average } from './math'
 
 describe('average', () => {
-  it('divides by the count of non-zero months when monthsElapsed is not provided', () => {
-    // 400 spread over 4 non-zero months = 100, not 400 / 12 = 33.33
+  it('divides by 12 (values.length) even when some months are 0, when monthsElapsed is not provided', () => {
+    // A closed year always averages over all 12 calendar months, matching the source spreadsheet's
+    // AVERAGE(B:M) over always-filled cells: 400 / 12 = 33.33, not / 4 non-zero months = 100.
     const values = [100, 100, 100, 100, 0, 0, 0, 0, 0, 0, 0, 0]
-    expect(average(values)).toBe(100)
+    expect(average(values)).toBeCloseTo(33.33, 2)
   })
 
-  it('divides by 12 when all 12 months are non-zero (matches the old fixed-12 behavior)', () => {
+  it('divides by 12 when all 12 months are non-zero', () => {
     const values = [100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210]
     expect(average(values)).toBe(155)
   })

--- a/Financial.Web/src/utils/math.test.ts
+++ b/Financial.Web/src/utils/math.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { average } from './math'
+
+describe('average', () => {
+  it('divides by the count of non-zero months when monthsElapsed is not provided', () => {
+    // 400 spread over 4 non-zero months = 100, not 400 / 12 = 33.33
+    const values = [100, 100, 100, 100, 0, 0, 0, 0, 0, 0, 0, 0]
+    expect(average(values)).toBe(100)
+  })
+
+  it('divides by 12 when all 12 months are non-zero (matches the old fixed-12 behavior)', () => {
+    const values = [100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210]
+    expect(average(values)).toBe(155)
+  })
+
+  it('returns 0 when every month is 0 and monthsElapsed is not provided', () => {
+    expect(average(new Array(12).fill(0))).toBe(0)
+  })
+
+  it('divides by monthsElapsed and only sums the completed months when provided', () => {
+    // Only the first 3 entries (completed months) count; the rest (in-progress/future) are ignored
+    // even though they carry a non-zero value.
+    const values = [100, 0, 200, 9999, 9999, 9999, 9999, 9999, 9999, 9999, 9999, 9999]
+    expect(average(values, 3)).toBe(100)
+  })
+
+  it('counts a zero completed month in the divisor when monthsElapsed is provided (unlike the past-year fallback)', () => {
+    const values = [100, 0, 200, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    // (100 + 0 + 200) / 3 completed months = 100, not / 2 non-zero months = 150
+    expect(average(values, 3)).toBe(100)
+  })
+
+  it('returns 0 when monthsElapsed is 0 (no completed months yet)', () => {
+    const values = [9999, 9999, 9999, 9999, 9999, 9999, 9999, 9999, 9999, 9999, 9999, 9999]
+    expect(average(values, 0)).toBe(0)
+  })
+})

--- a/Financial.Web/src/utils/math.ts
+++ b/Financial.Web/src/utils/math.ts
@@ -1,5 +1,5 @@
 export function average(values: number[], monthsElapsed?: number): number {
-  const completedValues = monthsElapsed === undefined ? values : values.slice(0, monthsElapsed)
-  const divisor = monthsElapsed ?? completedValues.filter((v) => v !== 0).length
-  return divisor === 0 ? 0 : completedValues.reduce((sum, v) => sum + v, 0) / divisor
+  const relevantValues = monthsElapsed === undefined ? values : values.slice(0, monthsElapsed)
+  const divisor = monthsElapsed ?? relevantValues.length
+  return divisor === 0 ? 0 : relevantValues.reduce((sum, v) => sum + v, 0) / divisor
 }

--- a/Financial.Web/src/utils/math.ts
+++ b/Financial.Web/src/utils/math.ts
@@ -1,3 +1,5 @@
-export function average(values: number[]): number {
-  return values.reduce((sum, v) => sum + v, 0) / values.length
+export function average(values: number[], monthsElapsed?: number): number {
+  const completedValues = monthsElapsed === undefined ? values : values.slice(0, monthsElapsed)
+  const divisor = monthsElapsed ?? completedValues.filter((v) => v !== 0).length
+  return divisor === 0 ? 0 : completedValues.reduce((sum, v) => sum + v, 0) / divisor
 }

--- a/Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs
@@ -120,12 +120,18 @@ public class AnnualSummaryEndpointsTests
     [Fact]
     public async Task GetHistoricSummaryAverages_MergesIncomeIntoMatchingYearAndOmitsItFromYearsWithoutIncome()
     {
+        // Both years are definitively closed (well before the real current year), so the average
+        // always divides by all 12 calendar months regardless of which day this test happens to run.
+        var currentYear = DateTime.UtcNow.Year;
+        var yearA = currentYear - 10;
+        var yearB = yearA - 1;
+
         await using var factory = new ApiTestFactory();
         using var client = factory.CreateClient();
         await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
         {
-            Date = new DateOnly(2025, 6, 5),
-            Description = "2025 groceries",
+            Date = new DateOnly(yearB, 6, 5),
+            Description = "yearB groceries",
             Value = 120m,
             Category = "Mercado",
             PaymentSource = "Barclays",
@@ -133,7 +139,7 @@ public class AnnualSummaryEndpointsTests
         });
         await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
         {
-            Date = new DateOnly(2026, 1, 5),
+            Date = new DateOnly(yearA, 1, 5),
             Description = "January groceries",
             Value = 100m,
             Category = "Mercado",
@@ -142,7 +148,7 @@ public class AnnualSummaryEndpointsTests
         });
         await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
         {
-            Date = new DateOnly(2026, 3, 5),
+            Date = new DateOnly(yearA, 3, 5),
             Description = "March groceries",
             Value = 50m,
             Category = "Mercado",
@@ -151,7 +157,7 @@ public class AnnualSummaryEndpointsTests
         });
         await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
         {
-            Date = new DateOnly(2026, 1, 1),
+            Date = new DateOnly(yearA, 1, 1),
             IncomeSource = "Gleison",
             GrossValue = 3200m,
             NetValue = 2450m,
@@ -159,7 +165,7 @@ public class AnnualSummaryEndpointsTests
         });
         await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
         {
-            Date = new DateOnly(2026, 1, 8),
+            Date = new DateOnly(yearA, 1, 8),
             IncomeSource = "Ariana",
             GrossValue = 400m,
             NetValue = 350m,
@@ -167,31 +173,32 @@ public class AnnualSummaryEndpointsTests
         });
         await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
         {
-            Date = new DateOnly(2026, 3, 1),
+            Date = new DateOnly(yearA, 3, 1),
             IncomeSource = "DividendoJuros",
             GrossValue = null,
             NetValue = 15.50m,
             Bank = "Trading212"
         });
 
-        var response = await client.GetAsync("/api/v1/financial/annual-summary/2026/historic-summary-averages");
+        var response = await client.GetAsync($"/api/v1/financial/annual-summary/{yearA}/historic-summary-averages");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var result = await response.Content.ReadFromJsonAsync<List<CategoryAnnualAverageDTO>>();
         result.Should().HaveCount(2);
-        result![0].Year.Should().Be(2026);
-        result[1].Year.Should().Be(2025);
+        result![0].Year.Should().Be(yearA);
+        result[1].Year.Should().Be(yearB);
 
-        // 2026: Mercado's two recorded months (Jan 100 + Mar 50) average to 75; income is combined
-        // (Gleison + Ariana) per month before averaging, over the single recorded month each.
-        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Mercado" && a.Average == 75m);
-        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Salary" && a.Average == 3600m);
-        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Salary after taxes" && a.Average == 2800m);
-        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Tax difference" && a.Average == 800m);
-        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Dividendo/Juros" && a.Average == 15.50m);
+        // yearA: Mercado's two recorded months (Jan 100 + Mar 50 = 150) still average over all 12
+        // calendar months (12.50), not just the 2 active ones; income is combined (Gleison + Ariana)
+        // per month before averaging, likewise over all 12 months.
+        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Mercado" && a.Average == 12.50m);
+        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Salary" && a.Average == 300.00m);
+        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Salary after taxes" && a.Average == 233.33m);
+        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Tax difference" && a.Average == 66.67m);
+        result[0].AnnualAverages.Should().ContainSingle(a => a.Category == "Dividendo/Juros" && a.Average == 1.29m);
 
-        // 2025 has expenses but no income, so no income rows should be merged in for that year.
-        result[1].AnnualAverages.Should().ContainSingle(a => a.Category == "Mercado" && a.Average == 120m);
+        // yearB has expenses but no income, so no income rows should be merged in for that year.
+        result[1].AnnualAverages.Should().ContainSingle(a => a.Category == "Mercado" && a.Average == 10.00m);
         result[1].AnnualAverages.Should().NotContain(a => a.Category == "Salary");
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -504,16 +504,59 @@ public class AnnualSummaryServiceTests
     {
         var repository = new StubCashFlowRepository();
         var service = new AnnualSummaryService(repository);
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Jan first", 100m, Category.Mercado, "Barclays", null));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 20), "Jan second", 100m, Category.Mercado, "Barclays", null));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 2, 10), "Feb", 400m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 1, 5), "Jan first", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 1, 20), "Jan second", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 2, 10), "Feb", 400m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetHistoricSummaryAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(PastYear);
 
         var mercadoAverage = result[0].AnnualAverages.Single(a => a.Category == nameof(Category.Mercado)).Average;
 
-        // Per-month average (spec): Jan total 200 + Feb total 400 → avg over 2 months = 300
-        mercadoAverage.Should().Be(300m);
+        // Per-month sums (Jan 200 + Feb 400 = 600) still average over all 12 calendar months of a
+        // closed year, not just the 2 active ones: 600 / 12 = 50
+        mercadoAverage.Should().Be(50m);
+    }
+
+    [Fact]
+    public void GetHistoricSummaryAverageFromYear_PastYear_DividesByTwelveEvenWhenSomeMonthsHaveNoRecordedActivity()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        // Only 4 of the 12 months have any Mercado expense; the other 8 are genuinely zero spend,
+        // and still count toward the divisor for a fully closed year.
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 1, 5), "Jan", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 2, 5), "Feb", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 3, 5), "Mar", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 4, 5), "Apr", 100m, Category.Mercado, "Barclays", null));
+
+        var result = service.GetHistoricSummaryAverageFromYear(PastYear);
+
+        // 400 total / 12 calendar months = 33.33, not / 4 active months = 100.00
+        result.Single(r => r.Year == PastYear).AnnualAverages.Single(a => a.Category == "Mercado").Average.Should().Be(33.33m);
+    }
+
+    [Fact]
+    public void GetHistoricSummaryAverageFromYear_CurrentYear_ZeroCompletedMonthStillCountsTowardTheDivisor()
+    {
+        var today = DateTime.UtcNow;
+        if (today.Month < 3)
+        {
+            // Need at least 2 completed months to demonstrate a zero one alongside a non-zero one.
+            return;
+        }
+
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        var currentYear = today.Year;
+        // January has spend; February (a completed month) genuinely has none - it must still count
+        // toward the divisor, unlike the past-year rule which would exclude a zero month entirely.
+        repository.Expenses.Add(Expense.Create(new DateOnly(currentYear, 1, 5), "Jan", 200m, Category.Mercado, "Barclays", null));
+
+        var result = service.GetHistoricSummaryAverageFromYear(currentYear);
+
+        var monthsCompleted = today.Month - 1;
+        var expected = Math.Round(200m / monthsCompleted, 2);
+        result.Single(r => r.Year == currentYear).AnnualAverages.Single(a => a.Category == "Mercado").Average.Should().Be(expected);
     }
 
     [Fact]
@@ -521,24 +564,29 @@ public class AnnualSummaryServiceTests
     {
         var repository = new StubCashFlowRepository();
         var service = new AnnualSummaryService(repository);
-        repository.Expenses.Add(Expense.Create(new DateOnly(2027, 4, 5), "Should not be there", 10m, Category.Mercado, "Barclays", null));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 4, 5), "2026", 10m, Category.Mercado, "Barclays", null));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2025, 4, 5), "2025", 10m, Category.Mercado, "Barclays", null));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2023, 4, 5), "2023", 10m, Category.Mercado, "Barclays", null));
-        repository.Incomes.Add(Income.Create(new DateOnly(2027, 4, 5), IncomeSource.Gleison, 9999m, 9999m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 4, 5), IncomeSource.Gleison, 1500m, 1500m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2025, 4, 5), IncomeSource.Gleison, 1200m, 1200m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2023, 4, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
+        var futureYear = PastYear + 100; // guaranteed to be after PastYear, excluded from the requested range
+        var yearA = PastYear;
+        var yearB = PastYear - 2;
+        var yearC = PastYear - 4;
+        repository.Expenses.Add(Expense.Create(new DateOnly(futureYear, 4, 5), "Should not be there", 10m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(yearA, 4, 5), "yearA", 10m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(yearB, 4, 5), "yearB", 10m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(yearC, 4, 5), "yearC", 10m, Category.Mercado, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(futureYear, 4, 5), IncomeSource.Gleison, 9999m, 9999m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(yearA, 4, 5), IncomeSource.Gleison, 1500m, 1500m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(yearB, 4, 5), IncomeSource.Gleison, 1200m, 1200m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(yearC, 4, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
 
-        var result = service.GetHistoricSummaryAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(yearA);
 
         result.Count.Should().Be(3);
-        result[0].Year.Should().Be(2026);
-        result[1].Year.Should().Be(2025);
-        result[2].Year.Should().Be(2023);
-        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1500m);
-        result[1].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1200m);
-        result[2].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1000m);
+        result[0].Year.Should().Be(yearA);
+        result[1].Year.Should().Be(yearB);
+        result[2].Year.Should().Be(yearC);
+        // Each year has a single April entry, but a closed year still averages over all 12 months.
+        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(125.00m); // 1500 / 12
+        result[1].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(100.00m); // 1200 / 12
+        result[2].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(83.33m);  // 1000 / 12
     }
 
     [Fact]
@@ -546,17 +594,17 @@ public class AnnualSummaryServiceTests
     {
         var repository = new StubCashFlowRepository();
         var service = new AnnualSummaryService(repository);
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 20), IncomeSource.Gleison, 500m, 400m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 2, 5), IncomeSource.Gleison, 3000m, 2400m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 1, 20), IncomeSource.Gleison, 500m, 400m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 2, 5), IncomeSource.Gleison, 3000m, 2400m, "Barclays"));
 
-        var result = service.GetHistoricSummaryAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(PastYear);
 
-        // Per-month gross: Jan total 1500 + Feb total 3000 → avg over 2 months = 2250
-        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(2250m);
+        // Per-month gross: Jan total 1500 + Feb total 3000 = 4500, over all 12 months of a closed year = 375
+        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(375m);
 
-        // Per-month net: Jan total 1200 + Feb total 2400 → avg over 2 months = 1800
-        result[0].AnnualAverages.Single(a => a.Category == "Salary after taxes").Average.Should().Be(1800m);
+        // Per-month net: Jan total 1200 + Feb total 2400 = 3600, over 12 months = 300
+        result[0].AnnualAverages.Single(a => a.Category == "Salary after taxes").Average.Should().Be(300m);
     }
 
     [Fact]
@@ -564,15 +612,15 @@ public class AnnualSummaryServiceTests
     {
         var repository = new StubCashFlowRepository();
         var service = new AnnualSummaryService(repository);
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 2, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Ariana, 500m, 500m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 1, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 2, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 3, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 1, 5), IncomeSource.Ariana, 500m, 500m, "Barclays"));
 
-        var result = service.GetHistoricSummaryAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(PastYear);
 
-        // Combined per-month salary: Jan 1500, Feb 1000, Mar 1000 → avg over 3 months = 1166.67
-        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1166.67m);
+        // Combined per-month salary: Jan 1500, Feb 1000, Mar 1000 = 3500, over 12 months = 291.67
+        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(291.67m);
     }
 
     [Fact]
@@ -580,14 +628,14 @@ public class AnnualSummaryServiceTests
     {
         var repository = new StubCashFlowRepository();
         var service = new AnnualSummaryService(repository);
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
 
-        var result = service.GetHistoricSummaryAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(PastYear);
 
         result.Count.Should().Be(1);
-        result[0].Year.Should().Be(2026);
-        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1000m);
-        result[0].AnnualAverages.Single(a => a.Category == "Salary after taxes").Average.Should().Be(800m);
+        result[0].Year.Should().Be(PastYear);
+        result[0].AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(83.33m);  // 1000 / 12
+        result[0].AnnualAverages.Single(a => a.Category == "Salary after taxes").Average.Should().Be(66.67m); // 800 / 12
     }
 
     [Fact]
@@ -595,16 +643,16 @@ public class AnnualSummaryServiceTests
     {
         var repository = new StubCashFlowRepository();
         var service = new AnnualSummaryService(repository);
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.DividendoJuros, null, 20m, "Barclays"));
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 1, 5), IncomeSource.DividendoJuros, null, 20m, "Barclays"));
 
-        var result = service.GetHistoricSummaryAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(PastYear);
 
-        // Total despesas must be the sum of the 14 expense category rows only (Mercado 100 + Investimento 30 = 130),
-        // never the income rows (Salary/Salary after taxes/Tax difference/Dividendo/Juros) merged in ahead of them.
-        result[0].AnnualAverages.Single(a => a.Category == "Total despesas").Average.Should().Be(130m);
+        // Total despesas must be the sum of the 14 expense category rows only (Mercado 100/12=8.33 +
+        // Investimento 30/12=2.5 = 10.83), never the income rows merged in ahead of them.
+        result[0].AnnualAverages.Single(a => a.Category == "Total despesas").Average.Should().Be(10.83m);
     }
 
     [Fact]
@@ -612,17 +660,17 @@ public class AnnualSummaryServiceTests
     {
         var repository = new StubCashFlowRepository();
         var service = new AnnualSummaryService(repository);
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
         // DividendoJuros is seeded deliberately: unlike Category Totals' own Resultado, this sub-tab's
         // Resultado excludes Dividendo/Juros entirely, so this income must NOT affect the expected value.
-        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.DividendoJuros, null, 20m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(PastYear, 1, 5), IncomeSource.DividendoJuros, null, 20m, "Barclays"));
 
-        var result = service.GetHistoricSummaryAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(PastYear);
 
-        // Resultado (R-D-Inv) = SalaryAfterTaxes(800) - TotalDespesas(130) + Investimento(30) = 700
-        result[0].AnnualAverages.Single(a => a.Category == "Resultado (R-D-Inv)").Average.Should().Be(700m);
+        // Resultado (R-D-Inv) = SalaryAfterTaxes(66.67) - TotalDespesas(10.83) + Investimento(2.5) = 58.34
+        result[0].AnnualAverages.Single(a => a.Category == "Resultado (R-D-Inv)").Average.Should().Be(58.34m);
     }
 
     [Fact]
@@ -630,15 +678,15 @@ public class AnnualSummaryServiceTests
     {
         var repository = new StubCashFlowRepository();
         var service = new AnnualSummaryService(repository);
-        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(PastYear, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetHistoricSummaryAverageFromYear(2026);
+        var result = service.GetHistoricSummaryAverageFromYear(PastYear);
 
         // Every one of the 14 Category enum values must appear, even with zero recorded expenses that year.
         foreach (var category in Enum.GetValues<Category>())
         {
             var entry = result[0].AnnualAverages.Single(a => a.Category == category.ToString());
-            entry.Average.Should().Be(category == Category.Mercado ? 100m : 0m);
+            entry.Average.Should().Be(category == Category.Mercado ? 8.33m : 0m); // 100 / 12
         }
     }
 
@@ -674,16 +722,22 @@ public class AnnualSummaryServiceTests
         var repository = new StubCashFlowRepository();
         var service = new AnnualSummaryService(repository);
         var currentYear = today.Year;
-        repository.Expenses.Add(Expense.Create(new DateOnly(currentYear, 1, 5), "Completed month", 100m, Category.Mercado, "Barclays", null));
+        // Every completed month gets the same figures, so the average equals that same value no
+        // matter how many months have elapsed - isolating the in-progress-month exclusion itself
+        // from the "divide by how many months elapsed" behavior covered by other tests.
+        for (var month = 1; month < today.Month; month++)
+        {
+            repository.Expenses.Add(Expense.Create(new DateOnly(currentYear, month, 5), $"Month {month}", 100m, Category.Mercado, "Barclays", null));
+            repository.Incomes.Add(Income.Create(new DateOnly(currentYear, month, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        }
         repository.Expenses.Add(Expense.Create(DateOnly.FromDateTime(today), "In-progress month", 9999m, Category.Mercado, "Barclays", null));
-        repository.Incomes.Add(Income.Create(new DateOnly(currentYear, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
         repository.Incomes.Add(Income.Create(DateOnly.FromDateTime(today), IncomeSource.Gleison, 9999m, 9999m, "Barclays"));
 
         var result = service.GetHistoricSummaryAverageFromYear(currentYear);
 
         var currentYearRow = result.Single(r => r.Year == currentYear);
-        // Only January's figures count; the in-progress current-month entries (9999) must be excluded entirely,
-        // not treated as a completed month with a low value.
+        // The in-progress current-month entries (9999) must be excluded entirely, not treated as a
+        // completed month with a low value, nor folded into the sum.
         currentYearRow.AnnualAverages.Single(a => a.Category == "Mercado").Average.Should().Be(100m);
         currentYearRow.AnnualAverages.Single(a => a.Category == "Salary").Average.Should().Be(1000m);
         currentYearRow.AnnualAverages.Single(a => a.Category == "Salary after taxes").Average.Should().Be(800m);


### PR DESCRIPTION
## Summary

**Correction note:** the first commit on this branch fixed only the frontend Category Totals average and got the closed-year rule backwards. The actual bug the user noticed was in the backend's Historic Summary Average, and the confirmed correct rule is the opposite of what was first implemented. The second commit corrects this.

**Confirmed rule:**
- A **closed/past year** always averages over all **12 calendar months**, even when some months have zero recorded activity — a zero month is still a real elapsed month, matching the source spreadsheet's own `AVERAGE(B:M)` over always-filled cells.
- Only the **current (open) calendar year** excludes the in-progress month and divides by exactly the completed months so far (`current month - 1`) — a zero *completed* month still counts toward that divisor (unlike the closed-year case, an elapsed month is unambiguously real).
- Applies uniformly to income rows and expense category rows, in both places this is computed.

**Backend** (`Financial.CashFlow.Application/Services/AnnualSummaryService.cs`) — this is where the visible bug was, and where the fix matters most:
- `GetHistoricCategoriesAverageFromYear` and `GetAnnualAverageIncomeByGroupIncome` previously divided each category/income group's average by however many distinct months had *any* matching expense/income record — silently excluding zero-activity months from the divisor for every year, including closed ones.
- Rebuilt both to compute explicit 12-month totals per category/income group (0-filled for months with no activity, like `GetCategoryTotalsForYear` already does) and divide by a new `GetMonthsToAverage(year)`: `12` for a past year, `DateTime.Now.Month - 1` for the current year, `0` for a future year.

**Frontend** (`Financial.Web/src/utils/math.ts`) — Category Totals subtab's per-row Average column:
- Reverted the first commit's "exclude zero months" change for closed years back to dividing by `values.length` (12), matching the corrected backend rule.
- Kept the current-year fix: `average(values, monthsElapsed)` still slices to and divides by only the completed months when `monthsElapsed` is passed, excluding the in-progress month's partial data from both the sum and the divisor.

## Test plan
- [x] Backend: rewrote 9 existing `AnnualSummaryServiceTests` that had baked in the old "divide by active months" assumption (mostly by switching from a hardcoded year to the file's existing `PastYear` constant and recomputing expected `/12` values), added 2 new tests for the closed-year-always-12 and open-year-zero-completed-month-still-counts rules, and rewrote the one affected `AnnualSummaryEndpointsTests` integration test to use two definitively-past years. Full suites green: 218 `Financial.CashFlow.Application.Tests`, 187 `Financial.Api.Tests`.
- [x] Frontend: reverted the incorrect `math.test.ts` case and `AnnualSummaryPage.test.tsx` case for closed-year zero-exclusion back to closed-year-always-12; the open-year test from the first commit was already correct and unchanged. Full suite green: 651/651 (`Financial.Web`, vitest, 52 files). `tsc -b --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)