### PR TITLE
feat(cashflow): add Domain-layer income/expense classification and MonthlySeries

### DIFF
--- a/Financial.CashFlow.Application/DTOs/IncomeGroupValueDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/IncomeGroupValueDTO.cs
@@ -4,7 +4,7 @@ namespace Financial.CashFlow.Application.DTOs
 {
     public class IncomeGroupValueDTO
     {
-        public required string IncomeGroup { get; init; }
+        public required IncomeGroup IncomeGroup { get; init; }
         public decimal? GrossAverageValue { get; init; }
         public required decimal NetAverageValue { get; init; }
     }

--- a/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
+++ b/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
@@ -2,13 +2,13 @@ using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Domain.Enums;
 using Financial.CashFlow.Domain.Rules;
+using Financial.CashFlow.Domain.ValueObjects;
 
 namespace Financial.CashFlow.Application.Services;
 
 public sealed class AnnualSummaryService : IAnnualSummaryService
 {
     private const int MonthsInYear = 12;
-    private const string SalaryIncomeGroup = "Salary";
     public const int AverageDecimalPlaces = 2;
 
     private readonly ICashFlowRepository _repository;
@@ -28,16 +28,14 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
         return Enum.GetValues<Category>()
             .Select(category =>
             {
-                var monthlyTotals = new decimal[MonthsInYear];
-                for (var month = 1; month <= MonthsInYear; month++)
-                {
-                    monthlyTotals[month - 1] = totalsByCategoryAndMonth.GetValueOrDefault((category, month));
-                }
+                var monthlyTotals = MonthlySeries.FromMonthlyValues(Enumerable.Range(1, MonthsInYear)
+                    .Select(month => totalsByCategoryAndMonth.GetValueOrDefault((category, month)))
+                    .ToArray());
 
                 return new CategoryAnnualTotalDTO
                 {
                     Category = category.ToString(),
-                    MonthlyTotals = monthlyTotals,
+                    MonthlyTotals = monthlyTotals.AsReadOnly().ToArray(),
                     AnnualTotal = monthlyTotals.Sum()
                 };
             })
@@ -62,50 +60,50 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
 
         var hasPriorYearData = allSnapshots.Any(s => s.Year == year - 1);
 
-        var accounts = scopedAccounts
+        var accountSeries = scopedAccounts
             .Select(account =>
             {
-                var monthlyValues = new decimal[MonthsInYear];
-                for (var month = 1; month <= MonthsInYear; month++)
-                {
-                    monthlyValues[month - 1] = valueByAccountAndMonth.GetValueOrDefault((account.Name, month));
-                }
+                var monthlyValues = MonthlySeries.FromMonthlyValues(Enumerable.Range(1, MonthsInYear)
+                    .Select(month => valueByAccountAndMonth.GetValueOrDefault((account.Name, month)))
+                    .ToArray());
 
-                decimal? januaryDiff = hasPriorYearData
-                    ? monthlyValues[0] - priorYearDecemberByAccount.GetValueOrDefault(account.Name, 0m)
+                decimal? priorClosingValue = hasPriorYearData
+                    ? priorYearDecemberByAccount.GetValueOrDefault(account.Name, 0m)
                     : null;
 
-                return new InvestmentAccountAnnualDiffDTO
-                {
-                    Account = account.Name,
-                    IsLiability = account.IsLiability,
-                    MonthlyValues = monthlyValues,
-                    MonthlyDiffs = ComputeDiffs(monthlyValues, januaryDiff)
-                };
+                return (account, monthlyValues, diffs: monthlyValues.DiffsFrom(priorClosingValue));
             })
             .ToList();
 
-        var netPositionValues = new decimal[MonthsInYear];
-        for (var month = 0; month < MonthsInYear; month++)
-        {
-            netPositionValues[month] = accounts
-                .Sum(a => a.IsLiability ? -a.MonthlyValues[month] : a.MonthlyValues[month]);
-        }
+        var accounts = accountSeries
+            .Select(a => new InvestmentAccountAnnualDiffDTO
+            {
+                Account = a.account.Name,
+                IsLiability = a.account.IsLiability,
+                MonthlyValues = a.monthlyValues.AsReadOnly().ToArray(),
+                MonthlyDiffs = a.diffs.ToArray()
+            })
+            .ToList();
 
-        decimal? netPositionJanuaryDiff = hasPriorYearData
-            ? accounts.Sum(a => (a.IsLiability ? -1 : 1) * a.MonthlyDiffs[0]!.Value)
+        var netPositionSeries = accountSeries.Aggregate(MonthlySeries.Zero(), (net, a) =>
+            net.Add(a.account.IsLiability
+                ? MonthlySeries.FromMonthlyValues(a.monthlyValues.AsReadOnly().Select(v => -v).ToArray())
+                : a.monthlyValues));
+
+        decimal? netPositionPriorClosingValue = hasPriorYearData
+            ? accountSeries.Sum(a => (a.account.IsLiability ? -1m : 1m) * priorYearDecemberByAccount.GetValueOrDefault(a.account.Name, 0m))
             : null;
 
-        var netPositionDiffs = ComputeDiffs(netPositionValues, netPositionJanuaryDiff);
+        var netPositionDiffs = netPositionSeries.DiffsFrom(netPositionPriorClosingValue);
 
         var lastRelevantMonth = year >= DateTime.Now.Year ? Math.Min(DateTime.Now.Month, MonthsInYear) : MonthsInYear;
         var relevantDiffs = netPositionDiffs.Take(lastRelevantMonth).Where(d => d.HasValue).Select(d => d!.Value).ToList();
 
         var netPosition = new NetPositionAnnualDiffDTO
         {
-            MonthlyValues = netPositionValues,
-            MonthlyDiffs = netPositionDiffs,
-            FullYearNetChange = netPositionValues[lastRelevantMonth - 1] - netPositionValues[0],
+            MonthlyValues = netPositionSeries.AsReadOnly().ToArray(),
+            MonthlyDiffs = netPositionDiffs.ToArray(),
+            FullYearNetChange = netPositionSeries[lastRelevantMonth - 1] - netPositionSeries[0],
             AverageMonthResult = relevantDiffs.Count > 0 ? relevantDiffs.Average() : 0m,
             SumOfMonthResults = relevantDiffs.Sum()
         };
@@ -127,14 +125,15 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
         {
             var monthIndex = income.Date.Month - 1;
 
-            if (income.IncomeSource is IncomeSource.Gleison or IncomeSource.Ariana)
+            switch (income.Group)
             {
-                salaryMonthly[monthIndex] += income.GrossValue ?? 0m;
-                salaryAfterTaxesMonthly[monthIndex] += income.NetValue;
-            }
-            else if (income.IncomeSource == IncomeSource.DividendoJuros)
-            {
-                dividendoJurosMonthly[monthIndex] += income.NetValue;
+                case IncomeGroup.Salary:
+                    salaryMonthly[monthIndex] += income.GrossValue ?? 0m;
+                    salaryAfterTaxesMonthly[monthIndex] += income.NetValue;
+                    break;
+                case IncomeGroup.DividendoJuros:
+                    dividendoJurosMonthly[monthIndex] += income.NetValue;
+                    break;
             }
         }
 
@@ -199,14 +198,14 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
         foreach (var yearAverage in categoryAverages)
         {
             var totalCategory = yearAverage.AnnualAverages.Sum(c => c.Value);
-            var investmentCategory = yearAverage.AnnualAverages.FirstOrDefault(c => c.Category == "Investimento")?.Value ?? 0m;
+            var investmentCategory = yearAverage.AnnualAverages.FirstOrDefault(c => c.Category == nameof(Category.Investimento))?.Value ?? 0m;
 
             var salaryAfterTaxes = incomeAverages.FirstOrDefault(i => i.Year == yearAverage.Year)?.SalaryAfterTaxesAverage ?? 0m;
 
             yearAverage.AnnualAverages.Add(new CategoryGroupValueDTO
             {
                 Category = "Resultado (R-D-Inv)",
-                Value = salaryAfterTaxes - totalCategory + investmentCategory
+                Value = AnnualResultCalculator.ComputeResultado(salaryAfterTaxes, totalCategory, investmentCategory)
             });
 
             yearAverage.AnnualAverages.Add(new CategoryGroupValueDTO
@@ -289,12 +288,12 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
         var dividendoJuros = 0m;
         foreach (var incomeAverage in incomeYear.Value)
         {
-            if (incomeAverage.IncomeGroup == SalaryIncomeGroup)
+            if (incomeAverage.IncomeGroup == IncomeGroup.Salary)
             {
                 salary += incomeAverage.GrossAverageValue ?? 0m;
                 salaryAfterTaxes += incomeAverage.NetAverageValue;
             }
-            else if (incomeAverage.IncomeGroup == IncomeSource.DividendoJuros.ToString())
+            else if (incomeAverage.IncomeGroup == IncomeGroup.DividendoJuros)
             {
                 dividendoJuros += incomeAverage.NetAverageValue;
             }
@@ -306,7 +305,7 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
     {
         var monthlySumByIncomeSource = _repository.GetIncomes()
             .Where(e => e.Date.Year <= year && e.Date < new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1))
-            .GroupBy(e => new { e.Date.Year, e.Date.Month, IncomeGroup = GetIncomeGroup(e.IncomeSource) })
+            .GroupBy(e => new { e.Date.Year, e.Date.Month, IncomeGroup = e.Group })
             .Select(g => new
             {
                 Key = (g.Key.Year, g.Key.Month, g.Key.IncomeGroup),
@@ -331,11 +330,6 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
             2017 => 11,
             _ => 12,
           };
-
-    private static string GetIncomeGroup(IncomeSource incomeSource) =>
-        incomeSource is IncomeSource.Gleison or IncomeSource.Ariana
-            ? SalaryIncomeGroup
-            : IncomeSource.DividendoJuros.ToString();
 
     private IList<CategoryAnnualGroupValueDTO> GetHistoricCategoriesAverageFromYear(int year)
     {
@@ -364,17 +358,5 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
                 ]
             });
         return [.. averageExpenseByYear.OrderByDescending(a => a.Year)];
-    }
-
-    private static decimal?[] ComputeDiffs(decimal[] monthlyValues, decimal? januaryDiff)
-    {
-        var diffs = new decimal?[monthlyValues.Length];
-        diffs[0] = januaryDiff;
-        for (var month = 1; month < monthlyValues.Length; month++)
-        {
-            diffs[month] = monthlyValues[month] - monthlyValues[month - 1];
-        }
-
-        return diffs;
     }
 }

--- a/Financial.CashFlow.Domain/Entities/Expense.cs
+++ b/Financial.CashFlow.Domain/Entities/Expense.cs
@@ -1,5 +1,6 @@
 using System;
 using Financial.CashFlow.Domain.Enums;
+using Financial.CashFlow.Domain.Rules;
 
 namespace Financial.CashFlow.Domain.Entities;
 
@@ -24,6 +25,8 @@ public class Expense
         : ExpensePaymentStatus.CreditCardSettled;
 
     public decimal RoundUpSuggestion => Math.Ceiling(Value) - Value;
+
+    public bool IsInvestment => Category.IsInvestment();
 
     private Expense() { }
 

--- a/Financial.CashFlow.Domain/Entities/Income.cs
+++ b/Financial.CashFlow.Domain/Entities/Income.cs
@@ -1,5 +1,6 @@
 using System;
 using Financial.CashFlow.Domain.Enums;
+using Financial.CashFlow.Domain.Rules;
 
 namespace Financial.CashFlow.Domain.Entities;
 
@@ -11,6 +12,8 @@ public class Income
     public decimal? GrossValue { get; private set; }
     public decimal NetValue { get; private set; }
     public string Bank { get; private set; } = string.Empty;
+
+    public IncomeGroup Group => IncomeClassifier.Classify(IncomeSource);
 
     private Income() { }
 

--- a/Financial.CashFlow.Domain/Enums/IncomeGroup.cs
+++ b/Financial.CashFlow.Domain/Enums/IncomeGroup.cs
@@ -1,0 +1,8 @@
+namespace Financial.CashFlow.Domain.Enums;
+
+public enum IncomeGroup
+{
+    Salary,
+    DividendoJuros,
+    NonReportable
+}

--- a/Financial.CashFlow.Domain/Rules/AnnualResultCalculator.cs
+++ b/Financial.CashFlow.Domain/Rules/AnnualResultCalculator.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+using Financial.CashFlow.Domain.ValueObjects;
+
+namespace Financial.CashFlow.Domain.Rules;
+
+/// <summary>
+/// Computes Resultado (R-D-Inv): salary after taxes, minus total expenses, plus the Investimento
+/// category (which is already counted once inside total expenses, so it must be added back -
+/// money moved into an investment account isn't consumption).
+/// </summary>
+public static class AnnualResultCalculator
+{
+    public static decimal ComputeResultado(decimal salaryAfterTaxes, decimal totalDespesas, decimal investimentoCategoryValue) =>
+        salaryAfterTaxes - totalDespesas + investimentoCategoryValue;
+
+    public static MonthlySeries ComputeResultado(MonthlySeries salaryAfterTaxes, MonthlySeries totalDespesas, MonthlySeries investimento) =>
+        MonthlySeries.FromMonthlyValues(Enumerable.Range(0, MonthlySeries.MonthsInYear)
+            .Select(month => ComputeResultado(salaryAfterTaxes[month], totalDespesas[month], investimento[month]))
+            .ToArray());
+}

--- a/Financial.CashFlow.Domain/Rules/CategoryClassifier.cs
+++ b/Financial.CashFlow.Domain/Rules/CategoryClassifier.cs
@@ -1,0 +1,8 @@
+using Financial.CashFlow.Domain.Enums;
+
+namespace Financial.CashFlow.Domain.Rules;
+
+public static class CategoryClassifier
+{
+    public static bool IsInvestment(this Category category) => category == Category.Investimento;
+}

--- a/Financial.CashFlow.Domain/Rules/IncomeClassifier.cs
+++ b/Financial.CashFlow.Domain/Rules/IncomeClassifier.cs
@@ -1,0 +1,18 @@
+using Financial.CashFlow.Domain.Enums;
+
+namespace Financial.CashFlow.Domain.Rules;
+
+/// <summary>
+/// Groups an income source for reporting. Anything that isn't Salary (Gleison/Ariana) or
+/// DividendoJuros is NonReportable - e.g. Lottery, which must never be folded into another
+/// group's total.
+/// </summary>
+public static class IncomeClassifier
+{
+    public static IncomeGroup Classify(IncomeSource incomeSource) => incomeSource switch
+    {
+        IncomeSource.Gleison or IncomeSource.Ariana => IncomeGroup.Salary,
+        IncomeSource.DividendoJuros => IncomeGroup.DividendoJuros,
+        _ => IncomeGroup.NonReportable
+    };
+}

--- a/Financial.CashFlow.Domain/ValueObjects/MonthlySeries.cs
+++ b/Financial.CashFlow.Domain/ValueObjects/MonthlySeries.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Financial.CashFlow.Domain.ValueObjects;
+
+/// <summary>
+/// An immutable series of twelve monthly values (January through December) for a single,
+/// externally-tracked year. The year itself is not part of this value object - callers already
+/// know which year a series belongs to (a method parameter, a sibling DTO field), so keeping the
+/// series year-agnostic lets it be reused for category totals, investment values, and income
+/// figures alike.
+/// </summary>
+public sealed class MonthlySeries : IEquatable<MonthlySeries>
+{
+    public const int MonthsInYear = 12;
+
+    private readonly decimal[] _values;
+
+    private MonthlySeries(decimal[] values)
+    {
+        _values = values;
+    }
+
+    public static MonthlySeries Zero() => new(new decimal[MonthsInYear]);
+
+    public static MonthlySeries FromMonthlyValues(IReadOnlyList<decimal> values)
+    {
+        if (values is null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        if (values.Count != MonthsInYear)
+        {
+            throw new ArgumentException($"A monthly series requires exactly {MonthsInYear} values.", nameof(values));
+        }
+
+        return new MonthlySeries(values.ToArray());
+    }
+
+    public decimal this[int monthIndex] => _values[monthIndex];
+
+    public decimal Sum() => _values.Sum();
+
+    public decimal Average(int monthsElapsed, int decimalPlaces) =>
+        monthsElapsed <= 0 ? 0m : Math.Round(Sum() / monthsElapsed, decimalPlaces);
+
+    public IReadOnlyList<decimal?> DiffsFrom(decimal? priorClosingValue)
+    {
+        var diffs = new decimal?[MonthsInYear];
+        diffs[0] = priorClosingValue.HasValue ? _values[0] - priorClosingValue.Value : null;
+
+        for (var month = 1; month < MonthsInYear; month++)
+        {
+            diffs[month] = _values[month] - _values[month - 1];
+        }
+
+        return diffs;
+    }
+
+    public MonthlySeries Add(MonthlySeries other)
+    {
+        if (other is null)
+        {
+            throw new ArgumentNullException(nameof(other));
+        }
+
+        var summed = new decimal[MonthsInYear];
+        for (var month = 0; month < MonthsInYear; month++)
+        {
+            summed[month] = _values[month] + other._values[month];
+        }
+
+        return new MonthlySeries(summed);
+    }
+
+    public IReadOnlyList<decimal> AsReadOnly() => _values.ToArray();
+
+    public bool Equals(MonthlySeries? other) => other is not null && _values.SequenceEqual(other._values);
+
+    public override bool Equals(object? obj) => Equals(obj as MonthlySeries);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var value in _values)
+        {
+            hash.Add(value);
+        }
+        return hash.ToHashCode();
+    }
+}

--- a/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -661,6 +661,26 @@ public class AnnualSummaryServiceTests
     }
 
     [Fact]
