### PR TITLE
test: consolidate ICashFlowRepository test stubs (DRY)

### DIFF
--- a/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -29,7 +29,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsForYear_ReturnsAllFourteenCategories()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetCategoryTotalsForYear(2026);
@@ -40,7 +40,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsForYear_AnnualTotalEqualsSumOfMonthlyTotals()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Jan", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 3, 5), "Mar", 50m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 12, 5), "Dec", 25m, Category.Mercado, "Barclays", null));
@@ -59,7 +59,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsForYear_ExcludesExpensesFromOtherYears()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Last year", 999m, Category.Mercado, "Barclays", null));
         var service = new AnnualSummaryService(repository);
 
@@ -71,7 +71,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsForYear_CategoryWithNoExpenses_ReturnsAllZeroMonthsAndZeroAnnualTotal()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetCategoryTotalsForYear(2026);
@@ -84,19 +84,19 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_CurrentYear_ReturnsAllElevenActiveAccounts()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(CurrentYear);
 
-        result.Accounts.Should().HaveCount(repository.Accounts.Count);
+        result.Accounts.Should().HaveCount(repository.InvestmentAccounts.Count);
     }
 
     [Fact]
     public void GetInvestmentAnnualResultForYear_CurrentYear_ExcludesDisabledAccounts()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Accounts.Add(InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false));
+        var repository = CreateRepository();
+        repository.InvestmentAccounts.Add(InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false));
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(CurrentYear);
@@ -107,8 +107,8 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_PastYear_ReturnsOnlyAccountsPresentThatYear()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 100m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 100m));
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(PastYear);
@@ -121,11 +121,11 @@ public class AnnualSummaryServiceTests
     {
         // Mirrors PRD P18 F04's named acceptance criterion: Resumo2023 is confirmed (from the
         // source spreadsheet inspection during PRD authoring) to contain exactly these 9 accounts.
-        var repository = new StubCashFlowRepository();
-        repository.Accounts.Add(InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false));
-        repository.Accounts.Add(InvestmentAccount.Create("HelpToBuyIsaGgs", isActive: false, isLiability: false));
-        repository.Accounts.Add(InvestmentAccount.Create("HelpToBuyIsaAacs", isActive: false, isLiability: false));
-        repository.Accounts.Add(InvestmentAccount.Create("ChipEasyAccess", isActive: false, isLiability: false));
+        var repository = CreateRepository();
+        repository.InvestmentAccounts.Add(InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false));
+        repository.InvestmentAccounts.Add(InvestmentAccount.Create("HelpToBuyIsaGgs", isActive: false, isLiability: false));
+        repository.InvestmentAccounts.Add(InvestmentAccount.Create("HelpToBuyIsaAacs", isActive: false, isLiability: false));
+        repository.InvestmentAccounts.Add(InvestmentAccount.Create("ChipEasyAccess", isActive: false, isLiability: false));
         string[] presentIn2023 =
         [
             "EverydaySaver", "BlueRewardsSaver", "PlatinumVisa8003", "PlatinumVisa6007",
@@ -133,7 +133,7 @@ public class AnnualSummaryServiceTests
         ];
         foreach (var name in presentIn2023)
         {
-            repository.Snapshots.Add(InvestmentSnapshot.Create(name, 2023, 1, 100m));
+            repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create(name, 2023, 1, 100m));
         }
         // Accounts NOT present in 2023 (e.g. opened later, like Trading212Invested) get no snapshot that year.
         var service = new AnnualSummaryService(repository);
@@ -146,10 +146,10 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_MonthlyDiffsEqualThisMonthMinusPrevMonth()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 1000m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 2, 1200m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 3, 1100m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 1000m));
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 2, 1200m));
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 3, 1100m));
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(CurrentYear);
@@ -167,8 +167,8 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_MissingSnapshotForAMonth_ContributesZero()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 500m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 500m));
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(CurrentYear);
@@ -181,9 +181,9 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_WithPriorYearData_JanuaryDiffEqualsJanuaryMinusPriorDecember()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear - 1, 12, 800m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear - 1, 12, 800m));
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(PastYear);
@@ -195,8 +195,8 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_NoPriorYearDataAtAll_JanuaryDiffIsNullForEveryAccountAndNetPosition()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(PastYear);
@@ -208,11 +208,11 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_AccountAbsentFromPriorYear_JanuaryDiffTreatsPriorDecemberAsZero()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         // Some other account has prior-year data, so PastYear - 1 is not "no data at all" - but
         // ChaseSave itself has no December snapshot that prior year.
-        repository.Snapshots.Add(InvestmentSnapshot.Create("PlatinumVisa8003", PastYear - 1, 12, 50m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 300m));
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("PlatinumVisa8003", PastYear - 1, 12, 50m));
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 300m));
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(PastYear);
@@ -224,11 +224,11 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_NetPositionJanuaryDiffEqualsSumOfAccountJanuaryDiffs()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear - 1, 12, 800m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("PlatinumVisa8003", PastYear - 1, 12, 100m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("PlatinumVisa8003", PastYear, 1, 150m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear - 1, 12, 800m));
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("PlatinumVisa8003", PastYear - 1, 12, 100m));
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("PlatinumVisa8003", PastYear, 1, 150m));
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(PastYear);
@@ -240,9 +240,9 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_NetPositionSubtractsLiabilitiesFromAssets()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 1000m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("PlatinumVisa8003", CurrentYear, 1, 300m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 1000m));
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("PlatinumVisa8003", CurrentYear, 1, 300m));
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(CurrentYear);
@@ -253,8 +253,8 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_NetPositionSumsOnlyScopedAccounts()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
         // PlatinumVisa8003 has no snapshot in PastYear, so it's out of scope and must not contribute.
         var service = new AnnualSummaryService(repository);
 
@@ -266,9 +266,9 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_PastYear_FullYearNetChangeEqualsDecemberMinusJanuary()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 12, 1800m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 1, 1000m));
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 12, 1800m));
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(PastYear);
@@ -279,17 +279,17 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_CurrentYear_FullYearNetChangeUsesCurrentMonthNotDecember()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var currentMonth = DateTime.Now.Month;
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 1000m));
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 1, 1000m));
         if (currentMonth != 1)
         {
-            repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, currentMonth, 1300m));
+            repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, currentMonth, 1300m));
         }
         if (currentMonth != 12)
         {
             // A December value exists but must NOT be used - it hasn't happened yet this year.
-            repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 12, 9999m));
+            repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, 12, 9999m));
         }
         var service = new AnnualSummaryService(repository);
 
@@ -302,12 +302,12 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_PastYear_AverageAndSumIncludeAllTwelveMonthsIncludingJanuary()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear - 1, 12, 800m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear - 1, 12, 800m));
         var value = 900m;
         for (var month = 1; month <= 12; month++)
         {
-            repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, month, value));
+            repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, month, value));
             value += 50m;
         }
         var service = new AnnualSummaryService(repository);
@@ -323,13 +323,13 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_CurrentYear_AverageAndSumOnlyIncludeMonthsThroughTheCurrentMonth()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear - 1, 12, 500m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear - 1, 12, 500m));
         var currentMonth = DateTime.Now.Month;
         var value = 600m;
         for (var month = 1; month <= currentMonth; month++)
         {
-            repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, month, value));
+            repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", CurrentYear, month, value));
             value += 50m;
         }
         // No snapshots for any month after the current one - they must not contribute a fake
@@ -346,7 +346,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetInvestmentAnnualResultForYear_NoAccountsOrSnapshots_ReturnsEmptyAccountsAndAllZeroNetPosition()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetInvestmentAnnualResultForYear(PastYear);
@@ -364,7 +364,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_SalaryRowSumsGleisonAndArianaGrossValuesPerMonth()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 1), IncomeSource.Gleison, 3200m, 2450m, "Barclays"));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 8), IncomeSource.Ariana, 400m, 350m, "Chase"));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 2, 1), IncomeSource.Gleison, 3300m, 2500m, "Barclays"));
@@ -380,7 +380,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_SalaryAfterTaxesRowSumsGleisonAndArianaNetValuesPerMonth()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 1), IncomeSource.Gleison, 3200m, 2450m, "Barclays"));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 8), IncomeSource.Ariana, 400m, 350m, "Chase"));
         var service = new AnnualSummaryService(repository);
@@ -394,7 +394,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_TaxDifferenceRowEqualsSalaryMinusSalaryAfterTaxes()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 1), IncomeSource.Gleison, 3200m, 2450m, "Barclays"));
         var service = new AnnualSummaryService(repository);
 
@@ -407,7 +407,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_DividendoJurosRowSumsOnlyThatSourcesNetValues()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 1), IncomeSource.DividendoJuros, null, 15.50m, "Trading212"));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 5), IncomeSource.DividendoJuros, null, 4.50m, "Trading212"));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 10), IncomeSource.Gleison, 3200m, 2450m, "Barclays"));
@@ -422,7 +422,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_LotteryEntriesContributeToNoRow()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 4, 1), IncomeSource.Lottery, null, 500m, "Chase"));
         var service = new AnnualSummaryService(repository);
 
@@ -439,7 +439,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_EntryWithNullGrossValue_ContributesZeroToSalary()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 5, 1), IncomeSource.Ariana, null, 350m, "Chase"));
         var service = new AnnualSummaryService(repository);
 
@@ -452,7 +452,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_ExcludesIncomeFromOtherYears()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 1), IncomeSource.Gleison, 3200m, 2450m, "Barclays"));
         var service = new AnnualSummaryService(repository);
 
@@ -464,7 +464,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_WithNoIncome_ReturnsAllZeros()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetIncomeSummaryForYear(2026);
@@ -481,7 +481,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsAnnualForYear_TotalDespesasMonthlyEqualsSumOfAllCategoriesPerMonth()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 2, 5), "Groceries", 50m, Category.Mercado, "Barclays", null));
@@ -500,7 +500,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsAnnualForYear_ResultadoMonthlyExcludesDividendoJurosAndIncludesInvestimento()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
@@ -517,7 +517,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsAnnualForYear_AnnualTotalsEqualSumOfMonthlyValues()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 6, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 3, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
@@ -532,7 +532,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsAnnualForYear_NoRecordedData_ReturnsAllZeroSeries()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
 
         var result = service.GetCategoryTotalsAnnualForYear(2026);
@@ -552,7 +552,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsAnnualForYear_NestedCategoryTotalsAndIncomeSummaryMatchStandaloneMethods()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
         var service = new AnnualSummaryService(repository);
@@ -566,7 +566,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_ReturnsEmptyList_WhenNoExpensesForSpecifiedYear()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2027, 4, 5), "Should not be there", 1000m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Jan", 100m, Category.Mercado, "Barclays", null));
@@ -579,7 +579,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_ReturnsYearsUpToAndIncludingSpecifiedYear()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2027, 4, 5), "Should not be there", 1000m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Jan", 100m, Category.Mercado, "Barclays", null));
@@ -592,7 +592,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_ReturnsTheYearsInOrderDescending()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Jan", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 3, 5), "Mar", 50m, Category.Mercado, "Barclays", null));
@@ -614,7 +614,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_AveragesCategoryValuesForFullYear()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Jan first", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 20), "Jan second", 100m, Category.Mercado, "Barclays", null));
@@ -630,7 +630,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_AveragesCategoryValuesFor2017Year()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2017, 1, 5), "Jan first", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2017, 1, 20), "Jan second", 100m, Category.Mercado, "Barclays", null));
@@ -647,7 +647,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_MergesIncomeAveragesIntoMatchingYearsInDescendingOrder()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(DateTime.UtcNow.Year + 1, 4, 5), "Should not be there", 10m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 4, 5), "2025", 10m, Category.Mercado, "Barclays", null));
@@ -671,7 +671,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_AveragesIncomePerMonthNotPerTransaction()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
 
         repository.Incomes.Add(Income.Create(new DateOnly(CurrentYear, PinnedNow.Month, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
@@ -700,7 +700,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_SumsIncomeSourcesPerMonthBeforeAveragingWhenActiveMonthsDiffer()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
         repository.Incomes.Add(Income.Create(new DateOnly(2025, 2, 5), IncomeSource.Gleison, 1000m, 1000m, "Barclays"));
@@ -717,7 +717,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_IncludesYearsWithIncomeButNoExpenses()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 5), IncomeSource.Gleison, 1200m, 600m, "Barclays"));
 
