### PR TITLE
feat(P20-F01): add Bank Transfer domain and API

### DIFF
--- a/Financial.Api/Controllers/TransfersController.cs
+++ b/Financial.Api/Controllers/TransfersController.cs
@@ -1,0 +1,116 @@
+using Financial.CashFlow.Application.DTOs;
+using Financial.CashFlow.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Financial.Api.Controllers;
+
+/// <summary>
+/// Manages transfers of money between the user's own banks.
+/// </summary>
+[ApiController]
+[Route("transfers")]
+public sealed class TransfersController : ControllerBase
+{
+    private readonly ITransferService _transferService;
+
+    public TransfersController(ITransferService transferService)
+    {
+        _transferService = transferService ?? throw new ArgumentNullException(nameof(transferService));
+    }
+
+    /// <summary>Records a new transfer.</summary>
+    /// <param name="request">The transfer to create.</param>
+    /// <returns>200 OK with the created transfer, 400 Bad Request if the request is invalid or missing.</returns>
+    [HttpPost]
+    [ProducesResponseType(typeof(TransferDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<TransferDTO>> AddTransfer([FromBody] TransferCreateDTO? request)
+    {
+        if (request is null)
+        {
+            return BadRequest();
+        }
+
+        try
+        {
+            var transfer = await _transferService.AddTransferAsync(request);
+            return Ok(transfer);
+        }
+        catch (ArgumentException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+    }
+
+    /// <summary>Updates an existing transfer.</summary>
+    /// <param name="id">The transfer's identifier.</param>
+    /// <param name="request">The new transfer fields.</param>
+    /// <returns>200 OK with the updated transfer, 400 Bad Request if the request is invalid, or 404 Not Found if the transfer doesn't exist.</returns>
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(TransferDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<TransferDTO>> UpdateTransfer(Guid id, [FromBody] TransferUpdateDTO? request)
+    {
+        if (request is null)
+        {
+            return BadRequest();
+        }
+
+        try
+        {
+            var transfer = await _transferService.UpdateTransferAsync(id, request);
+            return Ok(transfer);
+        }
+        catch (ArgumentException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound);
+        }
+    }
+
+    /// <summary>Deletes a transfer.</summary>
+    /// <param name="id">The transfer's identifier.</param>
+    /// <returns>200 OK if deleted, or 404 Not Found if the transfer doesn't exist.</returns>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteTransfer(Guid id)
+    {
+        try
+        {
+            await _transferService.DeleteTransferAsync(id);
+            return Ok();
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status404NotFound);
+        }
+    }
+
+    /// <summary>Lists transfers recorded in a given month.</summary>
+    /// <param name="year">The year.</param>
+    /// <param name="month">The month (1-12).</param>
+    /// <returns>200 OK with the matching transfers.</returns>
+    [HttpGet("month/{year:int}/{month:int}")]
+    [ProducesResponseType(typeof(IReadOnlyList<TransferDTO>), StatusCodes.Status200OK)]
+    public ActionResult<IReadOnlyList<TransferDTO>> GetTransfersByMonth(int year, int month)
+    {
+        var result = _transferService.GetTransfersByMonth(year, month);
+        return Ok(result);
+    }
+
+    /// <summary>Lists all transfers touching a given bank, either as source or destination.</summary>
+    /// <param name="name">The bank's name.</param>
+    /// <returns>200 OK with the matching transfers.</returns>
+    [HttpGet("bank/{name}")]
+    [ProducesResponseType(typeof(IReadOnlyList<TransferDTO>), StatusCodes.Status200OK)]
+    public ActionResult<IReadOnlyList<TransferDTO>> GetTransfersByBank(string name)
+    {
+        var result = _transferService.GetTransfersByBank(name);
+        return Ok(result);
+    }
+}

--- a/Financial.CashFlow.Application/DTOs/TransferCreateDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/TransferCreateDTO.cs
@@ -1,0 +1,22 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Request to create a new transfer. The server generates the identifier.
+/// </summary>
+public sealed class TransferCreateDTO
+{
+    /// <summary>Transfer date.</summary>
+    public required DateOnly Date { get; init; }
+
+    /// <summary>Bank the money leaves.</summary>
+    public required string SourceBank { get; init; }
+
+    /// <summary>Bank the money enters.</summary>
+    public required string DestinationBank { get; init; }
+
+    /// <summary>Amount moved in GBP. Must be greater than zero.</summary>
+    public required decimal Amount { get; init; }
+
+    /// <summary>Optional free-text note.</summary>
+    public string? Note { get; init; }
+}

--- a/Financial.CashFlow.Application/DTOs/TransferDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/TransferDTO.cs
@@ -1,0 +1,25 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Read model for a transfer record.
+/// </summary>
+public sealed class TransferDTO
+{
+    /// <summary>Transfer identifier.</summary>
+    public required Guid Id { get; init; }
+
+    /// <summary>Transfer date.</summary>
+    public required DateOnly Date { get; init; }
+
+    /// <summary>Bank the money leaves.</summary>
+    public required string SourceBank { get; init; }
+
+    /// <summary>Bank the money enters.</summary>
+    public required string DestinationBank { get; init; }
+
+    /// <summary>Amount moved in GBP.</summary>
+    public required decimal Amount { get; init; }
+
+    /// <summary>Optional free-text note.</summary>
+    public string? Note { get; init; }
+}

--- a/Financial.CashFlow.Application/DTOs/TransferUpdateDTO.cs
+++ b/Financial.CashFlow.Application/DTOs/TransferUpdateDTO.cs
@@ -1,0 +1,22 @@
+namespace Financial.CashFlow.Application.DTOs;
+
+/// <summary>
+/// Request to update an existing transfer's details. The identifier comes from the route.
+/// </summary>
+public sealed class TransferUpdateDTO
+{
+    /// <summary>Transfer date.</summary>
+    public required DateOnly Date { get; init; }
+
+    /// <summary>Bank the money leaves.</summary>
+    public required string SourceBank { get; init; }
+
+    /// <summary>Bank the money enters.</summary>
+    public required string DestinationBank { get; init; }
+
+    /// <summary>Amount moved in GBP. Must be greater than zero.</summary>
+    public required decimal Amount { get; init; }
+
+    /// <summary>Optional free-text note.</summary>
+    public string? Note { get; init; }
+}

--- a/Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs
+++ b/Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class CashFlowApplicationServiceCollectionExtensions
         services.AddSingleton<IBankService, BankService>();
         services.AddSingleton<IIncomeService, IncomeService>();
         services.AddSingleton<ITitheService, TitheService>();
+        services.AddSingleton<ITransferService, TransferService>();
 
         return services;
     }

--- a/Financial.CashFlow.Application/Interfaces/ICashFlowRepository.cs
+++ b/Financial.CashFlow.Application/Interfaces/ICashFlowRepository.cs
@@ -35,5 +35,10 @@ public interface ICashFlowRepository
     void AddIncome(Income income);
     void DeleteIncome(Guid id);
 
+    IEnumerable<Transfer> GetTransfers();
+    void AddTransfer(Transfer transfer);
+    void UpdateTransfer(Transfer transfer);
+    void DeleteTransfer(Guid id);
+
     Task SaveChangesAsync();
 }

--- a/Financial.CashFlow.Application/Interfaces/ITransferService.cs
+++ b/Financial.CashFlow.Application/Interfaces/ITransferService.cs
@@ -1,0 +1,12 @@
+using Financial.CashFlow.Application.DTOs;
+
+namespace Financial.CashFlow.Application.Interfaces;
+
+public interface ITransferService
+{
+    Task<TransferDTO> AddTransferAsync(TransferCreateDTO request);
+    Task<TransferDTO> UpdateTransferAsync(Guid id, TransferUpdateDTO request);
+    Task DeleteTransferAsync(Guid id);
+    IReadOnlyList<TransferDTO> GetTransfersByMonth(int year, int month);
+    IReadOnlyList<TransferDTO> GetTransfersByBank(string bankName);
+}

--- a/Financial.CashFlow.Application/Services/TransferService.cs
+++ b/Financial.CashFlow.Application/Services/TransferService.cs
@@ -1,0 +1,96 @@
+using Financial.CashFlow.Application.DTOs;
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Application.Validation;
+using Financial.CashFlow.Domain.Entities;
+
+namespace Financial.CashFlow.Application.Services;
+
+public sealed class TransferService : ITransferService
+{
+    private readonly ICashFlowRepository _repository;
+
+    public TransferService(ICashFlowRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<TransferDTO> AddTransferAsync(TransferCreateDTO request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var (sourceBank, destinationBank) = ResolveBanks(request.SourceBank, request.DestinationBank);
+
+        var transfer = Transfer.Create(request.Date, sourceBank, destinationBank, request.Amount, request.Note);
+        _repository.AddTransfer(transfer);
+        await _repository.SaveChangesAsync().ConfigureAwait(false);
+
+        return ToDto(transfer);
+    }
+
+    public async Task<TransferDTO> UpdateTransferAsync(Guid id, TransferUpdateDTO request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var transfer = FindTransferOrThrow(id);
+        var (sourceBank, destinationBank) = ResolveBanks(request.SourceBank, request.DestinationBank);
+
+        transfer.UpdateDetails(request.Date, sourceBank, destinationBank, request.Amount, request.Note);
+        _repository.UpdateTransfer(transfer);
+        await _repository.SaveChangesAsync().ConfigureAwait(false);
+
+        return ToDto(transfer);
+    }
+
+    public async Task DeleteTransferAsync(Guid id)
+    {
+        FindTransferOrThrow(id);
+
+        _repository.DeleteTransfer(id);
+        await _repository.SaveChangesAsync().ConfigureAwait(false);
+    }
+
+    public IReadOnlyList<TransferDTO> GetTransfersByMonth(int year, int month) =>
+        _repository.GetTransfers()
+            .Where(t => t.Date.Year == year && t.Date.Month == month)
+            .Select(ToDto)
+            .ToList();
+
+    public IReadOnlyList<TransferDTO> GetTransfersByBank(string bankName) =>
+        _repository.GetTransfers()
+            .Where(t =>
+                string.Equals(t.SourceBank, bankName, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(t.DestinationBank, bankName, StringComparison.OrdinalIgnoreCase))
+            .Select(ToDto)
+            .ToList();
+
+    private Transfer FindTransferOrThrow(Guid id) =>
+        _repository.GetTransfers().FirstOrDefault(t => t.Id == id)
+            ?? throw new KeyNotFoundException($"Transfer '{id}' was not found.");
+
+    private (string SourceBank, string DestinationBank) ResolveBanks(string sourceBank, string destinationBank)
+    {
+        var banks = _repository.GetBanks();
+
+        if (!BankNameResolver.TryResolve(sourceBank, banks, out var resolvedSource))
+        {
+            throw new ArgumentException($"Bank '{sourceBank}' was not found.");
+        }
+
+        if (!BankNameResolver.TryResolve(destinationBank, banks, out var resolvedDestination))
+        {
+            throw new ArgumentException($"Bank '{destinationBank}' was not found.");
+        }
+
+        return (resolvedSource!.Name, resolvedDestination!.Name);
+    }
+
+    private static TransferDTO ToDto(Transfer transfer) => new()
+    {
+        Id = transfer.Id,
+        Date = transfer.Date,
+        SourceBank = transfer.SourceBank,
+        DestinationBank = transfer.DestinationBank,
+        Amount = transfer.Amount,
+        Note = transfer.Note
+    };
+}

--- a/Financial.CashFlow.Domain/Entities/CashFlowData.cs
+++ b/Financial.CashFlow.Domain/Entities/CashFlowData.cs
@@ -77,6 +77,14 @@ public class CashFlowData
         _incomes.AddRange(data);
     }
 
+    private List<Transfer> _transfers = new List<Transfer>();
+    public IReadOnlyCollection<Transfer> Transfers { get => _transfers.AsReadOnly(); private set => SetTransfers(value); }
+    private void SetTransfers(IReadOnlyCollection<Transfer> data)
+    {
+        _transfers.Clear();
+        _transfers.AddRange(data);
+    }
+
     private CashFlowData() { }
 
     public static CashFlowData Create() => new();
@@ -108,4 +116,17 @@ public class CashFlowData
     public void AddIncome(Income income) => _incomes.Add(income);
 
     public void RemoveIncome(Guid id) => _incomes.RemoveAll(i => i.Id == id);
+
+    public void AddTransfer(Transfer transfer) => _transfers.Add(transfer);
+
+    public void UpdateTransfer(Transfer transfer)
+    {
+        var index = _transfers.FindIndex(t => t.Id == transfer.Id);
+        if (index >= 0)
+        {
+            _transfers[index] = transfer;
+        }
+    }
+
+    public void RemoveTransfer(Guid id) => _transfers.RemoveAll(t => t.Id == id);
 }

--- a/Financial.CashFlow.Domain/Entities/Transfer.cs
+++ b/Financial.CashFlow.Domain/Entities/Transfer.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace Financial.CashFlow.Domain.Entities;
+
+public class Transfer
+{
+    public Guid Id { get; private set; }
+    public DateOnly Date { get; private set; }
+    public string SourceBank { get; private set; } = string.Empty;
+    public string DestinationBank { get; private set; } = string.Empty;
+    public decimal Amount { get; private set; }
+    public string? Note { get; private set; }
+
+    private Transfer() { }
+
+    public static Transfer Create(
+        DateOnly date,
+        string sourceBank,
+        string destinationBank,
+        decimal amount,
+        string? note)
+    {
+        Validate(sourceBank, destinationBank, amount);
+
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Date = date,
+            SourceBank = sourceBank,
+            DestinationBank = destinationBank,
+            Amount = amount,
+            Note = note
+        };
+    }
+
+    public void UpdateDetails(
+        DateOnly date,
+        string sourceBank,
+        string destinationBank,
+        decimal amount,
+        string? note)
+    {
+        Validate(sourceBank, destinationBank, amount);
+
+        Date = date;
+        SourceBank = sourceBank;
+        DestinationBank = destinationBank;
+        Amount = amount;
+        Note = note;
+    }
+
+    private static void Validate(string sourceBank, string destinationBank, decimal amount)
+    {
+        if (string.Equals(sourceBank, destinationBank, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("A transfer must move money between two different banks.");
+        }
+
+        if (amount <= 0)
+        {
+            throw new ArgumentException("Transfer amount must be greater than zero.");
+        }
+    }
+}

--- a/Financial.CashFlow.Infrastructure/Persistence/CashFlowTypeInfoResolver.cs
+++ b/Financial.CashFlow.Infrastructure/Persistence/CashFlowTypeInfoResolver.cs
@@ -18,7 +18,8 @@ public class CashFlowTypeInfoResolver : DefaultJsonTypeInfoResolver
         typeof(InvestmentSnapshot),
         typeof(InvestmentAccount),
         typeof(Bank),
-        typeof(Income)
+        typeof(Income),
+        typeof(Transfer)
     ];
 
     public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)