+    public void GetHistoricSummaryAverageFromYear_LotteryIncomeContributesToNoRow()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Groceries", 120m, Category.Mercado, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 5), IncomeSource.DividendoJuros, null, 20m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 5), IncomeSource.Lottery, null, 500m, "Barclays"));
+
+        var result = service.GetHistoricSummaryAverageFromYear(2025);
+
+        // Lottery must not leak into Dividendo/Juros (or any other row) - it must have the same
+        // effect as if it were never recorded at all.
+        result[0].AnnualAverages.Single(a => a.Category == "Salary").Value.Should().Be(83.33m);
+        result[0].AnnualAverages.Single(a => a.Category == "Salary after taxes").Value.Should().Be(66.67m);
+        result[0].AnnualAverages.Single(a => a.Category == "Dividendo/Juros").Value.Should().Be(1.67m);
+        result[0].AnnualAverages.Single(a => a.Category == "Resultado (R-D-Inv)").Value.Should().Be(56.67m);
+    }
+
+    [Fact]
     public void GetHistoricSummaryAverageFromYear_ZeroFillsCategoriesWithNoExpensesThatYear()
     {
         var repository = new StubCashFlowRepository();

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/ExpenseTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/ExpenseTests.cs
@@ -304,4 +304,23 @@ public class ExpenseTests
 
         expense.RoundUpAmount.Should().Be(0.60m);
     }
