### PR TITLE
feat(cashflow): add Investment Annual Result endpoint (server-side computation)

### DIFF
--- a/Financial.Api/Controllers/AnnualSummaryController.cs
+++ b/Financial.Api/Controllers/AnnualSummaryController.cs
@@ -49,4 +49,11 @@ public sealed class AnnualSummaryController : ControllerBase
     {
         return Ok(_annualSummaryService.GetCategoryTotalsAnnualForYear(year));
     }
+
+    [HttpGet("{year:int}/investment-annual-result")]
+    [ProducesResponseType(typeof(InvestmentAnnualResultDTO), StatusCodes.Status200OK)]
+    public ActionResult<InvestmentAnnualResultDTO> GetInvestmentAnnualResult(int year)
+    {
+        return Ok(_annualSummaryService.GetInvestmentAnnualResultForYear(year));
+    }
 }

--- a/Financial.CashFlow.Application/DTOs/InvestmentAnnualResultDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/InvestmentAnnualResultDTO.cs
@@ -1,0 +1,11 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Read model wrapping every investment account's annual results plus the combined net-position row.
+/// Reuses the existing per-account/net-position nested types verbatim.
+/// </summary>
+public sealed class InvestmentAnnualResultDTO
+{
+    public required InvestmentAccountAnnualDiffDTO[] Accounts { get; init; }
+    public required NetPositionAnnualDiffDTO NetPosition { get; init; }
+}

--- a/Financial.CashFlow.Application/Interfaces/IAnnualSummaryService.cs
+++ b/Financial.CashFlow.Application/Interfaces/IAnnualSummaryService.cs
@@ -9,4 +9,5 @@ public interface IAnnualSummaryService
     IncomeAnnualSummaryDTO GetIncomeSummaryForYear(int year);
     IReadOnlyList<CategoryAnnualGroupValueDTO> GetHistoricSummaryAverageFromYear(int year);
     CategoryTotalsAnnualDTO GetCategoryTotalsAnnualForYear(int year);
+    InvestmentAnnualResultDTO GetInvestmentAnnualResultForYear(int year);
 }

--- a/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
+++ b/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
@@ -1,5 +1,6 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Domain.Enums;
 using Financial.CashFlow.Domain.Rules;
 using Financial.CashFlow.Domain.ValueObjects;
