### PR TITLE
docs(readme): document the local deploy.ps1 script

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,24 @@ Defaults to reading `Despesas.xlsx` from the Downloads folder and writing to `da
 ### ImportGoogleSpreadSheets
 
 Legacy WPF desktop utility for a one-time import of Investment portfolio data from Google Sheets into `data.json`. Not runnable headless — open and run it from Visual Studio.
+
+## Local deploy tooling
+
+`scripts/deploy.ps1` publishes the current local state of `Financial.App` (WPF) and `Financial.Api` (API + SPA) to a local `deploy/` folder. Manual, local-only tooling — not part of CI/CD, and `deploy/` itself is git-ignored.
+
+```powershell
+./scripts/deploy.ps1
+```
+
+Re-run any time to refresh the deployed copies with whatever is currently on disk. On each run it:
+
+- Stops any currently running instances launched from `deploy/`.
+- Publishes `Financial.App` and `Financial.Api` (framework-dependent — the build machine must match the run machine) into `deploy/Financial.App` and `deploy/Financial.Web`.
+- Deploys each project's `appsettings.Production.json` (excluded from `dotnet publish` output) and stamps in the machine-local Google Drive credentials path.
+- Builds the React SPA and copies it into `deploy/Financial.Web/wwwroot`.
+- Copies the launcher scripts from `scripts/deploy-templates/` into `deploy/`.
+- Writes `deploy/deploy-info.txt` with the deployed branch and commit.
+
+First run creates `scripts/deploy.local.json` from `scripts/deploy.local.example.json` (both git-ignored except the example) — edit it to set `GoogleDriveCredentialsPath` to your service-account credentials file before starting the deployed apps. Both deployed apps run against `GoogleDriveJson` storage, fixed via the checked-in `appsettings.Production.json` files.
+
+After deploying, start everything with `deploy/start-all.ps1` (or `start-app.ps1`/`start-web.ps1` individually).


### PR DESCRIPTION
## Summary
- `scripts/deploy.ps1` (publishes `Financial.App` + `Financial.Api` to a local, git-ignored `deploy/` folder) wasn't mentioned in the README at all
- Adds a "Local deploy tooling" section covering what the script does, first-time setup (`scripts/deploy.local.json`), and how to start the deployed apps afterward

## Test plan
- [x] Documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)