@@ -732,7 +732,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_ComputesTotalDespesasAsSumOfCategoryRowsOnly()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
@@ -749,7 +749,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_ComputesResultadoFromSalaryAfterTaxesTotalDespesasAndInvestimentoExcludingDividendoJuros()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
@@ -767,7 +767,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_LotteryIncomeContributesToNoRow()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Groceries", 120m, Category.Mercado, "Barclays", null));
         repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
@@ -787,7 +787,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_ZeroFillsCategoriesWithNoExpensesThatYear()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Groceries", 1200m, Category.Mercado, "Barclays", null));
 
@@ -804,7 +804,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_RowOrderMatchesCategoryTotalsFixedOrder()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 1, 5), IncomeSource.Gleison, 1000m, 800m, "Barclays"));
@@ -822,7 +822,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_ExcludesInProgressCurrentMonthFromCurrentYearAverage()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
         repository.Expenses.Add(Expense.Create(new DateOnly(CurrentYear, 1, 5), "Completed months", 100m * PinnedMonthsElapsed, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(PinnedToday, "In-progress month", 9999m, Category.Mercado, "Barclays", null));
@@ -845,7 +845,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetHistoricSummaryAverageFromYear_OmitsCurrentYearEntirelyWhenOnlyInProgressMonthIsRecorded()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
         repository.Expenses.Add(Expense.Create(PinnedToday, "In-progress month", 9999m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(CurrentYear - 1, 12, 5), "Prior year", 50m, Category.Mercado, "Barclays", null));
@@ -861,7 +861,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsForYear_AverageDividesByTwelveForAnOrdinaryYear()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Jan first", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 20), "Jan second", 100m, Category.Mercado, "Barclays", null));
@@ -875,7 +875,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsForYear_AverageDividesByElevenFor2017()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2017, 1, 5), "Jan first", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2017, 1, 20), "Jan second", 100m, Category.Mercado, "Barclays", null));
@@ -889,7 +889,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsForYear_AverageForCurrentYearExcludesInProgressMonth()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
         repository.Expenses.Add(Expense.Create(new DateOnly(CurrentYear, 1, 5), "Completed months", 100m * PinnedMonthsElapsed, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(PinnedToday, "In-progress month", 9999m, Category.Mercado, "Barclays", null));
@@ -904,7 +904,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_AveragesDivideByTwelveForAnOrdinaryYear()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Incomes.Add(Income.Create(new DateOnly(2025, 1, 5), IncomeSource.Gleison, 1200m, 600m, "Barclays"));
 
@@ -918,7 +918,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_AveragesDivideByElevenFor2017()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Incomes.Add(Income.Create(new DateOnly(2017, 1, 5), IncomeSource.Gleison, 1200m, 600m, "Barclays"));
 
@@ -932,7 +932,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetIncomeSummaryForYear_AveragesForCurrentYearExcludeInProgressMonth()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
         repository.Incomes.Add(Income.Create(new DateOnly(CurrentYear, 1, 5), IncomeSource.Gleison, 1000m * PinnedMonthsElapsed, 800m * PinnedMonthsElapsed, "Barclays"));
         repository.Incomes.Add(Income.Create(PinnedToday, IncomeSource.Gleison, 9999m * PinnedMonthsElapsed, 9999m * PinnedMonthsElapsed, "Barclays"));
@@ -946,7 +946,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsAnnualForYear_TotalDespesasAndResultadoAveragesDivideByTwelveForAnOrdinaryYear()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2025, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
@@ -965,7 +965,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsAnnualForYear_TotalDespesasAndResultadoAveragesDivideByElevenFor2017()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository);
         repository.Expenses.Add(Expense.Create(new DateOnly(2017, 1, 5), "Groceries", 100m, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(new DateOnly(2017, 1, 5), "Investing", 30m, Category.Investimento, "Barclays", null));
@@ -981,7 +981,7 @@ public class AnnualSummaryServiceTests
     [Fact]
     public void GetCategoryTotalsAnnualForYear_TotalDespesasAndResultadoAveragesForCurrentYearExcludeInProgressMonth()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new AnnualSummaryService(repository, new FakeTimeProvider(PinnedNow));
         repository.Expenses.Add(Expense.Create(new DateOnly(CurrentYear, 1, 5), "Completed months", 100m * PinnedMonthsElapsed, Category.Mercado, "Barclays", null));
         repository.Expenses.Add(Expense.Create(PinnedToday, "In-progress month", 9999m, Category.Mercado, "Barclays", null));
@@ -994,70 +994,26 @@ public class AnnualSummaryServiceTests
         result.ResultadoAverage.Should().Be(700m);
     }
 
-    private sealed class StubCashFlowRepository : ICashFlowRepository
+    private static readonly (string Name, bool IsLiability)[] SeededAccounts =
+    [
+        ("BlueRewardsSaver", false),
+        ("PlatinumVisa8003", true),
+        ("PlatinumVisa6007", true),
+        ("ChaseMaster4023", true),
+        ("BaAmex", true),
+        ("PaypalCredit", true),
+        ("ChipCashIsaGleison", false),
+        ("ChaseSave", false),
+        ("ChipCashIsaAriana", false),
+        ("Trading212Invested", false),
+        ("ReservasPessoais", true)
+    ];
+
+    private static StubCashFlowRepository CreateRepository()
     {
-        private static readonly (string Name, bool IsLiability)[] SeededAccounts =
-        [
-            ("BlueRewardsSaver", false),
-            ("PlatinumVisa8003", true),
-            ("PlatinumVisa6007", true),
-            ("ChaseMaster4023", true),
-            ("BaAmex", true),
-            ("PaypalCredit", true),
-            ("ChipCashIsaGleison", false),
-            ("ChaseSave", false),
-            ("ChipCashIsaAriana", false),
-            ("Trading212Invested", false),
-            ("ReservasPessoais", true)
-        ];
-
-        public List<Expense> Expenses { get; } = new();
-        public List<InvestmentSnapshot> Snapshots { get; } = new();
-        public List<InvestmentAccount> Accounts { get; } =
-            SeededAccounts.Select(a => InvestmentAccount.Create(a.Name, isActive: true, isLiability: a.IsLiability)).ToList();
-        public List<Income> Incomes { get; } = new();
-
-        public IEnumerable<Expense> GetExpenses() => Expenses;
-        public void AddExpense(Expense expense) => Expenses.Add(expense);
-        public void DeleteExpense(Guid id) { }
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
-        public void AddReserveMovement(ReserveMovement movement) { }
-        public void DeleteReserveMovement(Guid id) { }
-
-        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
-        public void AddCardStatement(CardStatement statement) { }
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
-        public void AddRecurringBill(RecurringBill bill) { }
-        public void DeleteRecurringBill(Guid id) { }
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
-        public void DeleteMaeLedgerEntry(Guid id) { }
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Snapshots;
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) => Snapshots.Add(snapshot);
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Accounts;
-        public void AddInvestmentAccount(InvestmentAccount account) => Accounts.Add(account);
-
-        public IEnumerable<Bank> GetBanks() => Array.Empty<Bank>();
-
-        public IEnumerable<Income> GetIncomes() => Incomes;
-        public void AddIncome(Income income) { }
-        public void DeleteIncome(Guid id) { }
-
-        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
-        public void AddTransfer(Transfer transfer) { }
-        public void UpdateTransfer(Transfer transfer) { }
-        public void DeleteTransfer(Guid id) { }
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => Array.Empty<BalanceAdjustment>();
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void DeleteBalanceAdjustment(Guid id) { }
-
-        public Task SaveChangesAsync() => Task.CompletedTask;
+        var repository = new StubCashFlowRepository();
+        repository.InvestmentAccounts.AddRange(
+            SeededAccounts.Select(a => InvestmentAccount.Create(a.Name, isActive: true, isLiability: a.IsLiability)));
+        return repository;
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/BalanceAdjustmentServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/BalanceAdjustmentServiceTests.cs
@@ -1,6 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Domain.Enums;
 using FluentAssertions;
@@ -20,7 +21,7 @@ public class BalanceAdjustmentServiceTests
     [Fact]
     public async Task AddAdjustmentAsync_WithNoPriorActivity_ComputesDeltaAgainstOpeningBalance()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         repository.SetOpeningBalance("Barclays", 100m, new DateOnly(2026, 1, 1));
         var service = new BalanceAdjustmentService(repository);
 
@@ -45,7 +46,7 @@ public class BalanceAdjustmentServiceTests
     [Fact]
     public async Task AddAdjustmentAsync_WithPriorIncomesAndExpenses_ComputesCorrectDelta()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         repository.SetOpeningBalance("Barclays", 100m, new DateOnly(2026, 1, 1));
         repository.Incomes.Add(Income.Create(new DateOnly(2026, 7, 1), IncomeSource.Lottery, null, 200m, "Barclays"));
         repository.Expenses.Add(Expense.Create(new DateOnly(2026, 7, 5), "Groceries", 50m, Category.Mercado, "Barclays", null));