+
+    [Fact]
+    public void IsInvestment_InvestimentoCategory_IsTrue()
+    {
+        var expense = Expense.Create(new DateOnly(2026, 7, 1), "Trading212 top-up", 100m, Category.Investimento, "Chase", null);
+
+        expense.IsInvestment.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(Category.Mercado)]
+    [InlineData(Category.Casa)]
+    [InlineData(Category.Reserva)]
+    public void IsInvestment_OtherCategories_IsFalse(Category category)
+    {
+        var expense = Expense.Create(new DateOnly(2026, 7, 1), "Not investment", 100m, category, "Chase", null);
+
+        expense.IsInvestment.Should().BeFalse();
+    }
 }

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/IncomeTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/IncomeTests.cs
@@ -107,4 +107,16 @@ public class IncomeTests
 
         act.Should().Throw<ArgumentException>();
     }
+
+    [Theory]
+    [InlineData(IncomeSource.Gleison, IncomeGroup.Salary)]
+    [InlineData(IncomeSource.Ariana, IncomeGroup.Salary)]
+    [InlineData(IncomeSource.DividendoJuros, IncomeGroup.DividendoJuros)]
+    [InlineData(IncomeSource.Lottery, IncomeGroup.NonReportable)]
+    public void Group_ReflectsIncomeSourceClassification(IncomeSource incomeSource, IncomeGroup expected)
+    {
+        var income = Income.Create(new DateOnly(2026, 7, 1), incomeSource, null, 10m, "Chase");
+
+        income.Group.Should().Be(expected);
+    }
 }

