### PR TITLE
test: consolidate IRepository test stubs and dedupe seeded accounts

### DIFF
--- a/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -994,26 +994,10 @@ public class AnnualSummaryServiceTests
         result.ResultadoAverage.Should().Be(700m);
     }
 
-    private static readonly (string Name, bool IsLiability)[] SeededAccounts =
-    [
-        ("BlueRewardsSaver", false),
-        ("PlatinumVisa8003", true),
-        ("PlatinumVisa6007", true),
-        ("ChaseMaster4023", true),
-        ("BaAmex", true),
-        ("PaypalCredit", true),
-        ("ChipCashIsaGleison", false),
-        ("ChaseSave", false),
-        ("ChipCashIsaAriana", false),
-        ("Trading212Invested", false),
-        ("ReservasPessoais", true)
-    ];
-
     private static StubCashFlowRepository CreateRepository()
     {
         var repository = new StubCashFlowRepository();
-        repository.InvestmentAccounts.AddRange(
-            SeededAccounts.Select(a => InvestmentAccount.Create(a.Name, isActive: true, isLiability: a.IsLiability)));
+        SeededInvestmentAccounts.SeedInto(repository);
         return repository;
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/Services/InvestmentSnapshotServiceTests.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/Services/InvestmentSnapshotServiceTests.cs
@@ -151,26 +151,10 @@ public class InvestmentSnapshotServiceTests
         await act.Should().ThrowAsync<KeyNotFoundException>();
     }
 
-    private static readonly (string Name, bool IsLiability)[] SeededAccounts =
-    [
-        ("BlueRewardsSaver", false),
-        ("PlatinumVisa8003", true),
-        ("PlatinumVisa6007", true),
-        ("ChaseMaster4023", true),
-        ("BaAmex", true),
-        ("PaypalCredit", true),
-        ("ChipCashIsaGleison", false),
-        ("ChaseSave", false),
-        ("ChipCashIsaAriana", false),
-        ("Trading212Invested", false),
-        ("ReservasPessoais", true)
-    ];
-
     private static StubCashFlowRepository CreateRepository()
     {
         var repository = new StubCashFlowRepository();
-        repository.InvestmentAccounts.AddRange(
-            SeededAccounts.Select(a => InvestmentAccount.Create(a.Name, isActive: true, isLiability: a.IsLiability)));
+        SeededInvestmentAccounts.SeedInto(repository);
         return repository;
     }
 }

--- a/Tests/Financial.CashFlow.Application.Tests/TestHelpers/SeededInvestmentAccounts.cs
+++ b/Tests/Financial.CashFlow.Application.Tests/TestHelpers/SeededInvestmentAccounts.cs
@@ -1,0 +1,30 @@
+using Financial.CashFlow.Domain.Entities;
+
+namespace Financial.CashFlow.Application.Tests.TestHelpers;
+
+/// <summary>
+/// The 11 investment accounts a real deployment has after running the
+/// CashFlowSpreadsheetImport migration tool once (see InvestmentAccountMigrator),
+/// shared by tests that need a fully seeded account list rather than an empty one.
+/// </summary>
+internal static class SeededInvestmentAccounts
+{
+    private static readonly (string Name, bool IsLiability)[] Accounts =
+    [
+        ("BlueRewardsSaver", false),
+        ("PlatinumVisa8003", true),
+        ("PlatinumVisa6007", true),
+        ("ChaseMaster4023", true),
+        ("BaAmex", true),
+        ("PaypalCredit", true),
+        ("ChipCashIsaGleison", false),
+        ("ChaseSave", false),
+        ("ChipCashIsaAriana", false),
+        ("Trading212Invested", false),
+        ("ReservasPessoais", true)
+    ];
+
+    public static void SeedInto(StubCashFlowRepository repository) =>
+        repository.InvestmentAccounts.AddRange(
+            Accounts.Select(a => InvestmentAccount.Create(a.Name, isActive: true, isLiability: a.IsLiability)));
+}

--- a/Tests/Financial.Investment.Application.Tests/Services/BrokerBreakdownServiceTests.cs
+++ b/Tests/Financial.Investment.Application.Tests/Services/BrokerBreakdownServiceTests.cs
@@ -1,6 +1,6 @@
 using Financial.Investment.Application.Enums;
