### PR TITLE
feat(cashflow): add Category Totals endpoint (server-side computation)

### DIFF
--- a/Financial.Api/Controllers/AnnualSummaryController.cs
+++ b/Financial.Api/Controllers/AnnualSummaryController.cs
@@ -42,4 +42,11 @@ public sealed class AnnualSummaryController : ControllerBase
     {
         return Ok(_annualSummaryService.GetHistoricSummaryAverageFromYear(year));
     }
+
+    [HttpGet("{year:int}/category-totals")]
+    [ProducesResponseType(typeof(CategoryTotalsAnnualDTO), StatusCodes.Status200OK)]
+    public ActionResult<CategoryTotalsAnnualDTO> GetCategoryTotals(int year)
+    {
+        return Ok(_annualSummaryService.GetCategoryTotalsAnnualForYear(year));
+    }
 }

--- a/Financial.CashFlow.Application/DTOs/CategoryTotalsAnnualDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/CategoryTotalsAnnualDTO.cs
@@ -1,0 +1,19 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Combined read model for the Annual Summary page's Category Totals tab: category totals,
+/// income summary, and the server-computed Total despesas / Resultado (R-D-Inv) figures.
+/// </summary>
+public sealed class CategoryTotalsAnnualDTO
+{
+    public required IReadOnlyList<CategoryAnnualTotalDTO> CategoryTotals { get; init; }
+    public required IncomeAnnualSummaryDTO IncomeSummary { get; init; }
+
+    /// <summary>Sum of all category rows' MonthlyTotals, per month.</summary>
+    public required decimal[] TotalDespesasMonthly { get; init; }
+    public required decimal TotalDespesasAnnualTotal { get; init; }
+
+    /// <summary>Salary after taxes minus Total despesas plus the Investimento category value, per month (no Dividendo/Juros term).</summary>
+    public required decimal[] ResultadoMonthly { get; init; }
+    public required decimal ResultadoAnnualTotal { get; init; }
+}

--- a/Financial.CashFlow.Application/Interfaces/IAnnualSummaryService.cs
+++ b/Financial.CashFlow.Application/Interfaces/IAnnualSummaryService.cs
@@ -8,4 +8,5 @@ public interface IAnnualSummaryService
     InvestmentDiffsAnnualDTO GetInvestmentDiffsForYear(int year);
     IncomeAnnualSummaryDTO GetIncomeSummaryForYear(int year);
     IReadOnlyList<CategoryAnnualGroupValueDTO> GetHistoricSummaryAverageFromYear(int year);
+    CategoryTotalsAnnualDTO GetCategoryTotalsAnnualForYear(int year);
 }

--- a/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
+++ b/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
@@ -156,6 +156,34 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
         };
     }
 
+    public CategoryTotalsAnnualDTO GetCategoryTotalsAnnualForYear(int year)
+    {
+        var categoryTotals = GetCategoryTotalsForYear(year);
+        var incomeSummary = GetIncomeSummaryForYear(year);
+
+        var totalDespesasSeries = categoryTotals.Aggregate(
+            MonthlySeries.Zero(),
+            (total, category) => total.Add(MonthlySeries.FromMonthlyValues(category.MonthlyTotals)));
+
+        var investimentoSeries = MonthlySeries.FromMonthlyValues(
+            categoryTotals.FirstOrDefault(c => c.Category == nameof(Category.Investimento))?.MonthlyTotals
+                ?? new decimal[MonthsInYear]);
+
+        var salaryAfterTaxesSeries = MonthlySeries.FromMonthlyValues(incomeSummary.SalaryAfterTaxesMonthly);
+
+        var resultadoSeries = AnnualResultCalculator.ComputeResultado(salaryAfterTaxesSeries, totalDespesasSeries, investimentoSeries);
+
+        return new CategoryTotalsAnnualDTO
+        {
+            CategoryTotals = categoryTotals,
+            IncomeSummary = incomeSummary,
+            TotalDespesasMonthly = totalDespesasSeries.AsReadOnly().ToArray(),
+            TotalDespesasAnnualTotal = totalDespesasSeries.Sum(),
+            ResultadoMonthly = resultadoSeries.AsReadOnly().ToArray(),
+            ResultadoAnnualTotal = resultadoSeries.Sum()
+        };
+    }
+
     public IReadOnlyList<CategoryAnnualGroupValueDTO> GetHistoricSummaryAverageFromYear(int year)
     {
         var incomeAverages = GetHistoricIncomeAverageFromYear(year);

--- a/Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs
@@ -211,4 +211,72 @@ public class AnnualSummaryEndpointsTests
         result[1].AnnualAverages.Should().ContainSingle(a => a.Category == "Mercado" && a.Value == 10m);
         result[1].AnnualAverages.Should().NotContain(a => a.Category == "Salary");
     }