--- a/Financial.CashFlow.Infrastructure/Repositories/CashFlowJsonRepository.cs
+++ b/Financial.CashFlow.Infrastructure/Repositories/CashFlowJsonRepository.cs
@@ -49,6 +49,11 @@ public sealed class CashFlowJsonRepository : ICashFlowRepository
     public void AddIncome(Income income) => _data.AddIncome(income);
     public void DeleteIncome(Guid id) => _data.RemoveIncome(id);
 
+    public IEnumerable<Transfer> GetTransfers() => _data.Transfers;
+    public void AddTransfer(Transfer transfer) => _data.AddTransfer(transfer);
+    public void UpdateTransfer(Transfer transfer) => _data.UpdateTransfer(transfer);
+    public void DeleteTransfer(Guid id) => _data.RemoveTransfer(id);
+
     public async Task SaveChangesAsync()
     {
         var json = _serializer.Serialize(_data);

--- a/Tests/Financial.Api.Tests/TransfersEndpointsTests.cs
+++ b/Tests/Financial.Api.Tests/TransfersEndpointsTests.cs
@@ -1,0 +1,230 @@
+using Financial.CashFlow.Application.DTOs;
+using FluentAssertions;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace Financial.Api.Tests;
+
+public class TransfersEndpointsTests
+{
+    [Fact]
+    public async Task AddTransfer_ValidRequest_ReturnsOk()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new TransferCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 25),
+            SourceBank = "Barclays",
+            DestinationBank = "Trading212",
+            Amount = 500.00m,
+            Note = "Round-up top-up"
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/transfers", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var transfer = await response.Content.ReadFromJsonAsync<TransferDTO>();
+        transfer.Should().NotBeNull();
+        transfer!.SourceBank.Should().Be("Barclays");
+        transfer.DestinationBank.Should().Be("Trading212");
+        transfer.Amount.Should().Be(500.00m);
+        transfer.Note.Should().Be("Round-up top-up");
+    }
+
+    [Fact]
+    public async Task AddTransfer_SameSourceAndDestination_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new TransferCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 25),
+            SourceBank = "Barclays",
+            DestinationBank = "Barclays",
+            Amount = 100m
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/transfers", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AddTransfer_NonPositiveAmount_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new TransferCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 25),
+            SourceBank = "Barclays",
+            DestinationBank = "Trading212",
+            Amount = 0m
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/transfers", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AddTransfer_UnresolvableBank_ReturnsBadRequest()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var request = new TransferCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 25),
+            SourceBank = "NotABank",
+            DestinationBank = "Trading212",
+            Amount = 100m
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/financial/transfers", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdateTransfer_ExistingId_ReturnsOkAndUpdatesFields()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var created = await client.PostAsJsonAsync("/api/v1/financial/transfers", new TransferCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 1),
+            SourceBank = "Barclays",
+            DestinationBank = "Trading212",
+            Amount = 100m
+        });
+        var createdTransfer = await created.Content.ReadFromJsonAsync<TransferDTO>();
+
+        var response = await client.PutAsJsonAsync($"/api/v1/financial/transfers/{createdTransfer!.Id}", new TransferUpdateDTO
+        {
+            Date = new DateOnly(2026, 7, 2),
+            SourceBank = "Chase",
+            DestinationBank = "Trading212",
+            Amount = 250m,
+            Note = "Updated"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await response.Content.ReadFromJsonAsync<TransferDTO>();
+        updated!.SourceBank.Should().Be("Chase");
+        updated.Amount.Should().Be(250m);
+        updated.Note.Should().Be("Updated");
+    }
+
+    [Fact]
+    public async Task UpdateTransfer_UnknownId_ReturnsNotFound()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PutAsJsonAsync($"/api/v1/financial/transfers/{Guid.NewGuid()}", new TransferUpdateDTO
+        {
+            Date = new DateOnly(2026, 7, 1),
+            SourceBank = "Barclays",
+            DestinationBank = "Trading212",
+            Amount = 100m
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteTransfer_ExistingId_ReturnsOkAndRemovesTransfer()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        var created = await client.PostAsJsonAsync("/api/v1/financial/transfers", new TransferCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 5),
+            SourceBank = "Barclays",
+            DestinationBank = "Trading212",
+            Amount = 100m
+        });
+        var createdTransfer = await created.Content.ReadFromJsonAsync<TransferDTO>();
+
+        var response = await client.DeleteAsync($"/api/v1/financial/transfers/{createdTransfer!.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var list = await client.GetFromJsonAsync<List<TransferDTO>>("/api/v1/financial/transfers/month/2026/7");
+        list.Should().NotContain(t => t.Id == createdTransfer.Id);
+    }
+
+    [Fact]
+    public async Task DeleteTransfer_UnknownId_ReturnsNotFound()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.DeleteAsync($"/api/v1/financial/transfers/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetTransfersByMonth_ReturnsOnlyTransfersForThatMonth()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/financial/transfers", new TransferCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 1),
+            SourceBank = "Barclays",
+            DestinationBank = "Trading212",
+            Amount = 100m
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/transfers", new TransferCreateDTO
+        {
+            Date = new DateOnly(2026, 8, 1),
+            SourceBank = "Barclays",
+            DestinationBank = "Trading212",
+            Amount = 100m
+        });
+
+        var response = await client.GetAsync("/api/v1/financial/transfers/month/2026/7");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await response.Content.ReadFromJsonAsync<List<TransferDTO>>();
+        items.Should().ContainSingle();
+        items!.Single().Date.Month.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task GetTransfersByBank_ReturnsTransfersWhereBankIsSourceOrDestination()
+    {
+        await using var factory = new ApiTestFactory();
+        using var client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/financial/transfers", new TransferCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 1),
+            SourceBank = "Barclays",
+            DestinationBank = "Trading212",
+            Amount = 100m
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/transfers", new TransferCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 2),
+            SourceBank = "Chase",
+            DestinationBank = "Barclays",
+            Amount = 50m
+        });
+        await client.PostAsJsonAsync("/api/v1/financial/transfers", new TransferCreateDTO
+        {
+            Date = new DateOnly(2026, 7, 3),
+            SourceBank = "Chase",
+            DestinationBank = "Trading212",
+            Amount = 25m
+        });
+
+        var response = await client.GetAsync("/api/v1/financial/transfers/bank/Barclays");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await response.Content.ReadFromJsonAsync<List<TransferDTO>>();
+        items.Should().HaveCount(2);
+    }
+}

--- a/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -1048,6 +1048,11 @@ public class AnnualSummaryServiceTests
         public void AddIncome(Income income) { }
         public void DeleteIncome(Guid id) { }
 
+        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
+        public void AddTransfer(Transfer transfer) { }
+        public void UpdateTransfer(Transfer transfer) { }
+        public void DeleteTransfer(Guid id) { }
+
         public Task SaveChangesAsync() => Task.CompletedTask;
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs
@@ -232,6 +232,11 @@ public class BankServiceTests
         public void AddIncome(Income income) { }
         public void DeleteIncome(Guid id) { }
 
