### PR TITLE
fix(cashflow): make credit-card-area scope dynamic instead of a hardcoded month list

### DIFF
--- a/Integrations/CashFlowSpreadsheetImport/Program.cs
+++ b/Integrations/CashFlowSpreadsheetImport/Program.cs
@@ -42,6 +42,7 @@ if (File.Exists(outputPath))
 var report = new ImportReport();
 var serializer = new CashFlowSerializerAdapter();
 var storage = new LocalJsonStorage(outputPath);
+var today = DateOnly.FromDateTime(DateTime.Now);
 
 // Loaded once up front regardless of mode: this is also where Banks/Incomes/CardStatements
 // come from for a full rebuild below, since the spreadsheet never produces them itself.
@@ -76,7 +77,7 @@ if (mensaisOnly)
 }
 else
 {
-    ImportMonthlyExpenseSheets(workbook, data, report);
+    ImportMonthlyExpenseSheets(workbook, data, report, today);
     ImportReservasSheet(workbook, data, report);
     ImportMensaisSheet(workbook, data, report);
     ImportControleMaeSheet(workbook, data, report);
@@ -85,7 +86,7 @@ else
 
 // Always run, in both modes: every migration below is idempotent, so re-running is always safe.
 var bankSummary = BankMigrator.Migrate(data);
-var bankOpeningBalanceSummary = BankOpeningBalanceMigrator.Migrate(data, DateOnly.FromDateTime(DateTime.Now));
+var bankOpeningBalanceSummary = BankOpeningBalanceMigrator.Migrate(data, today);
 var incomeSummary = IncomeMigrator.Migrate(data, workbook);
 var paymentStateSummary = ExpensePaymentStateMigrator.Migrate(data);
 // Re-run (seeding is idempotent) so the reported summary's snapshot audit reflects the
@@ -128,7 +129,7 @@ static void CarryOverDataTheSpreadsheetDoesNotOwn(CashFlowData existingData, Cas
     }
 }
 
