### PR TITLE
feat: add Yahoo Finance fallback for tickers Google Finance doesn't track

### DIFF
--- a/Financial.App/Financial.App.csproj
+++ b/Financial.App/Financial.App.csproj
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetProjects.WpfToolkit.DataVisualization" Version="6.1.94" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.2.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />

--- a/Financial.Investment.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Investment.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -29,11 +29,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IDividendDataSource, DividendDataSourceAdapter>();
         services.AddSingleton<IAssetSnapshotSource, AssetSnapshotSourceAdapter>();
         services.AddSingleton<GoogleFinanceService>();
-        services.AddHttpClient<YahooFinanceService>(client =>
-        {
-            client.BaseAddress = new Uri(YahooFinanceService.BaseAddress);
-            client.DefaultRequestHeaders.UserAgent.ParseAdd(YahooFinanceService.UserAgent);
-        });
+        services.AddHttpClient<YahooFinanceService>();
         services.AddSingleton<IFinanceService>(sp => new FallbackFinanceService(
             sp.GetRequiredService<GoogleFinanceService>(),
             sp.GetRequiredService<YahooFinanceService>()));

--- a/Financial.Investment.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Financial.Investment.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -28,7 +28,15 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IInvestmentsSerializer, InvestmentsSerializerAdapter>();
         services.AddSingleton<IDividendDataSource, DividendDataSourceAdapter>();
         services.AddSingleton<IAssetSnapshotSource, AssetSnapshotSourceAdapter>();
-        services.AddSingleton<IFinanceService, GoogleFinanceService>();
+        services.AddSingleton<GoogleFinanceService>();
+        services.AddHttpClient<YahooFinanceService>(client =>
+        {
+            client.BaseAddress = new Uri(YahooFinanceService.BaseAddress);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(YahooFinanceService.UserAgent);
+        });
+        services.AddSingleton<IFinanceService>(sp => new FallbackFinanceService(
+            sp.GetRequiredService<GoogleFinanceService>(),
+            sp.GetRequiredService<YahooFinanceService>()));
         services.AddSingleton<StatusInvestFinanceService>();
         services.AddSingleton<IAssetPriceFetcher, StandardAssetPriceFetcher>();
         services.AddSingleton<IAssetPriceFetcher, CryptocurrencyAssetPriceFetcher>();

--- a/Financial.Investment.Infrastructure/Financial.Investment.Infrastructure.csproj
+++ b/Financial.Investment.Infrastructure/Financial.Investment.Infrastructure.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
   </ItemGroup>
 

--- a/Financial.Investment.Infrastructure/Services/FallbackFinanceService.cs
+++ b/Financial.Investment.Infrastructure/Services/FallbackFinanceService.cs
@@ -1,0 +1,43 @@
+using Financial.Investment.Domain.ValueObjects;
+using Financial.Investment.Infrastructure.DTOs;
+using Financial.Investment.Infrastructure.Interfaces;
+
+namespace Financial.Investment.Infrastructure.Services;
+
+/// <summary>
+/// Tries <paramref name="primary"/> first; on failure for an exchange-based (stock) lookup,
+/// retries with <paramref name="fallback"/>. Crypto lookups (identified by a missing Exchange)
+/// are not retried, since the fallback provider doesn't support the Currency-based lookup shape.
+/// </summary>
+public sealed class FallbackFinanceService : IFinanceService
+{
+    private readonly IFinanceService _primary;
+    private readonly IFinanceService _fallback;
+
+    public FallbackFinanceService(IFinanceService primary, IFinanceService fallback)
+    {
+        _primary = primary ?? throw new ArgumentNullException(nameof(primary));
+        _fallback = fallback ?? throw new ArgumentNullException(nameof(fallback));
+    }
+
+    public AssetValueSnapshot GetAssetValue(AssetValueRequestDTO request)
+    {
+        try
+        {
+            return _primary.GetAssetValue(request);
+        }
+        catch (InvalidOperationException primaryException) when (!string.IsNullOrWhiteSpace(request.Exchange))
+        {
+            try
+            {
+                return _fallback.GetAssetValue(request);
+            }
+            catch (Exception fallbackException)
+            {
+                throw new InvalidOperationException(
+                    $"Both finance providers failed to fetch a price for ticker '{request.Ticker}'.",
+                    new AggregateException(primaryException, fallbackException));
+            }
+        }
+    }
+}