-using Financial.Investment.Application.Interfaces;
 using Financial.Investment.Application.Services;
+using Financial.Investment.Application.Tests.TestHelpers;
 using Financial.Investment.Domain.Entities;
 using FluentAssertions;
 
@@ -104,7 +104,7 @@ public class BrokerBreakdownServiceTests
 
         CreateService().GetBrokerBreakdown("XPI");
 
-        _repository.LastRequestedScope.Should().Be(InvestmentScope.Active);
+        _repository.LastGetBrokerListScope.Should().Be(InvestmentScope.Active);
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class BrokerBreakdownServiceTests
 
         CreateService().GetBrokerBreakdown("XPI", InvestmentScope.Historic);
 
-        _repository.LastRequestedScope.Should().Be(InvestmentScope.Historic);
+        _repository.LastGetBrokerListScope.Should().Be(InvestmentScope.Historic);
     }
 
     [Fact]
@@ -271,21 +271,4 @@ public class BrokerBreakdownServiceTests
         return broker;
     }
 
-    private sealed class StubRepository : IRepository
-    {
-        public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
-        public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
-        public IEnumerable<Broker> Brokers { get; set; } = [];
-        public InvestmentScope? LastRequestedScope { get; private set; }
-
-        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
-        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active)
-        {
-            LastRequestedScope = scope;
-            return Brokers;
-        }
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
-        public Task SaveChangesAsync() => Task.CompletedTask;
-    }
 }

--- a/Tests/Financial.Investment.Application.Tests/Services/CreditServiceTests.cs
+++ b/Tests/Financial.Investment.Application.Tests/Services/CreditServiceTests.cs
@@ -1,7 +1,7 @@
 using Financial.Investment.Application.DTOs;
 using Financial.Investment.Application.Enums;
-using Financial.Investment.Application.Interfaces;
 using Financial.Investment.Application.Services;
+using Financial.Investment.Application.Tests.TestHelpers;
 using Financial.Investment.Domain.Entities;
 using FluentAssertions;
 
@@ -302,7 +302,7 @@ public class CreditServiceTests
     {
         CreateService().GetCreditsByBroker("XPI");
 
-        _repository.LastBrokerScope.Should().Be(InvestmentScope.Active);
+        _repository.LastGetAssetsByBrokerScope.Should().Be(InvestmentScope.Active);
     }
 
     [Fact]
@@ -310,7 +310,7 @@ public class CreditServiceTests
     {
         CreateService().GetCreditsByBroker("XPI", InvestmentScope.Historic);
 
-        _repository.LastBrokerScope.Should().Be(InvestmentScope.Historic);
+        _repository.LastGetAssetsByBrokerScope.Should().Be(InvestmentScope.Historic);
     }
 
     [Fact]
@@ -318,7 +318,7 @@ public class CreditServiceTests
     {
         CreateService().GetCreditsByPortfolio("XPI", "Default", InvestmentScope.Historic);
 
-        _repository.LastPortfolioScope.Should().Be(InvestmentScope.Historic);
+        _repository.LastGetAssetsByBrokerPortfolioScope.Should().Be(InvestmentScope.Historic);
     }
 
     private CreditService CreateService() => new(_repository, new NavigationService(_repository));
@@ -326,35 +326,4 @@ public class CreditServiceTests
     private static Asset MakeAsset(string name = "AAAA") =>
         Asset.Create(name, "ISIN", "BVMF", name);
 
-    private sealed class StubRepository : IRepository
-    {
-        public Asset? Asset { get; set; }
-        public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
-        public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
-        public IEnumerable<Broker> Brokers { get; set; } = [];
-        public int SaveChangesCallCount { get; private set; }
-        public InvestmentScope? LastBrokerScope { get; private set; }
-        public InvestmentScope? LastPortfolioScope { get; private set; }
-
-        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active)
-        {
-            LastBrokerScope = scope;
-            return AssetsByBroker;
-        }
-
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
-        {
-            LastPortfolioScope = scope;
-            return AssetsByBrokerPortfolio;
-        }
-
-        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => Brokers;
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => Asset;
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            return Task.CompletedTask;
-        }
-    }
 }

