### PR TITLE
fix(cashflow): allow gross value below net value on Income

### DIFF
--- a/Financial.CashFlow.Domain/Entities/Income.cs
+++ b/Financial.CashFlow.Domain/Entities/Income.cs
@@ -61,11 +61,6 @@ public class Income
         {
             throw new ArgumentException("Net value cannot be negative.");
         }
-
-        if (grossValue is not null && grossValue < netValue)
-        {
-            throw new ArgumentException("Gross value must be greater than or equal to net value.");
-        }
     }
 
     private static void ValidateBank(string bank)

--- a/Tests/Financial.Api.Tests/IncomesEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/IncomesEndpointsTests.cs
@@ -52,25 +52,6 @@ public class IncomesEndpointsTests
     }
 
     [Fact]
-    public async Task AddIncome_GrossValueBelowNetValue_ReturnsBadRequest()
-    {
-        await using var factory = new ApiTestFactory();
-        using var client = factory.CreateClient();
-        var request = new IncomeCreateDTO
-        {
-            Date = new DateOnly(2026, 7, 25),
-            IncomeSource = "Ariana",
-            GrossValue = 100m,
-            NetValue = 200m,
-            Bank = "Chase"
-        };
-
-        var response = await client.PostAsJsonAsync("/api/v1/financial/incomes", request);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-    }
-
-    [Fact]
     public async Task AddIncome_NegativeNetValue_ReturnsBadRequest()
     {
         await using var factory = new ApiTestFactory();

--- a/Tests/Financial.CashFlow.Application.Tests/Services/IncomeServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/IncomeServiceTests.cs
@@ -58,17 +58,6 @@ public class IncomeServiceTests
     }
 
     [Fact]
-    public async Task AddIncomeAsync_WithGrossValueBelowNetValue_ThrowsArgumentException()
-    {
-        var service = new IncomeService(new StubCashFlowRepository());
-        var request = ToCreateDto(ValidCreateRequest() with { GrossValue = 100m, NetValue = 200m });
-
-        var act = async () => await service.AddIncomeAsync(request);
-
-        await act.Should().ThrowAsync<ArgumentException>();
-    }
-
-    [Fact]
     public async Task AddIncomeAsync_WithNegativeNetValue_ThrowsArgumentException()
     {
         var service = new IncomeService(new StubCashFlowRepository());

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/IncomeTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/IncomeTests.cs
@@ -39,17 +39,9 @@ public class IncomeTests
     }
 
     [Fact]
-    public void Create_WithGrossValueBelowNetValue_Throws()
+    public void Create_WithGrossValueBelowNetValue_DoesNotThrow()
     {
         var act = () => Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Ariana, 100m, 150m, "Chase");
-
-        act.Should().Throw<ArgumentException>();
-    }
-
-    [Fact]
-    public void Create_WithGrossValueEqualToNetValue_DoesNotThrow()
-    {
-        var act = () => Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Ariana, 100m, 100m, "Chase");
 
         act.Should().NotThrow();
     }
@@ -89,13 +81,13 @@ public class IncomeTests
     }
 
     [Fact]
-    public void UpdateDetails_WithGrossValueBelowNetValue_Throws()
+    public void UpdateDetails_WithGrossValueBelowNetValue_DoesNotThrow()
     {
         var income = Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Gleison, 3000m, 2400m, "Barclays");
 
         var act = () => income.UpdateDetails(income.Date, income.IncomeSource, 100m, 200m, income.Bank);
 
-        act.Should().Throw<ArgumentException>();
+        act.Should().NotThrow();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Removes the domain invariant on `Income` that required `GrossValue >= NetValue`
- Some compensation (e.g. certain benefits) is are tax free, so gross can legitimately be lower than net value
- Updates the corresponding unit tests to reflect the new allowed behavior instead of the removed rule

## Test plan
- [x] `Create_WithGrossValueBelowNetValue_DoesNotThrow` — gross below net no longer throws
- [x] `UpdateDetails_WithGrossValueBelowNetValue_DoesNotThrow` — same for updates
- [x] Removed `Create_WithGrossValueEqualToNetValue_DoesNotThrow` (redundant once the comparison rule no longer exists)
- [x] `dotnet test Tests/Financial.CashFlow.Domain.Tests --filter FullyQualifiedName~IncomeTests` — 15/15 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)