--- a/Financial.Investment.Infrastructure/Services/YahooFinanceService.cs
+++ b/Financial.Investment.Infrastructure/Services/YahooFinanceService.cs
@@ -1,0 +1,131 @@
+using System.Text.Json;
+using Financial.Investment.Domain.ValueObjects;
+using Financial.Investment.Infrastructure.DTOs;
+using Financial.Investment.Infrastructure.Interfaces;
+
+namespace Financial.Investment.Infrastructure.Services;
+
+/// <summary>
+/// Fallback finance service for tickers Google Finance doesn't track (e.g. B3 fractional-lot
+/// tickers like BBAS3F). Uses Yahoo Finance's unauthenticated chart JSON endpoint.
+/// </summary>
+public sealed class YahooFinanceService : IFinanceService
+{
+    public const string BaseAddress = "https://query1.finance.yahoo.com/";
+
+    public const string UserAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36";
+
+    private static readonly IReadOnlyDictionary<string, string> ExchangeSuffixes =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["BVMF"] = "SA",
+            ["NASDAQ"] = string.Empty,
+            ["NYSE"] = string.Empty,
+            ["LON"] = "L",
+        };
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    private readonly HttpClient _httpClient;
+
+    public YahooFinanceService(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    public AssetValueSnapshot GetAssetValue(AssetValueRequestDTO request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Ticker))
+        {
+            throw new ArgumentException("Ticker is required.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Exchange))
+        {
+            throw new ArgumentException("Yahoo Finance fallback requires an Exchange.", nameof(request));
+        }
+
+        if (!ExchangeSuffixes.TryGetValue(request.Exchange, out var suffix))
+        {
+            throw new InvalidOperationException(
+                $"Exchange '{request.Exchange}' is not supported by the Yahoo Finance fallback.");
+        }
+
+        var symbol = suffix.Length == 0 ? request.Ticker : $"{request.Ticker}.{suffix}";
+
+        return FetchSnapshot(symbol, request.Ticker);
+    }
+
+    private AssetValueSnapshot FetchSnapshot(string symbol, string ticker)
+    {
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Get, $"v8/finance/chart/{symbol}");
+
+        HttpResponseMessage httpResponse;
+        try
+        {
+            httpResponse = _httpClient.Send(httpRequest);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new InvalidOperationException($"Yahoo Finance request failed for ticker '{ticker}'.", ex);
+        }
+
+        using (httpResponse)
+        {
+            if (!httpResponse.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException(
+                    $"Yahoo Finance returned {(int)httpResponse.StatusCode} for ticker '{ticker}'.");
+            }
+
+            YahooChartResponse? response;
+            try
+            {
+                using var stream = httpResponse.Content.ReadAsStream();
+                response = JsonSerializer.Deserialize<YahooChartResponse>(stream, JsonOptions);
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException($"Yahoo Finance returned an unreadable response for ticker '{ticker}'.", ex);
+            }
+
+            var meta = response?.Chart?.Result?.FirstOrDefault()?.Meta;
+            if (meta?.RegularMarketPrice is not decimal price)
+            {
+                throw new InvalidOperationException($"Yahoo Finance response did not include a price for ticker '{ticker}'.");
+            }
+
+            var name = string.IsNullOrWhiteSpace(meta.ShortName) ? ticker : meta.ShortName.Trim();
+            var asOf = meta.RegularMarketTime is long unixSeconds
+                ? DateTimeOffset.FromUnixTimeSeconds(unixSeconds)
+                : DateTimeOffset.UtcNow;
+
+            return new AssetValueSnapshot(ticker, name, price, asOf);
+        }
+    }
+
+    private sealed class YahooChartResponse
+    {
+        public YahooChart? Chart { get; set; }
+    }
+
+    private sealed class YahooChart
+    {
+        public List<YahooChartResult>? Result { get; set; }
+    }
+
+    private sealed class YahooChartResult
+    {
+        public YahooChartMeta? Meta { get; set; }
+    }
+
+    private sealed class YahooChartMeta
+    {
+        public decimal? RegularMarketPrice { get; set; }
+
+        public long? RegularMarketTime { get; set; }
+
+        public string? ShortName { get; set; }
+    }
+}