-static void ImportMonthlyExpenseSheets(XLWorkbook workbook, CashFlowData data, ImportReport report)
+static void ImportMonthlyExpenseSheets(XLWorkbook workbook, CashFlowData data, ImportReport report, DateOnly today)
 {
     var monthlySheets = workbook.Worksheets
         .Select(sheet => (Sheet: sheet, Parsed: SheetNameParser.TryParseMonthlySheetName(sheet.Name, out var year, out var month), Year: year, Month: month))
@@ -137,7 +138,7 @@ static void ImportMonthlyExpenseSheets(XLWorkbook workbook, CashFlowData data, I
 
     foreach (var (sheet, _, year, month) in monthlySheets)
     {
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, year, month, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, year, month, today, report);
         foreach (var expense in expenses)
         {
             data.AddExpense(expense);

--- a/Integrations/CashFlowSpreadsheetImport/SheetImporters/MonthlyExpenseSheetImporter.cs
+++ b/Integrations/CashFlowSpreadsheetImport/SheetImporters/MonthlyExpenseSheetImporter.cs
@@ -9,19 +9,20 @@ namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowSpreadsheetImpo
 /// <summary>
 /// Parses one "MonYYYY" monthly expense tab into <see cref="Expense"/> entities. Tolerant of the
 /// 11-18 column range across eras and the "Quem"/"Motivo" header-label swap (see
-/// <see cref="ColumnResolver"/>). Historical months never record which of the 5 cards a charge
-/// used, so no <see cref="Expense.CardTag"/> is set for them (see F10's spec.md). For the months
-/// listed in <see cref="MonthsWithFixedCardSections"/>, the source spreadsheet instead groups
-/// card charges into sections that each start at a known row number (see
-/// <see cref="CardSectionStartRows"/>), so rows in those months are tagged by row position when
-/// column E is blank or carries the "X"/"x" credit-card marker - "X" confirms the row belongs to
-/// the card section it falls in, it never names a specific card. An explicit "T"/"C" tag still
-/// takes precedence over row position (it means the row was paid directly from that bank, not a
-/// card). A row that does resolve a card tag imports as an unsettled credit card charge -
-/// <see cref="Expense.PaymentSource"/> stays null - and settlement is applied afterward in-app by
-/// marking the card statement paid, never inferred by the import. If "X" can't be matched to a
-/// card section (row/month falls outside every known section), the row is flagged and skipped
-/// rather than defaulting to the Barclays bank payment source blank rows fall back to.
+/// <see cref="ColumnResolver"/>). For the current calendar month and any later month (relative to
+/// the <c>today</c> passed to <see cref="Import"/>), the source spreadsheet groups card charges
+/// into sections that each start at a known row number (see <see cref="CardSectionStartRows"/>),
+/// so rows in those months are tagged by row position when column E is blank or carries the
+/// "X"/"x" credit-card marker - "X" confirms the row belongs to the card section it falls in, it
+/// never names a specific card. An explicit "T"/"C" tag still takes precedence over row position
+/// (it means the row was paid directly from that bank, not a card). A row that does resolve a
+/// card tag imports as an unsettled credit card charge - <see cref="Expense.PaymentSource"/>
+/// stays null - and settlement is applied afterward in-app by marking the card statement paid,
+/// never inferred by the import. Months before the current one never resolve a card tag by row
+/// position - by the time a past month is imported, its statement has already been settled and
+/// consolidated in the spreadsheet, so those rows (and any "X" that can't be matched to a card
+/// section even in an eligible month) fall back to the normal column-E rule, which defaults an
+/// unrecognized tag to the Barclays bank payment source.
 /// </summary>
 public static class MonthlyExpenseSheetImporter
 {
@@ -44,16 +45,7 @@ public static class MonthlyExpenseSheetImporter
         (BaAmexStartRow, CreditCard.BaAmex),
     ];
 
-    // Only the sheets for these months follow the fixed-row card layout above; every other month
-    // (past or future) keeps using the column-E "T"/"C" tag exclusively. Extend this list as later
-    // months are confirmed to follow the same layout.
-    private static readonly (int Year, int Month)[] MonthsWithFixedCardSections =
-    [
-        (2026, 7),
-        (2026, 8),
-    ];
-
-    public static IReadOnlyList<Expense> Import(IXLWorksheet sheet, int year, int month, ImportReport report)
+    public static IReadOnlyList<Expense> Import(IXLWorksheet sheet, int year, int month, DateOnly today, ImportReport report)
     {
         var (descriptionColumn, categoryColumn) = ResolveColumns(sheet);
         var lastRow = sheet.LastRowUsed()?.RowNumber() ?? 1;
@@ -100,16 +92,7 @@ public static class MonthlyExpenseSheetImporter
 
             var description = sheet.Cell(row, descriptionColumn).GetString();
             var rawPaymentSourceTag = sheet.Cell(row, PaymentSourceColumn).GetString();
-            var cardTag = ResolveCardTag(row, year, month, rawPaymentSourceTag);
-
-            if (cardTag is null && IsCreditCardMarker(rawPaymentSourceTag))
-            {
-                report.RowFlagged(
-                    sheet.Name, row, "PaymentSource", rawPaymentSourceTag,
-                    "Credit card marker (\"X\") could not be matched to a card section - expense not imported");
-                continue;
-            }
-
+            var cardTag = ResolveCardTag(row, year, month, today, rawPaymentSourceTag);
             string? paymentSource = cardTag is null ? ResolvePaymentSource(rawPaymentSourceTag) : null;
 
             expenses.Add(Expense.Create(date, description, value.Value, category, paymentSource, cardTag));
@@ -145,7 +128,7 @@ public static class MonthlyExpenseSheetImporter
             _ => "Barclays",
         };
 
-    private static CreditCard? ResolveCardTag(int row, int year, int month, string? rawPaymentSourceTag)
+    private static CreditCard? ResolveCardTag(int row, int year, int month, DateOnly today, string? rawPaymentSourceTag)
     {
         var isCardSectionEligible = string.IsNullOrWhiteSpace(rawPaymentSourceTag) || IsCreditCardMarker(rawPaymentSourceTag);
         if (!isCardSectionEligible)
@@ -153,7 +136,9 @@ public static class MonthlyExpenseSheetImporter
             return null;
         }
 
-        if (!MonthsWithFixedCardSections.Contains((year, month)))
+        var tabMonth = new DateOnly(year, month, 1);
+        var currentMonth = new DateOnly(today.Year, today.Month, 1);
+        if (tabMonth < currentMonth)
         {
             return null;
         }

--- a/Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/MonthlyExpenseSheetImporterTests.cs
+++ b/Tests/Financial.CashFlowSpreadsheetImport.Tests/SheetImporters/MonthlyExpenseSheetImporterTests.cs
@@ -8,6 +8,8 @@ namespace Financial.CashFlowSpreadsheetImport.Tests.SheetImporters;
 
 public class MonthlyExpenseSheetImporterTests
 {
+    private static readonly DateOnly Today = new(2026, 7, 15);
+
     [Fact]
     public void Import_2017ShapedSheet_QuemThenMotivo_ParsesExpensesCorrectly()
     {
@@ -32,7 +34,7 @@ public class MonthlyExpenseSheetImporterTests
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2017, 2, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2017, 2, Today, report);
 
         expenses.Should().HaveCount(2);
         var first = expenses.Single(e => e.Description == "Lidl UK");
@@ -66,7 +68,7 @@ public class MonthlyExpenseSheetImporterTests
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, Today, report);
 
         expenses.Should().ContainSingle();
         var expense = expenses.Single();
@@ -92,7 +94,7 @@ public class MonthlyExpenseSheetImporterTests
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2017, 10, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2017, 10, Today, report);
 
         expenses.Should().BeEmpty();
         report.RowIssues.Should().ContainSingle(i => i.RawValue == "TotallyUnknownCategory" && i.SheetName == "Out2017");
@@ -115,7 +117,7 @@ public class MonthlyExpenseSheetImporterTests
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2017, 10, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2017, 10, Today, report);
 
         expenses.Should().ContainSingle().Which.Category.Should().Be(Category.Casa);
         report.RowIssues.Should().BeEmpty();
@@ -140,7 +142,7 @@ public class MonthlyExpenseSheetImporterTests
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 2, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 2, Today, report);
 
         expenses.Should().ContainSingle();
         expenses[0].Date.Should().Be(new DateOnly(2026, 2, 28));