--- a/Tests/Financial.Investment.Application.Tests/Services/NavigationServiceTests.cs
+++ b/Tests/Financial.Investment.Application.Tests/Services/NavigationServiceTests.cs
@@ -1,7 +1,7 @@
 using Financial.Investment.Application.DTOs;
 using Financial.Investment.Application.Enums;
-using Financial.Investment.Application.Interfaces;
 using Financial.Investment.Application.Services;
+using Financial.Investment.Application.Tests.TestHelpers;
 using Financial.Investment.Domain.Entities;
 using FluentAssertions;
 
@@ -315,22 +315,4 @@ public class NavigationServiceTests
         return broker;
     }
 
-    private sealed class StubRepository : IRepository
-    {
-        public Broker? Broker { get; set; }
-        public IEnumerable<Broker>? Brokers { get; set; }
-
-        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) =>
-            Broker == null ? [] : Broker.Portfolios.SelectMany(p => p.Assets);
-
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) =>
-            Broker?.Portfolios.FirstOrDefault(p => p.Name == portfolio)?.Assets ?? [];
-
-        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) =>
-            Brokers ?? (Broker == null ? [] : [Broker]);
-
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) =>
-            Broker?.Portfolios.FirstOrDefault(p => p.Name == portfolioName)?.Assets.FirstOrDefault(a => a.Name == assetName);
-        public Task SaveChangesAsync() => Task.CompletedTask;
-    }
 }

--- a/Tests/Financial.Investment.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs
+++ b/Tests/Financial.Investment.Application.Tests/Services/PortfolioAssetSummaryServiceTests.cs
@@ -1,6 +1,6 @@
 using Financial.Investment.Application.Enums;
-using Financial.Investment.Application.Interfaces;
 using Financial.Investment.Application.Services;
+using Financial.Investment.Application.Tests.TestHelpers;
 using Financial.Investment.Domain.Entities;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -22,7 +22,7 @@ public class PortfolioAssetSummaryServiceTests
     public void GetPortfolioAssetsSummary_ReturnsAssetClass_MatchingAssetClassification()
     {
         var asset = Asset.Create("Bitcoin", "", "", "BTC", CountryCode.UK, "", GlobalAssetClass.Cryptocurrency);
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("Coinbase", "Cryptocurrency");
 
@@ -37,7 +37,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddTransaction(Transaction.Create(new DateTime(2021, 3, 1), Transaction.TransactionType.Buy, 10m, 100m, 0m));
         asset.AddTransaction(Transaction.Create(new DateTime(2021, 5, 1), Transaction.TransactionType.Buy, 15m, 100m, 0m));
         asset.AddTransaction(Transaction.Create(new DateTime(2022, 1, 1), Transaction.TransactionType.Sell, 5m, 110m, 0m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -59,7 +59,7 @@ public class PortfolioAssetSummaryServiceTests
     [Fact]
     public void GetPortfolioAssetsSummary_SortsAlphabetically()
     {
-        _repository.Assets = [
+        _repository.AssetsByBrokerPortfolio = [
             MakeAsset("ZEBRA", "ZBR", "BVMF"),
             MakeAsset("APPLE", "APL", "BVMF"),
             MakeAsset("MANGO", "MNG", "BVMF"),
@@ -79,7 +79,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset2 = MakeAsset("BETA", "BET", "BVMF");
         asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 700m, 0m));
 
-        _repository.Assets = [asset1, asset2];
+        _repository.AssetsByBrokerPortfolio = [asset1, asset2];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -99,7 +99,7 @@ public class PortfolioAssetSummaryServiceTests
         asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 200m, 0m));
         asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 200m, 0m));
 