--- a/Financial.Investment.Infrastructure/Services/YahooFinanceService.cs
+++ b/Financial.Investment.Infrastructure/Services/YahooFinanceService.cs
@@ -11,9 +11,9 @@ namespace Financial.Investment.Infrastructure.Services;
 /// </summary>
 public sealed class YahooFinanceService : IFinanceService
 {
-    public const string BaseAddress = "https://query1.finance.yahoo.com/";
+    private const string BaseAddress = "https://query1.finance.yahoo.com/";
 
-    public const string UserAgent =
+    private const string UserAgent =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36";
 
     private static readonly IReadOnlyDictionary<string, string> ExchangeSuffixes =
@@ -32,6 +32,8 @@ public sealed class YahooFinanceService : IFinanceService
     public YahooFinanceService(HttpClient httpClient)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _httpClient.BaseAddress = new Uri(BaseAddress);
+        _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
     }
 
     public AssetValueSnapshot GetAssetValue(AssetValueRequestDTO request)

--- a/Tests/Financial.Investment.Infrastructure.Tests/Financial.Investment.Infrastructure.Tests.csproj
+++ b/Tests/Financial.Investment.Infrastructure.Tests/Financial.Investment.Infrastructure.Tests.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.4" />
     <PackageReference Include="xunit.extensibility.core" Version="2.6.4" />