@@ -10,6 +11,14 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
 {
     private const int MonthsInYear = 12;
     public const int AverageDecimalPlaces = 2;
+
+    /// <summary>
+    /// Investment averages/sums are intentionally never rounded (unlike the 2-decimal-place
+    /// income/category averages), so this endpoint's values stay byte-identical to the
+    /// pre-refactor investment-diffs output. Decimal division already caps at this many
+    /// fractional digits, so rounding to it is a no-op in practice.
+    /// </summary>
+    private const int FullPrecisionDecimalPlaces = 28;
 
     private readonly ICashFlowRepository _repository;
 
@@ -44,6 +53,77 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
 
     public InvestmentDiffsAnnualDTO GetInvestmentDiffsForYear(int year)
     {
+        var series = ComputeInvestmentSeriesForYear(year);
+
+        var accounts = series.AccountSeries
+            .Select(a => new InvestmentAccountAnnualDiffDTO
+            {
+                Account = a.Account.Name,
+                IsLiability = a.Account.IsLiability,
+                MonthlyValues = a.MonthlyValues.AsReadOnly().ToArray(),
+                MonthlyDiffs = a.Diffs.ToArray()
+            })
+            .ToList();
+
+        var relevantDiffs = series.NetPositionDiffs.Take(series.LastRelevantMonth).Where(d => d.HasValue).Select(d => d!.Value).ToList();
+
+        var netPosition = new NetPositionAnnualDiffDTO
+        {
+            MonthlyValues = series.NetPositionSeries.AsReadOnly().ToArray(),
+            MonthlyDiffs = series.NetPositionDiffs.ToArray(),
+            FullYearNetChange = series.NetPositionSeries[series.LastRelevantMonth - 1] - series.NetPositionSeries[0],
+            AverageMonthResult = relevantDiffs.Count > 0 ? relevantDiffs.Average() : 0m,
+            SumOfMonthResults = relevantDiffs.Sum()
+        };
+
+        return new InvestmentDiffsAnnualDTO
+        {
+            Accounts = accounts.ToArray(),
+            NetPosition = netPosition
+        };
+    }
+
+    public InvestmentAnnualResultDTO GetInvestmentAnnualResultForYear(int year)
+    {
+        var series = ComputeInvestmentSeriesForYear(year);
+
+        var accounts = series.AccountSeries
+            .Select(a => new InvestmentAccountAnnualDiffDTO
+            {
+                Account = a.Account.Name,
+                IsLiability = a.Account.IsLiability,
+                MonthlyValues = a.MonthlyValues.AsReadOnly().ToArray(),
+                MonthlyDiffs = a.Diffs.ToArray()
+            })
+            .ToList();
+
+        var relevantDiffsSeries = MonthlySeries.FromMonthlyValues(Enumerable.Range(0, MonthsInYear)
+            .Select(month => month < series.LastRelevantMonth ? series.NetPositionDiffs[month] ?? 0m : 0m)
+            .ToArray());
+        var monthsElapsed = series.NetPositionDiffs.Take(series.LastRelevantMonth).Count(d => d.HasValue);
+
+        var netPosition = new NetPositionAnnualDiffDTO
+        {
+            MonthlyValues = series.NetPositionSeries.AsReadOnly().ToArray(),
+            MonthlyDiffs = series.NetPositionDiffs.ToArray(),
+            FullYearNetChange = series.NetPositionSeries[series.LastRelevantMonth - 1] - series.NetPositionSeries[0],
+            AverageMonthResult = relevantDiffsSeries.Average(monthsElapsed, FullPrecisionDecimalPlaces),
+            SumOfMonthResults = relevantDiffsSeries.Sum()
+        };
+
+        return new InvestmentAnnualResultDTO
+        {
+            Accounts = accounts.ToArray(),
+            NetPosition = netPosition
+        };
+    }
+
+    private (
+        List<(InvestmentAccount Account, MonthlySeries MonthlyValues, IReadOnlyList<decimal?> Diffs)> AccountSeries,
+        MonthlySeries NetPositionSeries,
+        IReadOnlyList<decimal?> NetPositionDiffs,
+        int LastRelevantMonth) ComputeInvestmentSeriesForYear(int year)
+    {
         var allSnapshots = _repository.GetInvestmentSnapshots().ToList();
         var allAccounts = _repository.GetInvestmentAccounts().ToList();
         var scopedAccounts = YearScopedInvestmentAccountResolver.ResolveForYear(allAccounts, allSnapshots, year, DateTime.Now.Year);
@@ -71,17 +151,7 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
                     ? priorYearDecemberByAccount.GetValueOrDefault(account.Name, 0m)
                     : null;
 
-                return (account, monthlyValues, diffs: monthlyValues.DiffsFrom(priorClosingValue));
-            })
-            .ToList();
-
-        var accounts = accountSeries
-            .Select(a => new InvestmentAccountAnnualDiffDTO
-            {
-                Account = a.account.Name,
-                IsLiability = a.account.IsLiability,
-                MonthlyValues = a.monthlyValues.AsReadOnly().ToArray(),
-                MonthlyDiffs = a.diffs.ToArray()
+                return (account, monthlyValues, diffs: (IReadOnlyList<decimal?>)monthlyValues.DiffsFrom(priorClosingValue));
             })
             .ToList();
 
@@ -97,22 +167,8 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
         var netPositionDiffs = netPositionSeries.DiffsFrom(netPositionPriorClosingValue);
 
         var lastRelevantMonth = year >= DateTime.Now.Year ? Math.Min(DateTime.Now.Month, MonthsInYear) : MonthsInYear;
-        var relevantDiffs = netPositionDiffs.Take(lastRelevantMonth).Where(d => d.HasValue).Select(d => d!.Value).ToList();
 
-        var netPosition = new NetPositionAnnualDiffDTO
-        {
-            MonthlyValues = netPositionSeries.AsReadOnly().ToArray(),
-            MonthlyDiffs = netPositionDiffs.ToArray(),
-            FullYearNetChange = netPositionSeries[lastRelevantMonth - 1] - netPositionSeries[0],
-            AverageMonthResult = relevantDiffs.Count > 0 ? relevantDiffs.Average() : 0m,
-            SumOfMonthResults = relevantDiffs.Sum()
-        };
-
-        return new InvestmentDiffsAnnualDTO
-        {
-            Accounts = accounts.ToArray(),
-            NetPosition = netPosition
-        };
+        return (accountSeries, netPositionSeries, netPositionDiffs, lastRelevantMonth);
     }
 
     public IncomeAnnualSummaryDTO GetIncomeSummaryForYear(int year)