@@ -64,7 +65,7 @@ public class BalanceAdjustmentServiceTests
     [Fact]
     public async Task AddAdjustmentAsync_WithExistingAdjustmentForSameBank_StacksDelta()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         repository.SetOpeningBalance("Barclays", 100m, new DateOnly(2026, 1, 1));
         var service = new BalanceAdjustmentService(repository);
         var first = await service.AddAdjustmentAsync("Barclays", new BalanceAdjustmentCreateDTO
@@ -87,7 +88,7 @@ public class BalanceAdjustmentServiceTests
     [Fact]
     public async Task AddAdjustmentAsync_WithUnresolvableBank_ThrowsArgumentException()
     {
-        var service = new BalanceAdjustmentService(new StubCashFlowRepository());
+        var service = new BalanceAdjustmentService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var act = async () => await service.AddAdjustmentAsync("NotABank", new BalanceAdjustmentCreateDTO
         {
@@ -101,7 +102,7 @@ public class BalanceAdjustmentServiceTests
     [Fact]
     public async Task AddAdjustmentAsync_WithNegativeTargetBalance_ThrowsArgumentException()
     {
-        var service = new BalanceAdjustmentService(new StubCashFlowRepository());
+        var service = new BalanceAdjustmentService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var act = async () => await service.AddAdjustmentAsync("Barclays", new BalanceAdjustmentCreateDTO
         {
@@ -115,7 +116,7 @@ public class BalanceAdjustmentServiceTests
     [Fact]
     public async Task UpdateAdjustmentAsync_WithExistingId_RecomputesAndPersistsDelta()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         repository.SetOpeningBalance("Barclays", 100m, new DateOnly(2026, 1, 1));
         var service = new BalanceAdjustmentService(repository);
         var added = await service.AddAdjustmentAsync("Barclays", new BalanceAdjustmentCreateDTO
@@ -146,7 +147,7 @@ public class BalanceAdjustmentServiceTests
     [Fact]
     public async Task UpdateAdjustmentAsync_WithUnknownId_ThrowsKeyNotFoundException()
     {
-        var service = new BalanceAdjustmentService(new StubCashFlowRepository());
+        var service = new BalanceAdjustmentService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var act = async () => await service.UpdateAdjustmentAsync("Barclays", Guid.NewGuid(), new BalanceAdjustmentUpdateDTO
         {
@@ -160,7 +161,7 @@ public class BalanceAdjustmentServiceTests
     [Fact]
     public async Task DeleteAdjustmentAsync_WithExistingId_RemovesAndSaves()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         repository.SetOpeningBalance("Barclays", 100m, new DateOnly(2026, 1, 1));
         var service = new BalanceAdjustmentService(repository);
         var added = await service.AddAdjustmentAsync("Barclays", new BalanceAdjustmentCreateDTO
@@ -178,7 +179,7 @@ public class BalanceAdjustmentServiceTests
     [Fact]
     public async Task DeleteAdjustmentAsync_WithUnknownId_ThrowsKeyNotFoundException()
     {
-        var service = new BalanceAdjustmentService(new StubCashFlowRepository());
+        var service = new BalanceAdjustmentService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var act = async () => await service.DeleteAdjustmentAsync("Barclays", Guid.NewGuid());
 
@@ -188,7 +189,7 @@ public class BalanceAdjustmentServiceTests
     [Fact]
     public async Task GetAdjustmentsByBank_ReturnsOnlyThatBanksAdjustments()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         repository.SetOpeningBalance("Barclays", 100m, new DateOnly(2026, 1, 1));
         repository.SetOpeningBalance("Chase", 100m, new DateOnly(2026, 1, 1));
         var service = new BalanceAdjustmentService(repository);
@@ -203,81 +204,10 @@ public class BalanceAdjustmentServiceTests
     [Fact]
     public void GetAdjustmentsByBank_WithUnrecognizedBank_ReturnsEmptyList()
     {
-        var service = new BalanceAdjustmentService(new StubCashFlowRepository());
+        var service = new BalanceAdjustmentService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var result = service.GetAdjustmentsByBank("NotABank");
 
         result.Should().BeEmpty();
-    }
-
-    private sealed class StubCashFlowRepository : ICashFlowRepository
-    {
-        public List<BalanceAdjustment> BalanceAdjustments { get; } = new();
-        public List<Income> Incomes { get; } = new();
-        public List<Expense> Expenses { get; } = new();
-        public List<Bank> Banks { get; } = new()
-        {
-            Bank.Create("Barclays", roundUpEnabled: false),
-            Bank.Create("Trading212", roundUpEnabled: true),
-            Bank.Create("Chase", roundUpEnabled: true)
-        };
-        public int SaveChangesCallCount { get; private set; }
-
-        public void SetOpeningBalance(string bankName, decimal openingBalance, DateOnly openingBalanceDate) =>
-            Banks.First(b => b.Name == bankName).SetOpeningBalance(openingBalance, openingBalanceDate);
-
-        public IEnumerable<Expense> GetExpenses() => Expenses;
-        public void AddExpense(Expense expense) { }
-        public void DeleteExpense(Guid id) { }
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
-        public void AddReserveMovement(ReserveMovement movement) { }
-        public void DeleteReserveMovement(Guid id) { }
-
-        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
-        public void AddCardStatement(CardStatement statement) { }
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
-        public void AddRecurringBill(RecurringBill bill) { }
-        public void DeleteRecurringBill(Guid id) { }
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
-        public void DeleteMaeLedgerEntry(Guid id) { }
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Array.Empty<InvestmentAccount>();
-        public void AddInvestmentAccount(InvestmentAccount account) { }
-
-        public IEnumerable<Bank> GetBanks() => Banks;
-
-        public IEnumerable<Income> GetIncomes() => Incomes;
-        public void AddIncome(Income income) { }
-        public void DeleteIncome(Guid id) { }
-
-        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
-        public void AddTransfer(Transfer transfer) { }
-        public void UpdateTransfer(Transfer transfer) { }
-        public void DeleteTransfer(Guid id) { }
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => BalanceAdjustments;
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) => BalanceAdjustments.Add(adjustment);
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment)
-        {
-            var index = BalanceAdjustments.FindIndex(a => a.Id == adjustment.Id);
-            if (index >= 0)
-            {
-                BalanceAdjustments[index] = adjustment;
-            }
-        }
-        public void DeleteBalanceAdjustment(Guid id) => BalanceAdjustments.RemoveAll(a => a.Id == id);
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            return Task.CompletedTask;
-        }
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/BankServiceTests.cs
@@ -1,6 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Domain.Enums;
 using FluentAssertions;
@@ -194,58 +195,4 @@ public class BankServiceTests
         result.Should().ContainSingle(b => b.Bank == "Barclays" && b.Balance == 0m);
     }
 
-    private sealed class StubCashFlowRepository : ICashFlowRepository
-    {
-        public List<Bank> Banks { get; } = new();
-        public List<Expense> Expenses { get; } = new();
-        public List<Income> Incomes { get; } = new();
-        public int SaveChangesCallCount { get; private set; }
-
-        public IEnumerable<Expense> GetExpenses() => Expenses;
-        public void AddExpense(Expense expense) { }
-        public void DeleteExpense(Guid id) { }
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
-        public void AddReserveMovement(ReserveMovement movement) { }
-        public void DeleteReserveMovement(Guid id) { }
-
-        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
-        public void AddCardStatement(CardStatement statement) { }
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
-        public void AddRecurringBill(RecurringBill bill) { }
-        public void DeleteRecurringBill(Guid id) { }
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
-        public void DeleteMaeLedgerEntry(Guid id) { }
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Array.Empty<InvestmentAccount>();
-        public void AddInvestmentAccount(InvestmentAccount account) { }
-
-        public IEnumerable<Bank> GetBanks() => Banks;
-
-        public IEnumerable<Income> GetIncomes() => Incomes;
-        public void AddIncome(Income income) { }
-        public void DeleteIncome(Guid id) { }
-
-        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
-        public void AddTransfer(Transfer transfer) { }
-        public void UpdateTransfer(Transfer transfer) { }
-        public void DeleteTransfer(Guid id) { }
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => Array.Empty<BalanceAdjustment>();
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void DeleteBalanceAdjustment(Guid id) { }
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            return Task.CompletedTask;
-        }
-    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/CardStatementServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/CardStatementServiceTests.cs
@@ -1,6 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Domain.Enums;
 using FluentAssertions;
@@ -30,7 +31,7 @@ public class CardStatementServiceTests
     [Fact]
     public async Task GetStatementsForMonthAsync_FirstCall_GeneratesExactlyFiveUnpaidStatements()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new CardStatementService(repository);
 
         var result = await service.GetStatementsForMonthAsync(2026, 7);
@@ -39,14 +40,14 @@ public class CardStatementServiceTests
         {
             result.Should().HaveCount(5);
             result.Should().OnlyContain(s => !s.IsPaid);
-            repository.Statements.Should().HaveCount(5);
+            repository.CardStatements.Should().HaveCount(5);
         }
     }
 
     [Fact]
     public async Task GetStatementsForMonthAsync_SecondCallSameMonth_DoesNotCreateDuplicates()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new CardStatementService(repository);
 
         await service.GetStatementsForMonthAsync(2026, 7);
@@ -55,7 +56,7 @@ public class CardStatementServiceTests
         using (new AssertionScope())
         {
             result.Should().HaveCount(5);
-            repository.Statements.Should().HaveCount(5);
+            repository.CardStatements.Should().HaveCount(5);
             repository.SaveChangesCallCount.Should().Be(1);
         }
     }
@@ -63,7 +64,7 @@ public class CardStatementServiceTests
     [Fact]
     public async Task GetStatementsForMonthAsync_OutstandingTotalSumsThatMonthsChargesForTheCard()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
         AddCharge(repository, new DateOnly(2026, 7, 15), 20m, CreditCard.BarclaysPlatinumVisa8003);
         AddCharge(repository, new DateOnly(2026, 8, 1), 100m, CreditCard.BarclaysPlatinumVisa8003);
@@ -78,7 +79,7 @@ public class CardStatementServiceTests
     [Fact]
     public async Task GetStatementsForMonthAsync_ExcludesSettledAndImmediateExpensesFromOutstandingTotal()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var settled = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
         settled.Settle("Barclays", new DateOnly(2026, 7, 20));
         AddCharge(repository, new DateOnly(2026, 7, 11), 20m, CreditCard.BarclaysPlatinumVisa8003);
@@ -93,14 +94,14 @@ public class CardStatementServiceTests
     [Fact]
     public async Task MarkStatementPaidAsync_SettlesEveryChargeForTheCardMonthWithBankAndToday()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var first = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
         var second = AddCharge(repository, new DateOnly(2026, 7, 15), 20m, CreditCard.BarclaysPlatinumVisa8003);
         var otherMonth = AddCharge(repository, new DateOnly(2026, 8, 1), 100m, CreditCard.BarclaysPlatinumVisa8003);
         var otherCard = AddCharge(repository, new DateOnly(2026, 7, 12), 999m, CreditCard.BaAmex);
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
-        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003 && s.Month == 7);
+        var statement = repository.CardStatements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003 && s.Month == 7);
 
         var result = await service.MarkStatementPaidAsync(statement.Id, PaidBy("Trading212"));
 
@@ -127,11 +128,11 @@ public class CardStatementServiceTests
     [InlineData("NotABank")]
     public async Task MarkStatementPaidAsync_WithMissingOrUnknownPaymentSource_ThrowsWithoutChangingState(string? paymentSource)
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var charge = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
-        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
+        var statement = repository.CardStatements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
         var savesBefore = repository.SaveChangesCallCount;
 
         var act = async () => await service.MarkStatementPaidAsync(statement.Id, PaidBy(paymentSource));
@@ -148,10 +149,10 @@ public class CardStatementServiceTests
     [Fact]
     public async Task MarkStatementPaidAsync_CalledAgainOnAlreadyPaidStatement_IsANoOpThatStillSucceeds()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
-        var statement = repository.Statements.First();
+        var statement = repository.CardStatements.First();
         await service.MarkStatementPaidAsync(statement.Id, PaidBy("Barclays"));
         var savesBefore = repository.SaveChangesCallCount;
 
@@ -164,11 +165,11 @@ public class CardStatementServiceTests
     [Fact]
     public async Task MarkStatementPaidAsync_WhenSaveFails_RollsBackStatementAndCascadedExpenses()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var charge = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
-        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
+        var statement = repository.CardStatements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
         repository.ThrowOnNextSave = true;
 
         var act = async () => await service.MarkStatementPaidAsync(statement.Id, PaidBy("Barclays"));
@@ -186,7 +187,7 @@ public class CardStatementServiceTests
     [Fact]
     public async Task MarkStatementPaidAsync_WithUnknownId_ThrowsKeyNotFoundException()
     {
-        var service = new CardStatementService(new StubCashFlowRepository());
+        var service = new CardStatementService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var act = async () => await service.MarkStatementPaidAsync(Guid.NewGuid(), PaidBy("Barclays"));
 
@@ -196,12 +197,12 @@ public class CardStatementServiceTests
     [Fact]
     public async Task UnmarkStatementPaidAsync_RevertsEverySettledExpenseForTheCardMonth()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var first = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
         var second = AddCharge(repository, new DateOnly(2026, 7, 15), 20m, CreditCard.BarclaysPlatinumVisa8003);
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
-        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
+        var statement = repository.CardStatements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
         await service.MarkStatementPaidAsync(statement.Id, PaidBy("Barclays"));
 
         var result = await service.UnmarkStatementPaidAsync(statement.Id);
@@ -222,10 +223,10 @@ public class CardStatementServiceTests
     [Fact]
     public async Task UnmarkStatementPaidAsync_OnAlreadyUnpaidStatement_IsANoOpThatStillSucceeds()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
-        var statement = repository.Statements.First();
+        var statement = repository.CardStatements.First();
         var savesBefore = repository.SaveChangesCallCount;
 
         var result = await service.UnmarkStatementPaidAsync(statement.Id);
@@ -237,10 +238,10 @@ public class CardStatementServiceTests
     [Fact]
     public async Task UnmarkStatementPaidAsync_WithNoSettledExpenses_StillFlipsStatementToUnpaid()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
-        var statement = repository.Statements.First();
+        var statement = repository.CardStatements.First();
         await service.MarkStatementPaidAsync(statement.Id, PaidBy("Barclays"));
 
         var result = await service.UnmarkStatementPaidAsync(statement.Id);
@@ -252,11 +253,11 @@ public class CardStatementServiceTests
     [Fact]
     public async Task UnmarkStatementPaidAsync_WhenSaveFails_RollsBackStatementAndCascadedExpenses()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var charge = AddCharge(repository, new DateOnly(2026, 7, 10), 30m, CreditCard.BarclaysPlatinumVisa8003);
         var service = new CardStatementService(repository);
         await service.GetStatementsForMonthAsync(2026, 7);
-        var statement = repository.Statements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
+        var statement = repository.CardStatements.Single(s => s.Card == CreditCard.BarclaysPlatinumVisa8003);
         await service.MarkStatementPaidAsync(statement.Id, PaidBy("Trading212"));
         var settledAt = charge.SettledAt;
         repository.ThrowOnNextSave = true;
@@ -276,77 +277,11 @@ public class CardStatementServiceTests
     [Fact]
     public async Task UnmarkStatementPaidAsync_WithUnknownId_ThrowsKeyNotFoundException()
     {
-        var service = new CardStatementService(new StubCashFlowRepository());
+        var service = new CardStatementService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var act = async () => await service.UnmarkStatementPaidAsync(Guid.NewGuid());
 
         await act.Should().ThrowAsync<KeyNotFoundException>();
     }
 
-    private sealed class StubCashFlowRepository : ICashFlowRepository
-    {
-        public List<CardStatement> Statements { get; } = new();
-        public List<Expense> Expenses { get; } = new();
-        public List<Bank> Banks { get; } = new()
-        {
-            Bank.Create("Barclays", roundUpEnabled: false),
-            Bank.Create("Trading212", roundUpEnabled: true),
-            Bank.Create("Chase", roundUpEnabled: true)
-        };
-        public int SaveChangesCallCount { get; private set; }
-        public bool ThrowOnNextSave { get; set; }
-
-        public IEnumerable<Expense> GetExpenses() => Expenses;
-        public void AddExpense(Expense expense) => Expenses.Add(expense);
-        public void DeleteExpense(Guid id) { }
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
-        public void AddReserveMovement(ReserveMovement movement) { }
-        public void DeleteReserveMovement(Guid id) { }
-
-        public IEnumerable<CardStatement> GetCardStatements() => Statements;
-        public void AddCardStatement(CardStatement statement) => Statements.Add(statement);
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
-        public void AddRecurringBill(RecurringBill bill) { }
-        public void DeleteRecurringBill(Guid id) { }
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
-        public void DeleteMaeLedgerEntry(Guid id) { }
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Array.Empty<InvestmentAccount>();
-        public void AddInvestmentAccount(InvestmentAccount account) { }
-
-        public IEnumerable<Bank> GetBanks() => Banks;
-
-        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
-        public void AddIncome(Income income) { }
-        public void DeleteIncome(Guid id) { }
-
-        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
-        public void AddTransfer(Transfer transfer) { }
-        public void UpdateTransfer(Transfer transfer) { }
-        public void DeleteTransfer(Guid id) { }
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => Array.Empty<BalanceAdjustment>();
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void DeleteBalanceAdjustment(Guid id) { }
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            if (ThrowOnNextSave)
-            {
-                ThrowOnNextSave = false;
-                throw new InvalidOperationException("Simulated save failure.");
-            }
-
-            return Task.CompletedTask;
-        }
-    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ControleMaeServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ControleMaeServiceTests.cs
@@ -1,6 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Domain.Enums;
 using FluentAssertions;
@@ -44,7 +45,7 @@ public class ControleMaeServiceTests
         {
             result.BrlValue.Should().Be(350m);
             result.GbpValue.Should().Be(51.1m);
-            repository.Entries.Should().ContainSingle();
+            repository.MaeLedgerEntries.Should().ContainSingle();
             repository.SaveChangesCallCount.Should().Be(1);
         }
     }
@@ -68,7 +69,7 @@ public class ControleMaeServiceTests
         {
             result.GbpValue.Should().Be(40m);
             result.BrlValue.Should().BeNull();
-            repository.Entries.Should().ContainSingle();
+            repository.MaeLedgerEntries.Should().ContainSingle();
         }
     }
 
@@ -91,7 +92,7 @@ public class ControleMaeServiceTests
         using (new AssertionScope())
         {
             await act.Should().ThrowAsync<ArgumentException>();
-            repository.Entries.Should().BeEmpty();
+            repository.MaeLedgerEntries.Should().BeEmpty();
             provider.CallCount.Should().Be(0);
         }
     }
@@ -148,9 +149,9 @@ public class ControleMaeServiceTests
     public void GetEntriesFromDate_ReturnsOnlyEntriesOnOrAfterDate()
     {
         var repository = new StubCashFlowRepository();
-        repository.Entries.Add(MaeLedgerEntry.Create(new DateOnly(2026, 6, 30), "Before", string.Empty, Currency.BRL, 10m, 1m));
-        repository.Entries.Add(MaeLedgerEntry.Create(new DateOnly(2026, 7, 1), "OnDate", string.Empty, Currency.BRL, 10m, 1m));
-        repository.Entries.Add(MaeLedgerEntry.Create(new DateOnly(2026, 8, 10), "After", string.Empty, Currency.BRL, 10m, 1m));
+        repository.MaeLedgerEntries.Add(MaeLedgerEntry.Create(new DateOnly(2026, 6, 30), "Before", string.Empty, Currency.BRL, 10m, 1m));
+        repository.MaeLedgerEntries.Add(MaeLedgerEntry.Create(new DateOnly(2026, 7, 1), "OnDate", string.Empty, Currency.BRL, 10m, 1m));
+        repository.MaeLedgerEntries.Add(MaeLedgerEntry.Create(new DateOnly(2026, 8, 10), "After", string.Empty, Currency.BRL, 10m, 1m));
         var service = new ControleMaeService(repository, new StubExchangeRateProvider(1.5m));
 
         var result = service.GetEntriesFromDate(new DateOnly(2026, 7, 1));
@@ -163,8 +164,8 @@ public class ControleMaeServiceTests
     public void GetTotals_SumsBrlAndGbpAcrossAllEntriesRegardlessOfDate()
     {
         var repository = new StubCashFlowRepository();
-        repository.Entries.Add(MaeLedgerEntry.Create(new DateOnly(2020, 1, 1), "Old", string.Empty, Currency.BRL, 100m, 10m));
-        repository.Entries.Add(MaeLedgerEntry.Create(new DateOnly(2026, 7, 10), "Recent", string.Empty, Currency.GBP, null, 5m));
+        repository.MaeLedgerEntries.Add(MaeLedgerEntry.Create(new DateOnly(2020, 1, 1), "Old", string.Empty, Currency.BRL, 100m, 10m));
+        repository.MaeLedgerEntries.Add(MaeLedgerEntry.Create(new DateOnly(2026, 7, 10), "Recent", string.Empty, Currency.GBP, null, 5m));
         var service = new ControleMaeService(repository, new StubExchangeRateProvider(1.5m));
 
         var result = service.GetTotals();
@@ -178,7 +179,7 @@ public class ControleMaeServiceTests
     {
         var repository = new StubCashFlowRepository();
         var entry = MaeLedgerEntry.Create(new DateOnly(2026, 7, 1), "Medical appointment", "Note", Currency.GBP, null, 40m);
-        repository.Entries.Add(entry);
+        repository.MaeLedgerEntries.Add(entry);
         var service = new ControleMaeService(repository, new StubExchangeRateProvider(1.5m));
 
         var result = await service.UpdateEntryValuesAsync(entry.Id, new UpdateMaeLedgerEntryValuesDTO
@@ -216,12 +217,12 @@ public class ControleMaeServiceTests
     {
         var repository = new StubCashFlowRepository();
         var entry = MaeLedgerEntry.Create(new DateOnly(2026, 7, 1), "School supplies", string.Empty, Currency.BRL, 350m, 51.1m);
-        repository.Entries.Add(entry);
+        repository.MaeLedgerEntries.Add(entry);
         var service = new ControleMaeService(repository, new StubExchangeRateProvider(1.5m));
 
         await service.DeleteEntryAsync(entry.Id);
 
-        repository.Entries.Should().BeEmpty();
+        repository.MaeLedgerEntries.Should().BeEmpty();
         repository.SaveChangesCallCount.Should().Be(1);
     }
 
@@ -253,56 +254,4 @@ public class ControleMaeServiceTests
         }
     }
 
-    private sealed class StubCashFlowRepository : ICashFlowRepository
-    {
-        public List<MaeLedgerEntry> Entries { get; } = new();
-        public int SaveChangesCallCount { get; private set; }
-
-        public IEnumerable<Expense> GetExpenses() => Array.Empty<Expense>();
-        public void AddExpense(Expense expense) { }
-        public void DeleteExpense(Guid id) { }
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
-        public void AddReserveMovement(ReserveMovement movement) { }
-        public void DeleteReserveMovement(Guid id) { }
-
-        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
-        public void AddCardStatement(CardStatement statement) { }
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
-        public void AddRecurringBill(RecurringBill bill) { }
-        public void DeleteRecurringBill(Guid id) { }
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Entries;
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) => Entries.Add(entry);
-        public void DeleteMaeLedgerEntry(Guid id) => Entries.RemoveAll(e => e.Id == id);
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Array.Empty<InvestmentAccount>();
-        public void AddInvestmentAccount(InvestmentAccount account) { }
-
-        public IEnumerable<Bank> GetBanks() => Array.Empty<Bank>();
-
-        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
-        public void AddIncome(Income income) { }
-        public void DeleteIncome(Guid id) { }
-
-        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
-        public void AddTransfer(Transfer transfer) { }
-        public void UpdateTransfer(Transfer transfer) { }
-        public void DeleteTransfer(Guid id) { }
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => Array.Empty<BalanceAdjustment>();
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void DeleteBalanceAdjustment(Guid id) { }
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            return Task.CompletedTask;
-        }
-    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ExpenseServiceTests.cs
@@ -1,6 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -19,7 +20,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithValidRequest_SavesAndReturnsExpense()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new ExpenseService(repository);
         var request = ToCreateDto(ValidCreateRequest());
 
@@ -42,7 +43,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithCardTagAndNoPaymentSource_SavesAsCreditCardCharge()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new ExpenseService(repository);
         var request = ValidCreateRequest() with { PaymentSource = null, CardTag = "BarclaysPlatinumVisa8003" };
 
@@ -60,7 +61,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithNeitherPaymentSourceNorCardTag_ThrowsArgumentException()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = null, CardTag = null });
 
         var act = async () => await service.AddExpenseAsync(request);
@@ -71,7 +72,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithBothPaymentSourceAndCardTag_ThrowsArgumentException()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { CardTag = "BarclaysPlatinumVisa8003" });
 
         var act = async () => await service.AddExpenseAsync(request);
@@ -82,7 +83,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task UpdateExpenseAsync_WithBothPaymentSourceAndCardTag_ThrowsArgumentException()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new ExpenseService(repository);
         var added = await service.AddExpenseAsync(ToCreateDto(ValidCreateRequest()));
         var updateRequest = ToUpdateDto(ValidCreateRequest() with { CardTag = "BaAmex" });
@@ -95,7 +96,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithZeroValue_ThrowsArgumentException()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { Value = 0m });
 
         var act = async () => await service.AddExpenseAsync(request);
@@ -106,7 +107,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithMissingCategory_ThrowsArgumentException()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { Category = "NotACategory" });
 
         var act = async () => await service.AddExpenseAsync(request);