--- a/Tests/Financial.CashFlow.Domain.Tests/Rules/AnnualResultCalculatorTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Rules/AnnualResultCalculatorTests.cs
@@ -1,0 +1,32 @@
+using Financial.CashFlow.Domain.Rules;
+using Financial.CashFlow.Domain.ValueObjects;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Domain.Tests.Rules;
+
+public class AnnualResultCalculatorTests
+{
+    [Fact]
+    public void ComputeResultado_Scalar_ReturnsSalaryMinusDespesasPlusInvestimento()
+    {
+        var result = AnnualResultCalculator.ComputeResultado(
+            salaryAfterTaxes: 2000m,
+            totalDespesas: 1500m,
+            investimentoCategoryValue: 300m);
+
+        result.Should().Be(800m);
+    }
+
+    [Fact]
+    public void ComputeResultado_MonthlySeries_ComputesElementWise()
+    {
+        var salaryAfterTaxes = MonthlySeries.FromMonthlyValues(Enumerable.Repeat(2000m, 12).ToArray());
+        var totalDespesas = MonthlySeries.FromMonthlyValues(Enumerable.Repeat(1500m, 12).ToArray());
+        var investimento = MonthlySeries.FromMonthlyValues(Enumerable.Repeat(300m, 12).ToArray());
+
+        var result = AnnualResultCalculator.ComputeResultado(salaryAfterTaxes, totalDespesas, investimento);
+
+        result[0].Should().Be(800m);
+        result[11].Should().Be(800m);
+    }
+}