--- a/Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs
@@ -279,4 +279,47 @@ public class AnnualSummaryEndpointsTests
         result.TotalDespesasMonthly.Should().OnlyContain(v => v == 0m);
         result.ResultadoMonthly.Should().OnlyContain(v => v == 0m);
     }
+
+    [Fact]
+    public async Task GetInvestmentAnnualResult_ReturnsOkMatchingSeededSnapshots()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var januarySnapshots = await client.GetAsync("/api/v1/financial/investment-snapshots/2026/1");
+        var january = await januarySnapshots.Content.ReadFromJsonAsync<List<InvestmentSnapshotDTO>>();
+        var chaseSaveJan = january!.First(s => s.Account == "ChaseSave");
+        await client.PutAsJsonAsync($"/api/v1/financial/investment-snapshots/{chaseSaveJan.Id}", new UpdateInvestmentSnapshotValueDTO { Value = 1000m });
+        var februarySnapshots = await client.GetAsync("/api/v1/financial/investment-snapshots/2026/2");
+        var february = await februarySnapshots.Content.ReadFromJsonAsync<List<InvestmentSnapshotDTO>>();
+        var chaseSaveFeb = february!.First(s => s.Account == "ChaseSave");
+        await client.PutAsJsonAsync($"/api/v1/financial/investment-snapshots/{chaseSaveFeb.Id}", new UpdateInvestmentSnapshotValueDTO { Value = 1200m });
+
+        var response = await client.GetAsync("/api/v1/financial/annual-summary/2026/investment-annual-result");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<InvestmentAnnualResultDTO>();
+        result!.Accounts.Should().HaveCount(11);
+        var chaseSave = result.Accounts.Single(a => a.Account == "ChaseSave");
+        chaseSave.MonthlyValues[0].Should().Be(1000m);
+        chaseSave.MonthlyValues[1].Should().Be(1200m);
+        chaseSave.MonthlyDiffs[0].Should().BeNull();
+        chaseSave.MonthlyDiffs[1].Should().Be(200m);
+        result.NetPosition.MonthlyValues[0].Should().Be(1000m);
+        result.NetPosition.FullYearNetChange.Should().Be(-1000m);
+    }
+
+    [Fact]
+    public async Task GetInvestmentAnnualResult_NoData_ReturnsEmptyAccountsArray()
+    {
+        var pastYear = DateTime.UtcNow.Year - 5;
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/api/v1/financial/annual-summary/{pastYear}/investment-annual-result");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<InvestmentAnnualResultDTO>();
+        result!.Accounts.Should().BeEmpty();
+        result.NetPosition.MonthlyValues.Should().OnlyContain(v => v == 0m);
+    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -343,6 +343,59 @@ public class AnnualSummaryServiceTests
     }
 
     [Fact]