@@ -117,7 +118,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithInvalidPaymentSource_ThrowsArgumentException()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "NotASource" });
 
         var act = async () => await service.AddExpenseAsync(request);
@@ -128,7 +129,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithInvalidCardTag_ThrowsArgumentException()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { CardTag = "NotACard" });
 
         var act = async () => await service.AddExpenseAsync(request);
@@ -139,7 +140,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithBlankDescription_ThrowsArgumentException()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { Description = "  " });
 
         var act = async () => await service.AddExpenseAsync(request);
@@ -150,7 +151,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithDescriptionOver200Characters_ThrowsArgumentException()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { Description = new string('a', 201) });
 
         var act = async () => await service.AddExpenseAsync(request);
@@ -161,7 +162,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task UpdateExpenseAsync_WithExistingId_UpdatesInPlace()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new ExpenseService(repository);
         var added = await service.AddExpenseAsync(ToCreateDto(ValidCreateRequest()));
 
@@ -189,7 +190,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task UpdateExpenseAsync_WithUnknownId_ThrowsKeyNotFoundException()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var updateRequest = ToUpdateDto(ValidCreateRequest());
 
         var act = async () => await service.UpdateExpenseAsync(Guid.NewGuid(), updateRequest);
@@ -200,7 +201,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task DeleteExpenseAsync_WithExistingId_RemovesAndSaves()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new ExpenseService(repository);
         var added = await service.AddExpenseAsync(ToCreateDto(ValidCreateRequest()));
 
@@ -213,7 +214,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task DeleteExpenseAsync_WithUnknownId_ThrowsKeyNotFoundException()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var act = async () => await service.DeleteExpenseAsync(Guid.NewGuid());
 
