### PR TITLE
chore(docker): pin frontend build stage to node:24.13.0-slim to match CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build React frontend
-FROM node:22-slim AS web-build
+FROM node:24.13.0-slim AS web-build
 WORKDIR /app
 COPY Financial.Web/package*.json .
 RUN npm install


### PR DESCRIPTION
## Summary
- The Dockerfile's frontend build stage was on `node:22-slim` while `.github/workflows/build.yml`'s `web-build-test`/`browser-smoke-test` jobs pin `24.13.0`. Different Node majors building the same source can diverge — CI green doesn't guarantee the deployed image builds the same way.
- Pins the Dockerfile to `node:24.13.0-slim`, the exact Node patch version CI uses, so both build the frontend under identical Node runtimes.

## Test plan
- [x] `docker build --target web-build .` — builds cleanly on `node:24.13.0-slim`
- [x] `docker build .` (full multi-stage image) — builds cleanly end to end