+    public void GetInvestmentAnnualResultForYear_AccountsAndNetPositionMatchGetInvestmentDiffsForYearExactly()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear - 1, 12, 800m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 2, 1200m));
+        repository.Snapshots.Add(InvestmentSnapshot.Create("PlatinumVisa8003", PastYear, 1, 300m));
+        var service = new AnnualSummaryService(repository);
+
+        var expected = service.GetInvestmentDiffsForYear(PastYear);
+        var result = service.GetInvestmentAnnualResultForYear(PastYear);
+
+        result.Accounts.Should().BeEquivalentTo(expected.Accounts);
+        result.NetPosition.Should().BeEquivalentTo(expected.NetPosition);
+    }
+
+    [Fact]
+    public void GetInvestmentAnnualResultForYear_AverageMonthResultUsesMonthlySeriesAverageNotNaiveRounding()
+    {
+        var repository = new StubCashFlowRepository();
+        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear - 1, 12, 800m));
+        var value = 900m;
+        for (var month = 1; month <= 12; month++)
+        {
+            repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, month, value));
+            value += 50m;
+        }
+        var service = new AnnualSummaryService(repository);
+
+        var result = service.GetInvestmentAnnualResultForYear(PastYear);
+
+        // Same data as GetInvestmentDiffsForYear_PastYear_AverageAndSumIncludeAllTwelveMonthsIncludingJanuary:
+        // January diff = 900 - 800 = 100; the remaining 11 months each diff by 50. Sum = 650, over 12 months.
+        result.NetPosition.SumOfMonthResults.Should().Be(650m);
+        result.NetPosition.AverageMonthResult.Should().Be(650m / 12m);
+    }
+
+    [Fact]
+    public void GetInvestmentAnnualResultForYear_NoAccountsOrSnapshots_ReturnsEmptyAccountsAndAllZeroNetPosition()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+
+        var result = service.GetInvestmentAnnualResultForYear(PastYear);
+
+        result.Accounts.Should().BeEmpty();
+        result.NetPosition.MonthlyValues.Should().OnlyContain(v => v == 0m);
+        result.NetPosition.FullYearNetChange.Should().Be(0m);
+        result.NetPosition.AverageMonthResult.Should().Be(0m);
+        result.NetPosition.SumOfMonthResults.Should().Be(0m);
+    }
+
+    [Fact]
     public void GetIncomeSummaryForYear_SalaryRowSumsGleisonAndArianaGrossValuesPerMonth()
     {
         var repository = new StubCashFlowRepository();

--- a/docs/P19-F03-investment-annual-result-endpoint/plan.md
+++ b/docs/P19-F03-investment-annual-result-endpoint/plan.md
@@ -1,0 +1,26 @@
+# Implementation Plan: F03. Investment Annual Result Endpoint (Server-Side Computation)
+
+**Prerequisites:**
+- .NET solution builds and existing test suite passes on `main` (F01, F02, F04 already merged)
+- No new NuGet/npm packages, environment variables, or configuration files required
+- Branch `feat/P19-F03-investment-annual-result-endpoint`, already created from `main`
+
+### Stage 1: Application Layer
+
+**1. Combined Response DTO** - Add `InvestmentAnnualResultDTO`, reusing the existing `InvestmentAccountAnnualDiffDTO`/`NetPositionAnnualDiffDTO` nested types verbatim under the new top-level wrapper name.
+
+**2. Extract Shared Investment Series Computation** - Pull the account-resolution and per-account/net-position `MonthlySeries`/diff-sequence logic out of `GetInvestmentDiffsForYear` into a private helper, with `GetInvestmentDiffsForYear` itself unchanged in behavior and output.
+
+**3. New Combined Computation Method** - Add `GetInvestmentAnnualResultForYear` to `IAnnualSummaryService` and `AnnualSummaryService`, consuming the shared helper and computing `AverageMonthResult`/`SumOfMonthResults` via F01's `MonthlySeries.Average`/`.Sum()` at full (unrounded) precision, so the new endpoint's values stay byte-identical to the existing `investment-diffs` output.
+
+### Stage 2: Presentation Layer
+
+**4. New Endpoint** - Add a `GetInvestmentAnnualResult` action to `AnnualSummaryController` at `[HttpGet("{year:int}/investment-annual-result")]`, thin pass-through, alongside (not replacing) the existing `investment-diffs` action.
+
+### Stage 3: Test Suite
+
+**5. Service Unit Tests** - Add tests to `AnnualSummaryServiceTests.cs` confirming the new method's `Accounts`/`NetPosition` are byte-identical to `GetInvestmentDiffsForYear`'s output for the same data (including the unrounded `AverageMonthResult`), and that a year with no accounts/snapshots returns an empty accounts array and all-zero net position.
+
+**6. API Integration Tests** - Add tests to `AnnualSummaryEndpointsTests.cs` covering a `200 OK` response for seeded snapshot data and for no data, and confirm the existing `investment-diffs` test still passes unmodified.
+
+**7. Full Suite Verification** - Run the complete backend test suite (`dotnet test`) and confirm the solution still builds cleanly, verifying the extracted helper introduced no regressions to `GetInvestmentDiffsForYear`'s existing behavior.

--- a/docs/P19-F03-investment-annual-result-endpoint/spec.md
+++ b/docs/P19-F03-investment-annual-result-endpoint/spec.md
@@ -1,0 +1,113 @@
+## 1. Technical Overview
+
+**What:** New endpoint `GET /annual-summary/{year}/investment-annual-result` returning the same response shape currently returned by `investment-diffs` (`Accounts[]` + `NetPosition`), reusing the existing `InvestmentAccountAnnualDiffDTO`/`NetPositionAnnualDiffDTO` nested types under a new top-level `InvestmentAnnualResultDTO`. The shared account-resolution/diff-computation logic is extracted into a private helper so both the old `GetInvestmentDiffsForYear` and the new `GetInvestmentAnnualResultForYear` consume it without duplicating ~50 lines of account/diff logic. `NetPosition.AverageMonthResult`/`SumOfMonthResults` for the new method are computed via F01's `MonthlySeries.Average`/`.Sum()` (the one PRD-named gap — `DiffsFrom` is already used by the current implementation).
+
+**Why:** Follows the same "build pieces, then merge" pattern as F02/Historic Summary Average, and closes the one remaining spot where investment annual figures are computed with inline LINQ instead of the shared F01 `MonthlySeries` building block.
+
+**Scope:**
+- Included: new `InvestmentAnnualResultDTO`; new `AnnualSummaryService.GetInvestmentAnnualResultForYear(int year)`; a private helper extracted from `GetInvestmentDiffsForYear` for the shared per-account/net-position series computation; new controller action/route; unit tests confirming the new endpoint's values are byte-identical to the existing `investment-diffs` output and that `AverageMonthResult`/diffs are produced via `MonthlySeries.Average`/`DiffsFrom`; integration test for the new route.
+- Excluded / deferred (same decision as F02, see its spec.md): removing the `investment-diffs` route and its controller action, and renaming `InvestmentDiffsAnnualDTO` away. `useAnnualSummary.ts` still depends on `investment-diffs` via the same `Promise.all`, so it stays fully intact and unmodified until F05 migrates the frontend and removes it in the same PR. Per the PRD's own wording, only the *top-level* wrapper type is meant to be renamed (`InvestmentDiffsAnnualDTO` → `InvestmentAnnualResultDTO`); the nested `InvestmentAccountAnnualDiffDTO`/`NetPositionAnnualDiffDTO` types are explicitly "retained" — so this feature reuses them as-is under the new wrapper rather than introducing parallel nested types F05 would have to clean up.
+
+## 2. Architecture Impact
+
+**Affected components:**
+
+| File Path | New/Modified | Purpose |
+|-----------|--------------|---------|
+| `Financial.CashFlow.Application/DTOs/InvestmentAnnualResultDTO.cs` | New | New top-level wrapper DTO, reusing the existing nested `InvestmentAccountAnnualDiffDTO`/`NetPositionAnnualDiffDTO` types |
+| `Financial.CashFlow.Application/Interfaces/IAnnualSummaryService.cs` | Modified | Add `GetInvestmentAnnualResultForYear(int year)` |
+| `Financial.CashFlow.Application/Services/AnnualSummaryService.cs` | Modified | Extract a private `ComputeInvestmentSeriesForYear` helper from `GetInvestmentDiffsForYear`'s body (account resolution, per-account/net-position `MonthlySeries`, `DiffsFrom`, `lastRelevantMonth`); `GetInvestmentDiffsForYear` now calls it and is otherwise behavior-unchanged; add `GetInvestmentAnnualResultForYear`, which also calls it and computes `AverageMonthResult`/`SumOfMonthResults` via `MonthlySeries.Average`/`.Sum()` |
+| `Financial.Api/Controllers/AnnualSummaryController.cs` | Modified | Add `GetInvestmentAnnualResult` action, `[HttpGet("{year:int}/investment-annual-result")]` |
+| `Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs` | Modified | New tests for `GetInvestmentAnnualResultForYear` |
+| `Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs` | Modified | New integration test for `investment-annual-result` |
+
+No Domain-layer changes — `MonthlySeries` (F01) is consumed, not modified.
+
+```mermaid
+graph TD
+    A["AnnualSummaryService.ComputeInvestmentSeriesForYear (private, extracted)"] --> B["GetInvestmentDiffsForYear (existing, behavior-unchanged)"]
+    A --> C["GetInvestmentAnnualResultForYear (new)"]
+    B --> D["InvestmentDiffsAnnualDTO (unchanged route: investment-diffs)"]
+    C --> E["InvestmentAnnualResultDTO (new route: investment-annual-result)"]
+    C --> F["NetPosition.AverageMonthResult/SumOfMonthResults via MonthlySeries.Average/.Sum()"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|------------------|-------------------------|-----------|
+| Old route/DTO removal timing | Deferred to F05, same decision as F02 (`investment-diffs` stays fully intact) | Remove now per PRD's literal F03 wording | Same reasoning as F02: `useAnnualSummary.ts`'s single `Promise.all` would break the whole Annual Summary page and the CI browser smoke test before F05 lands. |
+| Avoiding duplicated account/diff logic between the old and new methods | Extract a private `ComputeInvestmentSeriesForYear(int year)` helper from `GetInvestmentDiffsForYear`'s existing body; both public methods call it | Write `GetInvestmentAnnualResultForYear` as a fully independent ~70-line method | `GetInvestmentDiffsForYear`'s account-resolution/diff logic is nontrivial (year-scoped resolver, prior-year December carryover, liability-weighted net position). Duplicating it risks the two endpoints silently drifting, which is exactly the anti-pattern this PRD exists to eliminate. Extracting it is a behavior-preserving refactor (same inputs, same intermediate values) — `GetInvestmentDiffsForYear`'s own output and existing tests are unaffected. |
+| `AverageMonthResult`/`SumOfMonthResults` precision for the new method | Build a 12-element `MonthlySeries` from `netPositionDiffs` (nulls and out-of-range months zero-filled) and call `.Average(monthsElapsed, FullPrecisionDecimalPlaces)`/`.Sum()`, where `FullPrecisionDecimalPlaces = 28` (decimal's max) is a new named constant on `AnnualSummaryService`, documented in code as "no intentional rounding — matches `GetInvestmentDiffsForYear`'s unrounded LINQ `.Average()` exactly, unlike the 2-decimal-place income/category averages" | Reuse the existing `AverageDecimalPlaces = 2` constant | `GetInvestmentDiffsForYear`'s own tests (e.g. `..._AverageAndSumIncludeAllTwelveMonthsIncludingJanuary`) assert the *unrounded* value (`BeApproximately(650m / 12m, 0.0001m)`) — rounding to 2 places would fail F03's own "byte-identical to the pre-refactor `investment-diffs` output" AC. `Math.Round(x, 28)` is provably a no-op here: decimal division already caps at ≤28 significant fractional digits, so this satisfies the AC's "route through `MonthlySeries.Average`" requirement with zero behavior change. |
+| `monthsElapsed` for the new `MonthlySeries.Average` call | Count of non-null diffs within `Take(lastRelevantMonth)` (mirrors the old method's `relevantDiffs.Count`) | A fixed 12 or `lastRelevantMonth` | Only January's diff can ever be `null` (no prior-year data at all); using its actual presence/absence as the divisor is what makes the result mathematically identical to the old method's `relevantDiffs.Average()`. |
+| New DTO shape | `InvestmentAnnualResultDTO { Accounts: InvestmentAccountAnnualDiffDTO[], NetPosition: NetPositionAnnualDiffDTO }`, reusing the existing nested types verbatim | Introduce renamed nested types (`InvestmentAccountAnnualResultDTO`, `NetPositionAnnualResultDTO`) now | PRD explicitly says the nested types are "retained" (not renamed) even after the eventual full cutover — reusing them now means F05 only ever deletes the old top-level `InvestmentDiffsAnnualDTO` and route, with zero further type churn. |
+
+## 4. Component Overview
+
+**Backend — Application (`Financial.CashFlow.Application`):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|----------------------|
+| `DTOs/InvestmentAnnualResultDTO.cs` | New | Combined Investments tab read model (new route) | `Accounts: InvestmentAccountAnnualDiffDTO[]`, `NetPosition: NetPositionAnnualDiffDTO` — sealed, `required`-init |
+| `Interfaces/IAnnualSummaryService.cs` | Modified | Service contract | Add `InvestmentAnnualResultDTO GetInvestmentAnnualResultForYear(int year)` |
+| `Services/AnnualSummaryService.cs` | Modified | Annual investment computation | Extract `ComputeInvestmentSeriesForYear` (year-scoped account resolution, per-account/net-position `MonthlySeries` + `DiffsFrom`, `lastRelevantMonth`) from `GetInvestmentDiffsForYear`'s body; new `GetInvestmentAnnualResultForYear` calls it and maps to the new DTO, computing `AverageMonthResult`/`SumOfMonthResults` via `MonthlySeries.Average(monthsElapsed, FullPrecisionDecimalPlaces)`/`.Sum()`; new `FullPrecisionDecimalPlaces = 28` constant |
+
+**Backend — Presentation (`Financial.Api`):**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|----------------------|
+| `Controllers/AnnualSummaryController.cs` | Modified | Thin pass-through controller | New `[HttpGet("{year:int}/investment-annual-result")]` action `GetInvestmentAnnualResult(int year)` returning `Ok(_annualSummaryService.GetInvestmentAnnualResultForYear(year))`; existing actions untouched |
+
+No Domain or Infrastructure files change.
+
+## 5. API Contracts
+
+**Endpoint:** `GET /api/v1/financial/annual-summary/{year}/investment-annual-result`
+
+**Response — `200 OK`** (identical shape to today's `investment-diffs`):
+
+```json
+{
+  "accounts": [
+    { "account": "ChaseSave", "isLiability": false, "monthlyValues": [1000,1200,1100,0,0,0,0,0,0,0,0,0], "monthlyDiffs": [null,200,-100,-1100,0,0,0,0,0,0,0,0] }
+  ],
+  "netPosition": {
+    "monthlyValues": [1000,1200,1100,0,0,0,0,0,0,0,0,0],
+    "monthlyDiffs": [null,200,-100,-1100,0,0,0,0,0,0,0,0],
+    "fullYearNetChange": -1000,
+    "averageMonthResult": -250,
+    "sumOfMonthResults": -1000
+  }
+}
+```
+
+**Response — no investment accounts/snapshots for the year:** `accounts: []`, `netPosition` all-zero (`monthlyValues`/`monthlyDiffs` all `0`, `fullYearNetChange`/`averageMonthResult`/`sumOfMonthResults` all `0`) — falls out for free from the shared helper's existing zero-fill behavior.
+
+**Unchanged endpoints (not modified by this feature):** `GET .../expense-categories`, `GET .../income-summary`, `GET .../investment-diffs`, `GET .../historic-summary-averages`, `GET .../category-totals` all continue to behave exactly as today.
+
+## 6. Data Model
+
+No entity or persisted JSON shape changes — read-only computed response from existing `InvestmentAccount`/`InvestmentSnapshot` repository data.
+
+**Cross-Database Notes:** Not applicable — no relational database is used anywhere in this solution.
+
+## 7. Testing Strategy
+
+**Test File Structure:**
+
+| Test File | Test Type | Target | Coverage Goal |
+|-----------|-----------|--------|----------------|
+| `Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs` | Unit | `AnnualSummaryService.GetInvestmentAnnualResultForYear` | Byte-identical parity with `GetInvestmentDiffsForYear` for the same seeded data (accounts, diffs, `AverageMonthResult`, `SumOfMonthResults`); no-data year returns empty accounts + all-zero net position |
+| `Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs` | Integration | `GET .../investment-annual-result` | `200 OK`, response shape, values matching seeded snapshots; existing `investment-diffs` test continues to pass unmodified |
+
+**Key test functions:**
+
+| Test Function | Description | Assertions |
+|----------------|-------------|------------|
+| `GetInvestmentAnnualResultForYear_AccountsAndNetPositionMatchGetInvestmentDiffsForYearExactly` | Multi-account, multi-month seeded data including prior-year December carryover | `result.Accounts`/`result.NetPosition` equal (`BeEquivalentTo`) `service.GetInvestmentDiffsForYear(year).Accounts`/`.NetPosition` field-by-field, including `AverageMonthResult`'s unrounded value |
+| `GetInvestmentAnnualResultForYear_AverageMonthResultUsesMonthlySeriesAverageNotNaiveRounding` | Data producing a non-terminating average (e.g. `650m` over 12 months, mirroring the existing `GetInvestmentDiffsForYear` test) | `result.NetPosition.AverageMonthResult` equals the exact unrounded `650m / 12m` value, not a 2-decimal-rounded figure |
+| `GetInvestmentAnnualResultForYear_NoAccountsOrSnapshots_ReturnsEmptyAccountsAndAllZeroNetPosition` | Empty repository | `result.Accounts` is empty; every `NetPosition` field is `0` |
+| `GetInvestmentAnnualResult_ReturnsOkMatchingSeededSnapshots` (Api, integration) | Seeded snapshots for one account across two months | `200 OK`; `accounts[0].monthlyValues`/`monthlyDiffs` match seeded values |
+| `GetInvestmentAnnualResult_NoData_ReturnsEmptyAccountsArray` (Api, integration) | No seeded snapshots | `200 OK`; `accounts` is an empty array |
+
+**Regression check:** Every existing `GetInvestmentDiffsForYear_*` test (in `AnnualSummaryServiceTests.cs`) and the existing `GetInvestmentDiffs_*` integration test must continue to pass unmodified — proof that extracting the shared helper did not change `investment-diffs`'s own behavior.

--- a/docs/prd/P19-prd-annual-summary-category-totals-server-computation/prd-annual-summary-category-totals-server-computation.md
+++ b/docs/prd/P19-prd-annual-summary-category-totals-server-computation/prd-annual-summary-category-totals-server-computation.md
@@ -233,11 +233,11 @@ graph TD
 - [x] Unit tests cover the Total despesas/Resultado formulas, including an all-zero-data year and a year including a non-zero Investimento category value
 
 ### F03. Investment Annual Result Endpoint (Server-Side Computation)
-- [ ] `GET /annual-summary/{year}/investment-annual-result` returns `200 OK` with `accounts[]` and `netPosition`, matching the field shapes previously returned by `investment-diffs`
-- [ ] Values (`monthlyValues`, `monthlyDiffs`, `fullYearNetChange`, `averageMonthResult`, `sumOfMonthResults`) for a fixed test year are byte-identical to the pre-refactor `investment-diffs` output
+- [x] `GET /annual-summary/{year}/investment-annual-result` returns `200 OK` with `accounts[]` and `netPosition`, matching the field shapes previously returned by `investment-diffs`
+- [x] Values (`monthlyValues`, `monthlyDiffs`, `fullYearNetChange`, `averageMonthResult`, `sumOfMonthResults`) for a fixed test year are byte-identical to the pre-refactor `investment-diffs` output
 - [ ] `GET /annual-summary/{year}/investment-diffs` returns `404 Not Found` (route removed)
-- [ ] A year with no investment accounts or snapshots returns an empty `accounts` array and an all-zero `netPosition`
-- [ ] Unit tests confirm `averageMonthResult` and diff sequences are produced via F01's `MonthlySeries.Average`/`MonthlySeries.DiffsFrom`
+- [x] A year with no investment accounts or snapshots returns an empty `accounts` array and an all-zero `netPosition`
+- [x] Unit tests confirm `averageMonthResult` and diff sequences are produced via F01's `MonthlySeries.Average`/`MonthlySeries.DiffsFrom`
 
 ### F04. Historic Summary Average Migration to Shared Calculation Service
 - [x] `GET /annual-summary/{year}/historic-summary-averages` continues to return `200 OK` with its existing response shape, unchanged


### PR DESCRIPTION
## Summary
- Adds `GET /annual-summary/{year}/investment-annual-result`, reusing the existing `InvestmentAccountAnnualDiffDTO`/`NetPositionAnnualDiffDTO` nested types under a new `InvestmentAnnualResultDTO` wrapper (per the PRD, only the top-level type is meant to be renamed — the nested types are "retained").
- Extracts a shared `ComputeInvestmentSeriesForYear` private helper out of `GetInvestmentDiffsForYear` so the new endpoint reuses the account-resolution/diff logic without duplicating it. `GetInvestmentDiffsForYear`'s own output is behavior-unchanged (all 17 of its existing tests pass unmodified).
- `NetPosition.AverageMonthResult`/`SumOfMonthResults` for the new endpoint route through F01's `MonthlySeries.Average`/`.Sum()` at full (unrounded) precision — closing the one remaining spot where investment figures used inline LINQ instead of the shared F01 building block, while staying byte-identical to the existing `investment-diffs` output.

## Sequencing note (same as F02, PR #278)
The old `investment-diffs` route is **intentionally left untouched**. `useAnnualSummary.ts` fetches every annual-summary endpoint via a single `Promise.all`, so removing it before the frontend migrates (F05) would break the entire Annual Summary page and fail the CI browser smoke test on this PR. Its removal (and the corresponding PRD F03 AC checkbox) is deferred to F05. Full rationale in `docs/P19-F03-investment-annual-result-endpoint/spec.md` → Technical Decisions.

## Acceptance Criteria (PRD Section 9, F03)
- [x] `GET /annual-summary/{year}/investment-annual-result` returns `200 OK` with `accounts[]`/`netPosition`, matching `investment-diffs`' field shapes
- [x] Values (`monthlyValues`, `monthlyDiffs`, `fullYearNetChange`, `averageMonthResult`, `sumOfMonthResults`) are byte-identical to the pre-refactor `investment-diffs` output
- [ ] `investment-diffs` returns `404` (route removed) — **deferred to F05**, see Sequencing note above
- [x] A year with no investment accounts or snapshots returns an empty `accounts` array and an all-zero `netPosition`
- [x] Unit tests confirm `averageMonthResult` and diff sequences are produced via F01's `MonthlySeries.Average`/`MonthlySeries.DiffsFrom`

## Test plan
- [x] `dotnet test` — full backend suite green (226 in `Financial.CashFlow.Application.Tests`, 191 in `Financial.Api.Tests`, all other projects unaffected), no regressions
- [x] New unit tests in `AnnualSummaryServiceTests.cs`, including exact parity with `GetInvestmentDiffsForYear`'s output
- [x] New integration tests in `AnnualSummaryEndpointsTests.cs` for the new route (happy path + no-data year)
- [ ] Frontend/browser smoke test — unaffected by this PR (old route still serves the existing frontend unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)