-        _repository.Assets = [asset1, asset2];
+        _repository.AssetsByBrokerPortfolio = [asset1, asset2];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -112,7 +112,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2021, 6, 1), Transaction.TransactionType.Buy, 5m, 10m, 0m));
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 15), Transaction.TransactionType.Buy, 5m, 10m, 0m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -122,7 +122,7 @@ public class PortfolioAssetSummaryServiceTests
     [Fact]
     public void GetPortfolioAssetsSummary_SetsFirstInvestmentDate_Null_WhenNoBuyTransactions()
     {
-        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
+        _repository.AssetsByBrokerPortfolio = [MakeAsset("TEST", "TST", "BVMF")];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -139,7 +139,7 @@ public class PortfolioAssetSummaryServiceTests
         inactive.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 10m, 0m));
         inactive.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 10m, 0m));
 
-        _repository.Assets = [active, inactive];
+        _repository.AssetsByBrokerPortfolio = [active, inactive];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -149,7 +149,7 @@ public class PortfolioAssetSummaryServiceTests
     [Fact]
     public void GetPortfolioAssetsSummary_ReturnsEmptyList_WhenPortfolioHasNoAssets()
     {
-        _repository.Assets = [];
+        _repository.AssetsByBrokerPortfolio = [];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -185,7 +185,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 10m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2023, 1, 1), Credit.CreditType.Dividend, 30m));
         asset.AddCredit(Credit.Create(new DateTime(2023, 6, 1), Credit.CreditType.Rent, 15m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -197,7 +197,7 @@ public class PortfolioAssetSummaryServiceTests
     {
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -209,7 +209,7 @@ public class PortfolioAssetSummaryServiceTests
     {
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 10m, 10m, 0m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -224,7 +224,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 10m, 10m, 0m));
         asset.AddTransaction(Transaction.Create(new DateTime(2022, 1, 1), Transaction.TransactionType.Sell, 5m, 10m, 0m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -238,7 +238,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 1m, 10m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2023, 3, 1), Credit.CreditType.Dividend, 25m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -253,7 +253,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddTransaction(Transaction.Create(new DateTime(2022, 6, 1), Transaction.TransactionType.Buy, 1m, 10m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2021, 9, 15), Credit.CreditType.Dividend, 5m));
         asset.AddTransaction(Transaction.Create(new DateTime(2023, 1, 1), Transaction.TransactionType.Sell, 1m, 12m, 0m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -267,7 +267,7 @@ public class PortfolioAssetSummaryServiceTests
     [Fact]
     public void GetPortfolioAssetsSummary_ReturnsCashFlows_Empty_WhenNoTransactionsOrCredits()
     {
-        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
+        _repository.AssetsByBrokerPortfolio = [MakeAsset("TEST", "TST", "BVMF")];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -282,7 +282,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 5m, 10m, 0m));
         asset.AddTransaction(Transaction.Create(new DateTime(2022, 1, 1), Transaction.TransactionType.Sell, 2m, 12m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2021, 6, 1), Credit.CreditType.Dividend, 8m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -297,7 +297,7 @@ public class PortfolioAssetSummaryServiceTests
     {
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2021, 1, 1), Transaction.TransactionType.Buy, 10m, 15m, 5m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -314,7 +314,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 20m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 10m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 6, 15), Credit.CreditType.Dividend, 8m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -329,7 +329,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddCredit(Credit.Create(new DateTime(2023, 6, 1), Credit.CreditType.Dividend, 100m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 20m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 6, 15), Credit.CreditType.Dividend, 8m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -342,7 +342,7 @@ public class PortfolioAssetSummaryServiceTests
     {
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -355,7 +355,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 6, 10), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -366,7 +366,7 @@ public class PortfolioAssetSummaryServiceTests
     public void GetPortfolioAssetsSummary_ReturnsLastCreditMonth_Null_WhenNoCredits()
     {
         var asset = MakeAsset("TEST", "TST", "BVMF");
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -382,7 +382,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
         asset.AddCredit(Credit.Create(pastDate, Credit.CreditType.Dividend, 10m));
         asset.AddCredit(Credit.Create(futureDate, Credit.CreditType.Dividend, 99m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -397,7 +397,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 10m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -411,7 +411,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 2, 1), Transaction.TransactionType.Sell, 1m, 100m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -423,7 +423,7 @@ public class PortfolioAssetSummaryServiceTests
     {
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -438,7 +438,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 2, 15), Credit.CreditType.Dividend, 5m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 3, 15), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -453,7 +453,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 4, 15), Credit.CreditType.Dividend, 5m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 7, 15), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -468,7 +468,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 5, 15), Credit.CreditType.Dividend, 5m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 9, 15), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -482,7 +482,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 6, 15), Credit.CreditType.Dividend, 3m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -496,7 +496,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 1, 15), Credit.CreditType.Dividend, 5m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 9, 15), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -511,7 +511,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 50m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 50m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 50m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -524,7 +524,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -539,7 +539,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 50m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 50m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 50m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -552,7 +552,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 6, 1), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -568,7 +568,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddCredit(Credit.Create(new DateTime(2024, 1, 1), Credit.CreditType.Dividend, 5m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 2, 1), Credit.CreditType.Dividend, 5m));
         asset.AddCredit(Credit.Create(new DateTime(2024, 3, 1), Credit.CreditType.Dividend, 5m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -584,7 +584,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddCredit(Credit.Create(new DateTime(today.Year, today.Month, 1), Credit.CreditType.Dividend, 12m));
         asset.AddCredit(Credit.Create(new DateTime(today.Year, today.Month, 10), Credit.CreditType.Dividend, 8m));
         asset.AddCredit(Credit.Create(today.AddMonths(-1), Credit.CreditType.Dividend, 99m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -597,7 +597,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 100m, 0m));
         asset.AddCredit(Credit.Create(DateTime.Today.AddMonths(-1), Credit.CreditType.Dividend, 15m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -607,11 +607,11 @@ public class PortfolioAssetSummaryServiceTests
     [Fact]
     public void GetPortfolioAssetsSummary_DefaultScope_QueriesActiveScopeFromRepository()
     {
-        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
+        _repository.AssetsByBrokerPortfolio = [MakeAsset("TEST", "TST", "BVMF")];
 
         CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
-        _repository.LastRequestedScope.Should().Be(InvestmentScope.Active);
+        _repository.LastGetAssetsByBrokerPortfolioScope.Should().Be(InvestmentScope.Active);
     }
 
     [Fact]
@@ -620,7 +620,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset = MakeAsset("TEST", "TST", "BVMF");
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 60m, 0m));
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 50m, 0m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Default");
 
@@ -630,11 +630,11 @@ public class PortfolioAssetSummaryServiceTests
     [Fact]
     public void GetPortfolioAssetsSummary_HistoricScope_QueriesHistoricScopeFromRepository()
     {
-        _repository.Assets = [MakeAsset("TEST", "TST", "BVMF")];
+        _repository.AssetsByBrokerPortfolio = [MakeAsset("TEST", "TST", "BVMF")];
 
         CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized", InvestmentScope.Historic);
 
-        _repository.LastRequestedScope.Should().Be(InvestmentScope.Historic);
+        _repository.LastGetAssetsByBrokerPortfolioScope.Should().Be(InvestmentScope.Historic);
     }
 
     [Fact]
@@ -643,7 +643,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset = MakeAsset("CLOSEDASSET", "CLOSEDASSET", "BVMF");
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 60m, 0m));
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 50m, 0m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized", InvestmentScope.Historic);
 