@@ -223,7 +224,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task GetExpensesByMonth_ReturnsOnlyExpensesInThatMonth()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new ExpenseService(repository);
         await service.AddExpenseAsync(ToCreateDto(ValidCreateRequest() with { Date = new DateOnly(2026, 7, 10) }));
         await service.AddExpenseAsync(ToCreateDto(ValidCreateRequest() with { Date = new DateOnly(2026, 8, 10) }));
@@ -236,7 +237,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task GetCategoryTotalsByMonth_SumsValuesPerCategoryForThatMonth()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new ExpenseService(repository);
         await service.AddExpenseAsync(ToCreateDto(ValidCreateRequest() with { Category = "Mercado", Value = 10m }));
         await service.AddExpenseAsync(ToCreateDto(ValidCreateRequest() with { Category = "Mercado", Value = 5m }));
@@ -255,7 +256,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task GetCategoryTotalsByMonth_NegativeValue_CountsTowardTotal()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new ExpenseService(repository);
         await service.AddExpenseAsync(ToCreateDto(ValidCreateRequest() with { Category = "Reserva", Value = 100m }));
         await service.AddExpenseAsync(ToCreateDto(ValidCreateRequest() with { Category = "Reserva", Value = -30m }));
@@ -268,7 +269,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithRoundUpAmountOnRoundUpEnabledBank_SavesAmount()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Trading212", Value = 9.40m, RoundUpAmount = 0.60m });
 
         var result = await service.AddExpenseAsync(request);
@@ -279,7 +280,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithRoundUpAmountOfZero_SavesExplicitZero()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Trading212", Value = 10.00m, RoundUpAmount = 0.00m });
 
         var result = await service.AddExpenseAsync(request);
@@ -290,7 +291,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithRoundUpAmountOnNonRoundUpBank_ThrowsNamingTheBank()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Barclays", RoundUpAmount = 0.50m });
 
         var act = async () => await service.AddExpenseAsync(request);
@@ -301,7 +302,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_WithRoundUpAmountOnCreditCardTaggedExpense_Throws()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = null, CardTag = "ChaseMaster4023", RoundUpAmount = 0.50m });
 
         var act = async () => await service.AddExpenseAsync(request);
@@ -314,7 +315,7 @@ public class ExpenseServiceTests
     [InlineData(1.00)]
     public async Task AddExpenseAsync_WithRoundUpAmountOutsideRange_Throws(decimal roundUpAmount)
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Chase", RoundUpAmount = roundUpAmount });
 
         var act = async () => await service.AddExpenseAsync(request);
@@ -325,7 +326,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_EligibleWithNoRoundUpAmount_ReturnsSuggestedAmount()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Trading212", Value = 9.40m });
 
         var result = await service.AddExpenseAsync(request);
@@ -337,7 +338,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_EligibleWithRoundUpAmountAlreadySaved_ReturnsNoSuggestion()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Trading212", Value = 9.40m, RoundUpAmount = 0.60m });
 
         var result = await service.AddExpenseAsync(request);
@@ -348,7 +349,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_OnNonRoundUpBank_ReturnsNoSuggestion()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = "Barclays", Value = 9.40m });
 
         var result = await service.AddExpenseAsync(request);
@@ -359,7 +360,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task AddExpenseAsync_CreditCardCharge_ReturnsNoSuggestion()
     {
-        var service = new ExpenseService(new StubCashFlowRepository());
+        var service = new ExpenseService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { PaymentSource = null, CardTag = "ChaseMaster4023", Value = 9.40m });
 
         var result = await service.AddExpenseAsync(request);
@@ -370,7 +371,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task UpdateExpenseAsync_ChangingValueOnly_LeavesRoundUpAmountUnchanged()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new ExpenseService(repository);
         var added = await service.AddExpenseAsync(ToCreateDto(
             ValidCreateRequest() with { PaymentSource = "Trading212", Value = 9.40m, RoundUpAmount = 0.60m }));
@@ -386,7 +387,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task UpdateExpenseAsync_WithNewRoundUpAmount_ChangesIt()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new ExpenseService(repository);
         var added = await service.AddExpenseAsync(ToCreateDto(
             ValidCreateRequest() with { PaymentSource = "Trading212", RoundUpAmount = 0.60m }));
@@ -400,7 +401,7 @@ public class ExpenseServiceTests
     [Fact]
     public async Task UpdateExpenseAsync_WithNullRoundUpAmount_ClearsAPreviouslySavedAmount()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new ExpenseService(repository);
         var added = await service.AddExpenseAsync(ToCreateDto(
             ValidCreateRequest() with { PaymentSource = "Trading212", RoundUpAmount = 0.60m }));
@@ -445,62 +446,4 @@ public class ExpenseServiceTests
         DateOnly Date, string Description, decimal Value, string Category, string? PaymentSource, string? CardTag,
         decimal? RoundUpAmount = null);
 
-    private sealed class StubCashFlowRepository : ICashFlowRepository
-    {
-        public List<Expense> Expenses { get; } = new();
-        public List<Bank> Banks { get; } = new()
-        {
-            Bank.Create("Barclays", roundUpEnabled: false),
-            Bank.Create("Trading212", roundUpEnabled: true),
-            Bank.Create("Chase", roundUpEnabled: true)
-        };
-        public int SaveChangesCallCount { get; private set; }
-
-        public IEnumerable<Expense> GetExpenses() => Expenses;
-        public void AddExpense(Expense expense) => Expenses.Add(expense);
-        public void DeleteExpense(Guid id) => Expenses.RemoveAll(e => e.Id == id);
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
-        public void AddReserveMovement(ReserveMovement movement) { }
-        public void DeleteReserveMovement(Guid id) { }
-
-        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
-        public void AddCardStatement(CardStatement statement) { }
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
-        public void AddRecurringBill(RecurringBill bill) { }
-        public void DeleteRecurringBill(Guid id) { }
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
-        public void DeleteMaeLedgerEntry(Guid id) { }
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Array.Empty<InvestmentAccount>();
-        public void AddInvestmentAccount(InvestmentAccount account) { }
-
-        public IEnumerable<Bank> GetBanks() => Banks;
-
-        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
-        public void AddIncome(Income income) { }
-        public void DeleteIncome(Guid id) { }
-
-        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
-        public void AddTransfer(Transfer transfer) { }
-        public void UpdateTransfer(Transfer transfer) { }
-        public void DeleteTransfer(Guid id) { }
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => Array.Empty<BalanceAdjustment>();
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void DeleteBalanceAdjustment(Guid id) { }
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            return Task.CompletedTask;
-        }
-    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/IncomeServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/IncomeServiceTests.cs
@@ -1,6 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -19,7 +20,7 @@ public class IncomeServiceTests
     [Fact]
     public async Task AddIncomeAsync_WithValidRequest_SavesAndReturnsIncome()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new IncomeService(repository);
 
         var result = await service.AddIncomeAsync(ToCreateDto(ValidCreateRequest()));
@@ -39,7 +40,7 @@ public class IncomeServiceTests
     [Fact]
     public async Task AddIncomeAsync_WithoutGrossValue_SavesNull()
     {
-        var service = new IncomeService(new StubCashFlowRepository());
+        var service = new IncomeService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { GrossValue = null });
 
         var result = await service.AddIncomeAsync(request);
@@ -50,7 +51,7 @@ public class IncomeServiceTests
     [Fact]
     public async Task AddIncomeAsync_MultipleEntriesForSameSourceAndMonth_AllPersist()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new IncomeService(repository);
         var request = ValidCreateRequest() with { IncomeSource = "Ariana", GrossValue = null };
 
@@ -64,7 +65,7 @@ public class IncomeServiceTests
     [Fact]
     public async Task AddIncomeAsync_WithNegativeNetValue_ThrowsArgumentException()
     {
-        var service = new IncomeService(new StubCashFlowRepository());
+        var service = new IncomeService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { GrossValue = null, NetValue = -1m });
 
         var act = async () => await service.AddIncomeAsync(request);
@@ -75,7 +76,7 @@ public class IncomeServiceTests
     [Fact]
     public async Task AddIncomeAsync_WithUnrecognizedIncomeSource_ThrowsArgumentException()
     {
-        var service = new IncomeService(new StubCashFlowRepository());
+        var service = new IncomeService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { IncomeSource = "NotASource" });
 
         var act = async () => await service.AddIncomeAsync(request);
@@ -86,7 +87,7 @@ public class IncomeServiceTests
     [Fact]
     public async Task AddIncomeAsync_WithUnrecognizedBank_ThrowsArgumentException()
     {
-        var service = new IncomeService(new StubCashFlowRepository());
+        var service = new IncomeService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { Bank = "NotABank" });
 
         var act = async () => await service.AddIncomeAsync(request);
@@ -97,7 +98,7 @@ public class IncomeServiceTests
     [Fact]
     public async Task UpdateIncomeAsync_WithExistingId_UpdatesInPlace()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new IncomeService(repository);
         var added = await service.AddIncomeAsync(ToCreateDto(ValidCreateRequest()));
 
@@ -117,7 +118,7 @@ public class IncomeServiceTests
     [Fact]
     public async Task UpdateIncomeAsync_WithUnknownId_ThrowsKeyNotFoundException()
     {
-        var service = new IncomeService(new StubCashFlowRepository());
+        var service = new IncomeService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var act = async () => await service.UpdateIncomeAsync(Guid.NewGuid(), ToUpdateDto(ValidCreateRequest()));
 
@@ -127,7 +128,7 @@ public class IncomeServiceTests
     [Fact]
     public async Task DeleteIncomeAsync_WithExistingId_RemovesAndSaves()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new IncomeService(repository);
         var added = await service.AddIncomeAsync(ToCreateDto(ValidCreateRequest()));
 
@@ -140,7 +141,7 @@ public class IncomeServiceTests
     [Fact]
     public async Task DeleteIncomeAsync_WithUnknownId_ThrowsKeyNotFoundException()
     {
-        var service = new IncomeService(new StubCashFlowRepository());
+        var service = new IncomeService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var act = async () => await service.DeleteIncomeAsync(Guid.NewGuid());
 
@@ -150,7 +151,7 @@ public class IncomeServiceTests
     [Fact]
     public async Task GetIncomesByMonth_ReturnsOnlyIncomesInThatMonth()
     {
-        var service = new IncomeService(new StubCashFlowRepository());
+        var service = new IncomeService(new StubCashFlowRepository(seedDefaultBanks: true));
         await service.AddIncomeAsync(ToCreateDto(ValidCreateRequest() with { Date = new DateOnly(2026, 7, 10) }));
         await service.AddIncomeAsync(ToCreateDto(ValidCreateRequest() with { Date = new DateOnly(2026, 8, 10) }));
 
@@ -187,62 +188,4 @@ public class IncomeServiceTests
     private sealed record IncomeCreateRequest(
         DateOnly Date, string IncomeSource, decimal? GrossValue, decimal NetValue, string Bank);
 
-    private sealed class StubCashFlowRepository : ICashFlowRepository
-    {
-        public List<Income> Incomes { get; } = new();
-        public List<Bank> Banks { get; } = new()
-        {
-            Bank.Create("Barclays", roundUpEnabled: false),
-            Bank.Create("Trading212", roundUpEnabled: true),
-            Bank.Create("Chase", roundUpEnabled: true)
-        };
-        public int SaveChangesCallCount { get; private set; }
-
-        public IEnumerable<Expense> GetExpenses() => Array.Empty<Expense>();
-        public void AddExpense(Expense expense) { }
-        public void DeleteExpense(Guid id) { }
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
-        public void AddReserveMovement(ReserveMovement movement) { }
-        public void DeleteReserveMovement(Guid id) { }
-
-        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
-        public void AddCardStatement(CardStatement statement) { }
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
-        public void AddRecurringBill(RecurringBill bill) { }
-        public void DeleteRecurringBill(Guid id) { }
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
-        public void DeleteMaeLedgerEntry(Guid id) { }
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Array.Empty<InvestmentAccount>();
-        public void AddInvestmentAccount(InvestmentAccount account) { }
-
-        public IEnumerable<Bank> GetBanks() => Banks;
-
-        public IEnumerable<Income> GetIncomes() => Incomes;
-        public void AddIncome(Income income) => Incomes.Add(income);
-        public void DeleteIncome(Guid id) => Incomes.RemoveAll(i => i.Id == id);
-
-        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
-        public void AddTransfer(Transfer transfer) { }
-        public void UpdateTransfer(Transfer transfer) { }
-        public void DeleteTransfer(Guid id) { }
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => Array.Empty<BalanceAdjustment>();
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void DeleteBalanceAdjustment(Guid id) { }
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            return Task.CompletedTask;
-        }
-    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/InvestmentSnapshotServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/InvestmentSnapshotServiceTests.cs
@@ -1,6 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -22,7 +23,7 @@ public class InvestmentSnapshotServiceTests
     [Fact]
     public async Task GetSnapshotsForMonthAsync_FirstCall_GeneratesExactlyElevenSnapshotsDefaultingToZero()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new InvestmentSnapshotService(repository);
 
         var result = await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
@@ -31,14 +32,14 @@ public class InvestmentSnapshotServiceTests
         {
             result.Should().HaveCount(11);
             result.Should().OnlyContain(s => s.Value == 0m);
-            repository.Snapshots.Should().HaveCount(11);
+            repository.InvestmentSnapshots.Should().HaveCount(11);
         }
     }
 
     [Fact]
     public async Task GetSnapshotsForMonthAsync_MarksTheSixLiabilityAccountsCorrectly()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new InvestmentSnapshotService(repository);
 
         var result = await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
@@ -55,7 +56,7 @@ public class InvestmentSnapshotServiceTests
     [Fact]
     public async Task GetSnapshotsForMonthAsync_SecondCallSameMonth_DoesNotCreateDuplicates()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new InvestmentSnapshotService(repository);
 
         await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
@@ -64,7 +65,7 @@ public class InvestmentSnapshotServiceTests
         using (new AssertionScope())
         {
             result.Should().HaveCount(11);
-            repository.Snapshots.Should().HaveCount(11);
+            repository.InvestmentSnapshots.Should().HaveCount(11);
             repository.SaveChangesCallCount.Should().Be(1);
         }
     }
@@ -72,8 +73,8 @@ public class InvestmentSnapshotServiceTests
     [Fact]
     public async Task GetSnapshotsForMonthAsync_CurrentYear_ExcludesDisabledAccounts()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Accounts.Add(InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false));
