### PR TITLE
fix(cashflow): stop dropping legitimate gross income and legacy Gleison-only net totals

### DIFF
--- a/Integrations/CashFlowSpreadsheetImport/Migrations/Incomes/SpreadsheetImport/IncomeTotalsReader.cs
+++ b/Integrations/CashFlowSpreadsheetImport/Migrations/Incomes/SpreadsheetImport/IncomeTotalsReader.cs
@@ -13,12 +13,20 @@ namespace Financial.CashFlow.Infrastructure.Integrations.CashFlowSpreadsheetImpo
 /// by a fixed row/column. Whatever numeric value(s) sit immediately to the right of a matched
 /// label are read: a single value is the net total; two values are gross then net. The "Dizimo"
 /// row is intentionally never matched here - it is tithe, not an <see cref="IncomeSource"/>.
+/// Confirmed empirically that Fev2017-Fev2018 sheets (before the labeled layout started in
+/// Mar2018) predate any label at all and instead carry a single bare net figure at J1 - Gleison
+/// was the sole earner for that period, so a sheet with zero matched labels falls back to reading
+/// that cell as his net income. From Mar2018 onward J1 is repurposed for something unrelated to
+/// income (it stops reconciling with the labeled totals), so this fallback only ever applies when
+/// no label matched - never alongside a labeled result.
 /// </summary>
 public static class IncomeTotalsReader
 {
     private const int LabelScanLastRow = 10;
     private const int FirstLabelColumn = 10; // J
     private const int LastLabelColumn = 11; // K
+    private const int LegacyUnlabeledNetRow = 1;
+    private const int LegacyUnlabeledNetColumn = FirstLabelColumn; // J1
 
     private static readonly Dictionary<IncomeSource, string> SourceLabelKeywords = new()
     {
@@ -47,7 +55,22 @@ public static class IncomeTotalsReader
             }
         }
 
+        if (totals.Count == 0)
+        {
+            var legacyTotal = ReadLegacyUnlabeledGleisonNet(sheet);
+            if (legacyTotal is not null)
+            {
+                totals.Add(legacyTotal.Value);
+            }
+        }
+
         return totals;
+    }
+
+    private static IncomeTotal? ReadLegacyUnlabeledGleisonNet(IXLWorksheet sheet)
+    {
+        var net = NumericCellReader.TryRead(sheet.Cell(LegacyUnlabeledNetRow, LegacyUnlabeledNetColumn));
+        return net is null ? null : new IncomeTotal(IncomeSource.Gleison, null, net.Value);
     }
 
     private static (int Row, int Column)? FindLabelCell(IXLWorksheet sheet, string keyword)
@@ -82,11 +105,8 @@ public static class IncomeTotalsReader
         }
 
         // The net column is what the spreadsheet's own tithe formula sums, so it's always
-        // trusted as NetValue. The gross column is occasionally smaller than net for Ariana's
-        // weekly-paycheck rows (the two totals were summed across slightly different manual
-        // entries) - when that happens the recorded "gross" isn't a real gross figure, so it's
-        // dropped rather than violating the domain's GrossValue >= NetValue invariant.
-        var grossValue = first >= second ? first : null;
-        return new IncomeTotal(source, grossValue, second.Value);
+        // trusted as NetValue. Gross can legitimately be lower than net (e.g. non-tax-free
+        // compensation), so whatever gross figure is recorded is imported as-is.
+        return new IncomeTotal(source, first, second.Value);
     }
 }

--- a/Tests/Financial.CashFlowSpreadsheetImport.Tests/Migrations/Incomes/SpreadsheetImport/IncomeTotalsReaderTests.cs
+++ b/Tests/Financial.CashFlowSpreadsheetImport.Tests/Migrations/Incomes/SpreadsheetImport/IncomeTotalsReaderTests.cs
@@ -58,11 +58,25 @@ public class IncomeTotalsReaderTests
     }
 
     [Fact]