@@ -661,7 +661,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 60m, 0m));
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 50m, 0m));
         asset.AddCredit(Credit.Create(DateTime.Today, Credit.CreditType.Dividend, 20m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized", InvestmentScope.Historic);
 
@@ -675,7 +675,7 @@ public class PortfolioAssetSummaryServiceTests
         var asset = MakeAsset("CLOSEDASSET", "CLOSEDASSET", "BVMF");
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 5m, 60m, 0m));
         asset.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 5m, 50m, 0m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized", InvestmentScope.Historic);
 
@@ -693,7 +693,7 @@ public class PortfolioAssetSummaryServiceTests
         asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Buy, 1m, 700m, 0m));
         asset2.AddTransaction(Transaction.Create(DateTime.Today, Transaction.TransactionType.Sell, 1m, 690m, 0m));
 
-        _repository.Assets = [asset1, asset2];
+        _repository.AssetsByBrokerPortfolio = [asset1, asset2];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized", InvestmentScope.Historic);
 
@@ -710,7 +710,7 @@ public class PortfolioAssetSummaryServiceTests
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 1, 1), Transaction.TransactionType.Buy, 1m, 1000m, 0m));
         asset.AddTransaction(Transaction.Create(new DateTime(2020, 6, 1), Transaction.TransactionType.Sell, 1m, 990m, 0m));
         asset.AddCredit(Credit.Create(new DateTime(2020, 3, 1), Credit.CreditType.Dividend, 10m));
