### PR TITLE
fix(web): freeze grid header row on scroll

### DIFF
--- a/Financial.Web/src/components/PortfolioSummaryTab.css
+++ b/Financial.Web/src/components/PortfolioSummaryTab.css
@@ -30,6 +30,12 @@
   text-align: center;
 }
 
+/* Second header row sits below the rowSpan=2 cells and group labels in the first row,
+   so its sticky offset must clear the first row's height instead of also using top: 0. */
+.portfolio-summary__table thead tr:nth-child(2) th {
+  top: 43px;
+}
+
 .portfolio-summary__profit--green {
   color: #2e7d32;
 }

--- a/Financial.Web/src/styles/data-table.css
+++ b/Financial.Web/src/styles/data-table.css
@@ -1,6 +1,8 @@
 .data-table {
   width: 100%;
-  border-collapse: collapse;
+  /* border-collapse: collapse breaks position: sticky on th in Chromium/WebKit */
+  border-collapse: separate;
+  border-spacing: 0;
   font-size: 13px;
 }
 
@@ -10,6 +12,10 @@
   padding: 8px 10px;
   border-bottom: 1px solid var(--border);
   white-space: nowrap;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg);
 }
 
 .data-table td {


### PR DESCRIPTION
## Summary
- Freezes the header row on every grid using the shared `.data-table` component (Investments and CashFlow), so it stays visible while rows scroll underneath — matches spreadsheet freeze-panes behavior.
- Root cause: `border-collapse: collapse` silently breaks `position: sticky` on `<th>` in Chromium/WebKit. Switched to `border-collapse: separate; border-spacing: 0` (visually identical here since only `border-bottom` is used).
- `PortfolioSummaryTab`'s grouped two-row header (Profit / Last Month / Est. Annual) needed the second row's sticky `top` offset pushed below the first row's height, otherwise both rows stack on top of each other.

## Test plan
- [x] `tsc -b --noEmit` passes
- [x] Verified live in browser (local dev API + Vite): CashFlow Monthly page "Cards" grid — header stays pinned while rows scroll
- [x] Verified live in browser: Investments FII summary grid (two-row grouped header) — both header rows stay pinned correctly, no overlap
- [x] No data mutations performed during verification (read-only navigation/scrolling only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)