+
+    [Fact]
+    public async Task GetCategoryTotals_ReturnsCombinedShapeWithComputedTotalDespesasAndResultado()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 1, 5),
+            Description = "January groceries",
+            Value = 100m,
+            Category = "Mercado",
+            PaymentSource = "Barclays",
+            CardTag = null
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
+        {
+            Date = new DateOnly(2026, 1, 5),
+            Description = "January investing",
+            Value = 30m,
+            Category = "Investimento",
+            PaymentSource = "Barclays",
+            CardTag = null
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 1, 1),
+            IncomeSource = "Gleison",
+            GrossValue = 1000m,
+            NetValue = 800m,
+            Bank = "Barclays"
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/incomes", new IncomeCreateDTO
+        {
+            Date = new DateOnly(2026, 1, 1),
+            IncomeSource = "DividendoJuros",
+            GrossValue = null,
+            NetValue = 20m,
+            Bank = "Trading212"
+        });
+
+        var response = await client.GetAsync("/api/v1/financial/annual-summary/2026/category-totals");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CategoryTotalsAnnualDTO>();
+        result!.CategoryTotals.Should().HaveCount(14);
+        result.IncomeSummary.SalaryAfterTaxesMonthly[0].Should().Be(800m);
+        result.TotalDespesasMonthly[0].Should().Be(130m);
+        result.TotalDespesasAnnualTotal.Should().Be(130m);
+        // Resultado = SalaryAfterTaxes(800) - TotalDespesas(130) + Investimento(30) = 700, excluding Dividendo/Juros.
+        result.ResultadoMonthly[0].Should().Be(700m);
+        result.ResultadoAnnualTotal.Should().Be(700m);
+    }
+
+    [Fact]
+    public async Task GetCategoryTotals_NoRecordedData_ReturnsAllZeroSeries()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/financial/annual-summary/2026/category-totals");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CategoryTotalsAnnualDTO>();
+        result!.CategoryTotals.Should().OnlyContain(c => c.AnnualTotal == 0m);
+        result.TotalDespesasMonthly.Should().OnlyContain(v => v == 0m);
+        result.ResultadoMonthly.Should().OnlyContain(v => v == 0m);
+    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -453,6 +453,84 @@ public class AnnualSummaryServiceTests
         result.DividendoJurosMonthly.Should().OnlyContain(v => v == 0m);
     }
 