--- a/Tests/Financial.Investment.Infrastructure.Tests/Services/FallbackFinanceServiceTests.cs
+++ b/Tests/Financial.Investment.Infrastructure.Tests/Services/FallbackFinanceServiceTests.cs
@@ -1,0 +1,92 @@
+using Financial.Investment.Domain.ValueObjects;
+using Financial.Investment.Infrastructure.DTOs;
+using Financial.Investment.Infrastructure.Interfaces;
+using Financial.Investment.Infrastructure.Services;
+using FluentAssertions;
+
+namespace Financial.Investment.Infrastructure.Tests.Services;
+
+public class FallbackFinanceServiceTests
+{
+    [Fact]
+    public void GetAssetValue_PrimarySucceeds_ReturnsPrimarySnapshot_AndNeverCallsFallback()
+    {
+        var snapshot = new AssetValueSnapshot("BBAS3", "Banco do Brasil", 19.17m, DateTimeOffset.UtcNow);
+        var primary = new FakeFinanceService(_ => snapshot);
+        var fallback = new FakeFinanceService(_ => throw new InvalidOperationException("fallback should not be called"));
+        var service = new FallbackFinanceService(primary, fallback);
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "BBAS3" };
+
+        var result = service.GetAssetValue(request);
+
+        result.Should().Be(snapshot);
+    }
+
+    [Fact]
+    public void GetAssetValue_PrimaryFailsForStockLookup_FallsBackAndReturnsFallbackSnapshot()
+    {
+        var snapshot = new AssetValueSnapshot("BBAS3F", "Banco do Brasil", 21.18m, DateTimeOffset.UtcNow);
+        var primary = new FakeFinanceService(_ => throw new InvalidOperationException("Google Finance main data node not found."));
+        var fallback = new FakeFinanceService(_ => snapshot);
+        var service = new FallbackFinanceService(primary, fallback);
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "BBAS3F" };
+
+        var result = service.GetAssetValue(request);
+
+        result.Should().Be(snapshot);
+    }
+
+    [Fact]
+    public void GetAssetValue_BothProvidersFail_ThrowsInvalidOperationExceptionWrappingBoth()
+    {
+        var primary = new FakeFinanceService(_ => throw new InvalidOperationException("google failed"));
+        var fallback = new FakeFinanceService(_ => throw new InvalidOperationException("yahoo failed"));
+        var service = new FallbackFinanceService(primary, fallback);
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "UNKNOWN" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Both finance providers failed*")
+            .Which.InnerException.Should().BeOfType<AggregateException>()
+            .Which.InnerExceptions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void GetAssetValue_PrimaryFailsForCryptoLookup_PropagatesWithoutCallingFallback()
+    {
+        var primary = new FakeFinanceService(_ => throw new InvalidOperationException("crypto lookup failed"));
+        var fallback = new FakeFinanceService(_ => throw new InvalidOperationException("fallback should not be called"));
+        var service = new FallbackFinanceService(primary, fallback);
+        var request = new AssetValueRequestDTO { Currency = "GBP", Ticker = "BTC" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("crypto lookup failed");
+    }
+
+    [Fact]
+    public void GetAssetValue_PrimaryThrowsArgumentException_PropagatesWithoutCallingFallback()
+    {
+        var primary = new FakeFinanceService(_ => throw new ArgumentException("Ticker is required."));
+        var fallback = new FakeFinanceService(_ => throw new InvalidOperationException("fallback should not be called"));
+        var service = new FallbackFinanceService(primary, fallback);
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<ArgumentException>().WithMessage("Ticker is required.*");
+    }
+
+    private sealed class FakeFinanceService : IFinanceService
+    {
+        private readonly Func<AssetValueRequestDTO, AssetValueSnapshot> _behavior;
+
+        public FakeFinanceService(Func<AssetValueRequestDTO, AssetValueSnapshot> behavior)
+        {
+            _behavior = behavior;
+        }
+
+        public AssetValueSnapshot GetAssetValue(AssetValueRequestDTO request) => _behavior(request);
+    }
+}

--- a/Tests/Financial.Investment.Infrastructure.Tests/Services/YahooFinanceServiceTests.cs
+++ b/Tests/Financial.Investment.Infrastructure.Tests/Services/YahooFinanceServiceTests.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using System.Net.Http;
+using Financial.Investment.Infrastructure.DTOs;
+using Financial.Investment.Infrastructure.Services;
+using FluentAssertions;
+
+namespace Financial.Investment.Infrastructure.Tests.Services;
+
+public class YahooFinanceServiceTests
+{
+    [Fact]
+    public void GetAssetValue_BlankTicker_ThrowsArgumentException()
+    {
+        var service = CreateService(_ => throw new InvalidOperationException("should not be called"));
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<ArgumentException>().WithMessage("Ticker is required.*");
+    }
+
+    [Fact]
+    public void GetAssetValue_MissingExchange_ThrowsArgumentException()
+    {
+        var service = CreateService(_ => throw new InvalidOperationException("should not be called"));
+        var request = new AssetValueRequestDTO { Ticker = "BBAS3F" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*requires an Exchange*");
+    }
+
+    [Fact]
+    public void GetAssetValue_UnsupportedExchange_ThrowsInvalidOperationException_WithoutCallingHttp()
+    {
+        var service = CreateService(_ => throw new InvalidOperationException("should not be called"));
+        var request = new AssetValueRequestDTO { Exchange = "TSX", Ticker = "SHOP" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*TSX*not supported*");
+    }
+
+    [Fact]
+    public void GetAssetValue_SuccessfulResponse_ParsesSnapshot()
+    {
+        var service = CreateService(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """
+                {"chart":{"result":[{"meta":{"regularMarketPrice":21.18,"regularMarketTime":1751500000,"shortName":"BRASIL      ON      NM"}}]}}
+                """)
+        });
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "BBAS3F" };
+
+        var result = service.GetAssetValue(request);
+
+        result.Ticker.Should().Be("BBAS3F");
+        result.Name.Should().Be("BRASIL      ON      NM");
+        result.Price.Should().Be(21.18m);
+        result.AsOf.Should().Be(DateTimeOffset.FromUnixTimeSeconds(1751500000));
+    }
+
+    [Fact]
+    public void GetAssetValue_SuccessfulResponseWithoutTimeOrName_FallsBackToTickerAndUtcNow()
+    {
+        var service = CreateService(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"chart":{"result":[{"meta":{"regularMarketPrice":10.5}}]}}""")
+        });
+        var request = new AssetValueRequestDTO { Exchange = "NASDAQ", Ticker = "AAPL" };
+
+        var result = service.GetAssetValue(request);
+
+        result.Name.Should().Be("AAPL");
+        result.AsOf.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void GetAssetValue_NonSuccessStatusCode_ThrowsInvalidOperationException()
+    {
+        var service = CreateService(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "BBAS3F" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*404*");
+    }
+
+    [Fact]
+    public void GetAssetValue_MalformedBody_ThrowsInvalidOperationException()
+    {
+        var service = CreateService(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("not json")
+        });
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "BBAS3F" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*unreadable*");
+    }
+
+    [Fact]
+    public void GetAssetValue_MissingPriceField_ThrowsInvalidOperationException()
+    {
+        var service = CreateService(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"chart":{"result":[]}}""")
+        });
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "BBAS3F" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*did not include a price*");
+    }
+
+    [Fact]
+    public void GetAssetValue_TransportException_ThrowsInvalidOperationException()
+    {
+        var service = CreateService(_ => throw new HttpRequestException("network down"));
+        var request = new AssetValueRequestDTO { Exchange = "BVMF", Ticker = "BBAS3F" };
+
+        Action act = () => service.GetAssetValue(request);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*request failed*");
+    }
+
+    private static YahooFinanceService CreateService(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        var handler = new FakeHttpMessageHandler(responder);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri(YahooFinanceService.BaseAddress) };
+        return new YahooFinanceService(httpClient);
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            _responder = responder;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(_responder(request));
+
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            _responder(request);
+    }
+}

