### PR TITLE
test(coverage): close CashFlowRepositoryFactory and dialog validation gaps

### DIFF
--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Repositories/CashFlowRepositoryFactoryTests.cs
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Repositories/CashFlowRepositoryFactoryTests.cs
@@ -1,3 +1,4 @@
+using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Infrastructure.Persistence;
 using Financial.CashFlow.Infrastructure.Repositories;
 using Financial.Shared.Infrastructure.Persistence;
@@ -85,6 +86,68 @@ public class CashFlowRepositoryFactoryTests
             .WithMessage("*IRemoteFileClientFactory*");
     }
 
+    [Fact]
+    public void Create_WithGoogleDriveProvider_ValidAbsoluteCredentialsPath_ReturnsCashFlowJsonRepository()
+    {
+        var credentialsPath = Path.GetTempFileName();
+        try
+        {
+            var options = new CashFlowRepositorySelectionOptions(
+                CashFlowRepositoryProvider.GoogleDriveJson,
+                null,
+                credentialsPath,
+                "Pessoais/Gleison/Financeiros");
+
+            var result = Factory.Create(options);
+
+            result.Should().BeOfType<CashFlowJsonRepository>();
+        }
+        finally
+        {
+            File.Delete(credentialsPath);
+        }
+    }
+
+    [Fact]
+    public void Create_WithGoogleDriveProvider_RelativeCredentialsPath_ResolvesRelativeToBaseDirectory()
+    {
+        var fileName = $"cashflow-credentials-{Guid.NewGuid()}.json";
+        var absolutePath = Path.Combine(AppContext.BaseDirectory, fileName);
+        File.WriteAllText(absolutePath, "{}");
+        try
+        {
+            var options = new CashFlowRepositorySelectionOptions(
+                CashFlowRepositoryProvider.GoogleDriveJson,
+                null,
+                fileName,
+                "Pessoais/Gleison/Financeiros");
+
+            var result = Factory.Create(options);
+
+            result.Should().BeOfType<CashFlowJsonRepository>();
+        }
+        finally
+        {
+            File.Delete(absolutePath);
+        }
+    }
+
+    [Fact]
+    public void Create_WithGoogleDriveProvider_CredentialsFileDoesNotExist_ThrowsFileNotFoundException()
+    {
+        var missingCredentialsPath = Path.Combine(Path.GetTempPath(), $"cashflow-credentials-{Guid.NewGuid()}.json");
+        var options = new CashFlowRepositorySelectionOptions(
+            CashFlowRepositoryProvider.GoogleDriveJson,
+            null,
+            missingCredentialsPath,
+            "Pessoais/Gleison/Financeiros");
+
+        Action act = () => Factory.Create(options);
+
+        act.Should().Throw<FileNotFoundException>()
+            .WithMessage("*Google Drive credentials file not found*");
+    }
+
     private sealed class StubRemoteFileClientFactory : IRemoteFileClientFactory
     {
         public IRemoteFileClient Create(string credentialsPath) => new StubRemoteFileClient();
@@ -92,7 +155,9 @@ public class CashFlowRepositoryFactoryTests
 
     private sealed class StubRemoteFileClient : IRemoteFileClient
     {
-        public string DownloadFileContent(string path) => throw new NotSupportedException();
+        public string DownloadFileContent(string path) =>
+            new CashFlowSerializerAdapter().Serialize(CashFlowData.Create());
+
         public void UploadFileContent(string path, string content) => throw new NotSupportedException();
     }
 }

--- a/Tests/Financial.Presentation.Tests/ViewModels/CreditDialogValidationTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/CreditDialogValidationTests.cs
@@ -1,0 +1,77 @@
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class CreditDialogValidationTests
+{
+    private static readonly DateTime ValidDate = new(2026, 7, 15);
+
+    [Fact]
+    public void BuildValidationMessage_DeleteMode_ReturnsEmpty()
+    {
+        var result = CreditDialogValidation.BuildValidationMessage(
+            isDeleteMode: true, date: DateTime.MinValue, type: null, value: -1);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildValidationMessage_AllFieldsValid_ReturnsEmpty()
+    {
+        var result = CreditDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: ValidDate, type: "Dividend", value: 10);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildValidationMessage_DateIsMinValue_IncludesDateError()
+    {
+        var result = CreditDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: DateTime.MinValue, type: "Dividend", value: 10);
+
+        result.Should().Contain("Date is required.");
+    }
+
+    [Fact]
+    public void BuildValidationMessage_InvalidType_IncludesTypeError()
+    {
+        var result = CreditDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: ValidDate, type: "Invalid", value: 10);
+
+        result.Should().Contain("Type must be Dividend or Rent.");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void BuildValidationMessage_ValueNotPositive_IncludesValueError(decimal value)
+    {
+        var result = CreditDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: ValidDate, type: "Dividend", value: value);
+
+        result.Should().Contain("Value must be greater than zero.");
+    }
+
+    [Fact]
+    public void BuildValidationMessage_AllFieldsInvalid_IncludesEveryError()
+    {
+        var result = CreditDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: DateTime.MinValue, type: null, value: 0);
+
+        result.Should().Contain("Date is required.");
+        result.Should().Contain("Type must be Dividend or Rent.");
+        result.Should().Contain("Value must be greater than zero.");
+    }
+
+    [Theory]
+    [InlineData("Dividend", true)]
+    [InlineData("rent", true)]
+    [InlineData("Invalid", false)]
+    [InlineData(null, false)]
+    public void IsValidCreditType_ReturnsExpectedResult(string? value, bool expected)
+    {
+        CreditDialogValidation.IsValidCreditType(value).Should().Be(expected);
+    }
+}