-    public void ReadTotals_NoMatchingLabels_ReturnsEmpty()
+    public void ReadTotals_NoMatchingLabelsButBareValueAtJ1_ReadsItAsGleisonsNetIncome()
+    {
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.AddWorksheet("Fev2017");
+        sheet.Cell(1, 10).Value = 3744.97;
+
+        var totals = IncomeTotalsReader.ReadTotals(sheet);
+
+        var gleison = totals.Should().ContainSingle().Which;
+        gleison.Source.Should().Be(IncomeSource.Gleison);
+        gleison.GrossValue.Should().BeNull();
+        gleison.NetValue.Should().Be(3744.97m);
+    }
+
+    [Fact]
+    public void ReadTotals_NoMatchingLabelsAndNoValueAtJ1_ReturnsEmpty()
     {
         using var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Jan2017");
-        sheet.Cell(1, 10).Value = 3744.97;
 
         var totals = IncomeTotalsReader.ReadTotals(sheet);
 
@@ -70,7 +84,7 @@ public class IncomeTotalsReaderTests
     }
 
     [Fact]
-    public void ReadTotals_NetColumnExceedsGrossColumn_DropsGrossRatherThanViolatingTheDomainInvariant()
+    public void ReadTotals_NetColumnExceedsGrossColumn_ImportsGrossAsIs()
     {
         using var workbook = new XLWorkbook();
         var sheet = workbook.AddWorksheet("Fev2026");
@@ -81,7 +95,7 @@ public class IncomeTotalsReaderTests
         var totals = IncomeTotalsReader.ReadTotals(sheet);
 
         var ariana = totals.Should().ContainSingle(t => t.Source == IncomeSource.Ariana).Which;
-        ariana.GrossValue.Should().BeNull();
+        ariana.GrossValue.Should().Be(343.18m);
         ariana.NetValue.Should().Be(642.18m);
     }
 


### PR DESCRIPTION
## Summary
Both bugs were found by manually checking the result of a real import run, and confirmed directly against the real workbook before fixing.

- **Gross-below-net dropped**: `IncomeTotalsReader` used to null out a recorded gross figure whenever it was lower than net, on the assumption that could only mean mismatched manual entries — a rule left over from before the `Income` domain invariant `GrossValue >= NetValue` was removed. Now that non-tax-free compensation can legitimately make gross < net, this was discarding real data. Confirmed: Fev/2026 Ariana and Jun/2026 Gleison both lost their gross this way. Fixed to import whatever gross figure is recorded, as-is.
- **Legacy Gleison-only months imported as zero income**: sheets before the labeled income layout started (Mar2018) carry no income labels at all — just a bare net figure at cell J1. Confirmed against the real workbook this spans Fev2017-Fev2018 (14 months), and that Gleison was the sole earner in that period (the J1 value reconciles exactly with `income - expenses = balance` for those months). From Mar2018 onward J1 stops meaning income at all (it no longer reconciles with the labeled totals), so the reader now falls back to J1-as-Gleison's-net only when zero income labels match — a date-agnostic condition that naturally stops applying once labels exist.

## Test plan
- [x] `ReadTotals_NetColumnExceedsGrossColumn_ImportsGrossAsIs` — gross below net is kept, not dropped
- [x] `ReadTotals_NoMatchingLabelsButBareValueAtJ1_ReadsItAsGleisonsNetIncome` — the Fev2017-style bare-J1 sheet now yields a Gleison net-only entry
- [x] `ReadTotals_NoMatchingLabelsAndNoValueAtJ1_ReturnsEmpty` — a genuinely empty sheet still returns nothing (no false data)
- [x] `dotnet test Tests/Financial.CashFlowSpreadsheetImport.Tests --filter FullyQualifiedName~IncomeTotalsReaderTests` — 6/6 passing
- [x] Full solution `dotnet build` + `dotnet test` — all green

## Note
These fixes only apply to future import runs. The already-imported `data-cashflow.json` still has the old (wrong) values until the spreadsheet is re-imported or the affected entries are edited manually in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)