--- a/Tests/Financial.Investment.Infrastructure.Tests/Services/YahooFinanceServiceTests.cs
+++ b/Tests/Financial.Investment.Infrastructure.Tests/Services/YahooFinanceServiceTests.cs
@@ -129,8 +129,7 @@ public class YahooFinanceServiceTests
     private static YahooFinanceService CreateService(Func<HttpRequestMessage, HttpResponseMessage> responder)
     {
         var handler = new FakeHttpMessageHandler(responder);
-        var httpClient = new HttpClient(handler) { BaseAddress = new Uri(YahooFinanceService.BaseAddress) };
-        return new YahooFinanceService(httpClient);
+        return new YahooFinanceService(new HttpClient(handler));
     }
 
     private sealed class FakeHttpMessageHandler : HttpMessageHandler


### PR DESCRIPTION
## Summary
- Google Finance has no page for some B3 tickers (e.g. `BBAS3F`, the fractional-lot variant of `BBAS3`), so price fetching threw `InvalidOperationException` for those assets.
- Added `YahooFinanceService : IFinanceService`, using Yahoo's unauthenticated `v8/finance/chart` JSON endpoint (no crumb/auth handshake needed), injected `HttpClient` via `AddHttpClient` typed-client registration.
- Added `FallbackFinanceService : IFinanceService`, which tries Google first and retries against Yahoo only for exchange-based (stock) lookups that fail with `InvalidOperationException`. Crypto lookups and bad-input `ArgumentException`s are untouched/not retried.
- DI now registers `FallbackFinanceService` as the app's `IFinanceService`; `StandardAssetPriceFetcher`/`CryptocurrencyAssetPriceFetcher` are unmodified since they already depend only on the `IFinanceService` abstraction.
- Bumped two stray `Microsoft.Extensions.*` package pins from `10.0.0` to `10.0.9` (`Financial.App.csproj`, the Investment Infrastructure test project) to resolve a transitive downgrade conflict introduced by the new `Microsoft.Extensions.Http` dependency.

## Test plan
- [x] New unit tests: `YahooFinanceServiceTests` (success, missing ticker/exchange, unsupported exchange, non-success status, malformed body, missing price field, transport exception) and `FallbackFinanceServiceTests` (primary succeeds, primary fails then falls back, both fail, crypto path not retried, bad input not retried) — all pass.
- [x] Full `Financial.Investment.Infrastructure.Tests` suite: 195 passed, 5 skipped (pre-existing manual-verification tests), 0 failed.
- [x] `Financial.Api` and `Financial.App` (WPF) both build cleanly after the package version fix.
- [x] Manually verified against the live network: Google fails for `BBAS3F` as before; Yahoo resolves it (R$21.18); `FallbackFinanceService` correctly falls through end-to-end. Also confirmed `BBAS3` still resolves via Google's primary path (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)