+        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
+        public void AddTransfer(Transfer transfer) { }
+        public void UpdateTransfer(Transfer transfer) { }
+        public void DeleteTransfer(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/CardStatementServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/CardStatementServiceTests.cs
@@ -327,6 +327,11 @@ public class CardStatementServiceTests
         public void AddIncome(Income income) { }
         public void DeleteIncome(Guid id) { }
 
+        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
+        public void AddTransfer(Transfer transfer) { }
+        public void UpdateTransfer(Transfer transfer) { }
+        public void DeleteTransfer(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ControleMaeServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ControleMaeServiceTests.cs
@@ -289,6 +289,11 @@ public class ControleMaeServiceTests
         public void AddIncome(Income income) { }
         public void DeleteIncome(Guid id) { }
 
+        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
+        public void AddTransfer(Transfer transfer) { }
+        public void UpdateTransfer(Transfer transfer) { }
+        public void DeleteTransfer(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
@@ -487,6 +487,11 @@ public class ExpenseServiceTests
         public void AddIncome(Income income) { }
         public void DeleteIncome(Guid id) { }
 
+        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
+        public void AddTransfer(Transfer transfer) { }
+        public void UpdateTransfer(Transfer transfer) { }
+        public void DeleteTransfer(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/IncomeServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/IncomeServiceTests.cs
@@ -229,6 +229,11 @@ public class IncomeServiceTests
         public void AddIncome(Income income) => Incomes.Add(income);
         public void DeleteIncome(Guid id) => Incomes.RemoveAll(i => i.Id == id);
 
+        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
+        public void AddTransfer(Transfer transfer) { }
+        public void UpdateTransfer(Transfer transfer) { }
+        public void DeleteTransfer(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/InvestmentSnapshotServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/InvestmentSnapshotServiceTests.cs
@@ -203,6 +203,11 @@ public class InvestmentSnapshotServiceTests
         public void AddIncome(Income income) { }
         public void DeleteIncome(Guid id) { }
 
+        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
+        public void AddTransfer(Transfer transfer) { }
+        public void UpdateTransfer(Transfer transfer) { }
+        public void DeleteTransfer(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/MensaisServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/MensaisServiceTests.cs
@@ -252,6 +252,11 @@ public class MensaisServiceTests
         public void AddIncome(Income income) { }
         public void DeleteIncome(Guid id) { }
 
+        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
+        public void AddTransfer(Transfer transfer) { }
+        public void UpdateTransfer(Transfer transfer) { }
+        public void DeleteTransfer(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
@@ -367,6 +367,11 @@ public class ReserveServiceTests
         public void AddIncome(Income income) { }
         public void DeleteIncome(Guid id) { }
 
+        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
+        public void AddTransfer(Transfer transfer) { }
+        public void UpdateTransfer(Transfer transfer) { }
+        public void DeleteTransfer(Guid id) { }
+
         public Task SaveChangesAsync()
         {
             SaveChangesCallCount++;

--- a/Tests/Financial.CashFlow.Application.Tests/Services/TitheServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/TitheServiceTests.cs
@@ -134,6 +134,11 @@ public class TitheServiceTests
         public void AddIncome(Income income) => Incomes.Add(income);
         public void DeleteIncome(Guid id) { }
 
+        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
+        public void AddTransfer(Transfer transfer) { }
+        public void UpdateTransfer(Transfer transfer) { }
+        public void DeleteTransfer(Guid id) { }
+
         public Task SaveChangesAsync() => Task.CompletedTask;
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/TransferServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/TransferServiceTests.cs
@@ -1,0 +1,271 @@
+using Financial.CashFlow.Application.DTOs;
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Domain.Entities;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace Financial.CashFlow.Application.Tests.Services;
+
+public class TransferServiceTests
+{
+    [Fact]
+    public void Constructor_WithNullRepository_Throws()
+    {
+        Action act = () => new TransferService(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("repository");
+    }
+
+    [Fact]
+    public async Task AddTransferAsync_WithValidRequest_SavesAndReturnsTransfer()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new TransferService(repository);
+
+        var result = await service.AddTransferAsync(ToCreateDto(ValidCreateRequest()));
+
+        using (new AssertionScope())
+        {
+            result.Date.Should().Be(new DateOnly(2026, 7, 25));
+            result.SourceBank.Should().Be("Barclays");
+            result.DestinationBank.Should().Be("Trading212");
+            result.Amount.Should().Be(500m);
+            result.Note.Should().Be("Round-up top-up");
+            repository.Transfers.Should().ContainSingle();
+            repository.SaveChangesCallCount.Should().Be(1);
+        }
+    }
+
+    [Fact]
+    public async Task AddTransferAsync_WithoutNote_SavesNull()
+    {
+        var service = new TransferService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { Note = null });
+
+        var result = await service.AddTransferAsync(request);
+
+        result.Note.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddTransferAsync_WithSameSourceAndDestinationBank_ThrowsArgumentException()
+    {
+        var service = new TransferService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { DestinationBank = "Barclays" });
+
+        var act = async () => await service.AddTransferAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*two different banks*");
+    }
+
+    [Fact]
+    public async Task AddTransferAsync_WithNonPositiveAmount_ThrowsArgumentException()
+    {
+        var service = new TransferService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { Amount = 0m });
+
+        var act = async () => await service.AddTransferAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*greater than zero*");
+    }
+
+    [Fact]
+    public async Task AddTransferAsync_WithUnresolvableSourceBank_ThrowsArgumentException()
+    {
+        var service = new TransferService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { SourceBank = "NotABank" });
+
+        var act = async () => await service.AddTransferAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Bank 'NotABank' was not found*");
+    }
+
+    [Fact]
+    public async Task AddTransferAsync_WithUnresolvableDestinationBank_ThrowsArgumentException()
+    {
+        var service = new TransferService(new StubCashFlowRepository());
+        var request = ToCreateDto(ValidCreateRequest() with { DestinationBank = "NotABank" });
+
+        var act = async () => await service.AddTransferAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Bank 'NotABank' was not found*");
+    }
+
+    [Fact]
+    public async Task UpdateTransferAsync_WithExistingId_UpdatesInPlace()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new TransferService(repository);
+        var added = await service.AddTransferAsync(ToCreateDto(ValidCreateRequest()));
+
+        var updateRequest = ToUpdateDto(ValidCreateRequest() with { Amount = 250m, SourceBank = "Chase", Note = "Updated" });
+        var result = await service.UpdateTransferAsync(added.Id, updateRequest);
+
+        using (new AssertionScope())
+        {
+            result.Id.Should().Be(added.Id);
+            result.Amount.Should().Be(250m);
+            result.SourceBank.Should().Be("Chase");
+            result.Note.Should().Be("Updated");
+            repository.Transfers.Should().ContainSingle();
+            repository.SaveChangesCallCount.Should().Be(2);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateTransferAsync_WithUnknownId_ThrowsKeyNotFoundException()
+    {
+        var service = new TransferService(new StubCashFlowRepository());
+
+        var act = async () => await service.UpdateTransferAsync(Guid.NewGuid(), ToUpdateDto(ValidCreateRequest()));
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task DeleteTransferAsync_WithExistingId_RemovesAndSaves()
+    {
+        var repository = new StubCashFlowRepository();
+        var service = new TransferService(repository);
+        var added = await service.AddTransferAsync(ToCreateDto(ValidCreateRequest()));
+
+        await service.DeleteTransferAsync(added.Id);
+
+        repository.Transfers.Should().BeEmpty();
+        repository.SaveChangesCallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DeleteTransferAsync_WithUnknownId_ThrowsKeyNotFoundException()
+    {
+        var service = new TransferService(new StubCashFlowRepository());
+
+        var act = async () => await service.DeleteTransferAsync(Guid.NewGuid());
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task GetTransfersByMonth_ReturnsOnlyTransfersInThatMonth()
+    {
+        var service = new TransferService(new StubCashFlowRepository());
+        await service.AddTransferAsync(ToCreateDto(ValidCreateRequest() with { Date = new DateOnly(2026, 7, 10) }));
+        await service.AddTransferAsync(ToCreateDto(ValidCreateRequest() with { Date = new DateOnly(2026, 8, 10) }));
+
+        var result = service.GetTransfersByMonth(2026, 7);
+
+        result.Should().ContainSingle().Which.Date.Should().Be(new DateOnly(2026, 7, 10));
+    }
+
+    [Fact]
+    public async Task GetTransfersByBank_ReturnsTransfersWhereBankIsSourceOrDestination()
+    {
+        var service = new TransferService(new StubCashFlowRepository());
+        await service.AddTransferAsync(ToCreateDto(ValidCreateRequest() with { SourceBank = "Barclays", DestinationBank = "Trading212" }));
+        await service.AddTransferAsync(ToCreateDto(ValidCreateRequest() with { SourceBank = "Chase", DestinationBank = "Barclays" }));
+        await service.AddTransferAsync(ToCreateDto(ValidCreateRequest() with { SourceBank = "Chase", DestinationBank = "Trading212" }));
+
+        var result = service.GetTransfersByBank("Barclays");
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void GetTransfersByBank_WithUnrecognizedBank_ReturnsEmptyList()
+    {
+        var service = new TransferService(new StubCashFlowRepository());
+
+        var result = service.GetTransfersByBank("NotABank");
+
+        result.Should().BeEmpty();
+    }
+
+    private static TransferCreateRequest ValidCreateRequest() => new(
+        new DateOnly(2026, 7, 25),
+        "Barclays",
+        "Trading212",
+        500m,
+        "Round-up top-up");
+
+    private static TransferCreateDTO ToCreateDto(TransferCreateRequest r) => new()
+    {
+        Date = r.Date,
+        SourceBank = r.SourceBank,
+        DestinationBank = r.DestinationBank,
+        Amount = r.Amount,
+        Note = r.Note
+    };
+
+    private static TransferUpdateDTO ToUpdateDto(TransferCreateRequest r) => new()
+    {
+        Date = r.Date,
+        SourceBank = r.SourceBank,
+        DestinationBank = r.DestinationBank,
+        Amount = r.Amount,
+        Note = r.Note
+    };
+
+    private sealed record TransferCreateRequest(
+        DateOnly Date, string SourceBank, string DestinationBank, decimal Amount, string? Note);
+
+    private sealed class StubCashFlowRepository : ICashFlowRepository
+    {
+        public List<Transfer> Transfers { get; } = new();
+        public List<Bank> Banks { get; } = new()
+        {
+            Bank.Create("Barclays", roundUpEnabled: false),
+            Bank.Create("Trading212", roundUpEnabled: true),
+            Bank.Create("Chase", roundUpEnabled: true)
+        };
+        public int SaveChangesCallCount { get; private set; }
+
+        public IEnumerable<Expense> GetExpenses() => Array.Empty<Expense>();
+        public void AddExpense(Expense expense) { }
+        public void DeleteExpense(Guid id) { }
+
+        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
+        public void AddReserveMovement(ReserveMovement movement) { }
+        public void DeleteReserveMovement(Guid id) { }
+
+        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
+        public void AddCardStatement(CardStatement statement) { }
+
+        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
+        public void AddRecurringBill(RecurringBill bill) { }
+        public void DeleteRecurringBill(Guid id) { }
+
+        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
+        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
+        public void DeleteMaeLedgerEntry(Guid id) { }
+
+        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
+        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
+
+        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Array.Empty<InvestmentAccount>();
+        public void AddInvestmentAccount(InvestmentAccount account) { }
+
+        public IEnumerable<Bank> GetBanks() => Banks;
+
+        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
+        public void AddIncome(Income income) { }
+        public void DeleteIncome(Guid id) { }
+
+        public IEnumerable<Transfer> GetTransfers() => Transfers;
+        public void AddTransfer(Transfer transfer) => Transfers.Add(transfer);
+        public void UpdateTransfer(Transfer transfer)
+        {
+            var index = Transfers.FindIndex(t => t.Id == transfer.Id);
+            if (index >= 0)
+            {
+                Transfers[index] = transfer;
+            }
+        }
+        public void DeleteTransfer(Guid id) => Transfers.RemoveAll(t => t.Id == id);
+
+        public Task SaveChangesAsync()
+        {
+            SaveChangesCallCount++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/CashFlowDataTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/CashFlowDataTests.cs
@@ -20,6 +20,7 @@ public class CashFlowDataTests
         data.InvestmentAccounts.Should().BeEmpty();
         data.Banks.Should().BeEmpty();
         data.Incomes.Should().BeEmpty();
+        data.Transfers.Should().BeEmpty();
     }
 
     [Fact]
@@ -260,4 +261,68 @@ public class CashFlowDataTests
 
     private static Income CreateIncome() =>
         Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Lottery, null, 10m, "Chase");
+
+    [Fact]
+    public void AddTransfer_AddsOnlyToTransfersCollection()
+    {
+        var data = CashFlowData.Create();
+
+        data.AddTransfer(CreateTransfer());
+
+        data.Transfers.Should().ContainSingle();
+        data.Expenses.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void UpdateTransfer_ReplacesTheMatchingEntry()
+    {
+        var data = CashFlowData.Create();
+        var transfer = CreateTransfer();
+        data.AddTransfer(transfer);
+        transfer.UpdateDetails(new DateOnly(2026, 8, 1), "Chase", "Trading212", 250m, "Updated");
+
+        data.UpdateTransfer(transfer);
+
+        data.Transfers.Should().ContainSingle().Which.Amount.Should().Be(250m);
+    }
+
+    [Fact]
+    public void UpdateTransfer_WithUnknownId_LeavesCollectionUnchanged()
+    {
+        var data = CashFlowData.Create();
+        data.AddTransfer(CreateTransfer());
+        var unknown = CreateTransfer();
+
+        data.UpdateTransfer(unknown);
+
+        data.Transfers.Should().ContainSingle().Which.Id.Should().NotBe(unknown.Id);
+    }
+
+    [Fact]
+    public void RemoveTransfer_RemovesOnlyTheMatchingTransfer()
+    {
+        var data = CashFlowData.Create();
+        var toKeep = CreateTransfer();
+        var toRemove = CreateTransfer();
+        data.AddTransfer(toKeep);
+        data.AddTransfer(toRemove);
+
+        data.RemoveTransfer(toRemove.Id);
+
+        data.Transfers.Should().ContainSingle().Which.Id.Should().Be(toKeep.Id);
+    }
+
+    [Fact]
+    public void RemoveTransfer_WithUnknownId_LeavesCollectionUnchanged()
+    {
+        var data = CashFlowData.Create();
+        data.AddTransfer(CreateTransfer());
+
+        data.RemoveTransfer(Guid.NewGuid());
+
+        data.Transfers.Should().ContainSingle();
+    }
+
+    private static Transfer CreateTransfer() =>
+        Transfer.Create(new DateOnly(2026, 7, 1), "Barclays", "Trading212", 500m, "Test transfer");
 }

--- a/Tests/Financial.CashFlow.Domain.Tests/Entities/TransferTests.cs
+++ b/Tests/Financial.CashFlow.Domain.Tests/Entities/TransferTests.cs
@@ -1,0 +1,118 @@
+using Financial.CashFlow.Domain.Entities;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace Financial.CashFlow.Domain.Tests;
+
+public class TransferTests
+{
+    private static Transfer CreateValidTransfer() =>
+        Transfer.Create(new DateOnly(2026, 7, 25), "Barclays", "Trading212", 500m, "Round-up top-up");
+
+    [Fact]
+    public void Create_AssignsAllFieldsAndANewId()
+    {
+        var date = new DateOnly(2026, 7, 25);
+
+        var transfer = Transfer.Create(date, "Barclays", "Trading212", 500m, "Round-up top-up");
+
+        using (new AssertionScope())
+        {
+            transfer.Id.Should().NotBeEmpty();
+            transfer.Date.Should().Be(date);
+            transfer.SourceBank.Should().Be("Barclays");
+            transfer.DestinationBank.Should().Be("Trading212");
+            transfer.Amount.Should().Be(500m);
+            transfer.Note.Should().Be("Round-up top-up");
+        }
+    }
+
+    [Fact]
+    public void Create_WithoutNote_AllowsNullNote()
+    {
+        var transfer = Transfer.Create(new DateOnly(2026, 7, 25), "Barclays", "Trading212", 500m, null);
+
+        transfer.Note.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_TwoTransfers_HaveDifferentIds()
+    {
+        var first = CreateValidTransfer();
+        var second = CreateValidTransfer();
+
+        first.Id.Should().NotBe(second.Id);
+    }
+
+    [Fact]
+    public void Create_WithSameSourceAndDestinationBank_Throws()
+    {
+        var act = () => Transfer.Create(new DateOnly(2026, 7, 25), "Barclays", "Barclays", 500m, null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*two different banks*");
+    }
+
+    [Fact]
+    public void Create_WithSameSourceAndDestinationBank_CaseInsensitive_Throws()
+    {
+        var act = () => Transfer.Create(new DateOnly(2026, 7, 25), "barclays", "BARCLAYS", 500m, null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*two different banks*");
+    }
+
+    [Fact]
+    public void Create_WithZeroAmount_Throws()
+    {
+        var act = () => Transfer.Create(new DateOnly(2026, 7, 25), "Barclays", "Trading212", 0m, null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*greater than zero*");
+    }
+
+    [Fact]
+    public void Create_WithNegativeAmount_Throws()
+    {
+        var act = () => Transfer.Create(new DateOnly(2026, 7, 25), "Barclays", "Trading212", -1m, null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*greater than zero*");
+    }
+
+    [Fact]
+    public void UpdateDetails_MutatesEveryFieldWithoutChangingId()
+    {
+        var transfer = CreateValidTransfer();
+        var originalId = transfer.Id;
+        var newDate = new DateOnly(2026, 8, 1);
+
+        transfer.UpdateDetails(newDate, "Chase", "Trading212", 250m, "Updated note");
+
+        using (new AssertionScope())
+        {
+            transfer.Id.Should().Be(originalId);
+            transfer.Date.Should().Be(newDate);
+            transfer.SourceBank.Should().Be("Chase");
+            transfer.DestinationBank.Should().Be("Trading212");
+            transfer.Amount.Should().Be(250m);
+            transfer.Note.Should().Be("Updated note");
+        }
+    }
+
+    [Fact]
+    public void UpdateDetails_WithSameSourceAndDestinationBank_Throws()
+    {
+        var transfer = CreateValidTransfer();
+
+        var act = () => transfer.UpdateDetails(transfer.Date, "Chase", "Chase", 100m, null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*two different banks*");
+    }
+
+    [Fact]
+    public void UpdateDetails_WithNonPositiveAmount_Throws()
+    {
+        var transfer = CreateValidTransfer();
+
+        var act = () => transfer.UpdateDetails(transfer.Date, "Barclays", "Trading212", 0m, null);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*greater than zero*");
+    }
+}

--- a/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs
+++ b/Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs
@@ -29,6 +29,7 @@ public class CashFlowSerializerAdapterTests
         var bank = Bank.Create("Barclays", roundUpEnabled: false);
         bank.SetOpeningBalance(1250.75m, new DateOnly(2026, 7, 1));
         var income = Income.Create(new DateOnly(2026, 7, 25), IncomeSource.Gleison, 3200.00m, 2450.00m, "Barclays");
+        var transfer = Transfer.Create(new DateOnly(2026, 7, 25), "Barclays", "Trading212", 500.00m, "Round-up top-up");
 
         original.AddExpense(expense);
         original.AddReserveMovement(reserveMovement);
@@ -39,6 +40,7 @@ public class CashFlowSerializerAdapterTests
         original.AddInvestmentAccount(investmentAccount);
         original.AddBank(bank);
         original.AddIncome(income);
+        original.AddTransfer(transfer);
 
         var json = serializer.Serialize(original);
         var result = serializer.Deserialize(json);
@@ -79,6 +81,13 @@ public class CashFlowSerializerAdapterTests
         resultIncome.GrossValue.Should().Be(income.GrossValue);
         resultIncome.NetValue.Should().Be(income.NetValue);
         resultIncome.Bank.Should().Be(income.Bank);
+        var resultTransfer = result.Transfers.Should().ContainSingle().Which;
+        resultTransfer.Id.Should().Be(transfer.Id);
+        resultTransfer.Date.Should().Be(transfer.Date);
+        resultTransfer.SourceBank.Should().Be(transfer.SourceBank);
+        resultTransfer.DestinationBank.Should().Be(transfer.DestinationBank);
+        resultTransfer.Amount.Should().Be(transfer.Amount);
+        resultTransfer.Note.Should().Be(transfer.Note);
     }
 
     [Fact]
@@ -99,5 +108,6 @@ public class CashFlowSerializerAdapterTests
         result.InvestmentAccounts.Should().BeEmpty();
         result.Banks.Should().BeEmpty();
         result.Incomes.Should().BeEmpty();
+        result.Transfers.Should().BeEmpty();
     }
 }

--- a/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F01-bank-transfer-domain-api/plan.md
+++ b/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F01-bank-transfer-domain-api/plan.md
@@ -1,0 +1,25 @@
+# Implementation Plan: Bank Transfer Domain & API
+
+**Prerequisites:**
+- .NET 10 SDK (existing solution target)
+- No new external dependencies or environment variables
+
+### Stage 1: Domain
+
+**1. Transfer Entity** - Add the `Transfer` entity (date, source bank, destination bank, amount, optional note), validating its own value-shape invariants (source and destination must differ, amount must be strictly positive) on creation and update, following the existing entity patterns in this domain.
+
+**2. CashFlowData Transfer Collection** - Extend `CashFlowData` with a `Transfers` collection and add/update/remove operations, following the same private-list-plus-readonly-property pattern used for every other collection on that aggregate, with update implemented as a find-by-id replace.
+
+### Stage 2: Application
+
+**3. Repository Contract** - Extend the repository interface with transfer query/add/update/delete operations.
+
+**4. Transfer DTOs** - Add the read, create, and update data transfer objects for a transfer entry, matching the field set and nullability established in the domain entity.
+
+**5. Transfer Service** - Implement the create/update/delete/get-by-month/get-by-bank workflow: resolving both bank names against the live bank list, delegating same-bank and amount validation to the entity, and mapping to the read DTO. Register the service for dependency injection.
+
+### Stage 3: Infrastructure and Presentation
+
+**6. Repository and Serializer Wiring** - Implement the new repository operations against the JSON-backed data store, and register the `Transfer` entity with the serializer's private-member wiring so it persists and reloads correctly.
+
+**7. Transfers API Endpoints** - Add the HTTP endpoints for creating, updating, deleting, and listing transfers by month and by bank, following the existing controller's routing, status code, and error response conventions.

--- a/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F01-bank-transfer-domain-api/spec.md
+++ b/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F01-bank-transfer-domain-api/spec.md
@@ -1,0 +1,186 @@
+# F01. Bank Transfer Domain & API
+
+## 1. Technical Overview
+
+**What:** Introduce a new `Transfer` entity (`Date`, `SourceBank`, `DestinationBank`, `Amount`, optional `Note`) to the CashFlow domain, together with the full create/edit/delete/query contract (Application service, DTOs, and API endpoints) that F03's balance engine, F04's web form, and F06's history view will all consume. A transfer represents money moving between two of the user's own bank accounts and is deliberately excluded from expense/income category totals.
+
+**Why:** `Transfer` is a brand-new concept with no prior representation in the codebase — today moving money between accounts has no correct home in `Expense` or `Income`. Establishing the entity, persistence, and full CRUD contract in one feature (rather than splitting the contract across F01 and F04) mirrors how `Income` shipped as a complete CRUD surface from its own foundational feature (P14-F01) — F04 then only has to build a form and list UI against an API that already exists, exactly as `IncomesController` predates `Income`'s frontend form.
+
+**Scope:**
+- Included: `Transfer` domain entity; `CashFlowData.Transfers` collection with add/update/remove; `ICashFlowRepository` additions (`GetTransfers`, `AddTransfer`, `UpdateTransfer`, `DeleteTransfer`); `ITransferService`/`TransferService` (add, update, delete, get-by-month, get-by-bank); `TransferDTO`/`TransferCreateDTO`/`TransferUpdateDTO`; `TransfersController` (POST, PUT, DELETE, GET by month, GET by bank); serializer wiring for the new entity; DI registration.
+- Excluded: any frontend UI (F04); balance calculation using transfer data (F03 — this feature only persists and exposes transfers, it does not compute balances); the history/balances view (F06).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.CashFlow.Domain/Entities/Transfer.cs` — new entity
+- `Financial.CashFlow.Domain/Entities/CashFlowData.cs` — new `Transfers` collection + `AddTransfer`/`UpdateTransfer`/`RemoveTransfer`
+- `Financial.CashFlow.Application/Interfaces/ICashFlowRepository.cs` — `GetTransfers()`, `AddTransfer(Transfer)`, `UpdateTransfer(Transfer)`, `DeleteTransfer(Guid)` added
+- `Financial.CashFlow.Application/Interfaces/ITransferService.cs` — new
+- `Financial.CashFlow.Application/Services/TransferService.cs` — new
+- `Financial.CashFlow.Application/DTOs/TransferDTO.cs`, `TransferCreateDTO.cs`, `TransferUpdateDTO.cs` — new
+- `Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs` — registers `ITransferService`
+- `Financial.CashFlow.Infrastructure/Persistence/CashFlowTypeInfoResolver.cs` — `Transfer` added to `ManagedTypes`
+- `Financial.CashFlow.Infrastructure/Repositories/CashFlowJsonRepository.cs` — implements the 4 new repository members
+- `Financial.Api/Controllers/TransfersController.cs` — new
+
+```mermaid
+graph TD
+  A["TransfersController"] --> B[TransferService]
+  B --> C["BankNameResolver"]
+  B --> D["ICashFlowRepository"]
+  D --> E["CashFlowJsonRepository"]
+  E --> F["CashFlowData.Transfers"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Where source/destination bank existence is validated | `TransferService` resolves both names against `_repository.GetBanks()` via the existing `BankNameResolver`, mirroring `ExpenseService.ValidateFields`'s resolution of `PaymentSource` | Resolve inside `Transfer.Create` | `Transfer` (like `Expense`/`Income`) has no repository access in the domain layer; every existing bank-name reference in this codebase is resolved at the Application layer, not inside the entity. Keeping this pattern avoids introducing a new precedent. |
+| Where same-bank and positive-amount validation live | `Transfer.Create`/`UpdateDetails` validate `SourceBank != DestinationBank` (string equality, post-resolution to canonical bank names) and `Amount > 0` as self-contained domain invariants | Validate exclusively in `TransferService` | These two checks require no external data (no repository lookup), matching `Income.Create`'s self-validation of `NetValue >= 0` and `Expense`'s `ValidatePaymentShape`. The service still performs bank-name resolution first and passes the canonical resolved names into `Transfer.Create`, so the domain check runs against normalized values regardless of the casing the caller submitted. |
+| `CashFlowData` gains an explicit `UpdateTransfer` | Added as `UpdateTransfer(Transfer transfer)`, replacing the stored instance by matching `Id` (find-index-and-replace in the backing list) | Rely on in-place mutation through the shared object reference, as `Expense`/`Income` do today (no `CashFlowData.UpdateExpense`/`UpdateIncome` exists) | The PRD (Section 6, F01 Capabilities) explicitly calls out `AddTransfer`/`UpdateTransfer`/`RemoveTransfer` as the three `CashFlowData` operations for this entity — a direct PRD requirement, not an open decision. Implementing it as an explicit replace (rather than a no-op wrapper around mutation) keeps `CashFlowData`'s public surface honest about what happens on update and avoids depending on reference-identity behavior that the JSON deserializer's `CreateObject`/`Set` wiring does not guarantee is preserved across a full reload. |
+| Repository update semantics | `CashFlowJsonRepository.UpdateTransfer` calls `_data.UpdateTransfer(transfer)` then the caller (service) triggers `SaveChangesAsync()`, matching the create/delete pattern exactly | Have the service mutate the existing entity and skip a dedicated repository call | Consistent with the previous decision — the repository contract exposes `UpdateTransfer` per the PRD, so the service calls it explicitly (find existing transfer, apply `UpdateDetails`, then call `_repository.UpdateTransfer`) rather than relying on implicit reference sharing. |
+
+## 4. Component Overview
+
+**Backend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.CashFlow.Domain/Entities/Transfer.cs` | New | Transfer identity | Private ctor + `Create(date, sourceBank, destinationBank, amount, note)` factory; `UpdateDetails(...)`; `Id`, `Date`, `SourceBank`, `DestinationBank`, `Amount`, `Note` (all private-set); validates `SourceBank != DestinationBank` and `Amount > 0` |
+| `Financial.CashFlow.Domain/Entities/CashFlowData.cs` | Modified | Transfer collection | `_transfers`/`Transfers` (`IReadOnlyCollection<Transfer>`) following the existing private-list-plus-readonly-property pattern; `AddTransfer(Transfer)`; `UpdateTransfer(Transfer)` (find-by-id-and-replace); `RemoveTransfer(Guid id)` |
+| `Financial.CashFlow.Application/Interfaces/ICashFlowRepository.cs` | Modified | Repository contract | `IEnumerable<Transfer> GetTransfers(); void AddTransfer(Transfer transfer); void UpdateTransfer(Transfer transfer); void DeleteTransfer(Guid id);` added |
+| `Financial.CashFlow.Application/Interfaces/ITransferService.cs` | New | Service contract | `AddTransferAsync`, `UpdateTransferAsync`, `DeleteTransferAsync`, `GetTransfersByMonth(int year, int month)`, `GetTransfersByBank(string bankName)` |
+| `Financial.CashFlow.Application/Services/TransferService.cs` | New | Transfer CRUD | Resolves `SourceBank`/`DestinationBank` via `BankNameResolver` against `_repository.GetBanks()`; throws `ArgumentException` on an unresolved bank name (before the domain's same-bank/amount checks run, so the error message names the specific bank, matching `ExpensesController`'s convention); throws `KeyNotFoundException` on update/delete of a missing id; `ToDto` maps entity to `TransferDTO` |
+| `Financial.CashFlow.Application/DTOs/TransferDTO.cs` | New | Read model | `Id`, `Date`, `SourceBank`, `DestinationBank`, `Amount`, `Note` |
+| `Financial.CashFlow.Application/DTOs/TransferCreateDTO.cs` | New | Create request | `Date`, `SourceBank`, `DestinationBank`, `Amount`, `Note` |
+| `Financial.CashFlow.Application/DTOs/TransferUpdateDTO.cs` | New | Update request | Same shape as create; id comes from the route |
+| `Financial.CashFlow.Application/DependencyInjection/CashFlowApplicationServiceCollectionExtensions.cs` | Modified | DI registration | `services.AddSingleton<ITransferService, TransferService>();` added |
+| `Financial.CashFlow.Infrastructure/Persistence/CashFlowTypeInfoResolver.cs` | Modified | Serializer wiring | `typeof(Transfer)` added to `ManagedTypes` |
+| `Financial.CashFlow.Infrastructure/Repositories/CashFlowJsonRepository.cs` | Modified | Repository impl | `GetTransfers() => _data.Transfers;`, `AddTransfer`, `UpdateTransfer`, `DeleteTransfer` delegating to `CashFlowData` |
+| `Financial.Api/Controllers/TransfersController.cs` | New | HTTP surface | `POST /transfers`, `PUT /transfers/{id}`, `DELETE /transfers/{id}`, `GET /transfers/month/{year}/{month}`, `GET /transfers/bank/{name}` — mirrors `ExpensesController`'s status codes and `Problem()` error shape exactly |
+
+## 5. API Contracts
+
+**Endpoint: Add Transfer**
+- **Method:** POST
+- **Path:** `/transfers`
+- **Authentication:** None (matches every other endpoint in this single-user app)
+
+**Request:**
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|--------------|
+| `date` | `date` | Yes | — | Transfer date |
+| `sourceBank` | `string` | Yes | must resolve against the live `Bank` list; must differ from `destinationBank` | Bank the money leaves |
+| `destinationBank` | `string` | Yes | must resolve against the live `Bank` list; must differ from `sourceBank` | Bank the money enters |
+| `amount` | `decimal` | Yes | `> 0` | Amount moved |
+| `note` | `string` | No | — | Free-text note |
+
+**Request Example:**
+```json
+{
+  "date": "2026-07-25",
+  "sourceBank": "Barclays",
+  "destinationBank": "Trading212",
+  "amount": 500.00,
+  "note": "Round-up top-up"
+}
+```
+
+**Response (Success - 200):**
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `id` | `uuid` | Generated identifier |
+| `date` | `date` | Transfer date |
+| `sourceBank` | `string` | Bank the money leaves |
+| `destinationBank` | `string` | Bank the money enters |
+| `amount` | `decimal` | Amount moved |
+| `note` | `string?` | Free-text note, if provided |
+
+**Response Example:**
+```json
+{
+  "id": "9c1b1e2a-1234-4a11-9abc-0f1e2d3c4b5a",
+  "date": "2026-07-25",
+  "sourceBank": "Barclays",
+  "destinationBank": "Trading212",
+  "amount": 500.00,
+  "note": "Round-up top-up"
+}
+```
+
+**Error Codes:**
+
+| Code | HTTP Status | Description |
+|------|-------------|--------------|
+| — | 400 | `"Bank '{name}' was not found."` (unresolved `sourceBank`/`destinationBank`), `"A transfer must move money between two different banks."`, or `"Transfer amount must be greater than zero."` (via `Problem()` with the exception message) |
+
+**Endpoint: Update Transfer**
+- **Method:** PUT
+- **Path:** `/transfers/{id}`
+- Same request/response shape as Add, plus a 404 (`Problem()`, `"Transfer '{id}' was not found."`) when `id` does not resolve to an existing transfer.
+
+**Endpoint: Delete Transfer**
+- **Method:** DELETE
+- **Path:** `/transfers/{id}`
+- **Response (Success - 200):** empty body. **Error:** 404 (`Problem()`, `"Transfer '{id}' was not found."`) when `id` does not resolve.
+
+**Endpoint: Get Transfers by Month**
+- **Method:** GET
+- **Path:** `/transfers/month/{year}/{month}`
+- **Response (Success - 200):** `TransferDTO[]` — every transfer dated within that year/month, same shape as the Add response.
+
+**Endpoint: Get Transfers by Bank**
+- **Method:** GET
+- **Path:** `/transfers/bank/{name}`
+- **Response (Success - 200):** `TransferDTO[]` — every transfer where `name` matches `sourceBank` or `destinationBank` (case-insensitive), regardless of month; consumed by F06's per-bank history list, which applies its own month filtering client-side against F01's other endpoints as needed. No 404 for an unrecognized bank name — returns an empty array, matching the read-only, filter-style semantics of `GetExpensesByMonth`.
+
+## 6. Data Model
+
+`data-cashflow.json` gains one new top-level array, `Transfers`, empty until the first transfer is created (no migration tool needed — `CashFlowData.Transfers` default-initializes to an empty list and a normal save adds the JSON key automatically, the same mechanism already used for `CashFlowData.Incomes` after its collection was introduced):
+
+```json
+{
+  "Transfers": []
+}
+```
+
+Each entry created afterward through the API takes this shape:
+
+```json
+{
+  "Id": "9c1b1e2a-1234-4a11-9abc-0f1e2d3c4b5a",
+  "Date": "2026-07-25",
+  "SourceBank": "Barclays",
+  "DestinationBank": "Trading212",
+  "Amount": 500.00,
+  "Note": "Round-up top-up"
+}
+```
+
+No other top-level collection's shape changes.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Tests/Financial.CashFlow.Domain.Tests/Entities/TransferTests.cs` | Unit | `Transfer` | `Create` sets all fields and assigns a new id; two `Create` calls produce different ids; rejects `SourceBank == DestinationBank`; rejects `Amount <= 0`; accepts a null `Note`; `UpdateDetails` re-validates and updates all fields |
+| `Tests/Financial.CashFlow.Domain.Tests/Entities/CashFlowDataTests.cs` | Unit | `CashFlowData` | `AddTransfer` appends to `Transfers`; `Transfers` starts empty on `Create()`; `UpdateTransfer` replaces the matching entry by id; `RemoveTransfer` removes by id and no-ops on an unknown id |
+| `Tests/Financial.CashFlow.Application.Tests/Services/TransferServiceTests.cs` | Unit | `TransferService` | Valid create/update/delete round-trip; unresolved `sourceBank`/`destinationBank` throws `ArgumentException` with the bank-not-found message; same source and destination throws `ArgumentException`; `amount <= 0` throws `ArgumentException`; update/delete of an unknown id throws `KeyNotFoundException`; `GetTransfersByMonth` filters by year and month; `GetTransfersByBank` returns transfers where the bank is either source or destination, and an empty list for an unrecognized bank name |
+| `Tests/Financial.CashFlow.Infrastructure.Tests/Persistence/CashFlowSerializerAdapterTests.cs` | Unit | Serializer | `Transfer` round-trips through `CashFlowTypeInfoResolver`'s private-setter wiring |
+| `Tests/Financial.Api.Tests/TransfersEndpointsTests.cs` | Integration | `TransfersController` | POST creates and returns 200; POST with an unresolvable bank, same source/destination, or non-positive amount returns 400 with the expected message; PUT updates and returns 200; PUT on unknown id returns 404; DELETE removes and returns 200; DELETE on unknown id returns 404; GET by month returns only that month's entries; GET by bank returns transfers where the bank is source or destination |
+
+**Acceptance tests (PRD Section 9, F01):**
+- Creating a transfer with two distinct, existing banks, a positive amount, and a date succeeds and is retrievable via `GET /transfers/month/{year}/{month}` → `TransferServiceTests`, `TransfersEndpointsTests`
+- Creating a transfer with the same bank as source and destination fails with a 400 error → `TransferTests`, `TransferServiceTests`, `TransfersEndpointsTests`
+- Creating a transfer with an amount of 0 or less fails with a 400 error → `TransferTests`, `TransferServiceTests`, `TransfersEndpointsTests`
+- Creating a transfer with an unresolvable bank name fails with a 400 error → `TransferServiceTests`, `TransfersEndpointsTests`
+- Editing a transfer's amount, date, or note persists the change and is reflected on the next `GET` → `TransferServiceTests`, `TransfersEndpointsTests`
+- Deleting a transfer removes it from `data-cashflow.json` and from all subsequent `GET` responses → `TransferServiceTests`, `TransfersEndpointsTests`
+
+**Cross-Feature Integration criteria touching F01 (PRD Section 9):**
+- "A transfer created via F01 is included in F03's balance computation for both its source and destination banks" — depends on `ICashFlowRepository.GetTransfers()` exposing every `Transfer.Amount`/`SourceBank`/`DestinationBank` correctly, guaranteed here by `TransferServiceTests` and `CashFlowDataTests`; the balance computation itself is verified in F03's own spec
+- "A transfer created through F04 is persisted via F01 and appears correctly in F06's history list and balance display" — the entire Section 5 API contract and `TransfersEndpointsTests` suite (including `GET /transfers/bank/{name}`) is the direct guarantee this criterion depends on; F04's and F06's own specs verify the consuming UI

--- a/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/prd-bank-transfers-and-balance-reconciliation.md
+++ b/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/prd-bank-transfers-and-balance-reconciliation.md
@@ -1,0 +1,313 @@
+# Bank Transfers and Balance Reconciliation
+
+## 1. Executive Summary
+
+This product adds two capabilities to the CashFlow domain of the Financial app: recording an internal **transfer** of money between two of the user's own bank accounts, and **reconciling** a bank's computed balance against what the real bank statement shows. Both are for a single user managing their own personal finances after retiring their spreadsheet as the source of truth.
+
+Today the CashFlow domain tracks money leaving a bank as an `Expense` and money entering as an `Income`, and computes a running per-bank balance from `Bank.OpeningBalance` plus the sum of incomes minus expenses. Neither concept fits moving money between two of the user's own accounts (it is not spending and not earning), and there is no way to correct that running balance when it drifts from reality — whether because the user is starting fresh from the spreadsheet and needs an initial figure, or because months of use have accumulated small untracked differences (bank fees, interest, cash movements) that the app has no way to see.
+
+At a high level, this product introduces two new backend entities — `Transfer` (source bank, destination bank, amount, date) and `BalanceAdjustment` (bank, date, target balance, computed delta) — both feeding into the same server-side balance formula that already powers the existing bank-balances view. The web frontend gains a way to record either from that view, and a history list to audit and correct past entries. All balance arithmetic remains exclusively on the backend; the frontend only ever displays numbers the API already computed.
+
+## 2. Problem and Opportunity
+
+**The Problem**
+
+- **No way to represent internal money movement.** Moving £500 from Barclays to Trading212 has no correct home today — recording it as an `Expense` would incorrectly reduce total spending totals shown in category/annual reports, and recording it as an `Income` would incorrectly inflate them. The two operations most personal-finance users perform constantly (paying a card, topping up savings, moving to a round-up account) currently cannot be captured at all.
+- **No onboarding path off the spreadsheet.** `Bank.OpeningBalance` exists but is a single fixed starting point set once; there is no dedicated, auditable way to say "as of today, Barclays actually holds £2,340.17" without manually reverse-engineering what opening balance and date would produce that figure through the existing formula.
+- **Balance drift has no correction mechanism.** Small amounts the app never sees (bank interest, a fee, a cash withdrawal) will accumulate over months of real use, and the computed balance will silently diverge from the real one — with nothing in the domain to close that gap short of re-deriving a new opening balance by hand.
+- **Risk of balance logic leaking into the frontend.** Without an explicit backend-only calculation contract, it would be easy for a "preview the new balance" UI feature to reimplement the balance formula in JavaScript, creating two sources of truth that can silently disagree.
+
+**The Opportunity**
+
+- A dedicated `Transfer` entity closes the "money movement" gap without touching category/expense/income totals — solving the mis-classification problem directly.
+- A `BalanceAdjustment` entity gives a first-class, auditable way to reconcile — usable both once (onboarding) and repeatedly (ongoing drift correction) — closing both the onboarding and drift problems with one concept instead of two.
+- Extending the existing single balance-calculation service (rather than adding a second one) keeps the "balance is only ever computed on the backend" guarantee intact, directly addressing the leakage risk.
+
+## 3. Target Audience
+
+### Primary Users
+
+**The App Owner**
+- A single user managing their own personal finances across 3 UK bank accounts (Barclays, Trading212, Chase), transitioning off a long-maintained spreadsheet.
+- Regularly moves money between their own accounts (e.g. funding a round-up savings account, paying off a linked card) and wants that reflected without distorting spending reports.
+- Wants confidence that the balance shown in the app matches their real bank app, and a low-friction way to fix it when it doesn't.
+
+## 4. Objectives
+
+**Product Objectives**
+
+- **Capture** internal bank-to-bank money movement without affecting expense/income category totals.
+- **Reconcile** any bank's computed balance to a real-world figure the user enters, with the correction stored as an auditable entry rather than a silent overwrite.
+- **Guarantee** all balance arithmetic executes exclusively on the backend, with the frontend acting as a pure display layer.
+- **Preserve** full editability (create, edit, delete) of transfers and adjustments, matching the existing Expense/Income UX.
+
+**Success Metrics**
+
+- 100% of transfer and adjustment amounts are computed and returned by backend endpoints — zero balance arithmetic present in `Financial.Web` source, verified by code review at completion.
+- A transfer between two existing banks is reflected in both banks' computed balances within the same request/response cycle (no separate recompute step needed).
+- A balance adjustment brings the computed balance for its bank to exactly the entered target balance as of its date, verified against `GetBankBalancesByMonth`/equivalent for that date.
+- Every transfer and adjustment created through the UI can be edited and deleted through the UI, with 0 orphaned entries left in `data-cashflow.json` after a delete.
+
+## 5. User Stories
+
+### F01. Bank Transfer Domain & API
+- As the system, I want to persist a transfer between two banks with a date, amount, and optional note so that the money movement is recorded without being treated as an expense or income.
+- As a user, I want the system to reject a transfer where the source and destination bank are the same so that I can't create a meaningless entry.
+- As a user, I want to edit a transfer I entered incorrectly so that my records stay accurate without deleting and re-creating it.
+- As a user, I want to delete a transfer I entered by mistake so that it stops affecting both banks' balances.
+
+### F02. Balance Adjustment Domain & API
+- As a user, I want to enter the balance shown on my real bank statement for a given date so that the app computes the correction needed to match it.
+- As the system, I want to store the computed delta at the moment the adjustment is created so that the correction remains a stable, auditable entry rather than a value that silently shifts if unrelated computations change later.
+- As a user, I want to edit a balance adjustment's target balance or date so that I can fix a mistake without deleting and re-entering it.
+- As a user, I want to delete a balance adjustment so that its correction no longer applies.
+
+### F03. Bank Balance Calculation Engine
+- As the system, I want to add a transfer's amount to the destination bank's balance and subtract it from the source bank's balance so that transfers are reflected correctly on both sides.
+- As the system, I want to apply a balance adjustment's stored delta to its bank's balance from the adjustment's date forward so that the computed balance matches what the user reconciled it to.
+- As a user, I want every balance figure I see to have been computed entirely by the backend so that the frontend can never show a number that disagrees with the API.
+
+### F04. Web Transfer Entry Form
+- As a user, I want to open a "Move money" form from a bank's row so that I can record a transfer without leaving the balances view.
+- As a user, I want to pick a source bank, a destination bank, an amount, a date, and an optional note so that I can fully describe the transfer.
+- As a user, I want a clear error if I pick the same bank as source and destination so that I notice the mistake before submitting.
+- As a user, I want to edit or delete an existing transfer from the same view so that corrections don't require a different screen.
+
+### F05. Web Balance Adjustment Entry Form
+- As a user, I want to open a "Correct balance" form from a bank's row and see the app's currently computed balance so that I know what I'm reconciling against.
+- As a user, I want to type the real balance from my bank statement and have the app compute the correction so that I never have to do the subtraction myself.
+- As a user, I want to see the resulting adjustment amount after saving so that I understand how large the correction was.
+
+### F06. Web Bank Balances & History View
+- As a user, I want to see each bank's current computed balance on the Monthly Summary subtab so that I know where I stand without opening my banking app.
+- As a user, I want to see a combined, reverse-chronological history of transfers and adjustments for a bank so that I can audit what changed its balance beyond income and expenses.
+- As a user, I want to edit or delete a past transfer or adjustment directly from the history list so that I can fix mistakes in place.
+
+## 6. Functionalities
+
+### F01. Bank Transfer Domain & API
+
+**Provides:**
+- Transfer records (id, date, source bank name, destination bank name, amount, note) (used by F03, F04, F06)
+
+**Capabilities:**
+- New `Transfer` entity in `Financial.CashFlow.Domain.Entities`: `Id` (Guid), `Date` (DateOnly), `SourceBank` (string), `DestinationBank` (string), `Amount` (decimal, must be strictly greater than 0), `Note` (string?, optional, no length limit — consistent with `Expense.Description`).
+- `SourceBank` and `DestinationBank` must each resolve to an existing `Bank` via the existing `BankNameResolver` (case-insensitive match against the 3 seeded banks), and must differ from each other.
+- Persisted following the exact pattern established for `Bank`/`Expense`/`Income`: `CashFlowData` gains a private `List<Transfer>` with `AddTransfer`/`UpdateTransfer`/`RemoveTransfer`; `Transfer` is registered in `CashFlowTypeInfoResolver.ManagedTypes`; `ICashFlowRepository`/`CashFlowJsonRepository` gain `GetTransfers`/`AddTransfer`/`UpdateTransfer`/`DeleteTransfer`; persisted under a new `"Transfers"` array in `data-cashflow.json`.
+- New `TransfersController` (`[Route("transfers")]`): `POST /transfers` (create), `PUT /transfers/{id:guid}` (update), `DELETE /transfers/{id:guid}` (delete), `GET /transfers/month/{year:int}/{month:int}` (month-scoped list), `GET /transfers/bank/{name}` (all transfers touching a given bank, either as source or destination, for history display).
+- Same error-handling convention as `ExpensesController`/`IncomesController`: `ArgumentException` → 400, `KeyNotFoundException` → 404.
+
+**Experience:**
+- API-only feature; no direct UI. Consumed by F04 (form) and F06 (history/balances view).
+
+**Error Handling:**
+- Creating a transfer with an unresolvable bank name → 400 "Bank '{name}' was not found."
+- Creating a transfer with `SourceBank == DestinationBank` → 400 "A transfer must move money between two different banks."
+- Creating a transfer with `Amount <= 0` → 400 "Transfer amount must be greater than zero."
+- Updating or deleting a transfer with an unknown id → 404 "Transfer '{id}' was not found."
+- Save failure (JSON write error) → surfaced as a 500 by the existing repository save path, unchanged from `Expense`/`Income`.
+
+### F02. Balance Adjustment Domain & API
+
+**Consumes:**
+- F03: computed balance for a bank as of a given date (used to derive the delta at creation/edit time)
+
+**Provides:**
+- Balance adjustment records (id, bank name, date, target balance, delta, note) (used by F03, F05, F06)
+
+**Capabilities:**
+- New `BalanceAdjustment` entity: `Id` (Guid), `Date` (DateOnly), `Bank` (string), `TargetBalance` (decimal, must be greater than or equal to 0 — mirrors the existing non-negative rule on `Bank.OpeningBalance`), `Delta` (decimal, computed and persisted at creation/edit time), `Note` (string?, optional).
+- `Bank` must resolve to an existing `Bank` via `BankNameResolver`.
+- `Delta` is computed server-side as `TargetBalance − (balance computed by F03's engine as of Date, excluding this adjustment)`, then stored — it is never recomputed on read. This keeps the correction stable and auditable: editing `TargetBalance` or `Date` recomputes and re-stores `Delta` at that moment; unrelated later changes elsewhere do not silently shift a past adjustment's recorded delta.
+- Persisted following the same pattern as F01 (`CashFlowData` list, repository methods, `CashFlowTypeInfoResolver` registration, new `"BalanceAdjustments"` array).
+- New endpoints folded into the existing `BanksController`, matching the precedent that balance reads already live there rather than a separate controller: `POST /banks/{name}/adjustments` (create), `PUT /banks/{name}/adjustments/{id:guid}` (update), `DELETE /banks/{name}/adjustments/{id:guid}` (delete), `GET /banks/{name}/adjustments` (history list).
+
+**Experience:**
+- API-only feature; no direct UI. Consumed by F05 (form) and F06 (history/balances view).
+
+**Error Handling:**
+- Unresolvable bank name → 400 "Bank '{name}' was not found."
+- `TargetBalance < 0` → 400 "Balance cannot be negative."
+- Unknown adjustment id on update/delete → 404 "Balance adjustment '{id}' was not found."
+
+### F03. Bank Balance Calculation Engine
+
+**Consumes:**
+- F01: transfer records (source bank, destination bank, amount, date)
+- F02: balance adjustment records (bank, date, delta)
+
+**Provides:**
+- Per-bank computed balance as of a given date (used by F02, F05, F06)
+
+**Capabilities:**
+- Extends the existing `IBankService.GetBankBalancesByMonth` (and adds a companion `GetBankBalanceAsOf(bankName, date)` used internally by F02 to compute a new adjustment's delta) so the formula becomes:
+  `Balance = OpeningBalance + Σ Income.NetValue − Σ(Expense.Value − RoundUpAmount) + Σ Transfer.Amount (DestinationBank = this bank) − Σ Transfer.Amount (SourceBank = this bank) + Σ BalanceAdjustment.Delta`,
+  every sum scoped to `[Bank.OpeningBalanceDate, as-of date]` inclusive — the same date-window rule already applied to Income/Expense.
+- This is the single, sole place balance arithmetic is implemented across the whole product. No other backend service and no frontend code duplicates this formula, satisfying the requirement that all balance calculation happen exclusively on the backend.
+
+**Experience:**
+- No UI of its own. The existing `GET /banks/month/{year}/{month}/balances` endpoint and its `BankBalanceDTO { Bank, Balance }` shape are unchanged at the contract level — `Balance` simply now factors in transfers and adjustments in addition to income/expense.
+
+### F04. Web Transfer Entry Form
+
+**Consumes:**
+- F01: create/update/delete transfer endpoints, and the existing bank list for the source/destination pickers
+
+**Capabilities:**
+- New `TransferForm` React component: source bank dropdown (the 3 existing banks), destination bank dropdown (excludes whatever is currently selected as source), amount input (GBP, 2 decimal places), date picker (defaults to today), optional single-line note field.
+- Client-side validation is limited to required-field and source≠destination checks for immediate feedback; the backend (F01) remains the authoritative validator, and its error message is surfaced verbatim on a 400 response.
+
+**Experience:**
+- Opened via a "Move money" action on each bank row in F06's balances view.
+- On submit, calls `POST /transfers` (create) or `PUT /transfers/{id}` (edit); the submit button shows a loading state; on success the form closes and F06's balances and history refresh.
+- Edit mode pre-fills all fields from the selected transfer. Delete is triggered from F06's history list, not from this form.
+
+**Error Handling:**
+- Backend validation errors (unknown bank, same source/destination, amount ≤ 0) are displayed inline under the relevant field.
+- A network or save failure shows a retry-capable error banner; the form retains the user's entered values so nothing is lost.
+
+### F05. Web Balance Adjustment Entry Form
+
+**Consumes:**
+- F02: create/update/delete adjustment endpoints
+- F03: current computed balance for the selected bank, shown as reference before the user enters the target
+
+**Capabilities:**
+- New `BalanceAdjustmentForm` React component: read-only "Current calculated balance: £X" line sourced from the existing balances endpoint (never computed in the browser), target balance input (GBP, 2 decimal places, ≥ 0), date picker (defaults to today), optional note field.
+- After a successful save, displays the resulting delta (e.g. "Adjustment of −£4.20 recorded") using the value returned in the backend response, not a client-side calculation.
+
+**Experience:**
+- Opened via a "Correct balance" action on each bank row in F06's balances view.
+- Edit mode pre-fills `TargetBalance`, `Date`, and `Note`; the backend recomputes `Delta` on save.
+
+**Error Handling:**
+- Negative target balance and unknown-bank backend errors surface inline, matching F04's pattern.
+- A network or save failure shows a retry-capable error banner, preserving entered values.
+
+### F06. Web Bank Balances & History View
+
+**Consumes:**
+- F01: transfer records, for the per-bank history list
+- F02: balance adjustment records, for the per-bank history list
+- F03: computed balance per bank
+
+**Capabilities:**
+- Extends the existing `BanksGrid` component (`Financial.Web/src/components/BanksGrid.tsx`) on the Monthly → Summary subtab: each bank row gains "Move money" (opens F04) and "Correct balance" (opens F05) actions, plus an expandable history section listing that bank's transfers and adjustments in reverse-chronological order — each row shows date, type (Transfer In / Transfer Out / Adjustment), counterpart bank (for transfers) or delta (for adjustments), note, and edit/delete actions.
+- The balance figure shown per bank is rendered exactly as returned by the backend (F03) — the component performs no arithmetic on income, expense, transfer, or adjustment data.
+
+**Experience:**
+- The history list is scoped to the month currently selected in Monthly, consistent with how the Expense and Income lists already scope to month.
+- Deleting a history entry shows a confirmation dialog before calling the corresponding `DELETE` endpoint (F01 or F02), then refreshes both the balance and the list.
+
+**Error Handling:**
+- A load failure for balances or history shows a retry action rather than a silent blank state, consistent with existing `MonthlyPage` error handling.
+
+## 7. Out of Scope
+
+**Bank management**
+- Adding, renaming, or removing banks. There is still no bank management screen — consistent with the explicit exclusion in P13-F01 and P14-F02. Transfers and adjustments only work against the 3 existing banks (Barclays, Trading212, Chase).
+
+**Other frontends**
+- WPF desktop implementation. This PRD covers the React web app only; WPF parity is deferred to a future PRD.
+
+**Money handling**
+- Multi-currency or FX conversion on transfers — all 3 existing banks are single-currency GBP. The Controle Mãe BRL/GBP conversion flow is a separate, unrelated concern.
+- Overdraft blocking or balance-sufficiency validation on transfers — transfers are allowed unrestricted, matching the fact that no such check exists anywhere else in the domain today.
+- Transfers to or from the Reserva pool, credit cards, or investment accounts — those are separate existing flows/domains, not `Bank` entities, and are not touched by this PRD.
+
+**Reporting**
+- Category totals or Annual Summary visibility for transfers and adjustments — both stay a Monthly/bank-balance-only concern and never appear in category or annual reporting.
+
+**History and migration**
+- A "view all history" page beyond the currently selected month.
+- Bulk import of historical transfers/adjustments from the spreadsheet — a future migration-tool concern following the same pattern as prior spreadsheet-import PRDs, not addressed here.
+
+**Notifications**
+- Alerts or reminders when a bank's computed balance drifts from a previously entered adjustment.
+
+## 8. Dependency Graph
+
+| # | Feature | Priority | Dependencies |
+|---|---------|----------|--------------|
+| F01 | Bank Transfer Domain & API | 1 | None |
+| F02 | Balance Adjustment Domain & API | 1 | None |
+| F03 | Bank Balance Calculation Engine | 1 | F01, F02 |
+| F04 | Web Transfer Entry Form | 1 | F01 |
+| F05 | Web Balance Adjustment Entry Form | 1 | F02, F03 |
+| F06 | Web Bank Balances & History View | 1 | F01, F02, F03, F04, F05 |
+
+### Execution Waves
+Features within the same wave can be built in parallel. A wave starts only after every feature in earlier waves is complete.
+
+- **Wave 1**: F01, F02
+- **Wave 2**: F03, F04
+- **Wave 3**: F05
+- **Wave 4**: F06
+
+### Priority levels
+- **1** = Essential — product does not work without it
+- **2** = Important — significant value addition
+- **3** = Desirable — incremental improvement
+
+```mermaid
+graph TD
+  F01[Transfer API] --> F03[Balance Engine]
+  F02[Adjustment API] --> F03
+  F01 --> F04[Transfer Form]
+  F02 --> F05[Adjustment Form]
+  F03 --> F05
+  F01 --> F06[Balances View]
+  F02 --> F06
+  F03 --> F06
+  F04 --> F06
+  F05 --> F06
+```
+
+## 9. Acceptance Criteria
+
+### F01. Bank Transfer Domain & API
+- [ ] Creating a transfer with two distinct, existing banks, a positive amount, and a date succeeds and is retrievable via `GET /transfers/month/{year}/{month}`.
+- [ ] Creating a transfer with the same bank as source and destination fails with a 400 error.
+- [ ] Creating a transfer with an amount of 0 or less fails with a 400 error.
+- [ ] Creating a transfer with an unresolvable bank name fails with a 400 error.
+- [ ] Editing a transfer's amount, date, or note persists the change and is reflected on the next `GET`.
+- [ ] Deleting a transfer removes it from `data-cashflow.json` and from all subsequent `GET` responses.
+
+### F02. Balance Adjustment Domain & API
+- [ ] Creating a balance adjustment with a valid bank, non-negative target balance, and date succeeds and returns the computed `Delta`.
+- [ ] The returned `Delta` equals `TargetBalance` minus the balance computed by F03 as of the adjustment's date (excluding the new adjustment itself).
+- [ ] Creating an adjustment with a negative target balance fails with a 400 error.
+- [ ] Creating an adjustment with an unresolvable bank name fails with a 400 error.
+- [ ] Editing an adjustment's target balance or date recomputes and persists a new `Delta`.
+- [ ] Deleting an adjustment removes it and its `Delta` no longer contributes to that bank's computed balance.
+
+### F03. Bank Balance Calculation Engine
+- [ ] A transfer's amount is subtracted from the source bank's computed balance and added to the destination bank's computed balance, both for any as-of date on or after the transfer's date.
+- [ ] A balance adjustment's stored `Delta` is added to its bank's computed balance for any as-of date on or after the adjustment's date.
+- [ ] A transfer or adjustment dated after the requested as-of date has no effect on the computed balance for that request.
+- [ ] The computed balance for a bank with no transfers or adjustments in the period is unchanged from the pre-existing Income/Expense-only formula.
+
+### F04. Web Transfer Entry Form
+- [ ] Submitting the form with a valid source bank, destination bank, amount, and date creates a transfer visible in F06's history list.
+- [ ] Selecting the same bank for source and destination shows an inline validation error and blocks submission.
+- [ ] Editing an existing transfer via the form updates it, reflected in F06's balances and history after save.
+- [ ] A backend validation error (e.g. amount ≤ 0) is displayed inline under the amount field.
+
+### F05. Web Balance Adjustment Entry Form
+- [ ] Opening the form for a bank displays the current calculated balance exactly as returned by the backend.
+- [ ] Submitting a target balance creates an adjustment and displays the backend-returned delta, not a client-computed one.
+- [ ] Submitting a negative target balance shows an inline validation error and blocks submission.
+- [ ] Editing an existing adjustment's target balance updates its stored delta, reflected in F06 after save.
+
+### F06. Web Bank Balances & History View
+- [ ] Each bank row displays the balance figure exactly as returned by the balances endpoint, with no client-side recalculation.
+- [ ] The history section for a bank lists both transfers (in and out) and adjustments touching that bank, in reverse-chronological order.
+- [ ] Deleting a transfer or adjustment from the history list removes it after confirmation and refreshes the displayed balance.
+- [ ] Editing a transfer or adjustment from the history list opens the corresponding form (F04 or F05) pre-filled with its current values.
+
+### Cross-Feature Integration
+- [ ] A transfer created via F01 is included in F03's balance computation for both its source and destination banks.
+- [ ] A balance adjustment created via F02, whose delta depends on F03's computed balance as of its date, produces a delta that brings F03's subsequent computed balance to exactly the entered target balance.
+- [ ] A transfer created through F04 is persisted via F01 and appears correctly in F06's history list and balance display.
+- [ ] An adjustment created through F05, using F03's current-balance reference and F02's create endpoint, appears correctly in F06's history list and balance display.
+- [ ] F06's displayed balances and history are consistent with the raw data returned directly by F01, F02, and F03's endpoints (no divergence between what F06 shows and what the APIs return).

--- a/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/prd-bank-transfers-and-balance-reconciliation.md
+++ b/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/prd-bank-transfers-and-balance-reconciliation.md
@@ -266,12 +266,12 @@ graph TD
 ## 9. Acceptance Criteria
 
 ### F01. Bank Transfer Domain & API
-- [ ] Creating a transfer with two distinct, existing banks, a positive amount, and a date succeeds and is retrievable via `GET /transfers/month/{year}/{month}`.
-- [ ] Creating a transfer with the same bank as source and destination fails with a 400 error.
-- [ ] Creating a transfer with an amount of 0 or less fails with a 400 error.
-- [ ] Creating a transfer with an unresolvable bank name fails with a 400 error.
-- [ ] Editing a transfer's amount, date, or note persists the change and is reflected on the next `GET`.
-- [ ] Deleting a transfer removes it from `data-cashflow.json` and from all subsequent `GET` responses.
+- [x] Creating a transfer with two distinct, existing banks, a positive amount, and a date succeeds and is retrievable via `GET /transfers/month/{year}/{month}`.
+- [x] Creating a transfer with the same bank as source and destination fails with a 400 error.
+- [x] Creating a transfer with an amount of 0 or less fails with a 400 error.
+- [x] Creating a transfer with an unresolvable bank name fails with a 400 error.
+- [x] Editing a transfer's amount, date, or note persists the change and is reflected on the next `GET`.
+- [x] Deleting a transfer removes it from `data-cashflow.json` and from all subsequent `GET` responses.
 
 ### F02. Balance Adjustment Domain & API
 - [ ] Creating a balance adjustment with a valid bank, non-negative target balance, and date succeeds and returns the computed `Delta`.


### PR DESCRIPTION
## Summary
- Adds the `Transfer` domain entity (date, source bank, destination bank, amount, optional note) with self-validating same-bank and non-positive-amount checks, following the existing `Expense`/`Income` pattern.
- Adds the full CRUD contract: `ICashFlowRepository` additions, `TransferService`, DTOs, and a `TransfersController` (`POST`, `PUT`, `DELETE`, `GET /transfers/month/{year}/{month}`, `GET /transfers/bank/{name}`), mirroring `ExpensesController`'s status codes and error shape.
- No balance calculation or frontend UI yet — this is the domain/API foundation that F03 (balance engine), F04 (web form), and F06 (history view) will build on.

## Test plan
- [x] `dotnet test` across the full solution — all green (1,455 passed, 5 pre-existing skips unrelated to this change)
- [x] Creating a transfer with two distinct, existing banks, a positive amount, and a date succeeds and is retrievable via `GET /transfers/month/{year}/{month}`
- [x] Creating a transfer with the same bank as source and destination fails with a 400 error
- [x] Creating a transfer with an amount of 0 or less fails with a 400 error
- [x] Creating a transfer with an unresolvable bank name fails with a 400 error
- [x] Editing a transfer's amount, date, or note persists the change and is reflected on the next `GET`
- [x] Deleting a transfer removes it from `data-cashflow.json` and from all subsequent `GET` responses

Spec/plan: `docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F01-bank-transfer-domain-api/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)