### PR TITLE
fix(cashflow): compute Category Totals average server-side with correct month scope

### DIFF
--- a/Financial.CashFlow.Application/DTOs/CategoryAnnualTotalDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/CategoryAnnualTotalDTO.cs
@@ -8,4 +8,5 @@ public sealed class CategoryAnnualTotalDTO
     public required string Category { get; init; }
     public required decimal[] MonthlyTotals { get; init; }
     public required decimal AnnualTotal { get; init; }
+    public required decimal Average { get; init; }
 }

--- a/Financial.CashFlow.Application/DTOs/CategoryTotalsAnnualDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/CategoryTotalsAnnualDTO.cs
@@ -12,8 +12,10 @@ public sealed class CategoryTotalsAnnualDTO
     /// <summary>Sum of all category rows' MonthlyTotals, per month.</summary>
     public required decimal[] TotalDespesasMonthly { get; init; }
     public required decimal TotalDespesasAnnualTotal { get; init; }
+    public required decimal TotalDespesasAverage { get; init; }
 
     /// <summary>Salary after taxes minus Total despesas plus the Investimento category value, per month (no Dividendo/Juros term).</summary>
     public required decimal[] ResultadoMonthly { get; init; }
     public required decimal ResultadoAnnualTotal { get; init; }
+    public required decimal ResultadoAverage { get; init; }
 }

--- a/Financial.CashFlow.Application/DTOs/IncomeAnnualSummaryDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/IncomeAnnualSummaryDTO.cs
@@ -8,16 +8,20 @@ public sealed class IncomeAnnualSummaryDTO
     /// <summary>Row 2 "Salary": sum of Gleison + Ariana gross values, per month.</summary>
     public required decimal[] SalaryMonthly { get; init; }
     public required decimal SalaryAnnualTotal { get; init; }
+    public required decimal SalaryAverage { get; init; }
 
     /// <summary>Row 3 "Salary after taxes": sum of Gleison + Ariana net values, per month.</summary>
     public required decimal[] SalaryAfterTaxesMonthly { get; init; }
     public required decimal SalaryAfterTaxesAnnualTotal { get; init; }
+    public required decimal SalaryAfterTaxesAverage { get; init; }
 
     /// <summary>Row 4 "Tax difference": SalaryMonthly minus SalaryAfterTaxesMonthly, per month.</summary>
     public required decimal[] TaxDifferenceMonthly { get; init; }
     public required decimal TaxDifferenceAnnualTotal { get; init; }
+    public required decimal TaxDifferenceAverage { get; init; }
 
     /// <summary>Row 6 "Dividendo/Juros": sum of DividendoJuros net values, per month.</summary>
     public required decimal[] DividendoJurosMonthly { get; init; }
     public required decimal DividendoJurosAnnualTotal { get; init; }
+    public required decimal DividendoJurosAverage { get; init; }
 }

