### PR TITLE
fix(config): nest Investment storage settings and fix CashFlow default-file collision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,12 +97,15 @@ jobs:
         mkdir -p publish/wwwroot
         cp -r Financial.Web/dist/. publish/wwwroot/
 
-    - name: Prepare CashFlow test data
-      run: cp Tests/Financial.Api.Tests/TestData/data-cashflow.test.json /tmp/data-cashflow.smoke-test.json
+    - name: Prepare smoke test data
+      run: |
+        cp Tests/Financial.Api.Tests/TestData/data.test.json /tmp/data.smoke-test.json
+        cp Tests/Financial.Api.Tests/TestData/data-cashflow.test.json /tmp/data-cashflow.smoke-test.json
 
     - name: Run browser smoke test
       env:
-        DataJsonFile: ${{ github.workspace }}/Tests/Financial.Api.Tests/TestData/data.test.json
+        Investment__Repository__Provider: LocalJson
+        Investment__DataJsonFile: /tmp/data.smoke-test.json
         CashFlow__Repository__Provider: LocalJson
         CashFlow__DataJsonFile: /tmp/data-cashflow.smoke-test.json
         ASPNETCORE_URLS: http://localhost:8080

--- a/Financial.Api/appsettings.Development.json
+++ b/Financial.Api/appsettings.Development.json
@@ -13,13 +13,15 @@
       "https://localhost:5174"
     ]
   },