--- a/Tests/Financial.Presentation.Tests/ViewModels/TransactionDialogValidationTests.cs
+++ b/Tests/Financial.Presentation.Tests/ViewModels/TransactionDialogValidationTests.cs
@@ -1,0 +1,97 @@
+using Financial.Presentation.App.ViewModels;
+using FluentAssertions;
+
+namespace Financial.Presentation.Tests.ViewModels;
+
+public class TransactionDialogValidationTests
+{
+    private static readonly DateTime ValidDate = new(2026, 7, 15);
+
+    [Fact]
+    public void BuildValidationMessage_DeleteMode_ReturnsEmpty()
+    {
+        var result = TransactionDialogValidation.BuildValidationMessage(
+            isDeleteMode: true, date: DateTime.MinValue, type: null, quantity: -1, unitPrice: -1, fees: -1);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildValidationMessage_AllFieldsValid_ReturnsEmpty()
+    {
+        var result = TransactionDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: ValidDate, type: "Buy", quantity: 10, unitPrice: 5, fees: 0);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildValidationMessage_DateIsMinValue_IncludesDateError()
+    {
+        var result = TransactionDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: DateTime.MinValue, type: "Buy", quantity: 10, unitPrice: 5, fees: 0);
+
+        result.Should().Contain("Date is required.");
+    }
+
+    [Fact]
+    public void BuildValidationMessage_InvalidType_IncludesTypeError()
+    {
+        var result = TransactionDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: ValidDate, type: "Invalid", quantity: 10, unitPrice: 5, fees: 0);
+
+        result.Should().Contain("Type must be Buy or Sell.");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void BuildValidationMessage_QuantityNotPositive_IncludesQuantityError(decimal quantity)
+    {
+        var result = TransactionDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: ValidDate, type: "Buy", quantity: quantity, unitPrice: 5, fees: 0);
+
+        result.Should().Contain("Quantity must be greater than zero.");
+    }
+
+    [Fact]
+    public void BuildValidationMessage_NegativeUnitPrice_IncludesUnitPriceError()
+    {
+        var result = TransactionDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: ValidDate, type: "Buy", quantity: 10, unitPrice: -1, fees: 0);
+
+        result.Should().Contain("Unit price cannot be negative.");
+    }
+
+    [Fact]
+    public void BuildValidationMessage_NegativeFees_IncludesFeesError()
+    {
+        var result = TransactionDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: ValidDate, type: "Buy", quantity: 10, unitPrice: 5, fees: -1);
+
+        result.Should().Contain("Fees cannot be negative.");
+    }
+
+    [Fact]
+    public void BuildValidationMessage_AllFieldsInvalid_IncludesEveryError()
+    {
+        var result = TransactionDialogValidation.BuildValidationMessage(
+            isDeleteMode: false, date: DateTime.MinValue, type: null, quantity: 0, unitPrice: -1, fees: -1);
+
+        result.Should().Contain("Date is required.");
+        result.Should().Contain("Type must be Buy or Sell.");
+        result.Should().Contain("Quantity must be greater than zero.");
+        result.Should().Contain("Unit price cannot be negative.");
+        result.Should().Contain("Fees cannot be negative.");
+    }
+
+    [Theory]
+    [InlineData("Buy", true)]
+    [InlineData("sell", true)]
+    [InlineData("Invalid", false)]
+    [InlineData(null, false)]
+    public void IsValidTransactionType_ReturnsExpectedResult(string? value, bool expected)
+    {
+        TransactionDialogValidation.IsValidTransactionType(value).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary
- `CashFlowRepositoryFactory` was at 79.5% line coverage: the GoogleDrive happy-path (`CreateGoogleDriveStorage`), the relative-credentials-path resolution branch, and the file-not-found branch were all untested. Added 3 tests to cover them; class is now 100%.
- `TransactionDialogValidation` and `CreditDialogValidation` (WPF) had 0% coverage despite containing real branching validation logic (date/type/quantity/price/fee checks). Added full `[Fact]`/`[Theory]` coverage for every branch and the `IsValidTransactionType`/`IsValidCreditType` normalizers; both classes are now 100%.
- Found via a full-solution coverage run (`dotnet test --collect:"XPlat Code Coverage"` + `reportgenerator`) done as part of a broader coverage review.

## Test plan
- [x] `dotnet test Tests/Financial.CashFlow.Infrastructure.Tests` — 29/29 passing (was 26)
- [x] `dotnet test Tests/Financial.Presentation.Tests` — 260/260 passing (was 236)
- [x] Verified via coverage report: `CashFlowRepositoryFactory`, `TransactionDialogValidation`, `CreditDialogValidation` all at 100% line coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)