@@ -167,7 +169,7 @@ public class MonthlyExpenseSheetImporterTests
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2017, 3, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2017, 3, Today, report);
 
         expenses.Should().ContainSingle().Which.Value.Should().Be(17.28m);
         report.RowIssues.Should().BeEmpty();
@@ -191,7 +193,7 @@ public class MonthlyExpenseSheetImporterTests
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, Today, report);
 
         var expense = expenses.Should().ContainSingle().Which;
         expense.CardTag.Should().Be(expectedCardTag);
@@ -214,7 +216,7 @@ public class MonthlyExpenseSheetImporterTests
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 8, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 8, Today, report);
 
         var expense = expenses.Should().ContainSingle().Subject;
         expense.PaymentSource.Should().Be("Chase");
@@ -235,7 +237,7 @@ public class MonthlyExpenseSheetImporterTests
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, Today, report);
 
         expenses.Should().HaveCount(6);
         expenses.Should().NotContain(e => e.PaymentSource != null && e.CardTag != null);
@@ -246,20 +248,36 @@ public class MonthlyExpenseSheetImporterTests
         expenses.Count(e => e.PaymentStatus == ExpensePaymentStatus.CreditCardCharge).Should().Be(3);
     }
 
-    [Theory]
-    [InlineData(2017, 10)]
-    [InlineData(2026, 9)]
-    public void Import_MonthOutsideFixedCardSectionScope_BlankPaymentSourceInCardRowRange_CardTagStaysNull(int year, int month)
+    [Fact]
+    public void Import_PastMonth_BlankPaymentSourceInCardRowRange_CardTagStaysNullAndDefaultsToBarclays()
     {
         using var workbook = new XLWorkbook();
-        var sheet = workbook.AddWorksheet($"Sheet{year}{month}");
+        var sheet = workbook.AddWorksheet("Out2017");
         WriteExpenseRow(sheet, row: 129, paymentSourceTag: null);
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, year, month, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2017, 10, Today, report);
 
-        expenses.Should().ContainSingle().Which.CardTag.Should().BeNull();
+        var expense = expenses.Should().ContainSingle().Which;
+        expense.CardTag.Should().BeNull();
+        expense.PaymentSource.Should().Be("Barclays");
+    }
+
+    [Fact]
+    public void Import_FutureMonthBeyondAnyPreviouslyConfirmedSheet_BlankPaymentSourceInCardRowRange_SetsCardTagByRowPosition()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Set2026");
+        WriteExpenseRow(sheet, row: 129, paymentSourceTag: null);
+
+        var report = new ImportReport();
+
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 9, Today, report);
+
+        var expense = expenses.Should().ContainSingle().Which;
+        expense.CardTag.Should().Be(CreditCard.BarclaysPlatinumVisa8003);
+        expense.PaymentSource.Should().BeNull();
     }
 
     [Theory]
@@ -274,7 +292,7 @@ public class MonthlyExpenseSheetImporterTests
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, Today, report);
 
         var expense = expenses.Should().ContainSingle().Which;
         expense.CardTag.Should().Be(CreditCard.BarclaysPlatinumVisa6007);
@@ -284,37 +302,56 @@ public class MonthlyExpenseSheetImporterTests
     }
 
     [Fact]
-    public void Import_FixedCardSectionMonth_CreditCardMarkerTagOutsideAnyCardSection_FlagsRowAndDoesNotImportAsBarclays()
+    public void Import_CurrentMonth_CreditCardMarkerTagOutsideAnyCardSection_DefaultsToBarclaysWithoutFlagging()
     {
         using var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Jul2026");
         // Row 50 is before the first card section (BarclaysPlatinumVisa8003StartRow = 129), so an
-        // "X" here can't be matched to any card - it must not silently fall back to Barclays.
+        // "X" here can't be matched to any card - it falls back to the normal column-E default.
         WriteExpenseRow(sheet, row: 50, paymentSourceTag: "X");
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 7, Today, report);
 
