### PR TITLE
fix(deploy): stamp GoogleDrive credentials under the new Investment: element

### DIFF
--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -73,7 +73,7 @@ foreach ($pair in @(
         @{ Source = (Join-Path $repoRoot 'Financial.Api\appsettings.Production.json'); Target = (Join-Path $webDeployDir 'appsettings.Production.json') }
     )) {
     $settings = Get-Content $pair.Source -Raw | ConvertFrom-Json
-    $settings.GoogleDrive.CredentialsPath = $localSettings.GoogleDriveCredentialsPath
+    $settings.Investment.GoogleDrive.CredentialsPath = $localSettings.GoogleDriveCredentialsPath
     $settings | ConvertTo-Json -Depth 10 | Set-Content -Path $pair.Target -Encoding utf8
 }
 


### PR DESCRIPTION
## Summary
- #288 (already merged into this branch) nested Investment's storage config under `Investment:` in `appsettings.Production.json`, but `scripts/deploy.ps1` still wrote `GoogleDrive.CredentialsPath` at the JSON root
- With `$ErrorActionPreference = 'Stop'`, the next local deploy would hard-fail partway through (after publishing both apps) trying to set a property on the now-null `$settings.GoogleDrive`
- Fixes the script to target `$settings.Investment.GoogleDrive.CredentialsPath` instead

## Test plan
- [x] Validated PowerShell syntax with `[System.Management.Automation.Language.Parser]::ParseFile`
- [x] Diffed against the current docs branch tip to confirm this is the only remaining change (the rest of this branch's history was already squash-merged via #288)

🤖 Generated with [Claude Code](https://claude.com/claude-code)