--- a/Tests/Financial.CashFlow.Domain.Tests/Rules/CategoryClassifierTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Rules/CategoryClassifierTests.cs
@@ -1,0 +1,23 @@
+using Financial.CashFlow.Domain.Enums;
+using Financial.CashFlow.Domain.Rules;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Domain.Tests.Rules;
+
+public class CategoryClassifierTests
+{
+    [Fact]
+    public void IsInvestment_Investimento_ReturnsTrue()
+    {
+        Category.Investimento.IsInvestment().Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(Category.Mercado)]
+    [InlineData(Category.Reserva)]
+    [InlineData(Category.Dizimo)]
+    public void IsInvestment_OtherCategories_ReturnsFalse(Category category)
+    {
+        category.IsInvestment().Should().BeFalse();
+    }
+}

--- a/Tests/Financial.CashFlow.Domain.Tests/Rules/IncomeClassifierTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Rules/IncomeClassifierTests.cs
@@ -1,0 +1,23 @@
+using Financial.CashFlow.Domain.Enums;
+using Financial.CashFlow.Domain.Rules;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Domain.Tests.Rules;
+
+public class IncomeClassifierTests
+{
+    [Theory]
+    [InlineData(IncomeSource.Gleison, IncomeGroup.Salary)]
+    [InlineData(IncomeSource.Ariana, IncomeGroup.Salary)]
+    [InlineData(IncomeSource.DividendoJuros, IncomeGroup.DividendoJuros)]
+    public void Classify_ReturnsExpectedGroup(IncomeSource incomeSource, IncomeGroup expected)
+    {
+        IncomeClassifier.Classify(incomeSource).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Classify_Lottery_ReturnsNonReportable()
+    {
+        IncomeClassifier.Classify(IncomeSource.Lottery).Should().Be(IncomeGroup.NonReportable);
+    }
+}

--- a/Tests/Financial.CashFlow.Domain.Tests/ValueObjects/MonthlySeriesTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/ValueObjects/MonthlySeriesTests.cs
@@ -1,0 +1,126 @@
+using Financial.CashFlow.Domain.ValueObjects;
+using FluentAssertions;
+
+namespace Financial.CashFlow.Domain.Tests.ValueObjects;
+
+public class MonthlySeriesTests
+{
+    private static readonly decimal[] TwelveMonths =
+        [10m, 20m, 30m, 40m, 50m, 60m, 70m, 80m, 90m, 100m, 110m, 120m];
+
+    [Fact]
+    public void FromMonthlyValues_With12Values_StoresThem()
+    {
+        var series = MonthlySeries.FromMonthlyValues(TwelveMonths);
+
+        series[0].Should().Be(10m);
+        series[11].Should().Be(120m);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(11)]
+    [InlineData(13)]
+    public void FromMonthlyValues_WithWrongLength_Throws(int length)
+    {
+        var values = new decimal[length];
+
+        var act = () => MonthlySeries.FromMonthlyValues(values);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Zero_AllTwelveMonthsAreZero()
+    {
+        var series = MonthlySeries.Zero();
+
+        series.AsReadOnly().Should().AllBeEquivalentTo(0m);
+    }
+
+    [Fact]
+    public void Sum_ReturnsTotalAcrossAllMonths()
+    {
+        var series = MonthlySeries.FromMonthlyValues(TwelveMonths);
+
+        series.Sum().Should().Be(780m);
+    }
+
+    [Fact]
+    public void Average_DividesByMonthsElapsedAndRounds()
+    {
+        var series = MonthlySeries.FromMonthlyValues([10m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m, 0m]);
+
+        series.Average(monthsElapsed: 3, decimalPlaces: 2).Should().Be(3.33m);
+    }
+
+    [Fact]
+    public void Average_WithZeroMonthsElapsed_ReturnsZero()
+    {
+        var series = MonthlySeries.FromMonthlyValues(TwelveMonths);
+
+        series.Average(monthsElapsed: 0, decimalPlaces: 2).Should().Be(0m);
+    }
+
+    [Fact]
+    public void DiffsFrom_WithPriorClosingValue_FirstElementIsJanuaryMinusPriorClosing()
+    {
+        var series = MonthlySeries.FromMonthlyValues(TwelveMonths);
+
+        var diffs = series.DiffsFrom(priorClosingValue: 5m);
+
+        diffs[0].Should().Be(5m);
+    }
+
+    [Fact]
+    public void DiffsFrom_WithNullPriorClosingValue_FirstElementIsNull()
+    {
+        var series = MonthlySeries.FromMonthlyValues(TwelveMonths);
+
+        var diffs = series.DiffsFrom(priorClosingValue: null);
+
+        diffs[0].Should().BeNull();
+    }
+
+    [Fact]
+    public void DiffsFrom_SubsequentElements_AreMonthMinusPreviousMonth()
+    {
+        var series = MonthlySeries.FromMonthlyValues(TwelveMonths);
+
+        var diffs = series.DiffsFrom(priorClosingValue: null);
+
+        diffs[1].Should().Be(10m);
+        diffs[11].Should().Be(10m);
+    }
+
+    [Fact]
+    public void Add_SumsElementWise_ReturnsNewInstance()
+    {
+        var first = MonthlySeries.FromMonthlyValues(TwelveMonths);
+        var second = MonthlySeries.Zero();
+
+        var result = first.Add(second);
+
+        result.Should().NotBeSameAs(first);
+        result[0].Should().Be(10m);
+        result[11].Should().Be(120m);
+    }
+
+    [Fact]
+    public void Equals_TwoInstancesWithSameValues_AreEqual()
+    {
+        var first = MonthlySeries.FromMonthlyValues(TwelveMonths);
+        var second = MonthlySeries.FromMonthlyValues(TwelveMonths);
+
+        first.Should().Be(second);
+    }
+
+    [Fact]
+    public void Equals_DifferentValues_AreNotEqual()
+    {
+        var first = MonthlySeries.FromMonthlyValues(TwelveMonths);
+        var second = MonthlySeries.Zero();
+
+        first.Should().NotBe(second);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `MonthlySeries` Domain value object (12-slot vector: Sum/Average/DiffsFrom/Add), replacing the manually-indexed monthly arrays previously reimplemented three times in `AnnualSummaryService`.
- Adds `IncomeClassifier`/`CategoryClassifier` Domain rules, exposed as computed `Income.Group` and `Expense.IsInvestment` properties (mirroring the existing `Expense.PaymentStatus` pattern), plus `AnnualResultCalculator` for the Resultado (R-D-Inv) formula.
- **Bug fix**: the historic-average path previously let `IncomeSource.Lottery` silently fold into the Dividendo/Juros bucket (`GetIncomeGroup`'s catch-all), while `GetIncomeSummaryForYear` already excluded it correctly. `IncomeClassifier` introduces a formal `NonReportable` group so both paths now agree — Lottery income no longer inflates historic-average figures.
- Also fixed a double-subtraction bug in `GetInvestmentDiffsForYear` introduced mid-refactor (caught by the existing test suite before this PR).

## Test plan
- [x] `dotnet build` — full solution builds clean, zero new warnings
- [x] `dotnet test` — full solution: all 1447 tests pass (5 pre-existing browser-integration skips, unrelated)
- [x] New Domain tests: `MonthlySeriesTests`, `IncomeClassifierTests`, `CategoryClassifierTests`, `AnnualResultCalculatorTests`, plus `Income.Group`/`Expense.IsInvestment` cases
- [x] New regression test `GetHistoricSummaryAverageFromYear_LotteryIncomeContributesToNoRow` locks in the Lottery fix
- [x] All pre-existing `AnnualSummaryServiceTests` pass unmodified — confirms byte-identical output for every year without Lottery income

🤖 Generated with [Claude Code](https://claude.com/claude-code)