### PR TITLE
chore(web): remove redundant grid/section H2 headings to reclaim vertical space

### DIFF
--- a/Financial.Web/src/components/BanksGrid.tsx
+++ b/Financial.Web/src/components/BanksGrid.tsx
@@ -10,7 +10,6 @@ interface BanksGridProps {
 export default function BanksGrid({ bankTotals, bankTotalsSum, roundUpTotalsSum }: BanksGridProps) {
   return (
     <section className="monthly-page__section monthly-page__section--grid">
-      <h2>Banks</h2>
       <div className="monthly-page__table-scroll">
         <table className="monthly-page__table data-table">
           <thead>

--- a/Financial.Web/src/components/CardsGrid.tsx
+++ b/Financial.Web/src/components/CardsGrid.tsx
@@ -22,7 +22,6 @@ export default function CardsGrid({
 }: CardsGridProps) {
   return (
     <section className="monthly-page__section monthly-page__section--grid">
-      <h2>Cards</h2>
       <div className="monthly-page__table-scroll">
         <table className="monthly-page__table data-table">
           <thead>

--- a/Financial.Web/src/components/CategoryTotalsGrid.tsx
+++ b/Financial.Web/src/components/CategoryTotalsGrid.tsx
@@ -9,7 +9,6 @@ interface CategoryTotalsGridProps {
 export default function CategoryTotalsGrid({ categoryTotals, categoryTotalsSum }: CategoryTotalsGridProps) {
   return (
     <section className="monthly-page__section monthly-page__section--grid">
-      <h2>Category Totals</h2>
       <div className="monthly-page__table-scroll">
         <table className="monthly-page__table data-table">
           <thead>

--- a/Financial.Web/src/components/ExpensesSection.tsx
+++ b/Financial.Web/src/components/ExpensesSection.tsx
@@ -55,7 +55,6 @@ export default function ExpensesSection({ expenses, onEdit, onDelete, onNewExpen
   return (
     <section className="expenses-section">
       <div className="expenses-section__header">
-        <h2>Expenses</h2>
         <button className="expenses-section__new-btn" type="button" onClick={onNewExpense}>
           New Expense
         </button>

--- a/Financial.Web/src/components/IncomeSection.tsx
+++ b/Financial.Web/src/components/IncomeSection.tsx
@@ -54,7 +54,6 @@ export default function IncomeSection({ incomes, onEdit, onDelete, onNewIncome }
   return (
     <section className="income-section">
       <div className="income-section__header">
-        <h2>Income</h2>
         <button className="income-section__new-btn" type="button" onClick={onNewIncome}>
           New Income
         </button>

--- a/Financial.Web/src/components/IncomingGrid.tsx
+++ b/Financial.Web/src/components/IncomingGrid.tsx
@@ -11,7 +11,6 @@ interface IncomingGridProps {
 export default function IncomingGrid({ incomeTotals, totalIncoming, titheSummary }: IncomingGridProps) {
   return (
     <section className="monthly-page__section monthly-page__section--grid">
-      <h2>Incoming</h2>
       <div className="monthly-page__table-scroll">
         <table className="monthly-page__table data-table">
           <thead>

--- a/Financial.Web/src/pages/AnnualSummaryPage.tsx
+++ b/Financial.Web/src/pages/AnnualSummaryPage.tsx
@@ -125,11 +125,10 @@ export default function AnnualSummaryPage() {
         <div className="annual-summary-page__content">
           {activeTab === 'categoryTotals' && (
             <section className="annual-summary-page__section">
-              <h2>Category Totals</h2>
               <table className="annual-summary-page__table data-table">
                 <thead>
                   <tr>
-                    <th />
+                    <th>Category</th>
                     {MONTH_LABELS.map((m) => (
                       <th key={m} className="data-table__col--numeric">
                         {m}
@@ -201,7 +200,6 @@ export default function AnnualSummaryPage() {
 
           {activeTab === 'investments' && investmentAnnualResult && (
             <section className="annual-summary-page__section">
-              <h2>Investments</h2>
               <table className="annual-summary-page__table data-table">
                 <thead>
                   <tr>
@@ -249,11 +247,10 @@ export default function AnnualSummaryPage() {
 
           {activeTab === 'historicSummaryAverage' && (
             <section className="annual-summary-page__section">
-              <h2>Historic Summary Average</h2>
               <table className="annual-summary-page__table data-table">
                 <thead>
                   <tr>
-                    <th />
+                    <th>Category</th>
                     {historicSummaryAverage && (
                       historicSummaryAverage.map((y) => (
                         <th key={y.year} className="data-table__col--numeric">

--- a/Financial.Web/src/pages/ControleMaePage.tsx
+++ b/Financial.Web/src/pages/ControleMaePage.tsx
@@ -227,7 +227,6 @@ export default function ControleMaePage() {
       ) : (
         <div className="controle-mae-page__content">
           <section className="controle-mae-page__section">
-            <h2>Ledger</h2>
             <table className="controle-mae-page__table data-table">
               <LedgerColumns />
               <thead>

--- a/Financial.Web/src/pages/MensaisPage.tsx
+++ b/Financial.Web/src/pages/MensaisPage.tsx
@@ -59,7 +59,6 @@ function BillRow({ bill, showBrasilFields, isDeleting, onEdit, onDelete }: BillR
 }
 
 interface BillTableProps {
-  title: string
   bills: RecurringBillDto[]
   showBrasilFields: boolean
   deletingBillId: string | null
@@ -67,10 +66,9 @@ interface BillTableProps {
   onDelete: (id: string) => void
 }
 
-function BillTable({ title, bills, showBrasilFields, deletingBillId, onEdit, onDelete }: BillTableProps) {
+function BillTable({ bills, showBrasilFields, deletingBillId, onEdit, onDelete }: BillTableProps) {
   return (
     <section className="mensais-page__section">
-      <h2>{title}</h2>
       <div className="mensais-page__table-scroll">
         <table className="mensais-page__table data-table">
           <thead>
@@ -292,7 +290,6 @@ export default function MensaisPage() {
       ) : (
         <div className="mensais-page__content">
           <BillTable
-            title="Brasil"
             bills={brasilBills}
             showBrasilFields
             deletingBillId={deletingBillId}
@@ -300,7 +297,6 @@ export default function MensaisPage() {
             onDelete={deleteBill}
           />
           <BillTable
-            title="UK"
             bills={ukBills}
             showBrasilFields={false}
             deletingBillId={deletingBillId}

--- a/Financial.Web/src/pages/ReservaPage.tsx
+++ b/Financial.Web/src/pages/ReservaPage.tsx
@@ -316,7 +316,6 @@ export default function ReservaPage() {
       <div className="reserva-page__content">
         <div className="reserva-page__grids-row">
           <section className="reserva-page__section reserva-page__section--grid reserva-page__section--balances">
-            <h2>Bucket Balances</h2>
             <div className="reserva-page__table-scroll">
               <table className="reserva-page__table data-table">
                 <BalanceColumns />
@@ -348,7 +347,6 @@ export default function ReservaPage() {
           </section>
 
           <section className="reserva-page__section reserva-page__section--grid reserva-page__section--movements">
-            <h2>Movement History</h2>
             <div className="reserva-page__table-scroll">
               <table className="reserva-page__table data-table">
                 <MovementColumns />

--- a/Financial.Web/src/pages/__tests__/AnnualSummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/AnnualSummaryPage.test.tsx
@@ -218,7 +218,6 @@ describe('AnnualSummaryPage', () => {
 
     expect(screen.queryByRole('cell', { name: 'Salary' })).not.toBeInTheDocument()
     expect(screen.queryByRole('cell', { name: 'Mercado' })).not.toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Investments' })).toBeInTheDocument()
     expect(screen.getByRole('cell', { name: 'ChaseSave' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Investments' })).toHaveClass('annual-summary-page__tab--active')
   })
@@ -402,11 +401,11 @@ describe('AnnualSummaryPage', () => {
 
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Investments' }))
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Investments' })).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'ChaseSave' })).toBeInTheDocument())
 
     fireEvent.change(screen.getByLabelText('Year'), { target: { value: '2027' } })
 
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Investments' })).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'ChaseSave' })).toBeInTheDocument())
     expect(screen.getByRole('button', { name: 'Investments' })).toHaveClass('annual-summary-page__tab--active')
   })
 
@@ -416,10 +415,10 @@ describe('AnnualSummaryPage', () => {
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Historic Summary Average' }))
 
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Historic Summary Average' })).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('columnheader', { name: '2025' })).toBeInTheDocument())
 
     const headerCells = screen.getAllByRole('columnheader').map((th) => th.textContent)
-    expect(headerCells).toEqual(['', '2026', '2025'])
+    expect(headerCells).toEqual(['Category', '2026', '2025'])
 
     const mercadoRow = screen.getByText('Mercado').closest('tr')!
     expect(within(mercadoRow).getByText('155.00')).toBeInTheDocument()
@@ -431,7 +430,7 @@ describe('AnnualSummaryPage', () => {
 
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Historic Summary Average' }))
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Historic Summary Average' })).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('columnheader', { name: '2025' })).toBeInTheDocument())
 
     const rowLabels = screen
       .getAllByRole('row')
@@ -458,7 +457,7 @@ describe('AnnualSummaryPage', () => {
 
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Historic Summary Average' }))
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Historic Summary Average' })).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('columnheader', { name: '2025' })).toBeInTheDocument())
 
     const resultadoRow = screen.getByText('Resultado (R-D-Inv)').closest('tr')!
     expect(resultadoRow).toHaveClass('annual-summary-page__emphasized-row')
@@ -474,9 +473,9 @@ describe('AnnualSummaryPage', () => {
 
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Historic Summary Average' }))
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Historic Summary Average' })).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('columnheader', { name: '2025' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Category Totals' }))
 
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Category Totals' })).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'Salary' })).toBeInTheDocument())
   })
 })

--- a/Financial.Web/src/pages/__tests__/MensaisPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MensaisPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import MensaisPage from '../MensaisPage'
 import type { FinancialApiClient } from '../../api/financialApiClient'
@@ -67,12 +67,15 @@ describe('MensaisPage', () => {
   })
 
   it('renders Brasil and UK as two separate grouped sections', async () => {
-    render(<MensaisPage />)
+    const { container } = render(<MensaisPage />)
 
-    await waitFor(() => expect(screen.getByText('Brasil')).toBeInTheDocument())
-    expect(screen.getByText('UK')).toBeInTheDocument()
-    expect(screen.getByText('INSS')).toBeInTheDocument()
-    expect(screen.getByText('Council Tax')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('INSS')).toBeInTheDocument())
+    const sections = container.querySelectorAll('.mensais-page__section')
+    expect(sections).toHaveLength(2)
+    expect(within(sections[0] as HTMLElement).getByText('INSS')).toBeInTheDocument()
+    expect(within(sections[0] as HTMLElement).getByText('NIT')).toBeInTheDocument()
+    expect(within(sections[1] as HTMLElement).getByText('Council Tax')).toBeInTheDocument()
+    expect(within(sections[1] as HTMLElement).queryByText('NIT')).not.toBeInTheDocument()
   })
 
   it('edits a row status/value via the toggled panel and saves, updating the displayed row', async () => {
@@ -111,7 +114,7 @@ describe('MensaisPage', () => {
   it('shows NIT and Min. Wage columns only in the Brasil section', async () => {
     render(<MensaisPage />)
 
-    await waitFor(() => expect(screen.getByText('Brasil')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('INSS')).toBeInTheDocument())
 
     expect(screen.getAllByText('NIT')).toHaveLength(1)
     expect(screen.getAllByText('Min. Wage')).toHaveLength(1)

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -131,12 +131,12 @@ describe('MonthlyPage', () => {
     render(<MonthlyPage />)
 
     await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
-    expect(screen.getByText('Category Totals')).toBeInTheDocument()
-    expect(screen.getByText('Cards')).toBeInTheDocument()
-    expect(screen.getByText('Banks')).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Incoming' })).toBeInTheDocument()
-    expect(screen.queryByText('Expenses')).not.toBeInTheDocument()
-    expect(screen.queryByText('Income')).not.toBeInTheDocument()
+    expect(screen.getByText(/^Total:/)).toBeInTheDocument()
+    expect(screen.getByText(/Combined adjustment figure/)).toBeInTheDocument()
+    expect(screen.getByText(/Bank Balance:/)).toBeInTheDocument()
+    expect(screen.getByText(/Total Incoming:/)).toBeInTheDocument()
+    expect(document.querySelector('.expenses-section')).not.toBeInTheDocument()
+    expect(document.querySelector('.income-section')).not.toBeInTheDocument()
   })
 
   it('marks Summary as the active tab button by default', async () => {
@@ -177,9 +177,9 @@ describe('MonthlyPage', () => {
     await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
 
-    expect(screen.queryByText('Category Totals')).not.toBeInTheDocument()
-    expect(screen.queryByText('Income')).not.toBeInTheDocument()
-    expect(screen.getByText('Expenses')).toBeInTheDocument()
+    expect(screen.queryByText(/^Total:/)).not.toBeInTheDocument()
+    expect(document.querySelector('.income-section')).not.toBeInTheDocument()
+    expect(document.querySelector('.expenses-section')).toBeInTheDocument()
     expect(screen.getByText('Lidl UK')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Expense' })).toHaveClass('monthly-page__tab--active')
   })
@@ -190,9 +190,9 @@ describe('MonthlyPage', () => {
     await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
 
-    expect(screen.queryByText('Category Totals')).not.toBeInTheDocument()
-    expect(screen.queryByText('Expenses')).not.toBeInTheDocument()
-    expect(screen.getByText('Income')).toBeInTheDocument()
+    expect(screen.queryByText(/^Total:/)).not.toBeInTheDocument()
+    expect(document.querySelector('.expenses-section')).not.toBeInTheDocument()
+    expect(document.querySelector('.income-section')).toBeInTheDocument()
     expect(screen.getByText('Gleison')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Incoming' })).toHaveClass('monthly-page__tab--active')
   })
@@ -227,11 +227,11 @@ describe('MonthlyPage', () => {
 
     await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: 'Expense' }))
-    await waitFor(() => expect(screen.getByText('Expenses')).toBeInTheDocument())
+    await waitFor(() => expect(document.querySelector('.expenses-section')).toBeInTheDocument())
 
     fireEvent.change(screen.getByLabelText('Month'), { target: { value: '2026-08' } })
 
-    await waitFor(() => expect(screen.getByText('Expenses')).toBeInTheDocument())
+    await waitFor(() => expect(document.querySelector('.expenses-section')).toBeInTheDocument())
     expect(screen.getByRole('button', { name: 'Expense' })).toHaveClass('monthly-page__tab--active')
   })
 
@@ -268,9 +268,8 @@ describe('MonthlyPage', () => {
     render(<MonthlyPage />)
 
     await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
-    expect(screen.getByText('Category Totals')).toBeInTheDocument()
+    expect(screen.getByText(/^Total:/)).toBeInTheDocument()
     expect(screen.getAllByText('Mercado').length).toBeGreaterThan(0)
-    expect(screen.getByText('Cards')).toBeInTheDocument()
     expect(screen.getByText(/Combined adjustment figure/)).toBeInTheDocument()
     expect(screen.getAllByText('100.00').length).toBeGreaterThan(0)
 
@@ -282,9 +281,8 @@ describe('MonthlyPage', () => {
     render(<MonthlyPage />)
 
     await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
-    expect(screen.getByText('Banks')).toBeInTheDocument()
 
-    const banksSection = within(screen.getByText('Banks').closest('section')!)
+    const banksSection = within(screen.getByText(/Bank Balance:/).closest('section')!)
     expect(banksSection.getByRole('cell', { name: 'Barclays' })).toBeInTheDocument()
     expect(banksSection.getByRole('cell', { name: 'Trading212' })).toBeInTheDocument()
     expect(banksSection.getByRole('cell', { name: 'Chase' })).toBeInTheDocument()
@@ -294,9 +292,9 @@ describe('MonthlyPage', () => {
     expect(banksSection.getAllByText('42.50').length).toBe(2)
     expect(banksSection.getAllByText('0.00').length).toBe(6)
 
-    expect(screen.getByText('Category Totals').closest('section')).toHaveClass('monthly-page__section--grid')
-    expect(screen.getByText('Cards').closest('section')).toHaveClass('monthly-page__section--grid')
-    expect(screen.getByText('Banks').closest('section')).toHaveClass('monthly-page__section--grid')
+    expect(screen.getByText(/^Total:/).closest('section')).toHaveClass('monthly-page__section--grid')
+    expect(screen.getByText(/Combined adjustment figure/).closest('section')).toHaveClass('monthly-page__section--grid')
+    expect(screen.getByText(/Bank Balance:/).closest('section')).toHaveClass('monthly-page__section--grid')
   })
 
   it('shows Mark Paid with a bank picker for unpaid cards and Unmark Paid for paid ones', async () => {
@@ -325,7 +323,7 @@ describe('MonthlyPage', () => {
     )
   })
 
-  it('renders Category Totals and Cards in the first Summary row, Banks and Incoming in the second, with no heading between them', async () => {
+  it('renders Category Totals and Cards in the first Summary row, Banks and Incoming in the second', async () => {
     render(<MonthlyPage />)
 
     await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
@@ -335,11 +333,13 @@ describe('MonthlyPage', () => {
     const rows = groups!.querySelectorAll(':scope > .monthly-page__grids-row')
     expect(rows).toHaveLength(2)
 
-    const firstRowHeadings = Array.from(rows[0].querySelectorAll('h2')).map((h) => h.textContent)
-    expect(firstRowHeadings).toEqual(['Category Totals', 'Cards'])
+    const firstRow = within(rows[0] as HTMLElement)
+    expect(firstRow.getByText(/^Total:/)).toBeInTheDocument()
+    expect(firstRow.getByText(/Combined adjustment figure/)).toBeInTheDocument()
 
-    const secondRowHeadings = Array.from(rows[1].querySelectorAll('h2')).map((h) => h.textContent)
-    expect(secondRowHeadings).toEqual(['Banks', 'Incoming'])
+    const secondRow = within(rows[1] as HTMLElement)
+    expect(secondRow.getByText(/Bank Balance:/)).toBeInTheDocument()
+    expect(secondRow.getByText(/Total Incoming:/)).toBeInTheDocument()
 
     expect(groups!.querySelectorAll(':scope > :not(.monthly-page__grids-row)')).toHaveLength(0)
   })
@@ -448,7 +448,7 @@ describe('MonthlyPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => expect(updateExpenseMock).toHaveBeenCalledWith('e1', expect.objectContaining({ value: 50 })))
-    const expensesSection = within(screen.getByText('Expenses').closest('section')!)
+    const expensesSection = within(document.querySelector('.expenses-section')!)
     await waitFor(() => expect(expensesSection.getByText('50.00')).toBeInTheDocument())
   })
 
@@ -467,8 +467,8 @@ describe('MonthlyPage', () => {
     render(<MonthlyPage />)
     fireEvent.click(screen.getByRole('button', { name: 'Incoming' }))
 
-    await waitFor(() => expect(screen.getByText('Income')).toBeInTheDocument())
-    const incomeSection = within(screen.getByText('Income').closest('section')!)
+    await waitFor(() => expect(document.querySelector('.income-section')).toBeInTheDocument())
+    const incomeSection = within(document.querySelector('.income-section')!)
     expect(incomeSection.getByText('Gleison')).toBeInTheDocument()
     expect(incomeSection.getByText('2,450.00')).toBeInTheDocument()
   })
@@ -553,7 +553,7 @@ describe('MonthlyPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => expect(updateIncomeMock).toHaveBeenCalledWith('i1', expect.objectContaining({ netValue: 500 })))
-    const incomeSection = within(screen.getByText('Income').closest('section')!)
+    const incomeSection = within(document.querySelector('.income-section')!)
     await waitFor(() => expect(incomeSection.getByText('500.00')).toBeInTheDocument())
   })
 
@@ -571,8 +571,8 @@ describe('MonthlyPage', () => {
   it('renders the Incoming card with one row per source and the calculated tithe and tithe balance', async () => {
     render(<MonthlyPage />)
 
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Incoming' })).toBeInTheDocument())
-    const incomingSection = within(screen.getByRole('heading', { name: 'Incoming' }).closest('section')!)
+    await waitFor(() => expect(screen.getByText(/Total Incoming:/)).toBeInTheDocument())
+    const incomingSection = within(screen.getByText(/Total Incoming:/).closest('section')!)
     expect(incomingSection.getByRole('cell', { name: 'Gleison' })).toBeInTheDocument()
     expect(incomingSection.getByText('3,200.00')).toBeInTheDocument()
     expect(incomingSection.getAllByText('2,450.00').length).toBeGreaterThanOrEqual(1)
@@ -606,7 +606,7 @@ describe('MonthlyPage', () => {
     await waitFor(() => expect(screen.getByText('Gleison')).toBeInTheDocument())
 
     fireEvent.click(screen.getByRole('button', { name: 'Summary' }))
-    const incomingSection = within(screen.getByRole('heading', { name: 'Incoming' }).closest('section')!)
+    const incomingSection = within(screen.getByText(/Total Incoming:/).closest('section')!)
     await waitFor(() => expect(incomingSection.getByRole('cell', { name: 'Lottery' })).toBeInTheDocument())
   })
 
@@ -693,8 +693,8 @@ describe('MonthlyPage', () => {
     ])
     render(<MonthlyPage />)
 
-    await waitFor(() => expect(screen.getByText('Banks')).toBeInTheDocument())
-    const banksSection = within(screen.getByText('Banks').closest('section')!)
+    await waitFor(() => expect(screen.getByText(/Bank Balance:/)).toBeInTheDocument())
+    const banksSection = within(screen.getByText(/Bank Balance:/).closest('section')!)
 
     const trading212Row = await banksSection.findByRole('row', { name: /Trading212/ })
     expect(within(trading212Row).getByRole('cell', { name: '8.80' })).toBeInTheDocument()

--- a/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/ReservaPage.test.tsx
@@ -62,18 +62,17 @@ describe('ReservaPage', () => {
   it('renders all 4 bucket balances and the movement history once loaded', async () => {
     render(<ReservaPage />)
 
-    await waitFor(() => expect(screen.getByText('Bucket Balances')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getAllByText('Ramsay').length).toBe(4))
     for (const b of BALANCES) {
       expect(screen.getAllByText(b.bucket).length).toBeGreaterThan(0)
     }
-    expect(screen.getAllByText('Ramsay').length).toBe(4)
   })
 
   it('shows a group total after the last movement of a same date+description split in history', async () => {
-    render(<ReservaPage />)
+    const { container } = render(<ReservaPage />)
 
-    await waitFor(() => expect(screen.getByText('Movement History')).toBeInTheDocument())
-    const movementSection = screen.getByText('Movement History').closest('section') as HTMLElement
+    await waitFor(() => expect(screen.getAllByText('Ramsay').length).toBe(4))
+    const movementSection = container.querySelector('.reserva-page__section--movements') as HTMLElement
     const rows = within(movementSection).getAllByRole('row')
     // header + 4 movement rows + 1 group-total row
     expect(rows).toHaveLength(6)
@@ -82,10 +81,10 @@ describe('ReservaPage', () => {
   })
 
   it('renders the total balance across all buckets, bold and always visible', async () => {
-    render(<ReservaPage />)
+    const { container } = render(<ReservaPage />)
 
-    await waitFor(() => expect(screen.getByText('Bucket Balances')).toBeInTheDocument())
-    const balancesSection = screen.getByText('Bucket Balances').closest('section') as HTMLElement
+    await waitFor(() => expect(screen.getAllByText('Ramsay').length).toBe(4))
+    const balancesSection = container.querySelector('.reserva-page__section--balances') as HTMLElement
     // 654.33 + 654.33 + 327.17 + 327.17 = 1963.00
     expect(within(balancesSection).getByText('1,963.00')).toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary
- Removes the `<h2>` heading from each CashFlow grid/section component (Category Totals, Cards, Banks, Incoming, Expenses, Income, Ledger, Bucket Balances, Movement History, Mensais Brasil/UK bill tables) — the tab or table context already identifies each one, so the heading was pure vertical space with no added information.
- `AnnualSummaryPage`'s Category Totals and Historic Summary Average tables got a `<th>Category</th>` in place of the empty `<th />` that used to sit under the removed heading, since that column otherwise had no label at all.
- `MensaisPage`'s `BillTable` `title` prop is removed — it became dead code (and a `tsc` build failure under `noUnusedParameters`) once its only use, the heading, was gone.
- Updates every test that queried the removed heading text (`getByText`/`getByRole('heading', ...)`) to locate the same content structurally instead — via each section's own CSS class (`.expenses-section`, `.income-section`, `.reserva-page__section--balances`/`--movements`) or a unique piece of footer/column text (`/Bank Balance:/`, `/Total Incoming:/`, `/Combined adjustment figure/`, `/^Total:/`).
- Fixes one test's expectation that had gone stale independent of the test-query mechanics: the Historic Summary Average header-cell array expected `['', '2026', '2025']`, but the first cell is now labeled `'Category'`.

## Test plan
- [x] `npx tsc -b --noEmit` — clean, no errors (confirms the `title` prop removal doesn't leave dead code / build breakage)
- [x] `npx vitest run` — 643/643 tests passing across all 51 test files
- [x] Manually traced every failing test back to the specific removed heading and rewired it to an equivalent structural query rather than loosening the assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)