+    [Fact]
+    public void GetCategoryTotalsAnnualForYear_TotalDespesasMonthlyEqualsSumOfAllCategoriesPerMonth()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 2, 5), "Groceries", 50m, Category.Mercado, "Barclays", null));
+        var service = new AnnualSummaryService(repository);
+
+        var result = service.GetCategoryTotalsAnnualForYear(2026);
+
+        result.TotalDespesasMonthly[0].Should().Be(130m);
+        result.TotalDespesasMonthly[1].Should().Be(50m);
+        result.TotalDespesasMonthly.Skip(2).Should().OnlyContain(v => v == 0m);
+    }
+
+    [Fact]
+    public void GetCategoryTotalsAnnualForYear_ResultadoMonthlyExcludesDividendoJurosAndIncludesInvestimento()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        // DividendoJuros is seeded deliberately: the corrected formula must exclude it entirely.
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.DividendoJuros, null, 20m, "Barclays"));
+        var service = new AnnualSummaryService(repository);
+
+        var result = service.GetCategoryTotalsAnnualForYear(2026);
+
+        // Resultado = SalaryAfterTaxes(800) - TotalDespesas(130) + Investimento(30) = 700, not 720.
+        result.ResultadoMonthly[0].Should().Be(700m);
+    }
+
+    [Fact]
+    public void GetCategoryTotalsAnnualForYear_AnnualTotalsEqualSumOfMonthlyValues()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 6, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        var service = new AnnualSummaryService(repository);
+
+        var result = service.GetCategoryTotalsAnnualForYear(2026);
+
+        result.TotalDespesasAnnualTotal.Should().Be(result.TotalDespesasMonthly.Sum());
+        result.ResultadoAnnualTotal.Should().Be(result.ResultadoMonthly.Sum());
+    }
+
+    [Fact]
+    public void GetCategoryTotalsAnnualForYear_NoRecordedData_ReturnsAllZeroSeries()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+
+        var result = service.GetCategoryTotalsAnnualForYear(2026);
+
+        result.CategoryTotals.Should().HaveCount(Enum.GetValues<Category>().Length)
+            .And.OnlyContain(c => c.AnnualTotal == 0m);
+        result.IncomeSummary.SalaryAnnualTotal.Should().Be(0m);
+        result.TotalDespesasMonthly.Should().OnlyContain(v => v == 0m);
+        result.TotalDespesasAnnualTotal.Should().Be(0m);
+        result.ResultadoMonthly.Should().OnlyContain(v => v == 0m);
+        result.ResultadoAnnualTotal.Should().Be(0m);
+    }
+
+    [Fact]
+    public void GetCategoryTotalsAnnualForYear_NestedCategoryTotalsAndIncomeSummaryMatchStandaloneMethods()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        var service = new AnnualSummaryService(repository);
+
+        var result = service.GetCategoryTotalsAnnualForYear(2026);
+
+        result.CategoryTotals.Should().BeEquivalentTo(service.GetCategoryTotalsForYear(2026));
+        result.IncomeSummary.Should().BeEquivalentTo(service.GetIncomeSummaryForYear(2026));
+    }
 
     [Fact]
     public void GetHistoricSummaryAverageFromYear_ReturnsEmptyList_WhenNoExpensesForSpecifiedYear()

--- a/docs/P19-F02-category-totals-endpoint/plan.md
+++ b/docs/P19-F02-category-totals-endpoint/plan.md
@@ -1,0 +1,24 @@
+# Implementation Plan: F02. Category Totals Endpoint (Server-Side Computation)
+
+**Prerequisites:**
+- .NET solution builds and existing test suite passes on `main` (F01, F04 already merged)
+- No new NuGet/npm packages, environment variables, or configuration files required
+- Branch `feat/P19-F02-category-totals-endpoint`, already created from `main`
+
+### Stage 1: Application Layer
+
+**1. Combined Response DTO** - Add `CategoryTotalsAnnualDTO` nesting the existing `CategoryAnnualTotalDTO` list and `IncomeAnnualSummaryDTO`, plus the four new computed fields (`TotalDespesasMonthly`/`TotalDespesasAnnualTotal`, `ResultadoMonthly`/`ResultadoAnnualTotal`), following the sealed/`required`-init style of its sibling DTOs.
+
+**2. Combined Computation Method** - Add `GetCategoryTotalsAnnualForYear` to `IAnnualSummaryService` and implement it in `AnnualSummaryService`, composing the existing `GetCategoryTotalsForYear`/`GetIncomeSummaryForYear` methods unchanged, aggregating Total despesas across all 14 categories per month, and computing Resultado via F01's `AnnualResultCalculator.ComputeResultado(MonthlySeries, MonthlySeries, MonthlySeries)` overload (salary-after-taxes, total despesas, Investimento category series) — the corrected formula with no Dividendo/Juros term.
+
+### Stage 2: Presentation Layer
+
+**3. New Endpoint** - Add a `GetCategoryTotals` action to `AnnualSummaryController` at `[HttpGet("{year:int}/category-totals")]`, thin pass-through to the new service method, alongside (not replacing) the existing `expense-categories`/`income-summary` actions.
+
+### Stage 3: Test Suite
+
+**4. Service Unit Tests** - Add tests to `AnnualSummaryServiceTests.cs` covering: Total despesas equals the per-month sum across all categories; Resultado excludes Dividendo/Juros and includes Investimento; annual totals equal the sum of their monthly series; a zero-data year returns all-zero series; and the nested `categoryTotals`/`incomeSummary` match the existing standalone methods' output exactly.
+
+**5. API Integration Tests** - Add tests to `AnnualSummaryEndpointsTests.cs` covering a `200 OK` response with the combined shape for seeded data and for a zero-data year, and confirm the existing endpoint tests (`expense-categories`, `income-summary`, `investment-diffs`, `historic-summary-averages`) still pass unmodified.
+
+**6. Full Suite Verification** - Run the complete backend test suite (`dotnet test`) and confirm the solution still builds cleanly, verifying this feature introduced no regressions to the unmodified existing endpoints.

