### PR TITLE
test(cashflow-web): expand browser smoke test to catch API/frontend contract drift

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,9 +97,14 @@ jobs:
         mkdir -p publish/wwwroot
         cp -r Financial.Web/dist/. publish/wwwroot/
 
+    - name: Prepare CashFlow test data
+      run: cp Tests/Financial.Api.Tests/TestData/data-cashflow.test.json /tmp/data-cashflow.smoke-test.json
+
     - name: Run browser smoke test
       env:
         DataJsonFile: ${{ github.workspace }}/Tests/Financial.Api.Tests/TestData/data.test.json
+        CashFlow__Repository__Provider: LocalJson
+        CashFlow__DataJsonFile: /tmp/data-cashflow.smoke-test.json
         ASPNETCORE_URLS: http://localhost:8080
         SMOKE_APP_URL: http://localhost:8080
       run: |

--- a/Financial.Web/scripts/smoke-test.mjs
+++ b/Financial.Web/scripts/smoke-test.mjs
@@ -1,14 +1,50 @@
 // Browser smoke test: loads the app against a running API and confirms
-// the tree renders with no console errors. Run via `npm run smoke-test`
-// after the API and web dev server are already up (see CI workflow).
+// the tree renders with no console errors, then seeds real CashFlow data
+// through the API and confirms a specific computed value renders correctly.
+// The second part exists because a bundle that merely *compiles* can still
+// render wrong/blank data if the frontend's hand-written API types drift
+// from what the backend actually returns (field renames, shape changes) -
+// tsc has no way to catch that on its own.
+// Run via `npm run smoke-test` after the API and web dev server are already
+// up (see CI workflow).
 import { chromium } from 'playwright'
 
 const APP_URL = process.env.SMOKE_APP_URL ?? 'http://localhost:5173'
+const API_BASE_URL = `${APP_URL}/api/v1/financial`
 const TIMEOUT_MS = 15000
 
+// A fully completed past year, so the average always divides by 12 months
+// regardless of what day this test happens to run on.
+const SEED_YEAR = new Date().getFullYear() - 2
+const SEED_MONTHLY_VALUE = 100
+const EXPECTED_MERCADO_AVERAGE = '25.00' // (100 * 3) / 12 months
+
+async function seedMercadoExpenses() {
+  for (const month of ['01', '02', '03']) {
+    const response = await fetch(`${API_BASE_URL}/expenses`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        date: `${SEED_YEAR}-${month}-05`,
+        description: 'Smoke test seed',
+        value: SEED_MONTHLY_VALUE,
+        category: 'Mercado',
+        paymentSource: 'Barclays',
+        cardTag: null,
+      }),
+    })
+    if (!response.ok) {
+      throw new Error(`Failed to seed expense for ${SEED_YEAR}-${month}: ${response.status} ${await response.text()}`)
+    }
+  }
+}
+
 async function main() {
+  await seedMercadoExpenses()
+
   const browser = await chromium.launch()
-  const page = await browser.newPage()
+  const context = await browser.newContext({ locale: 'en-US' })
+  const page = await context.newPage()
 
   const consoleErrors = []
   page.on('console', (msg) => {
@@ -21,6 +57,24 @@ async function main() {
   // Broker name from Tests/Financial.Api.Tests/TestData/data.test.json
   await page.getByText('XPI').first().waitFor({ timeout: TIMEOUT_MS })
 
+  await page.goto(`${APP_URL}/cashflow/annual-summary`, { waitUntil: 'domcontentloaded' })
+  await page.getByRole('button', { name: 'Historic Summary Average' }).click()
+
+  const mercadoCell = page.getByRole('cell', { name: 'Mercado', exact: true })
+  await mercadoCell.waitFor({ timeout: TIMEOUT_MS })
+  const mercadoRow = page.locator('tr', { has: mercadoCell })
+  const mercadoRowText = await mercadoRow.textContent()
+
+  if (!mercadoRowText?.includes(EXPECTED_MERCADO_AVERAGE)) {
+    console.error(
+      `Smoke test failed: Historic Summary Average did not show Mercado = ${EXPECTED_MERCADO_AVERAGE} for ${SEED_YEAR} ` +
+        `(seeded 100 in each of Jan/Feb/Mar, expected sum/12 months). Row text was: "${mercadoRowText}". This usually ` +
+        'means the frontend and API have drifted on the response shape for this endpoint.',
+    )
+    await browser.close()
+    process.exit(1)
+  }
+
   if (consoleErrors.length > 0) {
     console.error('Smoke test failed: console errors detected')
     for (const err of consoleErrors) console.error(` - ${err}`)
@@ -28,7 +82,7 @@ async function main() {
     process.exit(1)
   }
 
-  console.log('Smoke test passed: app loaded and rendered the navigation tree with no console errors')
+  console.log('Smoke test passed: app loaded, rendered the navigation tree, and the Historic Summary Average showed the expected computed value')
   await browser.close()
 }
 

--- a/Tests/Financial.Api.Tests/TestData/data-cashflow.test.json
+++ b/Tests/Financial.Api.Tests/TestData/data-cashflow.test.json
@@ -1,0 +1,5 @@
+{
+  "Banks": [
+    { "Name": "Barclays", "RoundUpEnabled": false }
+  ]
+}


### PR DESCRIPTION
## Summary
- The browser smoke test only confirmed the home page rendered without console errors. It never visited the Annual Summary page, so it did not catch the recent Historic Summary Average field rename (`average` -> `value`) even though that's exactly the kind of bug a real end-to-end check should catch: a build that fully compiles and passes CI can still render wrong/blank data if the frontend's hand-written API types drift from what the backend actually returns.
- Extends `smoke-test.mjs` to seed 3 real Mercado expenses (100 each, Jan/Feb/Mar of a fully-completed past year) through the running API, navigate to the Historic Summary Average tab, and assert the rendered value is exactly `25.00` (sum/12 months per the divisor fix in #272) - a field-name or shape mismatch would render `0.00` instead and fail the check.
- Adds `Tests/Financial.Api.Tests/TestData/data-cashflow.test.json`, a minimal fixture (Banks only, no seeded expenses/incomes - those are seeded live through the API, mirroring the existing `ApiTestFactory` C# test pattern) and wires `CashFlow__Repository__Provider`/`CashFlow__DataJsonFile` into the `browser-smoke-test` CI job so the published API has CashFlow data to serve, mirroring how `DataJsonFile` is already wired for investments.

## Test plan
- [x] Verified end-to-end against a locally published API (`dotnet run`, isolated port/fixture, no collision with anything real): seeding 3 x 100 Mercado expenses for a fully-past year returns `Mercado: 25` from `/annual-summary/{year}/historic-summary-averages`, confirming the fixture + seeding approach and the divisor math match.
- [x] `node --check` and `eslint` pass on the updated `smoke-test.mjs`.
- [ ] Full Playwright run (seed -> navigate -> click tab -> assert rendered `25.00`) is verified by the `browser-smoke-test` GitHub Actions job on this PR, not locally - a local dry run hit a pre-existing process already bound to port 8080 on the dev machine, so further local verification was intentionally skipped in favor of CI's clean, ephemeral runner.