### PR TITLE
fix: inject TimeProvider into AnnualSummaryService to remove DateTime.UtcNow test coupling

### DIFF
--- a/Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs
+++ b/Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ public static class CashFlowApplicationServiceCollectionExtensions
 {
     public static IServiceCollection AddFinancialCashFlowApplication(this IServiceCollection services)
     {
+        services.AddSingleton(TimeProvider.System);
         services.AddSingleton<IExpenseService, ExpenseService>();
         services.AddSingleton<IReserveService, ReserveService>();
         services.AddSingleton<IMensaisService, MensaisService>();

--- a/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
+++ b/Financial.CashFlow.Application/Services/AnnualSummaryService.cs
@@ -21,10 +21,12 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
     private const int FullPrecisionDecimalPlaces = 28;
 
     private readonly ICashFlowRepository _repository;
+    private readonly TimeProvider _timeProvider;
 
-    public AnnualSummaryService(ICashFlowRepository repository)
+    public AnnualSummaryService(ICashFlowRepository repository, TimeProvider? timeProvider = null)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public IReadOnlyList<CategoryAnnualTotalDTO> GetCategoryTotalsForYear(int year)
@@ -53,7 +55,8 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
     private IReadOnlyList<(Category Category, MonthlySeries Display, MonthlySeries ForAverage)> BuildAllCategorySeriesForYear(int year)
     {
         var yearExpenses = _repository.GetExpenses().Where(e => e.Date.Year == year).ToList();
-        var currentMonthCutoff = new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+        var now = _timeProvider.GetUtcNow();
+        var currentMonthCutoff = new DateOnly(now.Year, now.Month, 1);
 
         var totalsByCategoryAndMonth = BuildCategoryMonthlyTotals(yearExpenses);
         var totalsForAverageByCategoryAndMonth = BuildCategoryMonthlyTotals(yearExpenses.Where(e => e.Date < currentMonthCutoff));
@@ -116,7 +119,8 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
     {
         var allSnapshots = _repository.GetInvestmentSnapshots().ToList();
         var allAccounts = _repository.GetInvestmentAccounts().ToList();
-        var scopedAccounts = YearScopedInvestmentAccountResolver.ResolveForYear(allAccounts, allSnapshots, year, DateTime.Now.Year);
+        var now = _timeProvider.GetUtcNow();
+        var scopedAccounts = YearScopedInvestmentAccountResolver.ResolveForYear(allAccounts, allSnapshots, year, now.Year);
 
         var valueByAccountAndMonth = allSnapshots
             .Where(s => s.Year == year)
@@ -156,7 +160,7 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
 
         var netPositionDiffs = netPositionSeries.DiffsFrom(netPositionPriorClosingValue);
 
-        var lastRelevantMonth = year >= DateTime.Now.Year ? Math.Min(DateTime.Now.Month, MonthsInYear) : MonthsInYear;
+        var lastRelevantMonth = year >= now.Year ? Math.Min(now.Month, MonthsInYear) : MonthsInYear;
 
         return (accountSeries, netPositionSeries, netPositionDiffs, lastRelevantMonth);
     }
@@ -192,7 +196,8 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
     private (IncomeSeries Display, IncomeSeries ForAverage) BuildIncomeSeriesPairForYear(int year)
     {
         var yearIncomes = _repository.GetIncomes().Where(i => i.Date.Year == year).ToList();
-        var currentMonthCutoff = new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+        var now = _timeProvider.GetUtcNow();
+        var currentMonthCutoff = new DateOnly(now.Year, now.Month, 1);
 
         return (
             BuildIncomeSeries(yearIncomes),
@@ -437,8 +442,9 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
 
     private Dictionary<int, List<IncomeGroupValueDTO>> GetAnnualAverageIncomeByGroupIncome(int year)
     {
+        var now = _timeProvider.GetUtcNow();
         var incomes = _repository.GetIncomes()
-            .Where(e => e.Date.Year <= year && e.Date < new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1))
+            .Where(e => e.Date.Year <= year && e.Date < new DateOnly(now.Year, now.Month, 1))
             .ToList();
 
         var sumsByYearMonthGroup = incomes
@@ -474,17 +480,22 @@ public sealed class AnnualSummaryService : IAnnualSummaryService
             });
     }
 
-    private int NumberOfMonthsForAverage(int year) => year switch
-          {
-            var y when y == DateTime.UtcNow.Year => DateTime.UtcNow.Month - 1,
+    private int NumberOfMonthsForAverage(int year)
+    {
+        var now = _timeProvider.GetUtcNow();
+        return year switch
+        {
+            var y when y == now.Year => now.Month - 1,
             2017 => 11,
             _ => 12,
-          };
+        };
+    }
 
     private IList<CategoryAnnualGroupValueDTO> GetHistoricCategoriesAverageFromYear(int year)
     {
+        var now = _timeProvider.GetUtcNow();
         var expenses = _repository.GetExpenses()
-            .Where(e => e.Date.Year <= year && e.Date < new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1))
+            .Where(e => e.Date.Year <= year && e.Date < new DateOnly(now.Year, now.Month, 1))
             .ToList();
 
         var sumByYearMonthCategory = expenses

--- a/Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/AnnualSummaryEndpointsTests.cs
@@ -1,3 +1,4 @@
+using Financial.Api.Tests.TestHelpers;
 using Financial.CashFlow.Application.DTOs;
 using FluentAssertions;
 using System.Net;
@@ -43,18 +44,12 @@ public class AnnualSummaryEndpointsTests
     [Fact]
     public async Task GetHistoricSummaryAverages_MergesIncomeIntoMatchingYearAndOmitsItFromYearsWithoutIncome()
     {
-        var currentYear = DateTime.UtcNow.Year;
-        if (DateTime.UtcNow.Month == 1)
-        {
-            // The current year's income average divides by (current month - 1); January has no
-            // completed month yet, so this scenario is meaningless today.
-            return;
-        }
-
-        var monthsToAverage = DateTime.UtcNow.Month - 1;
+        var pinnedNow = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
+        var currentYear = pinnedNow.Year;
+        var monthsToAverage = pinnedNow.Month - 1;
         var pastYear = currentYear - 1;
 
-        await using var factory = new ApiTestFactory();
+        await using var factory = new ApiTestFactory(timeProviderOverride: new FakeTimeProvider(pinnedNow));
         using var client = factory.CreateClient();
         await client.PostAsJsonAsync("/api/v1/financial/expenses", new ExpenseCreateDTO
         {

--- a/Tests/Financial.Api.Tests/ApiTestFactory.cs
+++ b/Tests/Financial.Api.Tests/ApiTestFactory.cs
@@ -13,13 +13,15 @@ internal sealed class ApiTestFactory : WebApplicationFactory<Program>
     private readonly string _dataFilePath;
     private readonly string _cashFlowDataFilePath;
     private readonly IExchangeRateProvider? _exchangeRateProviderOverride;
+    private readonly TimeProvider? _timeProviderOverride;
     private bool _disposed;
 
-    public ApiTestFactory(IExchangeRateProvider? exchangeRateProviderOverride = null)
+    public ApiTestFactory(IExchangeRateProvider? exchangeRateProviderOverride = null, TimeProvider? timeProviderOverride = null)
     {
         _dataFilePath = CreateTempDataFile();
         _cashFlowDataFilePath = CreateTempCashFlowDataFilePath();
         _exchangeRateProviderOverride = exchangeRateProviderOverride;
+        _timeProviderOverride = timeProviderOverride;
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -42,6 +44,15 @@ internal sealed class ApiTestFactory : WebApplicationFactory<Program>
             {
                 services.RemoveAll<IExchangeRateProvider>();
                 services.AddSingleton(_exchangeRateProviderOverride);
+            });
+        }
+
+        if (_timeProviderOverride is not null)
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<TimeProvider>();
+                services.AddSingleton(_timeProviderOverride);
             });
         }
     }