-        _repository.Assets = [asset];
+        _repository.AssetsByBrokerPortfolio = [asset];
 
         var result = CreateService().GetPortfolioAssetsSummary("XPI", "Uncategorized", InvestmentScope.Historic);
 
@@ -723,19 +723,4 @@ public class PortfolioAssetSummaryServiceTests
     private static Asset MakeAsset(string name, string ticker, string exchange) =>
         Asset.Create(name, "ISIN", exchange, ticker);
 
-    private sealed class StubRepository : IRepository
-    {
-        public IEnumerable<Asset> Assets { get; set; } = [];
-        public InvestmentScope? LastRequestedScope { get; private set; }
-
-        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => [];
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
-        {
-            LastRequestedScope = scope;
-            return Assets;
-        }
-        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => [];
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
-        public Task SaveChangesAsync() => Task.CompletedTask;
-    }
 }

--- a/Tests/Financial.Investment.Application.Tests/Services/SummaryServiceTests.cs
+++ b/Tests/Financial.Investment.Application.Tests/Services/SummaryServiceTests.cs
@@ -1,6 +1,6 @@
 using Financial.Investment.Application.Enums;
-using Financial.Investment.Application.Interfaces;
 using Financial.Investment.Application.Services;
+using Financial.Investment.Application.Tests.TestHelpers;
 using Financial.Investment.Domain.Entities;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -85,7 +85,7 @@ public class SummaryServiceTests
 
         CreateService().GetBrokerSummary("XPI", InvestmentScope.Historic);
 
-        _repository.LastRequestedBrokerListScope.Should().Be(InvestmentScope.Historic);
+        _repository.LastGetBrokerListScope.Should().Be(InvestmentScope.Historic);
     }
 
     [Fact]
@@ -225,7 +225,7 @@ public class SummaryServiceTests
 
         CreateService().GetPortfolioSummary("XPI", "Default", InvestmentScope.Historic);
 
-        _repository.LastRequestedAssetsByBrokerPortfolioScope.Should().Be(InvestmentScope.Historic);
+        _repository.LastGetAssetsByBrokerPortfolioScope.Should().Be(InvestmentScope.Historic);
     }
 
     [Fact]
@@ -283,26 +283,4 @@ public class SummaryServiceTests
         return broker;
     }
 
-    private sealed class StubRepository : IRepository
-    {
-        public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
-        public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
-        public IEnumerable<Broker> Brokers { get; set; } = [];
-        public InvestmentScope? LastRequestedBrokerListScope { get; private set; }
-        public InvestmentScope? LastRequestedAssetsByBrokerPortfolioScope { get; private set; }
-
-        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
-        {
-            LastRequestedAssetsByBrokerPortfolioScope = scope;
-            return AssetsByBrokerPortfolio;
-        }
-        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active)
-        {
-            LastRequestedBrokerListScope = scope;
-            return Brokers;
-        }
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
-        public Task SaveChangesAsync() => Task.CompletedTask;
-    }
 }

--- a/Tests/Financial.Investment.Application.Tests/Services/TransactionServiceMutationTests.cs
+++ b/Tests/Financial.Investment.Application.Tests/Services/TransactionServiceMutationTests.cs
@@ -1,7 +1,7 @@
 using Financial.Investment.Application.DTOs;
 using Financial.Investment.Application.Enums;
-using Financial.Investment.Application.Interfaces;
 using Financial.Investment.Application.Services;
+using Financial.Investment.Application.Tests.TestHelpers;
 using Financial.Investment.Domain.Entities;
 using FluentAssertions;
 