+        var repository = CreateRepository();
+        repository.InvestmentAccounts.Add(InvestmentAccount.Create("EverydaySaver", isActive: false, isLiability: false));
         var service = new InvestmentSnapshotService(repository);
 
         var result = await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
@@ -85,20 +86,20 @@ public class InvestmentSnapshotServiceTests
     [Fact]
     public async Task GetSnapshotsForMonthAsync_PastYearWithNoExistingData_ReturnsEmptyNotAllAccounts()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new InvestmentSnapshotService(repository);
 
         var result = await service.GetSnapshotsForMonthAsync(PastYear, 7);
 
         result.Should().BeEmpty();
-        repository.Snapshots.Should().BeEmpty();
+        repository.InvestmentSnapshots.Should().BeEmpty();
     }
 
     [Fact]
     public async Task GetSnapshotsForMonthAsync_PastYearWithSomeAccountsPresent_ReturnsOnlyThose()
     {
-        var repository = new StubCashFlowRepository();
-        repository.Snapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 7, 100m));
+        var repository = CreateRepository();
+        repository.InvestmentSnapshots.Add(InvestmentSnapshot.Create("ChaseSave", PastYear, 7, 100m));
         var service = new InvestmentSnapshotService(repository);
 
         var result = await service.GetSnapshotsForMonthAsync(PastYear, 7);
@@ -109,13 +110,13 @@ public class InvestmentSnapshotServiceTests
     [Fact]
     public async Task UpdateSnapshotValueAsync_UpdatesOnlyTheTargetedSnapshot()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new InvestmentSnapshotService(repository);
         await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
         await service.GetSnapshotsForMonthAsync(CurrentYear, 8);
-        var julySnapshot = repository.Snapshots.Single(s => s.Month == 7 && s.Account == "ChaseSave");
-        var augustSnapshot = repository.Snapshots.Single(s => s.Month == 8 && s.Account == "ChaseSave");
-        var otherAccountSnapshot = repository.Snapshots.Single(s => s.Month == 7 && s.Account == "PlatinumVisa8003");
+        var julySnapshot = repository.InvestmentSnapshots.Single(s => s.Month == 7 && s.Account == "ChaseSave");
+        var augustSnapshot = repository.InvestmentSnapshots.Single(s => s.Month == 8 && s.Account == "ChaseSave");
+        var otherAccountSnapshot = repository.InvestmentSnapshots.Single(s => s.Month == 7 && s.Account == "PlatinumVisa8003");
 
         var result = await service.UpdateSnapshotValueAsync(julySnapshot.Id, new UpdateInvestmentSnapshotValueDTO { Value = 500m });
 
@@ -130,10 +131,10 @@ public class InvestmentSnapshotServiceTests
     [Fact]
     public async Task UpdateSnapshotValueAsync_WithNegativeValue_ThrowsArgumentException()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = CreateRepository();
         var service = new InvestmentSnapshotService(repository);
         await service.GetSnapshotsForMonthAsync(CurrentYear, 7);
-        var snapshot = repository.Snapshots.First();
+        var snapshot = repository.InvestmentSnapshots.First();
 
         var act = async () => await service.UpdateSnapshotValueAsync(snapshot.Id, new UpdateInvestmentSnapshotValueDTO { Value = -1m });
 
@@ -143,80 +144,33 @@ public class InvestmentSnapshotServiceTests
     [Fact]
     public async Task UpdateSnapshotValueAsync_WithUnknownId_ThrowsKeyNotFoundException()
     {
-        var service = new InvestmentSnapshotService(new StubCashFlowRepository());
+        var service = new InvestmentSnapshotService(CreateRepository());
 
         var act = async () => await service.UpdateSnapshotValueAsync(Guid.NewGuid(), new UpdateInvestmentSnapshotValueDTO { Value = 10m });
 
         await act.Should().ThrowAsync<KeyNotFoundException>();
     }
 
-    private sealed class StubCashFlowRepository : ICashFlowRepository
+    private static readonly (string Name, bool IsLiability)[] SeededAccounts =
+    [
+        ("BlueRewardsSaver", false),
+        ("PlatinumVisa8003", true),
+        ("PlatinumVisa6007", true),
+        ("ChaseMaster4023", true),
+        ("BaAmex", true),
+        ("PaypalCredit", true),
+        ("ChipCashIsaGleison", false),
+        ("ChaseSave", false),
+        ("ChipCashIsaAriana", false),
+        ("Trading212Invested", false),
+        ("ReservasPessoais", true)
+    ];
+
+    private static StubCashFlowRepository CreateRepository()
     {
-        private static readonly (string Name, bool IsLiability)[] SeededAccounts =
-        [
-            ("BlueRewardsSaver", false),
-            ("PlatinumVisa8003", true),
-            ("PlatinumVisa6007", true),
-            ("ChaseMaster4023", true),
-            ("BaAmex", true),
-            ("PaypalCredit", true),
-            ("ChipCashIsaGleison", false),
-            ("ChaseSave", false),
-            ("ChipCashIsaAriana", false),
-            ("Trading212Invested", false),
-            ("ReservasPessoais", true)
-        ];
-
-        public List<InvestmentSnapshot> Snapshots { get; } = new();
-        public List<InvestmentAccount> Accounts { get; } =
-            SeededAccounts.Select(a => InvestmentAccount.Create(a.Name, isActive: true, isLiability: a.IsLiability)).ToList();
-        public int SaveChangesCallCount { get; private set; }
-
-        public IEnumerable<Expense> GetExpenses() => Array.Empty<Expense>();
-        public void AddExpense(Expense expense) { }
-        public void DeleteExpense(Guid id) { }
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
-        public void AddReserveMovement(ReserveMovement movement) { }
-        public void DeleteReserveMovement(Guid id) { }
-
-        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
-        public void AddCardStatement(CardStatement statement) { }
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
-        public void AddRecurringBill(RecurringBill bill) { }
-        public void DeleteRecurringBill(Guid id) { }
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
-        public void DeleteMaeLedgerEntry(Guid id) { }
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Snapshots;
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) => Snapshots.Add(snapshot);
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Accounts;
-        public void AddInvestmentAccount(InvestmentAccount account) => Accounts.Add(account);
-
-        public IEnumerable<Bank> GetBanks() => Array.Empty<Bank>();
-
-        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
-        public void AddIncome(Income income) { }
-        public void DeleteIncome(Guid id) { }
-
-        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
-        public void AddTransfer(Transfer transfer) { }
-        public void UpdateTransfer(Transfer transfer) { }
-        public void DeleteTransfer(Guid id) { }
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => Array.Empty<BalanceAdjustment>();
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void DeleteBalanceAdjustment(Guid id) { }
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            return Task.CompletedTask;
-        }
+        var repository = new StubCashFlowRepository();
+        repository.InvestmentAccounts.AddRange(
+            SeededAccounts.Select(a => InvestmentAccount.Create(a.Name, isActive: true, isLiability: a.IsLiability)));
+        return repository;
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/MensaisServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/MensaisServiceTests.cs
@@ -1,6 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Domain.Enums;
 using FluentAssertions;
@@ -30,7 +31,7 @@ public class MensaisServiceTests
             result.Description.Should().Be("INSS");
             result.Area.Should().Be("Brasil");
             result.Status.Should().Be("Unset");
-            repository.Bills.Should().ContainSingle();
+            repository.RecurringBills.Should().ContainSingle();
             repository.SaveChangesCallCount.Should().Be(1);
         }
     }
@@ -107,14 +108,14 @@ public class MensaisServiceTests
     {
         var repository = new StubCashFlowRepository();
         var bill = RecurringBill.Create(10, "INSS", 850m, Area.Brasil, string.Empty, null, null);
-        repository.Bills.Add(bill);
+        repository.RecurringBills.Add(bill);
         var otherBill = RecurringBill.Create(15, "Council Tax", 120m, Area.UK, string.Empty, null, null);
-        repository.Bills.Add(otherBill);
+        repository.RecurringBills.Add(otherBill);
         var service = new MensaisService(repository);
 
         await service.DeleteBillAsync(bill.Id);
 
-        repository.Bills.Should().ContainSingle().Which.Id.Should().Be(otherBill.Id);
+        repository.RecurringBills.Should().ContainSingle().Which.Id.Should().Be(otherBill.Id);
     }
 
     [Fact]