--- a/docs/P19-F02-category-totals-endpoint/spec.md
+++ b/docs/P19-F02-category-totals-endpoint/spec.md
@@ -1,0 +1,132 @@
+## 1. Technical Overview
+
+**What:** New endpoint `GET /annual-summary/{year}/category-totals` that composes the existing `GetCategoryTotalsForYear` and `GetIncomeSummaryForYear` computations with two new computed figures — `totalDespesasMonthly`/`totalDespesasAnnualTotal` and `resultadoMonthly`/`resultadoAnnualTotal` — into one response DTO (`CategoryTotalsAnnualDTO`). `resultadoMonthly` is computed via F01's already-implemented `AnnualResultCalculator.ComputeResultado(MonthlySeries, MonthlySeries, MonthlySeries)` overload, which has no caller yet in the codebase.
+
+**Why:** Relocates two real business rules (Total despesas, Resultado R-D-Inv) that today live client-side in `useAnnualSummary.ts` into the Application/Domain layers, and adopts the corrected Resultado formula (no Dividendo/Juros term) for the Category Totals tab, matching what Historic Summary Average has always computed — resolving the drift documented in the PRD's Problem section.
+
+**Scope:**
+- Included: new `CategoryTotalsAnnualDTO`; new `AnnualSummaryService.GetCategoryTotalsAnnualForYear(int year)` composing the existing `GetCategoryTotalsForYear`/`GetIncomeSummaryForYear` methods as internal steps; new controller action and route; unit tests for the new formulas (including a zero-data year and a non-zero Investimento/Dividendo-Juros case); an integration test for the new route.
+- Excluded / deferred: removing the `expense-categories` and `income-summary` routes and their controller actions. **Decision (confirmed with user):** `useAnnualSummary.ts` fetches all annual-summary endpoints with a single `Promise.all`, so removing any one of the old routes before the frontend is migrated would break the entire Annual Summary page — including the already-shipped Historic Summary Average tab — and fail the CI browser smoke test on this feature's own PR. The old routes are therefore left fully intact and unchanged by F02; their removal (and the corresponding PRD F02 acceptance-criteria bullet "`expense-categories`/`income-summary` return 404") is deferred to F05, which migrates the frontend in the same PR that removes them. This mirrors the standard expand/contract migration pattern and keeps CI green on every PR. F03's `investment-annual-result` endpoint and `investment-diffs` removal are a separate feature, unaffected by this decision.
+
+## 2. Architecture Impact
+
+**Affected components:**
+
+| File Path | New/Modified | Purpose |
+|-----------|--------------|---------|
+| `Financial.CashFlow.Application/DTOs/CategoryTotalsAnnualDTO.cs` | New | Combined response read model for the new endpoint |
+| `Financial.CashFlow.Application/Interfaces/IAnnualSummaryService.cs` | Modified | Add `GetCategoryTotalsAnnualForYear(int year)` |
+| `Financial.CashFlow.Application/Services/AnnualSummaryService.cs` | Modified | Add `GetCategoryTotalsAnnualForYear`, composing existing `GetCategoryTotalsForYear`/`GetIncomeSummaryForYear` and calling F01's `AnnualResultCalculator.ComputeResultado(MonthlySeries, MonthlySeries, MonthlySeries)` |
+| `Financial.Api/Controllers/AnnualSummaryController.cs` | Modified | Add `GetCategoryTotals` action, `[HttpGet("{year:int}/category-totals")]` |
+| `Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs` | Modified | New tests for `GetCategoryTotalsAnnualForYear` |
+| `Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs` | Modified | New integration test for `category-totals` |
+
+No Domain-layer changes — `AnnualResultCalculator` and `MonthlySeries` already exist (F01, merged).
+
+```mermaid
+graph TD
+    A["AnnualSummaryService.GetCategoryTotalsAnnualForYear"] --> B["GetCategoryTotalsForYear (existing, unchanged)"]
+    A --> C["GetIncomeSummaryForYear (existing, unchanged)"]
+    B --> D["totalDespesasMonthly = sum of 14 categories' MonthlyTotals per month"]
+    C --> E["salaryAfterTaxesMonthly"]
+    B --> F["Investimento category's MonthlyTotals"]
+    D --> G["AnnualResultCalculator.ComputeResultado(MonthlySeries, MonthlySeries, MonthlySeries)"]
+    E --> G
+    F --> G
+    G --> H["resultadoMonthly / resultadoAnnualTotal"]
+    D --> I["CategoryTotalsAnnualDTO"]
+    H --> I
+    B --> I
+    C --> I
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|------------------|-------------------------|-----------|
+| Old route removal timing | Deferred to F05; `expense-categories`/`income-summary` stay fully functional and unmodified in this feature | Remove routes now per PRD's literal F02 wording | Removing now breaks the whole Annual Summary page (Promise.all in `useAnnualSummary.ts`) until F05 lands, failing CI's browser smoke test on this PR. Confirmed with user; standard expand/contract migration pattern. |
+| `GetCategoryTotalsForYear`/`GetIncomeSummaryForYear` visibility | Left exactly as-is: public on both `IAnnualSummaryService` and the concrete class | Make them `private` now that a combined method exists, per PRD's "internal (private) steps" wording | They must stay public on the interface anyway since the still-active `expense-categories`/`income-summary` controller actions call them through `IAnnualSummaryService`. Keeping them unchanged also means the ~15 existing direct-call unit tests for these two methods keep passing unmodified — zero risk, consistent with CLAUDE.md's no-over-engineering guidance for this personal project. |
+| Locating the Investimento category row | `categoryTotals.FirstOrDefault(c => c.Category == nameof(Category.Investimento))`, falling back to an all-zero series if absent | Add an `IsInvestment` flag to `CategoryAnnualTotalDTO` | Matches the exact string-comparison idiom `AnnualSummaryService.AddCategoryTotal` already uses to find the Investimento row in the historic-average path (`CategoryAnnualTotalDTO.Category` is already a flattened string, not a domain `Category` value, at this point in the pipeline) — no new DTO field needed. |
+| Building `totalDespesasMonthly` from the 14 per-category `CategoryAnnualTotalDTO.MonthlyTotals` arrays | Rebuild a `MonthlySeries` per category via `MonthlySeries.FromMonthlyValues(dto.MonthlyTotals)` and `Aggregate(MonthlySeries.Zero(), (acc, c) => acc.Add(c))` | Change `GetCategoryTotalsForYear` to also expose the underlying `MonthlySeries` objects instead of only `decimal[]` | Avoids touching a well-tested, unchanged existing method/DTO shape purely to serve this one new caller; the reconstruction is 14 cheap array wraps, negligible for a single-user app. |
+| New DTO name and field names | `CategoryTotalsAnnualDTO` with `CategoryTotals`, `IncomeSummary`, `TotalDespesasMonthly`, `TotalDespesasAnnualTotal`, `ResultadoMonthly`, `ResultadoAnnualTotal` | — | Field names are prescribed verbatim by PRD F02 Capabilities/Section 9 AC (camelCase on the wire via existing JSON serialization conventions); `Annual` suffix matches the sibling `IncomeAnnualSummaryDTO`/`InvestmentDiffsAnnualDTO` naming convention already in `Financial.CashFlow.Application/DTOs/`. |
+
+## 4. Component Overview
+
+**Backend — Application (`Financial.CashFlow.Application`):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|----------------------|
+| `DTOs/CategoryTotalsAnnualDTO.cs` | New | Combined Category Totals tab read model | `CategoryTotals: IReadOnlyList<CategoryAnnualTotalDTO>`, `IncomeSummary: IncomeAnnualSummaryDTO`, `TotalDespesasMonthly: decimal[]`, `TotalDespesasAnnualTotal: decimal`, `ResultadoMonthly: decimal[]`, `ResultadoAnnualTotal: decimal` — sealed, `required`-init, matching sibling DTO style |
+| `Interfaces/IAnnualSummaryService.cs` | Modified | Service contract | Add `CategoryTotalsAnnualDTO GetCategoryTotalsAnnualForYear(int year)` |
+| `Services/AnnualSummaryService.cs` | Modified | Annual summary computation | New public `GetCategoryTotalsAnnualForYear`: calls `GetCategoryTotalsForYear`/`GetIncomeSummaryForYear` internally, aggregates `totalDespesasMonthly` from the 14 category series, resolves the Investimento series, calls `AnnualResultCalculator.ComputeResultado(MonthlySeries, MonthlySeries, MonthlySeries)` for `resultadoMonthly`, sums both series for the two annual totals |
+
+**Backend — Presentation (`Financial.Api`):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|----------------------|
+| `Controllers/AnnualSummaryController.cs` | Modified | Thin pass-through controller | New `[HttpGet("{year:int}/category-totals")]` action `GetCategoryTotals(int year)` returning `Ok(_annualSummaryService.GetCategoryTotalsAnnualForYear(year))`; existing actions untouched |
+
+No Domain or Infrastructure files change — `AnnualResultCalculator` and `MonthlySeries` (F01) are consumed, not modified.
+
+## 5. API Contracts
+
+**Endpoint:** `GET /api/v1/financial/annual-summary/{year}/category-totals`
+
+**Response — `200 OK`:**
+
+```json
+{
+  "categoryTotals": [
+    { "category": "Ariana", "monthlyTotals": [0,0,0,0,0,0,0,0,0,0,0,0], "annualTotal": 0 },
+    { "category": "Investimento", "monthlyTotals": [500,500,500,500,500,500,500,500,500,500,500,500], "annualTotal": 6000 }
+  ],
+  "incomeSummary": {
+    "salaryMonthly": [3000,3000,3000,3000,3000,3000,3000,3000,3000,3000,3000,3000],
+    "salaryAnnualTotal": 36000,
+    "salaryAfterTaxesMonthly": [2500,2500,2500,2500,2500,2500,2500,2500,2500,2500,2500,2500],
+    "salaryAfterTaxesAnnualTotal": 30000,
+    "taxDifferenceMonthly": [500,500,500,500,500,500,500,500,500,500,500,500],
+    "taxDifferenceAnnualTotal": 6000,
+    "dividendoJurosMonthly": [100,100,100,100,100,100,100,100,100,100,100,100],
+    "dividendoJurosAnnualTotal": 1200
+  },
+  "totalDespesasMonthly": [1200,1200,1200,1200,1200,1200,1200,1200,1200,1200,1200,1200],
+  "totalDespesasAnnualTotal": 14400,
+  "resultadoMonthly": [1800,1800,1800,1800,1800,1800,1800,1800,1800,1800,1800,1800],
+  "resultadoAnnualTotal": 21600
+}
+```
+`resultadoMonthly[m] = salaryAfterTaxesMonthly[m] - totalDespesasMonthly[m] + Investimento.monthlyTotals[m]` — note `dividendoJurosMonthly` deliberately does not appear in this formula (the corrected, no-Dividendo/Juros formula).
+
+**Response — zero-data year:** all `categoryTotals[].monthlyTotals`/`annualTotal`, `incomeSummary` fields, `totalDespesasMonthly`/`totalDespesasAnnualTotal`, and `resultadoMonthly`/`resultadoAnnualTotal` are `0`-filled — no error, no missing fields (falls out for free from the existing zero-fill behavior of the two composed methods).
+
+**Unchanged endpoints (not modified by this feature):** `GET .../expense-categories`, `GET .../income-summary`, `GET .../investment-diffs`, `GET .../historic-summary-averages` all continue to behave exactly as today.
+
+## 6. Data Model
+
+No entity or persisted JSON shape changes — this is a read-only computed response composed from already-persisted `Expense`/`Income` data via the existing repository methods.
+
+**Cross-Database Notes:** Not applicable — no relational database is used anywhere in this solution.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs` | Unit | `AnnualSummaryService.GetCategoryTotalsAnnualForYear` | Total despesas sums all 14 categories per month; Resultado excludes Dividendo/Juros; zero-data year; nested `categoryTotals`/`incomeSummary` match the existing standalone methods' output byte-for-byte |
+| `Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs` | Integration | `GET .../category-totals` | `200 OK`, response shape, zero-data year; existing `expense-categories`/`income-summary`/`investment-diffs`/`historic-summary-averages` tests continue to pass unmodified (regression check that this feature didn't touch them) |
+
+**Key test functions:**
+
+| Test Function | Description | Assertions |
+|----------------|-------------|------------|
+| `GetCategoryTotalsAnnualForYear_TotalDespesasMonthlyEqualsSumOfAllCategoriesPerMonth` | Expenses across multiple categories/months | `TotalDespesasMonthly[m]` equals the sum of all 14 `CategoryTotals[*].MonthlyTotals[m]` for every `m` |
+| `GetCategoryTotalsAnnualForYear_ResultadoMonthlyExcludesDividendoJurosAndIncludesInvestimento` | Non-zero Investimento expenses and non-zero Dividendo/Juros income in the same year | `ResultadoMonthly[m] == SalaryAfterTaxesMonthly[m] - TotalDespesasMonthly[m] + Investimento.MonthlyTotals[m]`, confirmed to differ from a naively-including-DividendoJuros calculation |
+| `GetCategoryTotalsAnnualForYear_AnnualTotalsEqualSumOfMonthlyValues` | Any populated year | `TotalDespesasAnnualTotal == TotalDespesasMonthly.Sum()`; `ResultadoAnnualTotal == ResultadoMonthly.Sum()` |
+| `GetCategoryTotalsAnnualForYear_NoRecordedData_ReturnsAllZeroSeries` | Year with no expenses/income | Every field is zero-filled, no exception |
+| `GetCategoryTotalsAnnualForYear_NestedCategoryTotalsAndIncomeSummaryMatchStandaloneMethods` | Regression | `result.CategoryTotals` equals `GetCategoryTotalsForYear(year)`; `result.IncomeSummary` equals `GetIncomeSummaryForYear(year)`, field-by-field |
+| `GetCategoryTotals_ReturnsOkWithCombinedShape` (Api, integration) | Seeded expenses/income for a year | `200 OK`; deserialized body has non-null `categoryTotals`, `incomeSummary`, and correct `totalDespesasMonthly`/`resultadoMonthly` lengths (12) |
+| `GetCategoryTotals_NoRecordedData_ReturnsAllZeroSeries` (Api, integration) | Year with no seeded data | `200 OK`; all numeric fields zero |
+
+**Integration-level check:** No live-data run — this endpoint is additive only (old routes untouched), so the existing `expense-categories`/`income-summary` behavior the live app currently depends on is unaffected. Unit and integration tests are the full verification surface for this feature.

--- a/docs/prd/P19-prd-annual-summary-category-totals-server-computation/prd-annual-summary-category-totals-server-computation.md
+++ b/docs/prd/P19-prd-annual-summary-category-totals-server-computation/prd-annual-summary-category-totals-server-computation.md
@@ -224,13 +224,13 @@ graph TD
 - [x] Unit tests cover each method independently, including edge cases (empty/zero input, `null` `priorClosingValue`) — see `MonthlySeriesTests`, `AnnualResultCalculatorTests`, `IncomeClassifierTests`, `CategoryClassifierTests` in `Tests\Financial.CashFlow.Domain.Tests`
 
 ### F02. Category Totals Endpoint (Server-Side Computation)
-- [ ] `GET /annual-summary/{year}/category-totals` returns `200 OK` with a single JSON object containing `categoryTotals`, `incomeSummary`, `totalDespesasMonthly`, `totalDespesasAnnualTotal`, `resultadoMonthly`, `resultadoAnnualTotal`
-- [ ] `totalDespesasMonthly[m]` equals the sum of all category rows' monthly totals for month `m`, verified for every month 0-11 against a known test dataset
-- [ ] `resultadoMonthly[m]` equals `salaryAfterTaxesMonthly[m] - totalDespesasMonthly[m] + Investimento category's monthlyTotals[m]` (no Dividendo/Juros term), verified for every month against a known test dataset, including a case where Dividendo/Juros is non-zero to confirm it is correctly excluded
-- [ ] `totalDespesasAnnualTotal` equals the sum of `totalDespesasMonthly`, and `resultadoAnnualTotal` equals the sum of `resultadoMonthly`
-- [ ] A year with no recorded data returns all-zero series rather than an error or missing fields
+- [x] `GET /annual-summary/{year}/category-totals` returns `200 OK` with a single JSON object containing `categoryTotals`, `incomeSummary`, `totalDespesasMonthly`, `totalDespesasAnnualTotal`, `resultadoMonthly`, `resultadoAnnualTotal`
+- [x] `totalDespesasMonthly[m]` equals the sum of all category rows' monthly totals for month `m`, verified for every month 0-11 against a known test dataset
+- [x] `resultadoMonthly[m]` equals `salaryAfterTaxesMonthly[m] - totalDespesasMonthly[m] + Investimento category's monthlyTotals[m]` (no Dividendo/Juros term), verified for every month against a known test dataset, including a case where Dividendo/Juros is non-zero to confirm it is correctly excluded
+- [x] `totalDespesasAnnualTotal` equals the sum of `totalDespesasMonthly`, and `resultadoAnnualTotal` equals the sum of `resultadoMonthly`
+- [x] A year with no recorded data returns all-zero series rather than an error or missing fields
 - [ ] `GET /annual-summary/{year}/expense-categories` and `/income-summary` return `404 Not Found` (routes removed)
-- [ ] Unit tests cover the Total despesas/Resultado formulas, including an all-zero-data year and a year including a non-zero Investimento category value
+- [x] Unit tests cover the Total despesas/Resultado formulas, including an all-zero-data year and a year including a non-zero Investimento category value
 
 ### F03. Investment Annual Result Endpoint (Server-Side Computation)
 - [ ] `GET /annual-summary/{year}/investment-annual-result` returns `200 OK` with `accounts[]` and `netPosition`, matching the field shapes previously returned by `investment-diffs`


### PR DESCRIPTION
## Summary
- Adds `GET /annual-summary/{year}/category-totals`, composing the existing category-totals and income-summary computations with two new server-computed figures: `totalDespesasMonthly`/`totalDespesasAnnualTotal` and `resultadoMonthly`/`resultadoAnnualTotal`.
- `resultadoMonthly` is computed via F01's `AnnualResultCalculator.ComputeResultado(MonthlySeries, MonthlySeries, MonthlySeries)` overload (previously unused), adopting the corrected formula (no Dividendo/Juros term) that Historic Summary Average has always used.
- Relocates real business logic that today lives client-side in `useAnnualSummary.ts` into the Application/Domain layers, per CLAUDE.md's Clean Architecture rules.

## Sequencing note
The old `expense-categories`/`income-summary` routes are **intentionally left untouched** in this PR. `useAnnualSummary.ts` fetches every annual-summary endpoint via a single `Promise.all`, so removing either old route before the frontend migrates (F05) would break the entire Annual Summary page — including the already-shipped Historic Summary Average tab — and fail the CI browser smoke test on this PR. Their removal (and the corresponding PRD F02 AC checkbox) is deferred to F05, which switches the frontend over and removes the old routes in the same change. Full rationale in `docs/P19-F02-category-totals-endpoint/spec.md` → Technical Decisions.

## Acceptance Criteria (PRD Section 9, F02)
- [x] `GET /annual-summary/{year}/category-totals` returns `200 OK` with `categoryTotals`, `incomeSummary`, `totalDespesasMonthly`, `totalDespesasAnnualTotal`, `resultadoMonthly`, `resultadoAnnualTotal`
- [x] `totalDespesasMonthly[m]` equals the sum of all category rows' monthly totals for month `m`
- [x] `resultadoMonthly[m]` equals `salaryAfterTaxesMonthly[m] - totalDespesasMonthly[m] + Investimento[m]`, excluding Dividendo/Juros
- [x] `totalDespesasAnnualTotal`/`resultadoAnnualTotal` equal the sum of their monthly series
- [x] A year with no recorded data returns all-zero series, not an error
- [ ] `expense-categories`/`income-summary` return `404` (routes removed) — **deferred to F05**, see Sequencing note above
- [x] Unit tests cover the Total despesas/Resultado formulas, including a zero-data year and a non-zero Investimento case

## Test plan
- [x] `dotnet test` — full backend suite green (`Financial.CashFlow.Application.Tests`, `Financial.Api.Tests`, and all other projects), no regressions
- [x] New unit tests in `AnnualSummaryServiceTests.cs` for `GetCategoryTotalsAnnualForYear`
- [x] New integration tests in `AnnualSummaryEndpointsTests.cs` for the new route (happy path + zero-data year)
- [ ] Frontend/browser smoke test — unaffected by this PR (old routes still serve the existing frontend unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)