@@ -216,23 +216,4 @@ public class TransactionServiceMutationTests
     private static Asset MakeAsset(string name = "AAAA") =>
         Asset.Create(name, "ISIN", "BVMF", name);
 
-    private sealed class StubRepository : IRepository
-    {
-        public Asset? Asset { get; set; }
-        public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
-        public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
-        public IEnumerable<Broker> Brokers { get; set; } = [];
-        public int SaveChangesCallCount { get; private set; }
-
-        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active) => AssetsByBroker;
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active) => AssetsByBrokerPortfolio;
-        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => Brokers;
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => Asset;
-
-        public Task SaveChangesAsync()
-        {
-            SaveChangesCallCount++;
-            return Task.CompletedTask;
-        }
-    }
 }

--- a/Tests/Financial.Investment.Application.Tests/Services/TransactionServiceQueryTests.cs
+++ b/Tests/Financial.Investment.Application.Tests/Services/TransactionServiceQueryTests.cs
@@ -1,6 +1,6 @@
 using Financial.Investment.Application.Enums;
-using Financial.Investment.Application.Interfaces;
 using Financial.Investment.Application.Services;
+using Financial.Investment.Application.Tests.TestHelpers;
 using Financial.Investment.Domain.Entities;
 using FluentAssertions;
 
@@ -131,7 +131,7 @@ public class TransactionServiceQueryTests
     {
         CreateService().GetTransactionsByBroker("XPI");
 
-        _repository.LastBrokerScope.Should().Be(InvestmentScope.Active);
+        _repository.LastGetAssetsByBrokerScope.Should().Be(InvestmentScope.Active);
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class TransactionServiceQueryTests
     {
         CreateService().GetTransactionsByBroker("XPI", InvestmentScope.Historic);
 
-        _repository.LastBrokerScope.Should().Be(InvestmentScope.Historic);
+        _repository.LastGetAssetsByBrokerScope.Should().Be(InvestmentScope.Historic);
     }
 
     [Fact]
@@ -147,7 +147,7 @@ public class TransactionServiceQueryTests
     {
         CreateService().GetTransactionsByPortfolio("XPI", "Default", InvestmentScope.Historic);
 
-        _repository.LastPortfolioScope.Should().Be(InvestmentScope.Historic);
+        _repository.LastGetAssetsByBrokerPortfolioScope.Should().Be(InvestmentScope.Historic);
     }
 
     [Theory]
@@ -173,28 +173,4 @@ public class TransactionServiceQueryTests
     private static Asset MakeAsset(string name = "TEST") =>
         Asset.Create(name, "ISIN", "BVMF", name);
 
-    private sealed class StubRepository : IRepository
-    {
-        public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
-        public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
-        public IEnumerable<Broker> Brokers { get; set; } = [];
-        public InvestmentScope? LastBrokerScope { get; private set; }
-        public InvestmentScope? LastPortfolioScope { get; private set; }
-
-        public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active)
-        {
-            LastBrokerScope = scope;
-            return AssetsByBroker;
-        }
-
-        public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
-        {
-            LastPortfolioScope = scope;
-            return AssetsByBrokerPortfolio;
-        }
-
-        public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active) => Brokers;
-        public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) => null;
-        public Task SaveChangesAsync() => Task.CompletedTask;
-    }
 }