-        expenses.Should().BeEmpty();
-        report.RowIssues.Should().ContainSingle(i => i.SheetName == "Jul2026" && i.RawValue == "X");
+        var expense = expenses.Should().ContainSingle().Which;
+        expense.CardTag.Should().BeNull();
+        expense.PaymentSource.Should().Be("Barclays");
+        report.RowIssues.Should().BeEmpty();
     }
 
-    [Theory]
-    [InlineData(2017, 10)]
-    [InlineData(2026, 9)]
-    public void Import_MonthOutsideFixedCardSectionScope_CreditCardMarkerTag_FlagsRowAndDoesNotImportAsBarclays(int year, int month)
+    [Fact]
+    public void Import_PastMonth_CreditCardMarkerTagInCardRowRange_ImportsAsBarclaysMovementNotACharge()
     {
         using var workbook = new XLWorkbook();
-        var sheet = workbook.AddWorksheet($"Sheet{year}{month}");
+        var sheet = workbook.AddWorksheet("Out2017");
         WriteExpenseRow(sheet, row: 129, paymentSourceTag: "X");
 
         var report = new ImportReport();
 
-        var expenses = MonthlyExpenseSheetImporter.Import(sheet, year, month, report);
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2017, 10, Today, report);
 
-        expenses.Should().BeEmpty();
-        report.RowIssues.Should().ContainSingle(i => i.RawValue == "X");
+        var expense = expenses.Should().ContainSingle().Which;
+        expense.CardTag.Should().BeNull();
+        expense.PaymentSource.Should().Be("Barclays");
+        report.RowIssues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Import_FutureMonthBeyondAnyPreviouslyConfirmedSheet_CreditCardMarkerTag_SetsCardTagByRowPosition()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Set2026");
+        WriteExpenseRow(sheet, row: 129, paymentSourceTag: "X");
+
+        var report = new ImportReport();
+
+        var expenses = MonthlyExpenseSheetImporter.Import(sheet, 2026, 9, Today, report);
+
+        var expense = expenses.Should().ContainSingle().Which;
+        expense.CardTag.Should().Be(CreditCard.BarclaysPlatinumVisa8003);
+        expense.PaymentSource.Should().BeNull();
+        report.RowIssues.Should().BeEmpty();
     }
 
     private static void WriteExpenseRow(IXLWorksheet sheet, int row, string? paymentSourceTag)


### PR DESCRIPTION
## Summary
- `MonthlyExpenseSheetImporter` previously used a hardcoded `MonthsWithFixedCardSections` allowlist (`[(2026,7), (2026,8)]`) to decide which monthly tabs use the fixed-row credit-card-section layout. Replaced with a live comparison against a `today` parameter (current month or later = eligible), so it applies to every future month automatically instead of needing manual extension.
- An "X" marker found in a past month's credit-card row range no longer gets flagged and dropped as an unresolved charge — it now imports as a normal Barclays movement, since by the time a past month is imported its statement has already been settled/consolidated in the source spreadsheet.
- Any "X" that can't be matched to a card section at all (past or present) now defaults to Barclays the same way a blank column E does, instead of being flagged and skipped.
- `today` is threaded through as an explicit parameter (`Program.cs` computes it once via `DateOnly.FromDateTime(DateTime.Now)`, same pattern already used for `BankOpeningBalanceMigrator.Migrate`), keeping the importer pure/testable rather than reading the wall clock internally.

## Test plan
- [x] Past month, blank column E in card-row range → `CardTag` null, `PaymentSource` = Barclays
- [x] Future month beyond the old hardcoded list → still gets card tag by row position (proves eligibility isn't list-bound)
- [x] Current month, unmatched "X" (row before any card section) → defaults to Barclays, no flag
- [x] Past month, "X" in card-row range → imports as Barclays movement, no flag (the core bug fix)
- [x] Future month beyond old list, "X" in card-row range → resolves card tag by row position
- [x] All pre-existing blank/T/C precedence, mixed-sheet, and column-parsing tests unchanged
- [x] `dotnet test Tests/Financial.CashFlowSpreadsheetImport.Tests --filter FullyQualifiedName~MonthlyExpenseSheetImporterTests` — 25/25 passing
- [x] Full solution `dotnet build` + `dotnet test` — all green, no other callers of the old 4-arg `Import` overload

🤖 Generated with [Claude Code](https://claude.com/claude-code)