-  "Repository": {
-    "Provider": "LocalJson"
-  },
-  "DataJsonFile": "../../../../data/data.json",
-  "GoogleDrive": {
-    "CredentialsPath": "",
-    "FilePath": "Pessoais/Gleison/Financeiros/data.json"
+  "Investment": {
+    "Repository": {
+      "Provider": "LocalJson"
+    },
+    "DataJsonFile": "../../../../data/data.json",
+    "GoogleDrive": {
+      "CredentialsPath": "",
+      "FilePath": "Pessoais/Gleison/Financeiros/data.json"
+    }
   },
   "CashFlow": {
     "Repository": {

--- a/Financial.Api/appsettings.Production.json
+++ b/Financial.Api/appsettings.Production.json
@@ -1,10 +1,12 @@
 {
-  "Repository": {
-    "Provider": "GoogleDriveJson"
-  },
-  "GoogleDrive": {
-    "CredentialsPath": "",
-    "FilePath": "data.json"
+  "Investment": {
+    "Repository": {
+      "Provider": "GoogleDriveJson"
+    },
+    "GoogleDrive": {
+      "CredentialsPath": "",
+      "FilePath": "data.json"
+    }
   },
   "CashFlow": {
     "Repository": {

--- a/Financial.Api/appsettings.json
+++ b/Financial.Api/appsettings.json
@@ -6,13 +6,15 @@
     }
   },
   "AllowedHosts": "*",
-  "Repository": {
-    "Provider": "LocalJson"
-  },
-  "DataJsonFile": "",
-  "GoogleDrive": {
-    "CredentialsPath": "",
-    "FilePath": ""
+  "Investment": {
+    "Repository": {
+      "Provider": "LocalJson"
+    },
+    "DataJsonFile": "",
+    "GoogleDrive": {
+      "CredentialsPath": "",
+      "FilePath": ""
+    }
   },
   "CashFlow": {
     "Repository": {

--- a/Financial.App/appsettings.Development.json
+++ b/Financial.App/appsettings.Development.json
@@ -1,7 +1,9 @@
 {
-  "DataJsonFile": "../../../../data/data.json",
-  "GoogleDrive": {
-    "CredentialsPath": "",
-    "FilePath": ""
+  "Investment": {
+    "DataJsonFile": "../../../../data/data.json",
+    "GoogleDrive": {
+      "CredentialsPath": "",
+      "FilePath": ""
+    }
   }
 }

--- a/Financial.App/appsettings.Production.json
+++ b/Financial.App/appsettings.Production.json
@@ -1,10 +1,12 @@
 {
-  "Repository": {
-    "Provider": "GoogleDriveJson"
-  },
-  "GoogleDrive": {
-    "CredentialsPath": "",
-    "FilePath": "data.json"
+  "Investment": {
+    "Repository": {
+      "Provider": "GoogleDriveJson"
+    },
+    "GoogleDrive": {
+      "CredentialsPath": "",
+      "FilePath": "data.json"
+    }
   },
   "Serilog": {
     "MinimumLevel": {

--- a/Financial.App/appsettings.json
+++ b/Financial.App/appsettings.json
@@ -1,11 +1,13 @@
 {
-  "Repository": {
-    "Provider": "LocalJson"
-  },
-  "DataJsonFile": "",
-  "GoogleDrive": {
-    "CredentialsPath": "",
-    "FilePath": ""
+  "Investment": {
+    "Repository": {
+      "Provider": "LocalJson"
+    },
+    "DataJsonFile": "",
+    "GoogleDrive": {
+      "CredentialsPath": "",
+      "FilePath": ""
+    }
   },
   "Watchlist": {
     "Items": [

--- a/Financial.CashFlow.Infrastructure/Repositories/CashFlowRepositoryFactory.cs
+++ b/Financial.CashFlow.Infrastructure/Repositories/CashFlowRepositoryFactory.cs
@@ -7,6 +7,8 @@ namespace Financial.CashFlow.Infrastructure.Repositories;
 
 public sealed class CashFlowRepositoryFactory
 {
+    private const string DefaultDataFileName = "data-cashflow.json";
+
     private readonly ICashFlowSerializer _serializer;
     private readonly IRemoteFileClientFactory? _remoteFileClientFactory;
 
@@ -32,7 +34,7 @@ public sealed class CashFlowRepositoryFactory
         options.Provider switch
         {
             CashFlowRepositoryProvider.LocalJson =>
-                new LocalJsonStorage(options.LocalDataPath),
+                new LocalJsonStorage(options.LocalDataPath, DefaultDataFileName),
             CashFlowRepositoryProvider.GoogleDriveJson =>
                 CreateGoogleDriveStorage(options),
             _ => throw new ArgumentOutOfRangeException(

--- a/Financial.Investment.Infrastructure/Configuration/RepositoryConfigurationKeys.cs
+++ b/Financial.Investment.Infrastructure/Configuration/RepositoryConfigurationKeys.cs
@@ -1,0 +1,9 @@
+namespace Financial.Investment.Infrastructure.Configuration;
+
+public static class RepositoryConfigurationKeys
+{
+    public const string Provider = "Investment:Repository:Provider";
+    public const string LocalJsonDataFile = "Investment:DataJsonFile";
+    public const string GoogleDriveCredentialsPath = "Investment:GoogleDrive:CredentialsPath";
+    public const string GoogleDriveFilePath = "Investment:GoogleDrive:FilePath";
+}

--- a/Financial.Investment.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Investment.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
 using Financial.Investment.Application.Configuration;
 using Financial.Investment.Application.Interfaces;
+using Financial.Investment.Infrastructure.Configuration;
 using Financial.Investment.Infrastructure.Interfaces;
 using Financial.Investment.Infrastructure.Persistence;
 using Financial.Investment.Infrastructure.Repositories;
 using Financial.Investment.Infrastructure.Services;
-using Financial.Shared.Infrastructure.Configuration;
 using Financial.Shared.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/Financial.Investment.Infrastructure/Repositories/RepositoryFactory.cs
+++ b/Financial.Investment.Infrastructure/Repositories/RepositoryFactory.cs
@@ -1,6 +1,6 @@
 using Financial.Investment.Application.Interfaces;
+using Financial.Investment.Infrastructure.Configuration;
 using Financial.Investment.Infrastructure.Persistence;
-using Financial.Shared.Infrastructure.Configuration;
 using Financial.Shared.Infrastructure.Persistence;
 
 namespace Financial.Investment.Infrastructure.Repositories;

--- a/Financial.Shared.Infrastructure/Configuration/RepositoryConfigurationKeys.cs
+++ b/Financial.Shared.Infrastructure/Configuration/RepositoryConfigurationKeys.cs
@@ -1,9 +1,0 @@
-namespace Financial.Shared.Infrastructure.Configuration;
-
-public static class RepositoryConfigurationKeys
-{
-    public const string Provider = "Repository:Provider";
-    public const string LocalJsonDataFile = "DataJsonFile";
-    public const string GoogleDriveCredentialsPath = "GoogleDrive:CredentialsPath";
-    public const string GoogleDriveFilePath = "GoogleDrive:FilePath";
-}

--- a/Financial.Shared.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
+++ b/Financial.Shared.Infrastructure/Persistence/GoogleDriveJsonStorage.cs
@@ -1,5 +1,3 @@
-using Financial.Shared.Infrastructure.Configuration;
-
 namespace Financial.Shared.Infrastructure.Persistence;
 
 public sealed class GoogleDriveJsonStorage : IJsonStorage
@@ -33,7 +31,7 @@ public sealed class GoogleDriveJsonStorage : IJsonStorage
     {
         if (string.IsNullOrWhiteSpace(driveFilePath))
             throw new ArgumentException(
-                $"Drive file path must be configured via '{RepositoryConfigurationKeys.GoogleDriveFilePath}'.",
+                "Drive file path must be configured.",
                 nameof(driveFilePath));
         return driveFilePath;
     }

--- a/Financial.Shared.Infrastructure/Persistence/LocalJsonStorage.cs
+++ b/Financial.Shared.Infrastructure/Persistence/LocalJsonStorage.cs
@@ -1,5 +1,3 @@
-using Financial.Shared.Infrastructure.Configuration;
-
 namespace Financial.Shared.Infrastructure.Persistence;
 
 public sealed class LocalJsonStorage : IJsonStorage
@@ -7,10 +5,12 @@ public sealed class LocalJsonStorage : IJsonStorage
     public const string DefaultDataFileName = "data.json";
 
     private readonly string _dataFilePath;
+    private readonly string _defaultFileName;
 
-    public LocalJsonStorage(string? dataFilePath)
+    public LocalJsonStorage(string? dataFilePath, string defaultFileName = DefaultDataFileName)
     {
-        _dataFilePath = ResolveDataFilePath(dataFilePath);
+        _defaultFileName = defaultFileName;
+        _dataFilePath = ResolveDataFilePath(dataFilePath, defaultFileName);
     }
 
     public Task<string> ReadAsync()
@@ -18,7 +18,7 @@ public sealed class LocalJsonStorage : IJsonStorage
         if (!File.Exists(_dataFilePath))
         {
             throw new FileNotFoundException(
-                $"Data file not found at '{_dataFilePath}'. Configure '{RepositoryConfigurationKeys.LocalJsonDataFile}' or place '{DefaultDataFileName}' in the application directory.",
+                $"Data file not found at '{_dataFilePath}'. Configure the data file path, or place '{_defaultFileName}' in the application directory.",
                 _dataFilePath);
         }
 
@@ -30,15 +30,15 @@ public sealed class LocalJsonStorage : IJsonStorage
         return File.WriteAllTextAsync(_dataFilePath, json);
     }
 
-    private static string ResolveDataFilePath(string? dataFilePath)
+    private static string ResolveDataFilePath(string? dataFilePath, string defaultFileName)
     {
         var resolvedPath = string.IsNullOrWhiteSpace(dataFilePath)
-            ? Path.Combine(AppContext.BaseDirectory, DefaultDataFileName)
+            ? Path.Combine(AppContext.BaseDirectory, defaultFileName)
             : dataFilePath;
 
         if (Directory.Exists(resolvedPath))
         {
-            resolvedPath = Path.Combine(resolvedPath, DefaultDataFileName);
+            resolvedPath = Path.Combine(resolvedPath, defaultFileName);
         }
 
         if (!Path.IsPathRooted(resolvedPath))

--- a/README.md
+++ b/README.md
@@ -14,19 +14,21 @@ The Investment and CashFlow domains each load their data from their own JSON fil
 - Investment: copy `data/data.example.json` to `data/data.json`.
 - CashFlow: copy `data/data-cashflow.example.json` to `data/data-cashflow.json`.
 
-Configure the paths via environment variable or `appsettings.json`:
+Configure the paths via environment variable or `appsettings.json`. Each domain's storage settings live under their own JSON element — `Investment` and `CashFlow` — never at the config root:
 
-- Investment: `DataJsonFile`. Defaults to `data.json` in the application directory if unset.
-- CashFlow: `CashFlow:DataJsonFile` (env: `CashFlow__DataJsonFile`). **This has no domain-specific default** — if left unset, it silently falls back to the same `data.json` used by the Investment domain, so the two domains would end up reading/writing the same file. Always set it explicitly (e.g. to `data-cashflow.json`).
+- Investment: `Investment:DataJsonFile` (env: `Investment__DataJsonFile`). Defaults to `data.json` in the application directory if unset.
+- CashFlow: `CashFlow:DataJsonFile` (env: `CashFlow__DataJsonFile`). Defaults to `data-cashflow.json` in the application directory if unset.
+
+Each domain has its own distinct default filename, so leaving either one unset no longer risks the two domains sharing a file.
 
 ### Storage providers
 
-The Investment and CashFlow domains each select their storage backend independently.
+The Investment and CashFlow domains each select their storage backend independently, under their own config element.
 
-**Investment** — via `Repository:Provider` (env: `Repository__Provider`):
+**Investment** — via `Investment:Repository:Provider` (env: `Investment__Repository__Provider`):
 
-- **`LocalJson`** (default) — reads/writes `data.json` from the local filesystem. Set `DataJsonFile` to the file path.
-- **`GoogleDrive`** — reads/writes a JSON file stored in Google Drive. Requires `GoogleDrive:CredentialsPath` (path to the service-account credentials JSON) and `GoogleDrive:FilePath` (the Drive file ID or path).
+- **`LocalJson`** (default) — reads/writes the file set by `Investment:DataJsonFile`.
+- **`GoogleDrive`** — reads/writes a JSON file stored in Google Drive. Requires `Investment:GoogleDrive:CredentialsPath` (path to the service-account credentials JSON) and `Investment:GoogleDrive:FilePath` (the Drive file ID or path).
 
 **CashFlow** — via `CashFlow:Repository:Provider` (env: `CashFlow__Repository__Provider`):
 
@@ -85,8 +87,8 @@ docker build -t financial .
 ```bash
 docker run -p 8080:8080 \
   -v ./data:/app/data \
-  -e DataJsonFile=/app/data/data.json \
-  -e Repository__Provider=LocalJson \
+  -e Investment__DataJsonFile=/app/data/data.json \
+  -e Investment__Repository__Provider=LocalJson \
   -e CashFlow__DataJsonFile=/app/data/data-cashflow.json \
   -e CashFlow__Repository__Provider=LocalJson \
   financial

--- a/Tests/Financial.Api.Tests/ApiTestFactory.cs
+++ b/Tests/Financial.Api.Tests/ApiTestFactory.cs
@@ -28,8 +28,8 @@ internal sealed class ApiTestFactory : WebApplicationFactory<Program>
         {
             var settings = new Dictionary<string, string?>
             {
-                ["Repository:Provider"] = "LocalJson",
-                ["DataJsonFile"] = _dataFilePath,
+                ["Investment:Repository:Provider"] = "LocalJson",
+                ["Investment:DataJsonFile"] = _dataFilePath,
                 ["CashFlow:Repository:Provider"] = "LocalJson",
                 ["CashFlow:DataJsonFile"] = _cashFlowDataFilePath
             };

--- a/Tests/Financial.Investment.Infrastructure.Tests/DependencyInjection/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/Tests/Financial.Investment.Infrastructure.Tests/DependencyInjection/InfrastructureServiceCollectionExtensionsTests.cs
@@ -13,8 +13,8 @@ public class InfrastructureServiceCollectionExtensionsTests
     {
         var provider = BuildServiceProvider(new Dictionary<string, string?>
         {
-            ["Repository:Provider"] = "NotARealProvider",
-            ["DataJsonFile"] = TestDataPaths.DataJsonFile
+            ["Investment:Repository:Provider"] = "NotARealProvider",
+            ["Investment:DataJsonFile"] = TestDataPaths.DataJsonFile
         });
 
         Action act = () => provider.GetRequiredService<IRepository>();
@@ -28,7 +28,7 @@ public class InfrastructureServiceCollectionExtensionsTests
     {
         var provider = BuildServiceProvider(new Dictionary<string, string?>
         {
-            ["DataJsonFile"] = TestDataPaths.DataJsonFile
+            ["Investment:DataJsonFile"] = TestDataPaths.DataJsonFile
         });
 
         var repository = provider.GetRequiredService<IRepository>();

--- a/context.md
+++ b/context.md
@@ -93,10 +93,10 @@ Persistence uses JSON files. Two storage backends are implemented and selectable
 * **LocalJson** — reads/writes a JSON file on the local filesystem (default).
 * **GoogleDrive** — reads/writes a JSON file stored in Google Drive via the Google Drive API.
 
-**The Investment and CashFlow domains each select their storage backend independently**, with their own configuration keys and their own JSON file:
+**The Investment and CashFlow domains each select their storage backend independently**, with their own nested configuration element and their own JSON file — never floating at the config root:
 
-* Investment: `Repository:Provider` → `data.json`.
-* CashFlow: its own provider key (`CashFlowRepositoryConfigurationKeys`) → `data-cashflow.json`.
+* Investment: `Investment:Repository:Provider` (`RepositoryConfigurationKeys` in `Financial.Investment.Infrastructure`) → `data.json`.
+* CashFlow: `CashFlow:Repository:Provider` (`CashFlowRepositoryConfigurationKeys`) → `data-cashflow.json`.
 
 The persistence layer is abstracted behind a repository interface per domain so that storage implementations can be replaced with minimal impact on the rest of the application.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      DataJsonFile: /app/data/data.json
-      Repository__Provider: LocalJson
+      Investment__DataJsonFile: /app/data/data.json
+      Investment__Repository__Provider: LocalJson
       CashFlow__DataJsonFile: /app/data/data-cashflow.json
       CashFlow__Repository__Provider: LocalJson
     volumes:


### PR DESCRIPTION
## Summary
- Nests Investment's storage config (`Repository:Provider`, `DataJsonFile`, `GoogleDrive:*`) under an `Investment:` element in every `appsettings.json` (API + WPF, all environments), `docker-compose.yml`, and the CI workflow — matching CashFlow's already-namespaced shape
- Fixes the bug this asymmetry masked: `LocalJsonStorage` had one shared `"data.json"` fallback used by both domains, so an unset `CashFlow:DataJsonFile` silently fell back to Investment's file. `CashFlowRepositoryFactory` now passes its own `"data-cashflow.json"` default
- Moves `RepositoryConfigurationKeys` out of `Financial.Shared.Infrastructure` (which shouldn't know either domain's key names) into `Financial.Investment.Infrastructure.Configuration`, mirroring `CashFlowRepositoryConfigurationKeys`; `LocalJsonStorage`/`GoogleDriveJsonStorage` no longer reference domain-specific config keys in their error messages
- Fixes the CI browser-smoke-test job: it never set `ASPNETCORE_ENVIRONMENT`, so ASP.NET Core defaults to Production, where `appsettings.Production.json` forces `GoogleDriveJson` for both domains. CashFlow already overrode this back to `LocalJson`, Investment now does too, and both domains now copy their test fixture to `/tmp` before running so the smoke test doesn't write into the checked-out repo file

**Base branch note**: this PR targets `docs/cashflow-context-readme-update` (#287) since the Storage sections in `README.md`/`context.md` it touches were rewritten by that PR first. Once #287 merges to `main`, this PR's base should be retargeted to `main`.

## Test plan
- [x] `dotnet build Financial.slnx` — 0 errors
- [x] `dotnet test Financial.slnx` — all 1,479 tests pass (no test changes needed beyond 2 files with in-memory config-key renames, since the `LocalJsonStorage`/`GoogleDriveJsonStorage` signature changes are backward-compatible optional parameters)
- [x] Verified appsettings JSON files are well-formed after nesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)