@@ -131,7 +132,7 @@ public class MensaisServiceTests
     public void GetBills_ReturnsAllBills()
     {
         var repository = new StubCashFlowRepository();
-        repository.Bills.Add(RecurringBill.Create(10, "INSS", 850m, Area.Brasil, string.Empty, null, null));
+        repository.RecurringBills.Add(RecurringBill.Create(10, "INSS", 850m, Area.Brasil, string.Empty, null, null));
         var service = new MensaisService(repository);
 
         var result = service.GetBills();
@@ -144,7 +145,7 @@ public class MensaisServiceTests
     {
         var repository = new StubCashFlowRepository();
         var bill = RecurringBill.Create(10, "INSS", 850m, Area.Brasil, string.Empty, null, null);
-        repository.Bills.Add(bill);
+        repository.RecurringBills.Add(bill);
         var service = new MensaisService(repository);
 
         var result = await service.UpdateBillAsync(bill.Id, new UpdateRecurringBillDTO
@@ -176,7 +177,7 @@ public class MensaisServiceTests
     {
         var repository = new StubCashFlowRepository();
         var bill = RecurringBill.Create(10, "INSS", 850m, Area.Brasil, string.Empty, null, null);
-        repository.Bills.Add(bill);
+        repository.RecurringBills.Add(bill);
         var service = new MensaisService(repository);
 
         var act = async () => await service.UpdateBillAsync(bill.Id, new UpdateRecurringBillDTO
@@ -196,14 +197,14 @@ public class MensaisServiceTests
         paidBill.Update(BillStatus.Paid, 850m);
         var scheduledBill = RecurringBill.Create(15, "Council Tax", 120m, Area.UK, string.Empty, null, null);
         scheduledBill.Update(BillStatus.Scheduled, 120m);
-        repository.Bills.Add(paidBill);
-        repository.Bills.Add(scheduledBill);
+        repository.RecurringBills.Add(paidBill);
+        repository.RecurringBills.Add(scheduledBill);
         var service = new MensaisService(repository);
 
         var result = await service.ResetAllToUnsetAsync();
 
         result.Should().OnlyContain(b => b.Status == "Unset");
-        repository.Bills.Should().OnlyContain(b => b.Status == BillStatus.Unset);
+        repository.RecurringBills.Should().OnlyContain(b => b.Status == BillStatus.Unset);
         repository.SaveChangesCallCount.Should().Be(1);
     }
 
@@ -216,56 +217,4 @@ public class MensaisServiceTests
         Note = "Direct debit"
     };
 
-    private sealed class StubCashFlowRepository : ICashFlowRepository
-    {
-        public List<RecurringBill> Bills { get; } = new();
-        public int SaveChangesCallCount { get; private set; }
-
-        public IEnumerable<Expense> GetExpenses() => Array.Empty<Expense>();
-        public void AddExpense(Expense expense) { }
-        public void DeleteExpense(Guid id) { }
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
-        public void AddReserveMovement(ReserveMovement movement) { }
-        public void DeleteReserveMovement(Guid id) { }
-
-        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
-        public void AddCardStatement(CardStatement statement) { }
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Bills;
-        public void AddRecurringBill(RecurringBill bill) => Bills.Add(bill);
-        public void DeleteRecurringBill(Guid id) => Bills.RemoveAll(b => b.Id == id);
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
-        public void DeleteMaeLedgerEntry(Guid id) { }
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Array.Empty<InvestmentAccount>();
-        public void AddInvestmentAccount(InvestmentAccount account) { }
-
-        public IEnumerable<Bank> GetBanks() => Array.Empty<Bank>();
-
-        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
-        public void AddIncome(Income income) { }
-        public void DeleteIncome(Guid id) { }
-
-        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
-        public void AddTransfer(Transfer transfer) { }
-        public void UpdateTransfer(Transfer transfer) { }
-        public void DeleteTransfer(Guid id) { }
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => Array.Empty<BalanceAdjustment>();
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void DeleteBalanceAdjustment(Guid id) { }
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            return Task.CompletedTask;
-        }
-    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/ReserveServiceTests.cs
@@ -2,6 +2,7 @@ using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Exceptions;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Domain.Enums;
 using FluentAssertions;
@@ -83,7 +84,7 @@ public class ReserveServiceTests
     [Fact]
     public async Task PostIncomeSplitAsync_WhenSaveFails_RollsBackAllFourMovements()
     {
-        var repository = new StubCashFlowRepository { ThrowOnSave = true };
+        var repository = new StubCashFlowRepository { ThrowOnNextSave = true };
         var service = new ReserveService(repository);
 
         var act = async () => await service.PostIncomeSplitAsync(ValidIncomeSplitRequest());
@@ -327,65 +328,10 @@ public class ReserveServiceTests
         Description = "Ramsay"
     };
 
-    private sealed class StubCashFlowRepository : ICashFlowRepository
-    {
-        public List<ReserveMovement> ReserveMovements { get; } = new();
-        public int SaveChangesCallCount { get; private set; }
-        public bool ThrowOnSave { get; set; }
+}
 
-        public void Seed(ReserveBucket bucket, decimal amount, DateOnly? date = null) =>
-            ReserveMovements.Add(ReserveMovement.Create(bucket, amount, date ?? new DateOnly(2026, 1, 1), "Seed"));
-
-        public IEnumerable<Expense> GetExpenses() => Array.Empty<Expense>();
-        public void AddExpense(Expense expense) { }
-        public void DeleteExpense(Guid id) { }
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => ReserveMovements;
-        public void AddReserveMovement(ReserveMovement movement) => ReserveMovements.Add(movement);
-        public void DeleteReserveMovement(Guid id) => ReserveMovements.RemoveAll(m => m.Id == id);
-
-        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
-        public void AddCardStatement(CardStatement statement) { }
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
-        public void AddRecurringBill(RecurringBill bill) { }
-        public void DeleteRecurringBill(Guid id) { }
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
-        public void DeleteMaeLedgerEntry(Guid id) { }
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Array.Empty<InvestmentAccount>();
-        public void AddInvestmentAccount(InvestmentAccount account) { }
-
-        public IEnumerable<Bank> GetBanks() => Array.Empty<Bank>();
-
-        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
-        public void AddIncome(Income income) { }
-        public void DeleteIncome(Guid id) { }
-
-        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
-        public void AddTransfer(Transfer transfer) { }
-        public void UpdateTransfer(Transfer transfer) { }
-        public void DeleteTransfer(Guid id) { }
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => Array.Empty<BalanceAdjustment>();
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void DeleteBalanceAdjustment(Guid id) { }
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            if (ThrowOnSave)
-            {
-                throw new InvalidOperationException("Simulated save failure.");
-            }
-
-            return Task.CompletedTask;
-        }
-    }
+internal static class ReserveServiceTestsStubExtensions
+{
+    public static void Seed(this StubCashFlowRepository repository, ReserveBucket bucket, decimal amount, DateOnly? date = null) =>
+        repository.ReserveMovements.Add(ReserveMovement.Create(bucket, amount, date ?? new DateOnly(2026, 1, 1), "Seed"));
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/TitheServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/TitheServiceTests.cs
@@ -1,5 +1,6 @@
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using Financial.CashFlow.Domain.Enums;
 using FluentAssertions;
@@ -97,53 +98,4 @@ public class TitheServiceTests
         result.TitheBalance.Should().Be(0m);
     }
 
-    private sealed class StubCashFlowRepository : ICashFlowRepository
-    {
-        public List<Income> Incomes { get; } = new();
-        public List<Expense> Expenses { get; } = new();
-        public List<Bank> Banks { get; } = new();
-
-        public IEnumerable<Expense> GetExpenses() => Expenses;
-        public void AddExpense(Expense expense) => Expenses.Add(expense);
-        public void DeleteExpense(Guid id) { }
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
-        public void AddReserveMovement(ReserveMovement movement) { }
-        public void DeleteReserveMovement(Guid id) { }
-
-        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
-        public void AddCardStatement(CardStatement statement) { }
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
-        public void AddRecurringBill(RecurringBill bill) { }
-        public void DeleteRecurringBill(Guid id) { }
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
-        public void DeleteMaeLedgerEntry(Guid id) { }
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Array.Empty<InvestmentAccount>();
-        public void AddInvestmentAccount(InvestmentAccount account) { }
-
-        public IEnumerable<Bank> GetBanks() => Banks;
-
-        public IEnumerable<Income> GetIncomes() => Incomes;
-        public void AddIncome(Income income) => Incomes.Add(income);
-        public void DeleteIncome(Guid id) { }
-
-        public IEnumerable<Transfer> GetTransfers() => Array.Empty<Transfer>();
-        public void AddTransfer(Transfer transfer) { }
-        public void UpdateTransfer(Transfer transfer) { }
-        public void DeleteTransfer(Guid id) { }
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => Array.Empty<BalanceAdjustment>();
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void DeleteBalanceAdjustment(Guid id) { }
-
-        public Task SaveChangesAsync() => Task.CompletedTask;
-    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/TransferServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/TransferServiceTests.cs
@@ -1,6 +1,7 @@
 using Financial.CashFlow.Application.DTOs;
 using Financial.CashFlow.Application.Interfaces;
 using Financial.CashFlow.Application.Services;
+using Financial.CashFlow.Application.Tests.TestHelpers;
 using Financial.CashFlow.Domain.Entities;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -19,7 +20,7 @@ public class TransferServiceTests
     [Fact]
     public async Task AddTransferAsync_WithValidRequest_SavesAndReturnsTransfer()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new TransferService(repository);
 
         var result = await service.AddTransferAsync(ToCreateDto(ValidCreateRequest()));
@@ -39,7 +40,7 @@ public class TransferServiceTests
     [Fact]
     public async Task AddTransferAsync_WithoutNote_SavesNull()
     {
-        var service = new TransferService(new StubCashFlowRepository());
+        var service = new TransferService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { Note = null });
 
         var result = await service.AddTransferAsync(request);
@@ -50,7 +51,7 @@ public class TransferServiceTests
     [Fact]
     public async Task AddTransferAsync_WithSameSourceAndDestinationBank_ThrowsArgumentException()
     {
-        var service = new TransferService(new StubCashFlowRepository());
+        var service = new TransferService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { DestinationBank = "Barclays" });
 
         var act = async () => await service.AddTransferAsync(request);
@@ -61,7 +62,7 @@ public class TransferServiceTests
     [Fact]
     public async Task AddTransferAsync_WithNonPositiveAmount_ThrowsArgumentException()
     {
-        var service = new TransferService(new StubCashFlowRepository());
+        var service = new TransferService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { Amount = 0m });
 
         var act = async () => await service.AddTransferAsync(request);
@@ -72,7 +73,7 @@ public class TransferServiceTests
     [Fact]
     public async Task AddTransferAsync_WithUnresolvableSourceBank_ThrowsArgumentException()
     {
-        var service = new TransferService(new StubCashFlowRepository());
+        var service = new TransferService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { SourceBank = "NotABank" });
 
         var act = async () => await service.AddTransferAsync(request);
@@ -83,7 +84,7 @@ public class TransferServiceTests
     [Fact]
     public async Task AddTransferAsync_WithUnresolvableDestinationBank_ThrowsArgumentException()
     {
-        var service = new TransferService(new StubCashFlowRepository());
+        var service = new TransferService(new StubCashFlowRepository(seedDefaultBanks: true));
         var request = ToCreateDto(ValidCreateRequest() with { DestinationBank = "NotABank" });
 
         var act = async () => await service.AddTransferAsync(request);
@@ -94,7 +95,7 @@ public class TransferServiceTests
     [Fact]
     public async Task UpdateTransferAsync_WithExistingId_UpdatesInPlace()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new TransferService(repository);
         var added = await service.AddTransferAsync(ToCreateDto(ValidCreateRequest()));
 
@@ -115,7 +116,7 @@ public class TransferServiceTests
     [Fact]
     public async Task UpdateTransferAsync_WithUnknownId_ThrowsKeyNotFoundException()
     {
-        var service = new TransferService(new StubCashFlowRepository());
+        var service = new TransferService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var act = async () => await service.UpdateTransferAsync(Guid.NewGuid(), ToUpdateDto(ValidCreateRequest()));
 
@@ -125,7 +126,7 @@ public class TransferServiceTests
     [Fact]
     public async Task DeleteTransferAsync_WithExistingId_RemovesAndSaves()
     {
-        var repository = new StubCashFlowRepository();
+        var repository = new StubCashFlowRepository(seedDefaultBanks: true);
         var service = new TransferService(repository);
         var added = await service.AddTransferAsync(ToCreateDto(ValidCreateRequest()));
 
@@ -138,7 +139,7 @@ public class TransferServiceTests
     [Fact]
     public async Task DeleteTransferAsync_WithUnknownId_ThrowsKeyNotFoundException()
     {
-        var service = new TransferService(new StubCashFlowRepository());
+        var service = new TransferService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var act = async () => await service.DeleteTransferAsync(Guid.NewGuid());
 
@@ -148,7 +149,7 @@ public class TransferServiceTests
     [Fact]
     public async Task GetTransfersByMonth_ReturnsOnlyTransfersInThatMonth()
     {
-        var service = new TransferService(new StubCashFlowRepository());
+        var service = new TransferService(new StubCashFlowRepository(seedDefaultBanks: true));
         await service.AddTransferAsync(ToCreateDto(ValidCreateRequest() with { Date = new DateOnly(2026, 7, 10) }));
         await service.AddTransferAsync(ToCreateDto(ValidCreateRequest() with { Date = new DateOnly(2026, 8, 10) }));
 
@@ -160,7 +161,7 @@ public class TransferServiceTests
     [Fact]
     public async Task GetTransfersByBank_ReturnsTransfersWhereBankIsSourceOrDestination()
     {
-        var service = new TransferService(new StubCashFlowRepository());
+        var service = new TransferService(new StubCashFlowRepository(seedDefaultBanks: true));
         await service.AddTransferAsync(ToCreateDto(ValidCreateRequest() with { SourceBank = "Barclays", DestinationBank = "Trading212" }));
         await service.AddTransferAsync(ToCreateDto(ValidCreateRequest() with { SourceBank = "Chase", DestinationBank = "Barclays" }));
         await service.AddTransferAsync(ToCreateDto(ValidCreateRequest() with { SourceBank = "Chase", DestinationBank = "Trading212" }));
@@ -173,7 +174,7 @@ public class TransferServiceTests
     [Fact]
     public void GetTransfersByBank_WithUnrecognizedBank_ReturnsEmptyList()
     {
-        var service = new TransferService(new StubCashFlowRepository());
+        var service = new TransferService(new StubCashFlowRepository(seedDefaultBanks: true));
 
         var result = service.GetTransfersByBank("NotABank");
 
@@ -208,69 +209,4 @@ public class TransferServiceTests
     private sealed record TransferCreateRequest(
         DateOnly Date, string SourceBank, string DestinationBank, decimal Amount, string? Note);
 
-    private sealed class StubCashFlowRepository : ICashFlowRepository
-    {
-        public List<Transfer> Transfers { get; } = new();
-        public List<Bank> Banks { get; } = new()
-        {
-            Bank.Create("Barclays", roundUpEnabled: false),
-            Bank.Create("Trading212", roundUpEnabled: true),
-            Bank.Create("Chase", roundUpEnabled: true)
-        };
-        public int SaveChangesCallCount { get; private set; }
-
-        public IEnumerable<Expense> GetExpenses() => Array.Empty<Expense>();
-        public void AddExpense(Expense expense) { }
-        public void DeleteExpense(Guid id) { }
-
-        public IEnumerable<ReserveMovement> GetReserveMovements() => Array.Empty<ReserveMovement>();
-        public void AddReserveMovement(ReserveMovement movement) { }
-        public void DeleteReserveMovement(Guid id) { }
-
-        public IEnumerable<CardStatement> GetCardStatements() => Array.Empty<CardStatement>();
-        public void AddCardStatement(CardStatement statement) { }
-
-        public IEnumerable<RecurringBill> GetRecurringBills() => Array.Empty<RecurringBill>();
-        public void AddRecurringBill(RecurringBill bill) { }
-        public void DeleteRecurringBill(Guid id) { }
-
-        public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => Array.Empty<MaeLedgerEntry>();
-        public void AddMaeLedgerEntry(MaeLedgerEntry entry) { }
-        public void DeleteMaeLedgerEntry(Guid id) { }
-
-        public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => Array.Empty<InvestmentSnapshot>();
-        public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) { }
-
-        public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => Array.Empty<InvestmentAccount>();
-        public void AddInvestmentAccount(InvestmentAccount account) { }
-
-        public IEnumerable<Bank> GetBanks() => Banks;
-
-        public IEnumerable<Income> GetIncomes() => Array.Empty<Income>();
-        public void AddIncome(Income income) { }
-        public void DeleteIncome(Guid id) { }
-
-        public IEnumerable<Transfer> GetTransfers() => Transfers;
-        public void AddTransfer(Transfer transfer) => Transfers.Add(transfer);
-        public void UpdateTransfer(Transfer transfer)
-        {
-            var index = Transfers.FindIndex(t => t.Id == transfer.Id);
-            if (index >= 0)
-            {
-                Transfers[index] = transfer;
-            }
-        }
-        public void DeleteTransfer(Guid id) => Transfers.RemoveAll(t => t.Id == id);
-
-        public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => Array.Empty<BalanceAdjustment>();
-        public void AddBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void UpdateBalanceAdjustment(BalanceAdjustment adjustment) { }
-        public void DeleteBalanceAdjustment(Guid id) { }
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            return Task.CompletedTask;
-        }
-    }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/TestHelpers/StubCashFlowRepository.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/TestHelpers/StubCashFlowRepository.cs
@@ -1,0 +1,116 @@
+using Financial.CashFlow.Application.Interfaces;
+using Financial.CashFlow.Domain.Entities;
+
+namespace Financial.CashFlow.Application.Tests.TestHelpers;
+
+/// <summary>
+/// Shared in-memory <see cref="ICashFlowRepository"/> test double. Every collection is backed by a
+/// real list so CRUD operations behave correctly regardless of which entity a given test exercises;
+/// nothing is seeded by default. Adding a new member to <see cref="ICashFlowRepository"/> only
+/// requires updating this one class instead of every service test file.
+/// </summary>
+internal sealed class StubCashFlowRepository : ICashFlowRepository
+{
+    public List<Expense> Expenses { get; } = new();
+    public List<ReserveMovement> ReserveMovements { get; } = new();
+    public List<CardStatement> CardStatements { get; } = new();
+    public List<RecurringBill> RecurringBills { get; } = new();
+    public List<MaeLedgerEntry> MaeLedgerEntries { get; } = new();
+    public List<InvestmentSnapshot> InvestmentSnapshots { get; } = new();
+    public List<InvestmentAccount> InvestmentAccounts { get; } = new();
+    public List<Bank> Banks { get; } = new();
+    public List<Income> Incomes { get; } = new();
+    public List<Transfer> Transfers { get; } = new();
+    public List<BalanceAdjustment> BalanceAdjustments { get; } = new();
+
+    public int SaveChangesCallCount { get; private set; }
+
+    /// <summary>When true, the next <see cref="SaveChangesAsync"/> call throws once and resets to false.</summary>
+    public bool ThrowOnNextSave { get; set; }
+
+    public StubCashFlowRepository(bool seedDefaultBanks = false)
+    {
+        if (seedDefaultBanks)
+        {
+            Banks.AddRange(DefaultBanks());
+        }
+    }
+
+    /// <summary>The 3 banks seeded in a real deployment by the CashFlowSpreadsheetImport migration tool.</summary>
+    public static IEnumerable<Bank> DefaultBanks() =>
+    [
+        Bank.Create("Barclays", roundUpEnabled: false),
+        Bank.Create("Trading212", roundUpEnabled: true),
+        Bank.Create("Chase", roundUpEnabled: true)
+    ];
+
+    public void SetOpeningBalance(string bankName, decimal openingBalance, DateOnly openingBalanceDate) =>
+        Banks.First(b => b.Name == bankName).SetOpeningBalance(openingBalance, openingBalanceDate);
+
+    public IEnumerable<Expense> GetExpenses() => Expenses;
+    public void AddExpense(Expense expense) => Expenses.Add(expense);
+    public void DeleteExpense(Guid id) => Expenses.RemoveAll(e => e.Id == id);
+
+    public IEnumerable<ReserveMovement> GetReserveMovements() => ReserveMovements;
+    public void AddReserveMovement(ReserveMovement movement) => ReserveMovements.Add(movement);
+    public void DeleteReserveMovement(Guid id) => ReserveMovements.RemoveAll(m => m.Id == id);
+
+    public IEnumerable<CardStatement> GetCardStatements() => CardStatements;
+    public void AddCardStatement(CardStatement statement) => CardStatements.Add(statement);
+
+    public IEnumerable<RecurringBill> GetRecurringBills() => RecurringBills;
+    public void AddRecurringBill(RecurringBill bill) => RecurringBills.Add(bill);
+    public void DeleteRecurringBill(Guid id) => RecurringBills.RemoveAll(b => b.Id == id);
+
+    public IEnumerable<MaeLedgerEntry> GetMaeLedgerEntries() => MaeLedgerEntries;
+    public void AddMaeLedgerEntry(MaeLedgerEntry entry) => MaeLedgerEntries.Add(entry);
+    public void DeleteMaeLedgerEntry(Guid id) => MaeLedgerEntries.RemoveAll(e => e.Id == id);
+
+    public IEnumerable<InvestmentSnapshot> GetInvestmentSnapshots() => InvestmentSnapshots;
+    public void AddInvestmentSnapshot(InvestmentSnapshot snapshot) => InvestmentSnapshots.Add(snapshot);
+
+    public IEnumerable<InvestmentAccount> GetInvestmentAccounts() => InvestmentAccounts;
+    public void AddInvestmentAccount(InvestmentAccount account) => InvestmentAccounts.Add(account);
+
+    public IEnumerable<Bank> GetBanks() => Banks;
+
+    public IEnumerable<Income> GetIncomes() => Incomes;
+    public void AddIncome(Income income) => Incomes.Add(income);
+    public void DeleteIncome(Guid id) => Incomes.RemoveAll(i => i.Id == id);
+
+    public IEnumerable<Transfer> GetTransfers() => Transfers;
+    public void AddTransfer(Transfer transfer) => Transfers.Add(transfer);
+    public void UpdateTransfer(Transfer transfer)
+    {
+        var index = Transfers.FindIndex(t => t.Id == transfer.Id);
+        if (index >= 0)
+        {
+            Transfers[index] = transfer;
+        }
+    }
+    public void DeleteTransfer(Guid id) => Transfers.RemoveAll(t => t.Id == id);
+
+    public IEnumerable<BalanceAdjustment> GetBalanceAdjustments() => BalanceAdjustments;
+    public void AddBalanceAdjustment(BalanceAdjustment adjustment) => BalanceAdjustments.Add(adjustment);
+    public void UpdateBalanceAdjustment(BalanceAdjustment adjustment)
+    {
+        var index = BalanceAdjustments.FindIndex(a => a.Id == adjustment.Id);
+        if (index >= 0)
+        {
+            BalanceAdjustments[index] = adjustment;
+        }
+    }
+    public void DeleteBalanceAdjustment(Guid id) => BalanceAdjustments.RemoveAll(a => a.Id == id);
+
+    public Task SaveChangesAsync()
+    {
+        SaveChangesCallCount++;
+        if (ThrowOnNextSave)
+        {
+            ThrowOnNextSave = false;
+            throw new InvalidOperationException("Simulated save failure.");
+        }
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- Every service test file in `Tests/Financial.CashFlow.Application.Tests/Services/` (11 files) defined its own private nested `StubCashFlowRepository` implementing `ICashFlowRepository`. Adding F01's `Transfer` and F02's `BalanceAdjustment` members meant editing all 11 files each time — this was noticed as a real cost while working the P20 feature loop.
- Replaces them with a single shared `StubCashFlowRepository` in `Tests/Financial.CashFlow.Application.Tests/TestHelpers/` (an existing shared-test-helper folder already used for `FakeTimeProvider`), backed by a real `List<T>` for every entity so CRUD behaves correctly regardless of which entity a given test touches.
- Bank seeding stays **opt-in** (`seedDefaultBanks: true`) — files that previously started with an empty bank list (`BankServiceTests`, `ControleMaeServiceTests`, `AnnualSummaryServiceTests`, `InvestmentSnapshotServiceTests`, `MensaisServiceTests`, `ReserveServiceTests`, `TitheServiceTests`) keep that exact behavior; files that always seeded 3 banks now pass the flag explicitly.
- `CardStatementServiceTests`' `ThrowOnNextSave` (one-shot reset) and `ReserveServiceTests`' `ThrowOnSave` (no reset) were two slightly different save-failure-simulation flags; unified on the one-shot semantics since the one test using it only asserts on a single save call.
- `AnnualSummaryServiceTests` and `InvestmentSnapshotServiceTests` each seed the same 11 investment accounts; kept as a local `CreateRepository()` helper per file rather than folding into the shared stub, since that seed data is test-scenario-specific, not repository-shape boilerplate.
- Investment's `IRepository` (duplicated 7x in `Financial.Investment.Application.Tests`) was **left as-is** on purpose: the interface is tiny (4 methods) and stable, and each stub encodes materially different fake behavior (different tracked scope state, `NavigationServiceTests`' derives data from a single `Broker` object instead of flat lists) rather than repeated boilerplate — consolidating would trade a real duplication problem for a bolted-together configuration-flag grab bag.

No production code changed — test-only refactor.

## Test plan
- [x] `dotnet test` across the full solution — all green, identical pass counts to before the refactor (1,479 passed, 5 pre-existing skips), confirming no behavior changed
- [x] `Financial.CashFlow.Application.Tests` specifically — 258/258 passed (same count as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)