--- a/Tests/Financial.Investment.Application.Tests/TestHelpers/StubRepository.cs
+++ b/Tests/Financial.Investment.Application.Tests/TestHelpers/StubRepository.cs
@@ -1,0 +1,57 @@
+using Financial.Investment.Application.Enums;
+using Financial.Investment.Application.Interfaces;
+using Financial.Investment.Domain.Entities;
+
+namespace Financial.Investment.Application.Tests.TestHelpers;
+
+/// <summary>
+/// Shared in-memory <see cref="IRepository"/> test double. Two ways to configure a scenario:
+/// set <see cref="Broker"/> (and/or <see cref="Brokers"/>) to have every query method derive its
+/// answer from that real domain object graph, or leave them null and set the flat
+/// <see cref="AssetsByBroker"/>/<see cref="AssetsByBrokerPortfolio"/>/<see cref="Asset"/> fields
+/// directly for tests that don't need a full broker/portfolio/asset graph.
+/// </summary>
+internal sealed class StubRepository : IRepository
+{
+    public Broker? Broker { get; set; }
+    public IEnumerable<Broker>? Brokers { get; set; }
+    public IEnumerable<Asset> AssetsByBroker { get; set; } = [];
+    public IEnumerable<Asset> AssetsByBrokerPortfolio { get; set; } = [];
+    public Asset? Asset { get; set; }
+
+    public int SaveChangesCallCount { get; private set; }
+    public InvestmentScope? LastGetAssetsByBrokerScope { get; private set; }
+    public InvestmentScope? LastGetAssetsByBrokerPortfolioScope { get; private set; }
+    public InvestmentScope? LastGetBrokerListScope { get; private set; }
+
+    public IEnumerable<Asset> GetAssetsByBroker(string name, InvestmentScope scope = InvestmentScope.Active)
+    {
+        LastGetAssetsByBrokerScope = scope;
+        return Broker is not null ? Broker.Portfolios.SelectMany(p => p.Assets) : AssetsByBroker;
+    }
+
+    public IEnumerable<Asset> GetAssetsByBrokerPortfolio(string broker, string portfolio, InvestmentScope scope = InvestmentScope.Active)
+    {
+        LastGetAssetsByBrokerPortfolioScope = scope;
+        return Broker is not null
+            ? Broker.Portfolios.FirstOrDefault(p => p.Name == portfolio)?.Assets ?? []
+            : AssetsByBrokerPortfolio;
+    }
+
+    public IEnumerable<Broker> GetBrokerList(InvestmentScope scope = InvestmentScope.Active)
+    {
+        LastGetBrokerListScope = scope;
+        return Brokers ?? (Broker is not null ? [Broker] : []);
+    }
+
+    public Asset? GetAsset(string brokerName, string portfolioName, string assetName, InvestmentScope scope = InvestmentScope.Active) =>
+        Broker is not null
+            ? Broker.Portfolios.FirstOrDefault(p => p.Name == portfolioName)?.Assets.FirstOrDefault(a => a.Name == assetName)
+            : Asset;
+
+    public Task SaveChangesAsync()
+    {
+        SaveChangesCallCount++;
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #300 — applies the same DRY treatment to Investment's `IRepository`, and fixes a second duplication PR #300 knowingly left in place.

- `IRepository` (4 methods) was duplicated as a private nested `StubRepository` class in **7 files** under `Tests/Financial.Investment.Application.Tests/Services/`. Unlike the earlier assessment on #300, these turned out to be consolidatable without a "configuration grab bag": every file's stub either (a) returns flat, settable lists (`AssetsByBroker`, `AssetsByBrokerPortfolio`, `Brokers`, `Asset`), or (b) derives its answers from a single `Broker` object graph (`NavigationServiceTests`). A single shared `StubRepository` supports both: set `Broker`/`Brokers` for the derived behavior, or leave them null and set the flat fields directly — a strict superset that reproduces every existing file's exact behavior.
- Per-method scope-tracking properties (`LastRequestedScope`, `LastBrokerScope`, `LastPortfolioScope`, `LastRequestedBrokerListScope`, `LastRequestedAssetsByBrokerPortfolioScope` — five different names across the 7 files for essentially 3 concepts) are unified to `LastGetAssetsByBrokerScope`, `LastGetAssetsByBrokerPortfolioScope`, `LastGetBrokerListScope`, named consistently after the method they track.
- Also dedupes the 11-entry seeded investment account array that `AnnualSummaryServiceTests` and `InvestmentSnapshotServiceTests` (CashFlow side) each carried a full copy of, into a shared `SeededInvestmentAccounts` helper next to the existing `StubCashFlowRepository`/`FakeTimeProvider` test helpers.

No production code changed — test-only refactor.

## Test plan
- [x] `dotnet test` across the full solution — all green, identical pass counts to before (1,678 passed, 5 pre-existing skips), confirming no behavior changed
- [x] `Financial.Investment.Application.Tests` specifically — 260/260 passed (same count as before)
- [x] `Financial.CashFlow.Application.Tests` specifically — 258/258 passed (same count as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)