--- a/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
+++ b/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
@@ -29,27 +29,49 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
 
     public IReadOnlyList<CategoryAnnualTotalDTO> GetCategoryTotalsForYear(int year)
     {
-        var totalsByCategoryAndMonth = _repository.GetExpenses()
-            .Where(e => e.Date.Year == year)
-            .GroupBy(e => (e.Category, e.Date.Month))
-            .ToDictionary(g => g.Key, g => g.Sum(e => e.Value));
+        var monthsElapsed = NumberOfMonthsForAverage(year);
 
-        return Enum.GetValues<Category>()
-            .Select(category =>
+        return BuildAllCategorySeriesForYear(year)
+            .Select(c => new CategoryAnnualTotalDTO
             {
-                var monthlyTotals = MonthlySeries.FromMonthlyValues(Enumerable.Range(1, MonthsInYear)
-                    .Select(month => totalsByCategoryAndMonth.GetValueOrDefault((category, month)))
-                    .ToArray());
-
-                return new CategoryAnnualTotalDTO
-                {
-                    Category = category.ToString(),
-                    MonthlyTotals = monthlyTotals.AsReadOnly().ToArray(),
-                    AnnualTotal = monthlyTotals.Sum()
-                };
+                Category = c.Category.ToString(),
+                MonthlyTotals = c.Display.AsReadOnly().ToArray(),
+                AnnualTotal = c.Display.Sum(),
+                Average = c.ForAverage.Average(monthsElapsed, AverageDecimalPlaces)
             })
             .ToList();
     }
+
+    /// <summary>
+    /// Builds each category's monthly series twice: <c>Display</c> includes every recorded
+    /// expense for the year (so the in-progress current month's partial total still shows live
+    /// in the table), while <c>ForAverage</c> excludes anything dated in the current calendar
+    /// month - mirroring <see cref="GetHistoricCategoriesAverageFromYear"/>'s query-level cutoff -
+    /// so a partially-elapsed month never inflates the numerator an "Average" figure divides by
+    /// <see cref="NumberOfMonthsForAverage"/> completed months.
+    /// </summary>
+    private IReadOnlyList<(Category Category, MonthlySeries Display, MonthlySeries ForAverage)> BuildAllCategorySeriesForYear(int year)
+    {
+        var yearExpenses = _repository.GetExpenses().Where(e => e.Date.Year == year).ToList();
+        var currentMonthCutoff = new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+
+        var totalsByCategoryAndMonth = BuildCategoryMonthlyTotals(yearExpenses);
+        var totalsForAverageByCategoryAndMonth = BuildCategoryMonthlyTotals(yearExpenses.Where(e => e.Date < currentMonthCutoff));
+
+        return Enum.GetValues<Category>()
+            .Select(category => (
+                category,
+                Display: MonthlySeries.FromMonthlyValues(Enumerable.Range(1, MonthsInYear)
+                    .Select(month => totalsByCategoryAndMonth.GetValueOrDefault((category, month)))
+                    .ToArray()),
+                ForAverage: MonthlySeries.FromMonthlyValues(Enumerable.Range(1, MonthsInYear)
+                    .Select(month => totalsForAverageByCategoryAndMonth.GetValueOrDefault((category, month)))
+                    .ToArray())))
+            .ToList();
+    }
+
+    private static Dictionary<(Category, int), decimal> BuildCategoryMonthlyTotals(IEnumerable<Expense> expenses) =>
+        expenses.GroupBy(e => (e.Category, e.Date.Month)).ToDictionary(g => g.Key, g => g.Sum(e => e.Value));
 
     public InvestmentAnnualResultDTO GetInvestmentAnnualResultForYear(int year)
     {
@@ -141,11 +163,52 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
 
     public IncomeAnnualSummaryDTO GetIncomeSummaryForYear(int year)
     {
+        var (display, forAverage) = BuildIncomeSeriesPairForYear(year);
+        var monthsElapsed = NumberOfMonthsForAverage(year);
+
+        return new IncomeAnnualSummaryDTO
+        {
+            SalaryMonthly = display.Salary.AsReadOnly().ToArray(),
+            SalaryAnnualTotal = display.Salary.Sum(),
+            SalaryAverage = forAverage.Salary.Average(monthsElapsed, AverageDecimalPlaces),
+            SalaryAfterTaxesMonthly = display.SalaryAfterTaxes.AsReadOnly().ToArray(),
+            SalaryAfterTaxesAnnualTotal = display.SalaryAfterTaxes.Sum(),
+            SalaryAfterTaxesAverage = forAverage.SalaryAfterTaxes.Average(monthsElapsed, AverageDecimalPlaces),
+            TaxDifferenceMonthly = display.TaxDifference.AsReadOnly().ToArray(),
+            TaxDifferenceAnnualTotal = display.TaxDifference.Sum(),
+            TaxDifferenceAverage = forAverage.TaxDifference.Average(monthsElapsed, AverageDecimalPlaces),
+            DividendoJurosMonthly = display.DividendoJuros.AsReadOnly().ToArray(),
+            DividendoJurosAnnualTotal = display.DividendoJuros.Sum(),
+            DividendoJurosAverage = forAverage.DividendoJuros.Average(monthsElapsed, AverageDecimalPlaces)
+        };
+    }
+
+    /// <summary>
+    /// Builds the income monthly series twice for the same reason as <see cref="BuildAllCategorySeriesForYear"/>:
+    /// <c>Display</c> includes every recorded income for the year, while <c>ForAverage</c> excludes
+    /// anything dated in the current calendar month so a partially-elapsed month never inflates an
+    /// "Average" figure's numerator.
+    /// </summary>
+    private (IncomeSeries Display, IncomeSeries ForAverage) BuildIncomeSeriesPairForYear(int year)
+    {
+        var yearIncomes = _repository.GetIncomes().Where(i => i.Date.Year == year).ToList();
+        var currentMonthCutoff = new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+
+        return (
+            BuildIncomeSeries(yearIncomes),
+            BuildIncomeSeries(yearIncomes.Where(i => i.Date < currentMonthCutoff)));
+    }
+
+    private readonly record struct IncomeSeries(
+        MonthlySeries Salary, MonthlySeries SalaryAfterTaxes, MonthlySeries TaxDifference, MonthlySeries DividendoJuros);
+
+    private static IncomeSeries BuildIncomeSeries(IEnumerable<Income> incomes)
+    {
         var salaryMonthly = new decimal[MonthsInYear];
         var salaryAfterTaxesMonthly = new decimal[MonthsInYear];
         var dividendoJurosMonthly = new decimal[MonthsInYear];
 
-        foreach (var income in _repository.GetIncomes().Where(i => i.Date.Year == year))
+        foreach (var income in incomes)
         {
             var monthIndex = income.Date.Month - 1;
 
@@ -167,35 +230,52 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
             taxDifferenceMonthly[month] = salaryMonthly[month] - salaryAfterTaxesMonthly[month];
         }
 
-        return new IncomeAnnualSummaryDTO
-        {
-            SalaryMonthly = salaryMonthly,
-            SalaryAnnualTotal = salaryMonthly.Sum(),
-            SalaryAfterTaxesMonthly = salaryAfterTaxesMonthly,
-            SalaryAfterTaxesAnnualTotal = salaryAfterTaxesMonthly.Sum(),
-            TaxDifferenceMonthly = taxDifferenceMonthly,
-            TaxDifferenceAnnualTotal = taxDifferenceMonthly.Sum(),
-            DividendoJurosMonthly = dividendoJurosMonthly,
-            DividendoJurosAnnualTotal = dividendoJurosMonthly.Sum()
-        };
+        return new IncomeSeries(
+            MonthlySeries.FromMonthlyValues(salaryMonthly),
+            MonthlySeries.FromMonthlyValues(salaryAfterTaxesMonthly),
+            MonthlySeries.FromMonthlyValues(taxDifferenceMonthly),
+            MonthlySeries.FromMonthlyValues(dividendoJurosMonthly));
     }
 
     public CategoryTotalsAnnualDTO GetCategoryTotalsAnnualForYear(int year)
     {
-        var categoryTotals = GetCategoryTotalsForYear(year);
-        var incomeSummary = GetIncomeSummaryForYear(year);
+        var monthsElapsed = NumberOfMonthsForAverage(year);
 
-        var totalDespesasSeries = categoryTotals.Aggregate(
-            MonthlySeries.Zero(),
-            (total, category) => total.Add(MonthlySeries.FromMonthlyValues(category.MonthlyTotals)));
+        var categorySeries = BuildAllCategorySeriesForYear(year);
+        var categoryTotals = categorySeries
+            .Select(c => new CategoryAnnualTotalDTO
+            {
+                Category = c.Category.ToString(),
+                MonthlyTotals = c.Display.AsReadOnly().ToArray(),
+                AnnualTotal = c.Display.Sum(),
+                Average = c.ForAverage.Average(monthsElapsed, AverageDecimalPlaces)
+            })
+            .ToList();
 
-        var investimentoSeries = MonthlySeries.FromMonthlyValues(
-            categoryTotals.FirstOrDefault(c => c.Category == nameof(Category.Investimento))?.MonthlyTotals
-                ?? new decimal[MonthsInYear]);
+        var (incomeDisplay, incomeForAverage) = BuildIncomeSeriesPairForYear(year);
+        var incomeSummary = new IncomeAnnualSummaryDTO
+        {
+            SalaryMonthly = incomeDisplay.Salary.AsReadOnly().ToArray(),
+            SalaryAnnualTotal = incomeDisplay.Salary.Sum(),
+            SalaryAverage = incomeForAverage.Salary.Average(monthsElapsed, AverageDecimalPlaces),
+            SalaryAfterTaxesMonthly = incomeDisplay.SalaryAfterTaxes.AsReadOnly().ToArray(),
+            SalaryAfterTaxesAnnualTotal = incomeDisplay.SalaryAfterTaxes.Sum(),
+            SalaryAfterTaxesAverage = incomeForAverage.SalaryAfterTaxes.Average(monthsElapsed, AverageDecimalPlaces),
+            TaxDifferenceMonthly = incomeDisplay.TaxDifference.AsReadOnly().ToArray(),
+            TaxDifferenceAnnualTotal = incomeDisplay.TaxDifference.Sum(),
+            TaxDifferenceAverage = incomeForAverage.TaxDifference.Average(monthsElapsed, AverageDecimalPlaces),
+            DividendoJurosMonthly = incomeDisplay.DividendoJuros.AsReadOnly().ToArray(),
+            DividendoJurosAnnualTotal = incomeDisplay.DividendoJuros.Sum(),
+            DividendoJurosAverage = incomeForAverage.DividendoJuros.Average(monthsElapsed, AverageDecimalPlaces)
+        };
 
-        var salaryAfterTaxesSeries = MonthlySeries.FromMonthlyValues(incomeSummary.SalaryAfterTaxesMonthly);
+        var totalDespesasSeries = categorySeries.Aggregate(MonthlySeries.Zero(), (total, c) => total.Add(c.Display));
+        var totalDespesasForAverageSeries = categorySeries.Aggregate(MonthlySeries.Zero(), (total, c) => total.Add(c.ForAverage));
 
-        var resultadoSeries = AnnualResultCalculator.ComputeResultado(salaryAfterTaxesSeries, totalDespesasSeries, investimentoSeries);
+        var investimento = categorySeries.First(c => c.Category == Category.Investimento);
+
+        var resultadoSeries = AnnualResultCalculator.ComputeResultado(incomeDisplay.SalaryAfterTaxes, totalDespesasSeries, investimento.Display);
+        var resultadoForAverageSeries = AnnualResultCalculator.ComputeResultado(incomeForAverage.SalaryAfterTaxes, totalDespesasForAverageSeries, investimento.ForAverage);
 
         return new CategoryTotalsAnnualDTO
         {
@@ -203,8 +283,10 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
             IncomeSummary = incomeSummary,
             TotalDespesasMonthly = totalDespesasSeries.AsReadOnly().ToArray(),
             TotalDespesasAnnualTotal = totalDespesasSeries.Sum(),
+            TotalDespesasAverage = totalDespesasForAverageSeries.Average(monthsElapsed, AverageDecimalPlaces),
             ResultadoMonthly = resultadoSeries.AsReadOnly().ToArray(),
-            ResultadoAnnualTotal = resultadoSeries.Sum()
+            ResultadoAnnualTotal = resultadoSeries.Sum(),
+            ResultadoAverage = resultadoForAverageSeries.Average(monthsElapsed, AverageDecimalPlaces)
         };
     }
 

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -452,6 +452,7 @@ export interface CategoryAnnualTotalDto {
   category: string
   monthlyTotals: number[]
   annualTotal: number
+  average: number
 }
 
 export interface InvestmentAccountAnnualDiffDto {
@@ -477,12 +478,16 @@ export interface InvestmentAnnualResultDto {
 export interface IncomeAnnualSummaryDto {
   salaryMonthly: number[]
   salaryAnnualTotal: number
+  salaryAverage: number
   salaryAfterTaxesMonthly: number[]
   salaryAfterTaxesAnnualTotal: number
+  salaryAfterTaxesAverage: number
   taxDifferenceMonthly: number[]
   taxDifferenceAnnualTotal: number
+  taxDifferenceAverage: number
   dividendoJurosMonthly: number[]
   dividendoJurosAnnualTotal: number
+  dividendoJurosAverage: number
 }
 
 export interface CategoryTotalsAnnualDto {
@@ -490,8 +495,10 @@ export interface CategoryTotalsAnnualDto {
   incomeSummary: IncomeAnnualSummaryDto
   totalDespesasMonthly: number[]
   totalDespesasAnnualTotal: number
+  totalDespesasAverage: number
   resultadoMonthly: number[]
   resultadoAnnualTotal: number
+  resultadoAverage: number
 }
 
 export interface InvestmentSnapshotDto {

--- a/Financial.Web/src/hooks/useAnnualSummary.test.ts
+++ b/Financial.Web/src/hooks/useAnnualSummary.test.ts
@@ -19,21 +19,27 @@ vi.mock('../api/financialApiClient', () => ({
 }))
 
 const CATEGORY_TOTALS_ANNUAL: CategoryTotalsAnnualDto = {
-  categoryTotals: [{ category: 'Mercado', monthlyTotals: new Array(12).fill(100), annualTotal: 1200 }],
+  categoryTotals: [{ category: 'Mercado', monthlyTotals: new Array(12).fill(100), annualTotal: 1200, average: 100 }],
   incomeSummary: {
     salaryMonthly: new Array(12).fill(3200),
     salaryAnnualTotal: 38400,
+    salaryAverage: 3200,
     salaryAfterTaxesMonthly: new Array(12).fill(2450),
     salaryAfterTaxesAnnualTotal: 29400,
+    salaryAfterTaxesAverage: 2450,
     taxDifferenceMonthly: new Array(12).fill(750),
     taxDifferenceAnnualTotal: 9000,
+    taxDifferenceAverage: 750,
     dividendoJurosMonthly: new Array(12).fill(15.5),
     dividendoJurosAnnualTotal: 186,
+    dividendoJurosAverage: 15.5,
   },
   totalDespesasMonthly: new Array(12).fill(100),
   totalDespesasAnnualTotal: 1200,
+  totalDespesasAverage: 100,
   resultadoMonthly: new Array(12).fill(2350),
   resultadoAnnualTotal: 28200,
+  resultadoAverage: 2350,
 }
 
 const INVESTMENT_ANNUAL_RESULT: InvestmentAnnualResultDto = {

--- a/Financial.Web/src/hooks/useAnnualSummary.ts
+++ b/Financial.Web/src/hooks/useAnnualSummary.ts
@@ -8,8 +8,10 @@ interface AnnualSummaryState {
   incomeSummary: IncomeAnnualSummaryDto | null
   totalDespesasMonthly: number[]
   totalDespesasAnnualTotal: number
+  totalDespesasAverage: number
   resultadoMonthly: number[]
   resultadoAnnualTotal: number
+  resultadoAverage: number
   investmentAnnualResult: InvestmentAnnualResultDto | null
   historicSummaryAverage: CategoryAnnualAverageDto[]
   isLoading: boolean
@@ -27,8 +29,10 @@ type AnnualSummaryAction =
         incomeSummary: IncomeAnnualSummaryDto
         totalDespesasMonthly: number[]
         totalDespesasAnnualTotal: number
+        totalDespesasAverage: number
         resultadoMonthly: number[]
         resultadoAnnualTotal: number
+        resultadoAverage: number
         investmentAnnualResult: InvestmentAnnualResultDto
         historicSummaryAverage: CategoryAnnualAverageDto[]
       }
@@ -42,8 +46,10 @@ const INITIAL_STATE: AnnualSummaryState = {
   incomeSummary: null,
   totalDespesasMonthly: [],
   totalDespesasAnnualTotal: 0,
+  totalDespesasAverage: 0,
   resultadoMonthly: [],
   resultadoAnnualTotal: 0,
+  resultadoAverage: 0,
   investmentAnnualResult: null,
   historicSummaryAverage: [],
   isLoading: true,
@@ -65,8 +71,10 @@ function reducer(state: AnnualSummaryState, action: AnnualSummaryAction): Annual
         incomeSummary: action.payload.incomeSummary,
         totalDespesasMonthly: action.payload.totalDespesasMonthly,
         totalDespesasAnnualTotal: action.payload.totalDespesasAnnualTotal,
+        totalDespesasAverage: action.payload.totalDespesasAverage,
         resultadoMonthly: action.payload.resultadoMonthly,
         resultadoAnnualTotal: action.payload.resultadoAnnualTotal,
+        resultadoAverage: action.payload.resultadoAverage,
         investmentAnnualResult: action.payload.investmentAnnualResult,
         historicSummaryAverage: action.payload.historicSummaryAverage,
       }
@@ -86,8 +94,10 @@ export interface AnnualSummaryData {
   incomeSummary: IncomeAnnualSummaryDto | null
   totalDespesasMonthly: number[]
   totalDespesasAnnualTotal: number
+  totalDespesasAverage: number
   resultadoMonthly: number[]
   resultadoAnnualTotal: number
+  resultadoAverage: number
   investmentAnnualResult: InvestmentAnnualResultDto | null
   historicSummaryAverage: CategoryAnnualAverageDto[]
   isLoading: boolean
@@ -114,8 +124,10 @@ export function useAnnualSummary(): AnnualSummaryData {
             incomeSummary: categoryTotalsAnnual.incomeSummary,
             totalDespesasMonthly: categoryTotalsAnnual.totalDespesasMonthly,
             totalDespesasAnnualTotal: categoryTotalsAnnual.totalDespesasAnnualTotal,
+            totalDespesasAverage: categoryTotalsAnnual.totalDespesasAverage,
             resultadoMonthly: categoryTotalsAnnual.resultadoMonthly,
             resultadoAnnualTotal: categoryTotalsAnnual.resultadoAnnualTotal,
+            resultadoAverage: categoryTotalsAnnual.resultadoAverage,
             investmentAnnualResult,
             historicSummaryAverage,
           },
@@ -143,8 +155,10 @@ export function useAnnualSummary(): AnnualSummaryData {
     incomeSummary: state.incomeSummary,
     totalDespesasMonthly: state.totalDespesasMonthly,
     totalDespesasAnnualTotal: state.totalDespesasAnnualTotal,
+    totalDespesasAverage: state.totalDespesasAverage,
     resultadoMonthly: state.resultadoMonthly,
     resultadoAnnualTotal: state.resultadoAnnualTotal,
+    resultadoAverage: state.resultadoAverage,
     investmentAnnualResult: state.investmentAnnualResult,
     historicSummaryAverage: state.historicSummaryAverage,
     isLoading: state.isLoading,

--- a/Financial.Web/src/pages/AnnualSummaryPage.tsx
+++ b/Financial.Web/src/pages/AnnualSummaryPage.tsx
@@ -3,7 +3,6 @@ import ErrorState from '../components/ErrorState'
 import LoadingState from '../components/LoadingState'
 import { useAnnualSummary } from '../hooks/useAnnualSummary'
 import { formatN2 } from '../utils/formatters'
-import { average } from '../utils/math'
 import './AnnualSummaryPage.css'
 
 const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
@@ -20,11 +19,13 @@ const TABS: { id: AnnualSummaryTabId; label: string }[] = [
 function AnnualSummaryRow({
   label,
   monthlyValues,
+  average,
   annualTotal,
   emphasized = false,
 }: {
   label: string
   monthlyValues: number[]
+  average: number
   annualTotal: number
   emphasized?: boolean
 }) {
@@ -38,7 +39,7 @@ function AnnualSummaryRow({
         </td>
       ))}
       <td className="data-table__col--numeric">
-        <strong>{formatN2(average(monthlyValues))}</strong>
+        <strong>{formatN2(average)}</strong>
       </td>
       <td className="data-table__col--numeric">
         <strong>{formatN2(annualTotal)}</strong>
@@ -81,8 +82,10 @@ export default function AnnualSummaryPage() {
     historicSummaryAverage,
     totalDespesasMonthly,
     totalDespesasAnnualTotal,
+    totalDespesasAverage,
     resultadoMonthly,
     resultadoAnnualTotal,
+    resultadoAverage,
     isLoading,
     error,
     retry,
@@ -144,16 +147,19 @@ export default function AnnualSummaryPage() {
                       <AnnualSummaryRow
                         label="Salary"
                         monthlyValues={incomeSummary.salaryMonthly}
+                        average={incomeSummary.salaryAverage}
                         annualTotal={incomeSummary.salaryAnnualTotal}
                       />
                       <AnnualSummaryRow
                         label="Salary after taxes"
                         monthlyValues={incomeSummary.salaryAfterTaxesMonthly}
+                        average={incomeSummary.salaryAfterTaxesAverage}
                         annualTotal={incomeSummary.salaryAfterTaxesAnnualTotal}
                       />
                       <AnnualSummaryRow
                         label="Tax difference"
                         monthlyValues={incomeSummary.taxDifferenceMonthly}
+                        average={incomeSummary.taxDifferenceAverage}
                         annualTotal={incomeSummary.taxDifferenceAnnualTotal}
                       />
                       <tr>
@@ -162,6 +168,7 @@ export default function AnnualSummaryPage() {
                       <AnnualSummaryRow
                         label="Dividendo/Juros"
                         monthlyValues={incomeSummary.dividendoJurosMonthly}
+                        average={incomeSummary.dividendoJurosAverage}
                         annualTotal={incomeSummary.dividendoJurosAnnualTotal}
                       />
                     </>
@@ -172,7 +179,13 @@ export default function AnnualSummaryPage() {
                   </tr>
 
                   {categoryTotals.map((c) => (
-                    <AnnualSummaryRow key={c.category} label={c.category} monthlyValues={c.monthlyTotals} annualTotal={c.annualTotal} />
+                    <AnnualSummaryRow
+                      key={c.category}
+                      label={c.category}
+                      monthlyValues={c.monthlyTotals}
+                      average={c.average}
+                      annualTotal={c.annualTotal}
+                    />
                   ))}
 
                   <tr>
@@ -183,6 +196,7 @@ export default function AnnualSummaryPage() {
                     <AnnualSummaryRow
                       label="Resultado (R-D-Inv)"
                       monthlyValues={resultadoMonthly}
+                      average={resultadoAverage}
                       annualTotal={resultadoAnnualTotal}
                       emphasized
                     />
@@ -190,6 +204,7 @@ export default function AnnualSummaryPage() {
                   <AnnualSummaryRow
                     label="Total despesas"
                     monthlyValues={totalDespesasMonthly}
+                    average={totalDespesasAverage}
                     annualTotal={totalDespesasAnnualTotal}
                     emphasized
                   />

--- a/Financial.Web/src/pages/__tests__/AnnualSummaryPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/AnnualSummaryPage.test.tsx
@@ -22,23 +22,30 @@ const CATEGORY_TOTALS_ANNUAL: CategoryTotalsAnnualDto = {
       category: 'Mercado',
       monthlyTotals: [100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210],
       annualTotal: 1860,
+      average: 155,
     },
   ],
   incomeSummary: {
     salaryMonthly: [3200, 3200, 3200, 3200, 3200, 3200, 3200, 3200, 3200, 3200, 3200, 3600],
     salaryAnnualTotal: 38800,
+    salaryAverage: 3233.33,
     salaryAfterTaxesMonthly: [2450, 2450, 2450, 2450, 2450, 2450, 2450, 2450, 2450, 2450, 2450, 2650],
     salaryAfterTaxesAnnualTotal: 29350,
+    salaryAfterTaxesAverage: 2445.83,
     taxDifferenceMonthly: [750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 750, 950],
     taxDifferenceAnnualTotal: 9450,
+    taxDifferenceAverage: 787.5,
     dividendoJurosMonthly: [0, 0, 15.5, 0, 0, 0, 0, 0, 0, 0, 0, 4.5],
     dividendoJurosAnnualTotal: 20,
+    dividendoJurosAverage: 1.67,
   },
   // Server-computed (corrected, no-Dividendo/Juros formula): sum(salaryAfterTaxesMonthly) - totalDespesasAnnualTotal + 0 (no Investimento category) = 27,490.00
   totalDespesasMonthly: [100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210],
   totalDespesasAnnualTotal: 1860,
+  totalDespesasAverage: 155,
   resultadoMonthly: [2350, 2340, 2330, 2320, 2310, 2300, 2290, 2280, 2270, 2260, 2250, 2440],
   resultadoAnnualTotal: 27740,
+  resultadoAverage: 2311.67,
 }
 
 const INVESTMENT_ANNUAL_RESULT: InvestmentAnnualResultDto = {
@@ -178,7 +185,7 @@ describe('AnnualSummaryPage', () => {
     expect(within(taxDifferenceRow).getByText('9,450.00')).toBeInTheDocument()
   })
 
-  it('shows an Average column between the Dec and Annual Total columns for every row', async () => {
+  it('shows an Average column between the Dec and Annual Total columns, using the server-computed value', async () => {
     render(<AnnualSummaryPage />)
 
     await waitFor(() => expect(screen.getByText('Category Totals')).toBeInTheDocument())
@@ -189,7 +196,9 @@ describe('AnnualSummaryPage', () => {
     expect(averageIndex).toBe(decIndex + 1)
     expect(annualTotalIndex).toBe(averageIndex + 1)
 
-    // Mercado average = 1860 / 12 = 155.00
+    // Mercado's average (155.00) comes straight from the mocked API response, not a client
+    // recomputation from monthlyTotals - proven by the fact this must match CATEGORY_TOTALS_ANNUAL's
+    // explicit `average` field, not sum(monthlyTotals) / 12.
     const mercadoRow = screen.getByRole('cell', { name: 'Mercado' }).closest('tr')!
     expect(within(mercadoRow).getByText('155.00')).toBeInTheDocument()
   })
@@ -356,7 +365,7 @@ describe('AnnualSummaryPage', () => {
 
     const nextYearCategoryTotalsAnnual: CategoryTotalsAnnualDto = {
       ...CATEGORY_TOTALS_ANNUAL,
-      categoryTotals: [{ category: 'Carro', monthlyTotals: new Array(12).fill(50), annualTotal: 600 }],
+      categoryTotals: [{ category: 'Carro', monthlyTotals: new Array(12).fill(50), annualTotal: 600, average: 50 }],
       totalDespesasMonthly: new Array(12).fill(50),
       totalDespesasAnnualTotal: 600,
     }

--- a/Financial.Web/src/utils/math.ts
+++ b/Financial.Web/src/utils/math.ts
@@ -1,3 +1,0 @@
-export function average(values: number[]): number {
-  return values.reduce((sum, v) => sum + v, 0) / values.length
-}

--- a/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -847,6 +847,167 @@ public class AnnualSummaryServiceTests
         result.Should().ContainSingle(r => r.Year == currentYear - 1);
     }
 
+    [Fact]
+    public void GetCategoryTotalsForYear_AverageDividesByTwelveForAnOrdinaryYear()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Jan first", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 20), "Jan second", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2025, 2, 10), "Feb", 400m, Category.Mercado, "Barclays", null));
+
+        var result = service.GetCategoryTotalsForYear(2025);
+
+        result.Single(c => c.Category == "Mercado").Average.Should().Be(50m);
+    }
+
+    [Fact]
+    public void GetCategoryTotalsForYear_AverageDividesByElevenFor2017()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        repository.Expenses.Add(Expense.Create(new DateOnly(2017, 1, 5), "Jan first", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2017, 1, 20), "Jan second", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2017, 2, 10), "Feb", 400m, Category.Mercado, "Barclays", null));
+
+        var result = service.GetCategoryTotalsForYear(2017);
+
+        result.Single(c => c.Category == "Mercado").Average.Should().Be(54.55m);
+    }
+
+    [Fact]
+    public void GetCategoryTotalsForYear_AverageForCurrentYearExcludesInProgressMonth()
+    {
+        var today = DateTime.UtcNow;
+        if (today.Month == 1)
+        {
+            // No completed month exists yet this year; nothing meaningful to assert.
+            return;
+        }
+
+        var monthsElapsed = today.Month - 1;
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        var currentYear = today.Year;
+        repository.Expenses.Add(Expense.Create(new DateOnly(currentYear, 1, 5), "Completed months", 100m * monthsElapsed, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(DateOnly.FromDateTime(today), "In-progress month", 9999m, Category.Mercado, "Barclays", null));
+
+        var result = service.GetCategoryTotalsForYear(currentYear);
+
+        // The in-progress current-month entry (9999) must be excluded entirely from the average,
+        // not treated as a completed month with a low value.
+        result.Single(c => c.Category == "Mercado").Average.Should().Be(100m);
+    }
+
+    [Fact]
+    public void GetIncomeSummaryForYear_AveragesDivideByTwelveForAnOrdinaryYear()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 5), IncomeSource.Gleison, 1200m, 600m, "Barclays"));
+
+        var result = service.GetIncomeSummaryForYear(2025);
+
+        result.SalaryAverage.Should().Be(100m);
+        result.SalaryAfterTaxesAverage.Should().Be(50m);
+        result.TaxDifferenceAverage.Should().Be(50m);
+    }
+
+    [Fact]
+    public void GetIncomeSummaryForYear_AveragesDivideByElevenFor2017()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        repository.Incomes.Add(Income.Create(new DateOnly(2017, 1, 5), IncomeSource.Gleison, 1200m, 600m, "Barclays"));
+
+        var result = service.GetIncomeSummaryForYear(2017);
+
+        result.SalaryAverage.Should().Be(109.09m);
+        result.SalaryAfterTaxesAverage.Should().Be(54.55m);
+        result.TaxDifferenceAverage.Should().Be(54.55m);
+    }
+
+    [Fact]
+    public void GetIncomeSummaryForYear_AveragesForCurrentYearExcludeInProgressMonth()
+    {
+        var today = DateTime.UtcNow;
+        if (today.Month == 1)
+        {
+            return;
+        }
+
+        var monthsElapsed = today.Month - 1;
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        var currentYear = today.Year;
+        repository.Incomes.Add(Income.Create(new DateOnly(currentYear, 1, 5), IncomeSource.Gleison, 1000m * monthsElapsed, 800m * monthsElapsed, "Barclays"));
+        repository.Incomes.Add(Income.Create(DateOnly.FromDateTime(today), IncomeSource.Gleison, 9999m * monthsElapsed, 9999m * monthsElapsed, "Barclays"));
+
+        var result = service.GetIncomeSummaryForYear(currentYear);
+
+        result.SalaryAverage.Should().Be(1000m);
+        result.SalaryAfterTaxesAverage.Should().Be(800m);
+    }
+
+    [Fact]
+    public void GetCategoryTotalsAnnualForYear_TotalDespesasAndResultadoAveragesDivideByTwelveForAnOrdinaryYear()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 5), IncomeSource.DividendoJuros, null, 20m, "Barclays"));
+
+        var result = service.GetCategoryTotalsAnnualForYear(2025);
+
+        // Total despesas: (Mercado 100 + Investimento 30) / 12 = 10.83.
+        result.TotalDespesasAverage.Should().Be(10.83m);
+        // Resultado: the per-month series (SalaryAfterTaxes 800 - TotalDespesas 130 + Investimento 30 = 700
+        // in January, zero elsewhere) is averaged as a whole, i.e. 700 / 12 = 58.33.
+        result.ResultadoAverage.Should().Be(58.33m);
+    }
+
+    [Fact]
+    public void GetCategoryTotalsAnnualForYear_TotalDespesasAndResultadoAveragesDivideByElevenFor2017()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        repository.Expenses.Add(Expense.Create(new DateOnly(2017, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(2017, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(2017, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(2017, 1, 5), IncomeSource.DividendoJuros, null, 20m, "Barclays"));
+
+        var result = service.GetCategoryTotalsAnnualForYear(2017);
+
+        result.TotalDespesasAverage.Should().Be(11.82m);
+        result.ResultadoAverage.Should().Be(63.64m);
+    }
+
+    [Fact]
+    public void GetCategoryTotalsAnnualForYear_TotalDespesasAndResultadoAveragesForCurrentYearExcludeInProgressMonth()
+    {
+        var today = DateTime.UtcNow;
+        if (today.Month == 1)
+        {
+            return;
+        }
+
+        var monthsElapsed = today.Month - 1;
+        var repository = new StubCashFlowRepository();
+        var service = new AnnualSummaryService(repository);
+        var currentYear = today.Year;
+        repository.Expenses.Add(Expense.Create(new DateOnly(currentYear, 1, 5), "Completed months", 100m * monthsElapsed, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(DateOnly.FromDateTime(today), "In-progress month", 9999m, Category.Mercado, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(currentYear, 1, 5), IncomeSource.Gleison, 1000m * monthsElapsed, 800m * monthsElapsed, "Barclays"));
+        repository.Incomes.Add(Income.Create(DateOnly.FromDateTime(today), IncomeSource.Gleison, 9999m * monthsElapsed, 9999m * monthsElapsed, "Barclays"));
+
+        var result = service.GetCategoryTotalsAnnualForYear(currentYear);
+
+        result.TotalDespesasAverage.Should().Be(100m);
+        result.ResultadoAverage.Should().Be(700m);
+    }
+
     private sealed class StubCashFlowRepository : ICashFlowRepository
     {
         private static readonly (string Name, bool IsLiability)[] SeededAccounts =


### PR DESCRIPTION
## Summary
- The Category Totals tab's "Average" column was computed entirely client-side (`sum(monthlyValues) / 12`), unlike Historic Summary Average, which already correctly divides by 11 for 2017 and by elapsed completed months for the current year via `AnnualSummaryService.NumberOfMonthsForAverage`. Every row on the tab was affected: Salary, Salary after taxes, Tax difference, Dividendo/Juros, every expense category, Resultado (R-D-Inv), and Total despesas.
- Moved the calculation server-side, reusing `NumberOfMonthsForAverage` and `MonthlySeries.Average` — consistent with the codebase's existing server-computed-average pattern (e.g. `NetPositionAnnualDiffDTO.AverageMonthResult`).
- Found and fixed a related correctness issue along the way: unlike Historic Summary Average (whose underlying query already excludes the in-progress current month), Category Totals' query has no such cutoff — naively reusing `Sum()/monthsElapsed` would let a partially-elapsed month's already-entered data inflate the average's numerator. `GetCategoryTotalsForYear`, `GetIncomeSummaryForYear`, and `GetCategoryTotalsAnnualForYear` now each build a "display" series (full data, still shown live in the table) and a "for-average" series (current in-progress month excluded), mirroring the same query-level exclusion technique already used by Historic Summary Average.
- `AnnualSummaryRow` now takes `average` as a server-provided prop instead of computing it client-side; `utils/math.ts` (its only consumer) is deleted.

## Test plan
- [x] New backend tests covering all three affected methods × all three month-scope cases (12/11/elapsed-months): `GetCategoryTotalsForYear_AverageDividesByTwelveForAnOrdinaryYear`, `..._AverageDividesByElevenFor2017`, `..._AverageForCurrentYearExcludesInProgressMonth`, and the equivalent trio for `GetIncomeSummaryForYear` and `GetCategoryTotalsAnnualForYear` (9 new tests total)
- [x] `dotnet test Tests/Financial.CashFlow.Application.Tests --filter FullyQualifiedName~AnnualSummaryServiceTests` — 60/60 passing
- [x] Full solution `dotnet build` + `dotnet test` — 1,483 tests, all green
- [x] `npx tsc -b --noEmit` in `Financial.Web` — clean
- [x] `npx vitest run` in `Financial.Web` — 643/643 passing, including updated `AnnualSummaryPage.test.tsx`/`useAnnualSummary.test.ts` fixtures for the new required DTO fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)