--- a/Tests/Financial.Api.Tests/TestHelpers/FakeTimeProvider.cs
+++ b/Tests/Financial.Api.Tests/TestHelpers/FakeTimeProvider.cs
@@ -1,0 +1,10 @@
+namespace Financial.Api.Tests.TestHelpers;
+
+internal sealed class FakeTimeProvider : TimeProvider
+{
+    private readonly DateTimeOffset _now;
+
+    public FakeTimeProvider(DateTimeOffset now) => _now = now;
+
+    public override DateTimeOffset GetUtcNow() => _now;
+}

--- a/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -1,5 +1,6 @@
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Domain.Enums;
 using FluentAssertions;
@@ -11,6 +12,12 @@ public class AnnualSummaryServiceTests
 {
     private static readonly int CurrentYear = DateTime.Now.Year;
     private static readonly int PastYear = CurrentYear - 5;
+
+    // Pinned to a fixed mid-year date so "current year" averaging tests don't have to branch on
+    // (or silently no-op during) the real wall-clock month - June guarantees 5 completed months.
+    private static readonly DateTimeOffset PinnedNow = new(CurrentYear, 6, 15, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateOnly PinnedToday = DateOnly.FromDateTime(PinnedNow.UtcDateTime);
+    private const int PinnedMonthsElapsed = 5;
 
     [Fact]
     public void Constructor_WithNullRepository_Throws()
@@ -665,15 +672,10 @@ public class AnnualSummaryServiceTests
     public void GetHistoricSummaryAverageFromYear_AveragesIncomePerMonthNotPerTransaction()
     {
         var repository = new StubCashFlowRepository();
-        var service = new AnnualSummaryService(repository);
+        var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
 
-        var currentYearZero = DateTime.UtcNow.Month == 1;
-        var currentYearNumberOfMonths = currentYearZero ? 0 : DateTime.UtcNow.Month - 1;
-        repository.Incomes.Add(Income.Create(new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
-        if(DateTime.UtcNow.Month > 1)
-        {
-            repository.Incomes.Add(Income.Create(new DateOnly(DateTime.UtcNow.Year, DateTime.UtcNow.Month -1, 5), IncomeSource.Gleison, 2400m, 900m, "Barclays"));
-        }
+        repository.Incomes.Add(Income.Create(new DateOnly(CurrentYear, PinnedNow.Month, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
+        repository.Incomes.Add(Income.Create(new DateOnly(CurrentYear, PinnedNow.Month - 1, 5), IncomeSource.Gleison, 2400m, 900m, "Barclays"));
 
         repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
         repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 20), IncomeSource.Gleison, 500m, 400m, "Barclays"));
@@ -681,12 +683,12 @@ public class AnnualSummaryServiceTests
 
         repository.Incomes.Add(Income.Create(new DateOnly(2017, 7, 5), IncomeSource.Gleison, 1100m, 110m, "Barclays"));
 
+        var result = service.GetHistoricSummaryAverageFromYear(CurrentYear);
 
-        var result = service.GetHistoricSummaryAverageFromYear(2026);
-
-        // current year only use the information before the current month, so if the current month is January, the average will be 0
-        result[0].AnnualAverages.Single(a => a.Category == "Salary").Value.Should().Be(currentYearZero ? 0 : 2400m/currentYearNumberOfMonths);
-        result[0].AnnualAverages.Single(a => a.Category == "Salary after taxes").Value.Should().Be(currentYearZero ? 0 : 900m/currentYearNumberOfMonths);
+        // Only the completed month (May, one month before the pinned June "now") counts toward the
+        // current year's average; the in-progress June entry is excluded entirely.
+        result[0].AnnualAverages.Single(a => a.Category == "Salary").Value.Should().Be(2400m / PinnedMonthsElapsed);
+        result[0].AnnualAverages.Single(a => a.Category == "Salary after taxes").Value.Should().Be(900m / PinnedMonthsElapsed);
 
         result[1].AnnualAverages.Single(a => a.Category == "Salary").Value.Should().Be(375m);
         result[1].AnnualAverages.Single(a => a.Category == "Salary after taxes").Value.Should().Be(300m);
@@ -820,30 +822,18 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_ExcludesInProgressCurrentMonthFromCurrentYearAverage()
     {
-        var today = DateTime.UtcNow;
-        var numberOfValidMonthsInCurrentYear = today.Month - 1; // Exclude the current month, which is in progress.
         var repository = new StubCashFlowRepository();
-        var service = new AnnualSummaryService(repository);
-        var currentYear = today.Year;
-        repository.Expenses.Add(Expense.Create(new DateOnly(currentYear, 1, 5), "Completed month", 100m * numberOfValidMonthsInCurrentYear, Category.Mercado, "Barclays", null));
-        repository.Expenses.Add(Expense.Create(DateOnly.FromDateTime(today), "In-progress month", 9999m, Category.Mercado, "Barclays", null));
-        repository.Incomes.Add(Income.Create(new DateOnly(currentYear, 1, 5), IncomeSource.Gleison, 1000m * numberOfValidMonthsInCurrentYear, 800m * numberOfValidMonthsInCurrentYear, "Barclays"));
-        repository.Incomes.Add(Income.Create(DateOnly.FromDateTime(today), IncomeSource.Gleison, 9999m * numberOfValidMonthsInCurrentYear, 9999m * numberOfValidMonthsInCurrentYear, "Barclays"));
+        var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
+        repository.Expenses.Add(Expense.Create(new DateOnly(CurrentYear, 1, 5), "Completed months", 100m * PinnedMonthsElapsed, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(PinnedToday, "In-progress month", 9999m, Category.Mercado, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(CurrentYear, 1, 5), IncomeSource.Gleison, 1000m * PinnedMonthsElapsed, 800m * PinnedMonthsElapsed, "Barclays"));
+        repository.Incomes.Add(Income.Create(PinnedToday, IncomeSource.Gleison, 9999m * PinnedMonthsElapsed, 9999m * PinnedMonthsElapsed, "Barclays"));
 
-        var result = service.GetHistoricSummaryAverageFromYear(currentYear);
+        var result = service.GetHistoricSummaryAverageFromYear(CurrentYear);
 
-        if (numberOfValidMonthsInCurrentYear == 0)
-        {
-            // No completed month exists yet this year (today is in January): every seeded record
-            // falls within the in-progress cutoff, so the current year must not appear at all -
-            // the same behavior covered explicitly by the "omits current year entirely" test below.
-            result.Should().NotContain(r => r.Year == currentYear);
-            return;
-        }
-
-        var currentYearRow = result.Single(r => r.Year == currentYear);
-        // Only January's figures count; the in-progress current-month entries (9999) must be excluded entirely,
-        // not treated as a completed month with a low value.
+        var currentYearRow = result.Single(r => r.Year == CurrentYear);
+        // Only the completed months' figures count; the in-progress current-month entries (9999)
+        // must be excluded entirely, not treated as a completed month with a low value.
         using (new AssertionScope())
         {
             currentYearRow.AnnualAverages.Single(a => a.Category == "Mercado").Value.Should().Be(100m);
@@ -855,19 +845,17 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_OmitsCurrentYearEntirelyWhenOnlyInProgressMonthIsRecorded()
     {
-        var today = DateTime.UtcNow;
         var repository = new StubCashFlowRepository();
-        var service = new AnnualSummaryService(repository);
-        var currentYear = today.Year;
-        repository.Expenses.Add(Expense.Create(DateOnly.FromDateTime(today), "In-progress month", 9999m, Category.Mercado, "Barclays", null));
-        repository.Expenses.Add(Expense.Create(new DateOnly(currentYear - 1, 12, 5), "Prior year", 50m, Category.Mercado, "Barclays", null));
+        var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
+        repository.Expenses.Add(Expense.Create(PinnedToday, "In-progress month", 9999m, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(new DateOnly(CurrentYear - 1, 12, 5), "Prior year", 50m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetHistoricSummaryAverageFromYear(currentYear);
+        var result = service.GetHistoricSummaryAverageFromYear(CurrentYear);
 
         // The current year has no fully completed month yet, so it must not appear at all;
         // the range starts at the previous year instead.
-        result.Should().NotContain(r => r.Year == currentYear);
-        result.Should().ContainSingle(r => r.Year == currentYear - 1);
+        result.Should().NotContain(r => r.Year == CurrentYear);
+        result.Should().ContainSingle(r => r.Year == CurrentYear - 1);
     }
 
     [Fact]
@@ -901,21 +889,16 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsForYear_AverageForCurrentYearExcludesInProgressMonth()
     {
-        var today = DateTime.UtcNow;
-        var monthsElapsed = today.Month - 1;
         var repository = new StubCashFlowRepository();
-        var service = new AnnualSummaryService(repository);
-        var currentYear = today.Year;
-        repository.Expenses.Add(Expense.Create(new DateOnly(currentYear, 1, 5), "Completed months", 100m * monthsElapsed, Category.Mercado, "Barclays", null));
-        repository.Expenses.Add(Expense.Create(DateOnly.FromDateTime(today), "In-progress month", 9999m, Category.Mercado, "Barclays", null));
+        var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
+        repository.Expenses.Add(Expense.Create(new DateOnly(CurrentYear, 1, 5), "Completed months", 100m * PinnedMonthsElapsed, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(PinnedToday, "In-progress month", 9999m, Category.Mercado, "Barclays", null));
 
-        var result = service.GetCategoryTotalsForYear(currentYear);
+        var result = service.GetCategoryTotalsForYear(CurrentYear);
 
         // The in-progress current-month entry (9999) must be excluded entirely from the average,
-        // not treated as a completed month with a low value. When today is in January there are no
-        // completed months yet, so MonthlySeries.Average's monthsElapsed<=0 rule yields zero.
-        var expectedAverage = monthsElapsed == 0 ? 0m : 100m;
-        result.Single(c => c.Category == "Mercado").Average.Should().Be(expectedAverage);
+        // not treated as a completed month with a low value.
+        result.Single(c => c.Category == "Mercado").Average.Should().Be(100m);
     }
 
     [Fact]
@@ -949,22 +932,15 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_AveragesForCurrentYearExcludeInProgressMonth()
     {
-        var today = DateTime.UtcNow;
-        var monthsElapsed = today.Month - 1;
         var repository = new StubCashFlowRepository();
-        var service = new AnnualSummaryService(repository);
-        var currentYear = today.Year;
-        repository.Incomes.Add(Income.Create(new DateOnly(currentYear, 1, 5), IncomeSource.Gleison, 1000m * monthsElapsed, 800m * monthsElapsed, "Barclays"));
-        repository.Incomes.Add(Income.Create(DateOnly.FromDateTime(today), IncomeSource.Gleison, 9999m * monthsElapsed, 9999m * monthsElapsed, "Barclays"));
+        var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
+        repository.Incomes.Add(Income.Create(new DateOnly(CurrentYear, 1, 5), IncomeSource.Gleison, 1000m * PinnedMonthsElapsed, 800m * PinnedMonthsElapsed, "Barclays"));
+        repository.Incomes.Add(Income.Create(PinnedToday, IncomeSource.Gleison, 9999m * PinnedMonthsElapsed, 9999m * PinnedMonthsElapsed, "Barclays"));
 
-        var result = service.GetIncomeSummaryForYear(currentYear);
+        var result = service.GetIncomeSummaryForYear(CurrentYear);
 
-        // When today is in January there are no completed months yet, so MonthlySeries.Average's
-        // monthsElapsed<=0 rule yields zero instead of the completed-months figures below.
-        var expectedSalaryAverage = monthsElapsed == 0 ? 0m : 1000m;
-        var expectedSalaryAfterTaxesAverage = monthsElapsed == 0 ? 0m : 800m;
-        result.SalaryAverage.Should().Be(expectedSalaryAverage);
-        result.SalaryAfterTaxesAverage.Should().Be(expectedSalaryAfterTaxesAverage);
+        result.SalaryAverage.Should().Be(1000m);
+        result.SalaryAfterTaxesAverage.Should().Be(800m);
     }
 
     [Fact]
@@ -1005,24 +981,17 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsAnnualForYear_TotalDespesasAndResultadoAveragesForCurrentYearExcludeInProgressMonth()
     {
-        var today = DateTime.UtcNow;
-        var monthsElapsed = today.Month - 1;
         var repository = new StubCashFlowRepository();
-        var service = new AnnualSummaryService(repository);
-        var currentYear = today.Year;
-        repository.Expenses.Add(Expense.Create(new DateOnly(currentYear, 1, 5), "Completed months", 100m * monthsElapsed, Category.Mercado, "Barclays", null));
-        repository.Expenses.Add(Expense.Create(DateOnly.FromDateTime(today), "In-progress month", 9999m, Category.Mercado, "Barclays", null));
-        repository.Incomes.Add(Income.Create(new DateOnly(currentYear, 1, 5), IncomeSource.Gleison, 1000m * monthsElapsed, 800m * monthsElapsed, "Barclays"));
-        repository.Incomes.Add(Income.Create(DateOnly.FromDateTime(today), IncomeSource.Gleison, 9999m * monthsElapsed, 9999m * monthsElapsed, "Barclays"));
+        var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
+        repository.Expenses.Add(Expense.Create(new DateOnly(CurrentYear, 1, 5), "Completed months", 100m * PinnedMonthsElapsed, Category.Mercado, "Barclays", null));
+        repository.Expenses.Add(Expense.Create(PinnedToday, "In-progress month", 9999m, Category.Mercado, "Barclays", null));
+        repository.Incomes.Add(Income.Create(new DateOnly(CurrentYear, 1, 5), IncomeSource.Gleison, 1000m * PinnedMonthsElapsed, 800m * PinnedMonthsElapsed, "Barclays"));
+        repository.Incomes.Add(Income.Create(PinnedToday, IncomeSource.Gleison, 9999m * PinnedMonthsElapsed, 9999m * PinnedMonthsElapsed, "Barclays"));
 
-        var result = service.GetCategoryTotalsAnnualForYear(currentYear);
+        var result = service.GetCategoryTotalsAnnualForYear(CurrentYear);
 
-        // When today is in January there are no completed months yet, so MonthlySeries.Average's
-        // monthsElapsed<=0 rule yields zero instead of the completed-months figures below.
-        var expectedTotalDespesasAverage = monthsElapsed == 0 ? 0m : 100m;
-        var expectedResultadoAverage = monthsElapsed == 0 ? 0m : 700m;
-        result.TotalDespesasAverage.Should().Be(expectedTotalDespesasAverage);
-        result.ResultadoAverage.Should().Be(expectedResultadoAverage);
+        result.TotalDespesasAverage.Should().Be(100m);
+        result.ResultadoAverage.Should().Be(700m);
     }
 
     private sealed class StubCashFlowRepository : ICashFlowRepository

--- a/Tests/Financial.CashFlow.Application.Tests/TestHelpers/FakeTimeProvider.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/TestHelpers/FakeTimeProvider.cs
@@ -1,0 +1,10 @@
+namespace Financial.CashFlow.Application.Tests.TestHelpers;
+
+internal sealed class FakeTimeProvider : TimeProvider
+{
+    private readonly DateTimeOffset _now;
+
+    public FakeTimeProvider(DateTimeOffset now) => _now = now;
+
+    public override DateTimeOffset GetUtcNow() => _now;
+}


### PR DESCRIPTION
## Summary
- `AnnualSummaryService` called `DateTime.UtcNow`/`.Now` directly at 7 call sites to compute the current-month averaging cutoff, so tests had to branch on the real wall-clock month to predict expected values — the integration test covering historic summary averages silently no-op'd every January instead of exercising its assertions.
- Injected the BCL's `TimeProvider` (available since .NET 8, no new NuGet dependency) via an optional constructor parameter defaulting to `TimeProvider.System`, registered it in DI, and pinned the previously wall-clock-dependent tests to a fixed date through a small `FakeTimeProvider` test helper.
- Deliberately did not introduce a custom `IDateProvider` abstraction — the BCL already ships the equivalent, so this stays out-of-scope-free per the project's no-over-engineering guidance. `ControleMaeService`/`InvestmentSnapshotService` still use `DateTime.Now` directly; they have no fragile tests today, so migrating them was left out of scope.

## Details
- `AnnualSummaryService`: constructor now takes `TimeProvider? timeProvider = null`, defaulting to `TimeProvider.System`. All 7 `DateTime.UtcNow`/`.Now` call sites replaced with `_timeProvider.GetUtcNow()`. The optional default means the ~53 unrelated `new AnnualSummaryService(repository)` test call sites needed zero changes.
- `CashFlowApplicationServiceCollectionExtensions`: registers `TimeProvider.System` in DI, so `ApiTestFactory` can override it for integration tests the same way it already overrides `IExchangeRateProvider`.
- `ApiTestFactory`: added a `timeProviderOverride` constructor parameter, mirroring the existing `exchangeRateProviderOverride` pattern.
- 6 fragile unit tests in `AnnualSummaryServiceTests.cs` rewritten to construct the service with a `FakeTimeProvider` pinned to a fixed mid-year date, removing `DateTime.UtcNow.Month == 1` branches and degenerate "average == 0 in January" conditional assertions.
- `AnnualSummaryEndpointsTests.cs`'s `GetHistoricSummaryAverages_MergesIncomeIntoMatchingYearAndOmitsItFromYearsWithoutIncome` no longer early-returns in January; it now runs deterministically against a pinned date via `ApiTestFactory(timeProviderOverride: ...)`.

## Test plan
- [x] `dotnet build` succeeds across the touched projects
- [x] `Financial.CashFlow.Application.Tests` — 232/232 passed
- [x] `Financial.Api.Tests` — 196/196 passed (including the previously January-skipping integration test)
- [x] Full solution test suite (10 test projects) — all passed, no regressions (5 pre-existing unrelated skips in `Financial.Investment.Infrastructure.Tests`)
- [x] Verified no remaining test in the solution silently skips its assertion based on current month/year (searched all test projects for the `if (monthsElapsed/currentMonth == 0/1) { ...; return; }` pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)