### PR TITLE
feat(P20-F05): add web Balance Adjustment entry form

### DIFF
--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -5,6 +5,8 @@ import { createFinancialApiClient } from './financialApiClient'
 import type {
   AssetDetailsDto,
   AssetPriceDto,
+  BalanceAdjustmentDto,
+  CreateBalanceAdjustmentDto,
   CreateMaeLedgerEntryDto,
   CreateRecurringBillDto,
   CreateTransferDto,
@@ -18,6 +20,7 @@ import type {
   ReserveMovementDto,
   TransferDto,
   TreeNodeDto,
+  UpdateBalanceAdjustmentDto,
   UpdateInvestmentSnapshotValueDto,
   UpdateMaeLedgerEntryValuesDto,
   UpdateRecurringBillDto,
@@ -717,6 +720,44 @@ describe('financialApiClient', () => {
     expect(result).toEqual(responseBody)
     const [url, init] = fetchMock.mock.calls[0]
     expect(url).toBe(`${API_BASE_URL}/transfers/t1`)
+    expect(init?.method).toBe('PUT')
+    expect(JSON.parse(init?.body as string)).toEqual(requestBody)
+  })
+
+  it('posts a balance adjustment create request', async () => {
+    const requestBody: CreateBalanceAdjustmentDto = {
+      date: '2026-07-25',
+      targetBalance: 2340.17,
+      note: 'Matched against July statement',
+    }
+    const responseBody: BalanceAdjustmentDto = { id: 'a1', bank: 'Barclays', delta: -4.2, ...requestBody }
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.createBalanceAdjustment('Barclays', requestBody)
+
+    expect(result).toEqual(responseBody)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/banks/Barclays/adjustments`)
+    expect(init?.method).toBe('POST')
+    expect(JSON.parse(init?.body as string)).toEqual(requestBody)
+  })
+
+  it('puts a balance adjustment update', async () => {
+    const requestBody: UpdateBalanceAdjustmentDto = {
+      date: '2026-07-25',
+      targetBalance: 120,
+      note: 'Corrected',
+    }
+    const responseBody: BalanceAdjustmentDto = { id: 'a1', bank: 'Barclays', delta: 20, ...requestBody }
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.updateBalanceAdjustment('Barclays', 'a1', requestBody)
+
+    expect(result).toEqual(responseBody)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/banks/Barclays/adjustments/a1`)
     expect(init?.method).toBe('PUT')
     expect(JSON.parse(init?.body as string)).toEqual(requestBody)
   })

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -47,6 +47,9 @@ import type {
   TransferDto,
   CreateTransferDto,
   UpdateTransferDto,
+  BalanceAdjustmentDto,
+  CreateBalanceAdjustmentDto,
+  UpdateBalanceAdjustmentDto,
   TreeNodeDto,
   UpdateExpenseDto,
   UpdateIncomeDto,
@@ -121,6 +124,12 @@ export interface FinancialApiClient {
   deleteIncome: (id: string) => Promise<void>
   createTransfer: (request: CreateTransferDto) => Promise<TransferDto>
   updateTransfer: (id: string, request: UpdateTransferDto) => Promise<TransferDto>
+  createBalanceAdjustment: (bankName: string, request: CreateBalanceAdjustmentDto) => Promise<BalanceAdjustmentDto>
+  updateBalanceAdjustment: (
+    bankName: string,
+    id: string,
+    request: UpdateBalanceAdjustmentDto,
+  ) => Promise<BalanceAdjustmentDto>
   getCardStatementsByMonth: (year: number, month: number) => Promise<CardStatementDto[]>
   markCardStatementPaid: (id: string, request: MarkCardStatementPaidDto) => Promise<CardStatementDto>
   unmarkCardStatementPaid: (id: string) => Promise<CardStatementDto>
@@ -374,6 +383,16 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       }),
     updateTransfer: (id, requestBody) =>
       request<TransferDto>(`/transfers/${encodeURIComponent(id)}`, {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+      }),
+    createBalanceAdjustment: (bankName, requestBody) =>
+      request<BalanceAdjustmentDto>(`/banks/${encodeURIComponent(bankName)}/adjustments`, {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      }),
+    updateBalanceAdjustment: (bankName, id, requestBody) =>
+      request<BalanceAdjustmentDto>(`/banks/${encodeURIComponent(bankName)}/adjustments/${encodeURIComponent(id)}`, {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       }),

--- a/Financial.Web/src/api/types.ts
+++ b/Financial.Web/src/api/types.ts
@@ -548,3 +548,24 @@ export interface UpdateTransferDto {
   amount: number
   note: string | null
 }
+
+export interface BalanceAdjustmentDto {
+  id: string
+  date: string
+  bank: string
+  targetBalance: number
+  delta: number
+  note: string | null
+}
+
+export interface CreateBalanceAdjustmentDto {
+  date: string
+  targetBalance: number
+  note: string | null
+}
+
+export interface UpdateBalanceAdjustmentDto {
+  date: string
+  targetBalance: number
+  note: string | null
+}

--- a/Financial.Web/src/components/BalanceAdjustmentForm.tsx
+++ b/Financial.Web/src/components/BalanceAdjustmentForm.tsx
@@ -1,0 +1,106 @@
+import type { BalanceAdjustmentFormField } from '../hooks/mapBalanceAdjustmentErrorToField'
+import { formatN2 } from '../utils/formatters'
+
+interface BalanceAdjustmentFormProps {
+  isEditing: boolean
+  bankName: string
+  currentBalance: number
+  date: string
+  targetBalance: string
+  note: string
+  isSaving: boolean
+  saveError: string | null
+  saveErrorField: BalanceAdjustmentFormField | null
+  savedDelta: number | null
+  onFieldChange: (field: BalanceAdjustmentFormField, value: string) => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+export default function BalanceAdjustmentForm({
+  isEditing,
+  bankName,
+  currentBalance,
+  date,
+  targetBalance,
+  note,
+  isSaving,
+  saveError,
+  saveErrorField,
+  savedDelta,
+  onFieldChange,
+  onSave,
+  onCancel,
+}: BalanceAdjustmentFormProps) {
+  if (savedDelta !== null) {
+    const sign = savedDelta < 0 ? '-' : ''
+    return (
+      <div className="monthly-page__form-panel">
+        <p className="monthly-page__form-title">Balance Corrected</p>
+        <p>
+          Adjustment of {sign}£{formatN2(Math.abs(savedDelta))} recorded
+        </p>
+        <div className="monthly-page__form-actions">
+          <button className="monthly-page__submit-btn" type="button" onClick={onCancel}>
+            Close
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const fieldError = (field: BalanceAdjustmentFormField): string | null =>
+    saveErrorField === field ? saveError : null
+
+  const generalError = saveErrorField === null ? saveError : null
+
+  return (
+    <div className="monthly-page__form-panel">
+      <p className="monthly-page__form-title">{isEditing ? 'Edit Balance Adjustment' : 'Correct Balance'}</p>
+      <p className="monthly-page__form-reference">
+        Current calculated balance for {bankName}: £{formatN2(currentBalance)}
+      </p>
+      <div className="monthly-page__form">
+        <div className="monthly-page__form-field">
+          <label htmlFor="adjustment-date">Date</label>
+          <input
+            id="adjustment-date"
+            type="date"
+            value={date}
+            onChange={(e) => onFieldChange('date', e.target.value)}
+          />
+          {fieldError('date') && <p className="monthly-page__error">{fieldError('date')}</p>}
+        </div>
+        <div className="monthly-page__form-field">
+          <label htmlFor="adjustment-target-balance">Target Balance</label>
+          <input
+            id="adjustment-target-balance"
+            type="number"
+            step="0.01"
+            value={targetBalance}
+            onChange={(e) => onFieldChange('targetBalance', e.target.value)}
+          />
+          {fieldError('targetBalance') && <p className="monthly-page__error">{fieldError('targetBalance')}</p>}
+        </div>
+        <div className="monthly-page__form-field">
+          <label htmlFor="adjustment-note">Note</label>
+          <input
+            id="adjustment-note"
+            type="text"
+            value={note}
+            onChange={(e) => onFieldChange('note', e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="monthly-page__form-actions">
+        <button className="monthly-page__submit-btn" type="button" disabled={isSaving} onClick={onSave}>
+          {isSaving ? 'Saving...' : isEditing ? 'Save' : 'Correct Balance'}
+        </button>
+        <button className="monthly-page__cancel-btn" type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+      {generalError && <p className="monthly-page__error">{generalError}</p>}
+    </div>
+  )
+}

--- a/Financial.Web/src/components/__tests__/BalanceAdjustmentForm.test.tsx
+++ b/Financial.Web/src/components/__tests__/BalanceAdjustmentForm.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import BalanceAdjustmentForm from '../BalanceAdjustmentForm'
+
+const baseProps = {
+  isEditing: false,
+  bankName: 'Barclays',
+  currentBalance: 100,
+  date: '2026-07-25',
+  targetBalance: '',
+  note: '',
+  isSaving: false,
+  saveError: null,
+  saveErrorField: null,
+  savedDelta: null,
+  onFieldChange: vi.fn(),
+  onSave: vi.fn(),
+  onCancel: vi.fn(),
+}
+
+describe('BalanceAdjustmentForm', () => {
+  it('renders the current calculated balance from the currentBalance prop', () => {
+    render(<BalanceAdjustmentForm {...baseProps} bankName="Barclays" currentBalance={2344.37} />)
+
+    expect(screen.getByText('Current calculated balance for Barclays: £2,344.37')).toBeInTheDocument()
+  })
+
+  it('renders the create form title', () => {
+    const { container } = render(<BalanceAdjustmentForm {...baseProps} />)
+
+    expect(container.querySelector('.monthly-page__form-title')).toHaveTextContent('Correct Balance')
+  })
+
+  it('renders the edit form title and pre-filled values', () => {
+    const { container } = render(
+      <BalanceAdjustmentForm {...baseProps} isEditing targetBalance="150" note="Matched statement" />,
+    )
+
+    expect(container.querySelector('.monthly-page__form-title')).toHaveTextContent('Edit Balance Adjustment')
+    expect(screen.getByLabelText('Target Balance')).toHaveValue(150)
+    expect(screen.getByLabelText('Note')).toHaveValue('Matched statement')
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  })
+
+  it('shows the saved-state confirmation with a positive delta and hides the editable fields', () => {
+    render(<BalanceAdjustmentForm {...baseProps} savedDelta={4.2} />)
+
+    expect(screen.getByText('Adjustment of £4.20 recorded')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Target Balance')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+  })
+
+  it('shows the saved-state confirmation with a negative delta', () => {
+    render(<BalanceAdjustmentForm {...baseProps} savedDelta={-4.2} />)
+
+    expect(screen.getByText('Adjustment of -£4.20 recorded')).toBeInTheDocument()
+  })
+
+  it('calls onCancel when the Close button is clicked in the saved state', () => {
+    const onCancel = vi.fn()
+    render(<BalanceAdjustmentForm {...baseProps} savedDelta={4.2} onCancel={onCancel} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('calls onSave and onCancel', () => {
+    const onSave = vi.fn()
+    const onCancel = vi.fn()
+    render(<BalanceAdjustmentForm {...baseProps} onSave={onSave} onCancel={onCancel} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Correct Balance' }))
+    expect(onSave).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('renders a backend error under the field named by saveErrorField', () => {
+    render(<BalanceAdjustmentForm {...baseProps} saveError="Balance cannot be negative." saveErrorField="targetBalance" />)
+
+    const field = screen.getByLabelText('Target Balance').closest('.monthly-page__form-field')
+    expect(field).toHaveTextContent('Balance cannot be negative.')
+  })
+
+  it('renders a general error banner when saveErrorField is null', () => {
+    render(<BalanceAdjustmentForm {...baseProps} saveError="Network request failed" saveErrorField={null} />)
+
+    expect(screen.getByText('Network request failed')).toBeInTheDocument()
+  })
+
+  it('shows Saving... and disables the button while isSaving', () => {
+    render(<BalanceAdjustmentForm {...baseProps} isSaving />)
+
+    expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled()
+  })
+})

--- a/Financial.Web/src/hooks/mapBalanceAdjustmentErrorToField.test.ts
+++ b/Financial.Web/src/hooks/mapBalanceAdjustmentErrorToField.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { mapBalanceAdjustmentErrorToField } from './mapBalanceAdjustmentErrorToField'
+
+describe('mapBalanceAdjustmentErrorToField', () => {
+  it('maps a negative balance message to the targetBalance field', () => {
+    const result = mapBalanceAdjustmentErrorToField('Balance cannot be negative.')
+
+    expect(result).toBe('targetBalance')
+  })
+
+  it('returns null for an unresolvable bank message', () => {
+    const result = mapBalanceAdjustmentErrorToField("Bank 'NotABank' was not found.")
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for an unrecognized message', () => {
+    const result = mapBalanceAdjustmentErrorToField('Network request failed')
+
+    expect(result).toBeNull()
+  })
+})

--- a/Financial.Web/src/hooks/mapBalanceAdjustmentErrorToField.ts
+++ b/Financial.Web/src/hooks/mapBalanceAdjustmentErrorToField.ts
@@ -1,0 +1,13 @@
+export type BalanceAdjustmentFormField = 'date' | 'targetBalance' | 'note'
+
+/**
+ * Maps F02's known, fixed balance adjustment validation error message to the field it
+ * belongs to. There is no bank picker on this form (the bank is fixed by the row that
+ * opened it), so an unresolvable-bank message has nowhere to attach inline and falls
+ * back to a general banner, same as any unrecognized message.
+ */
+export function mapBalanceAdjustmentErrorToField(message: string): BalanceAdjustmentFormField | null {
+  if (message.includes('cannot be negative')) return 'targetBalance'
+
+  return null
+}

--- a/Financial.Web/src/hooks/useBalanceAdjustmentForm.test.ts
+++ b/Financial.Web/src/hooks/useBalanceAdjustmentForm.test.ts
@@ -1,0 +1,161 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FinancialApiClient } from '../api/financialApiClient'
+import { ApiError } from '../api/apiError'
+import type { BalanceAdjustmentDto } from '../api/types'
+import { useBalanceAdjustmentForm } from './useBalanceAdjustmentForm'
+
+const createBalanceAdjustmentMock = vi.fn<FinancialApiClient['createBalanceAdjustment']>()
+const updateBalanceAdjustmentMock = vi.fn<FinancialApiClient['updateBalanceAdjustment']>()
+
+vi.mock('../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    createBalanceAdjustment: createBalanceAdjustmentMock,
+    updateBalanceAdjustment: updateBalanceAdjustmentMock,
+  }),
+}))
+
+const ADJUSTMENT: BalanceAdjustmentDto = {
+  id: 'a1',
+  date: '2026-07-20',
+  bank: 'Barclays',
+  targetBalance: 150,
+  delta: 50,
+  note: 'Matched statement',
+}
+
+describe('useBalanceAdjustmentForm', () => {
+  beforeEach(() => {
+    createBalanceAdjustmentMock.mockReset()
+    updateBalanceAdjustmentMock.mockReset()
+  })
+
+  it('starts closed', () => {
+    const { result } = renderHook(() => useBalanceAdjustmentForm(vi.fn()))
+
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  it('openCreateForm defaults date to today and stores bank/currentBalance', () => {
+    const { result } = renderHook(() => useBalanceAdjustmentForm(vi.fn()))
+
+    act(() => result.current.openCreateForm('Barclays', 100))
+
+    const today = new Date().toISOString().slice(0, 10)
+    expect(result.current.isOpen).toBe(true)
+    expect(result.current.isEditing).toBe(false)
+    expect(result.current.bankName).toBe('Barclays')
+    expect(result.current.currentBalance).toBe(100)
+    expect(result.current.date).toBe(today)
+    expect(result.current.savedDelta).toBeNull()
+  })
+
+  it('openEditForm pre-fills targetBalance/date/note from the given adjustment', () => {
+    const { result } = renderHook(() => useBalanceAdjustmentForm(vi.fn()))
+
+    act(() => result.current.openEditForm('Barclays', 100, ADJUSTMENT))
+
+    expect(result.current.isOpen).toBe(true)
+    expect(result.current.isEditing).toBe(true)
+    expect(result.current.bankName).toBe('Barclays')
+    expect(result.current.currentBalance).toBe(100)
+    expect(result.current.date).toBe('2026-07-20')
+    expect(result.current.targetBalance).toBe('150')
+    expect(result.current.note).toBe('Matched statement')
+  })
+
+  it('cancel resets the form to closed and clears savedDelta', () => {
+    const { result } = renderHook(() => useBalanceAdjustmentForm(vi.fn()))
+    act(() => result.current.openEditForm('Barclays', 100, ADJUSTMENT))
+
+    act(() => result.current.cancel())
+
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.savedDelta).toBeNull()
+  })
+
+  it('submit blocks with an error when the target balance is missing', () => {
+    const { result } = renderHook(() => useBalanceAdjustmentForm(vi.fn()))
+    act(() => result.current.openCreateForm('Barclays', 100))
+
+    act(() => result.current.submit())
+
+    expect(result.current.saveErrorField).toBe('targetBalance')
+    expect(createBalanceAdjustmentMock).not.toHaveBeenCalled()
+  })
+
+  it('submit blocks with an error when the target balance is negative', () => {
+    const { result } = renderHook(() => useBalanceAdjustmentForm(vi.fn()))
+    act(() => result.current.openCreateForm('Barclays', 100))
+    act(() => result.current.setField('targetBalance', '-1'))
+
+    act(() => result.current.submit())
+
+    expect(result.current.saveErrorField).toBe('targetBalance')
+    expect(createBalanceAdjustmentMock).not.toHaveBeenCalled()
+  })
+
+  it('submit calls createBalanceAdjustment, sets isSaving, and sets savedDelta on success while staying open', async () => {
+    let resolveCreate!: (value: BalanceAdjustmentDto) => void
+    createBalanceAdjustmentMock.mockReturnValue(new Promise((resolve) => (resolveCreate = resolve)))
+    const onSaved = vi.fn()
+    const { result } = renderHook(() => useBalanceAdjustmentForm(onSaved))
+    act(() => result.current.openCreateForm('Barclays', 100))
+    act(() => result.current.setField('targetBalance', '150'))
+
+    act(() => result.current.submit())
+
+    expect(result.current.isSaving).toBe(true)
+    expect(createBalanceAdjustmentMock).toHaveBeenCalledWith('Barclays', {
+      date: expect.any(String),
+      targetBalance: 150,
+      note: null,
+    })
+
+    await act(async () => {
+      resolveCreate({ ...ADJUSTMENT, delta: -4.2 })
+      await Promise.resolve()
+    })
+
+    expect(result.current.isSaving).toBe(false)
+    expect(result.current.isOpen).toBe(true)
+    expect(result.current.savedDelta).toBe(-4.2)
+    expect(onSaved).toHaveBeenCalledOnce()
+  })
+
+  it('submit calls updateBalanceAdjustment when editing', async () => {
+    updateBalanceAdjustmentMock.mockResolvedValue(ADJUSTMENT)
+    const { result } = renderHook(() => useBalanceAdjustmentForm(vi.fn()))
+    act(() => result.current.openEditForm('Barclays', 100, ADJUSTMENT))
+    act(() => result.current.setField('targetBalance', '120'))
+
+    await act(async () => {
+      result.current.submit()
+      await Promise.resolve()
+    })
+
+    expect(updateBalanceAdjustmentMock).toHaveBeenCalledWith('Barclays', 'a1', {
+      date: '2026-07-20',
+      targetBalance: 120,
+      note: 'Matched statement',
+    })
+  })
+
+  it('sets saveError and saveErrorField from a failed request', async () => {
+    createBalanceAdjustmentMock.mockRejectedValue(new ApiError('Balance cannot be negative.', 400))
+    const { result } = renderHook(() => useBalanceAdjustmentForm(vi.fn()))
+    act(() => result.current.openCreateForm('Barclays', 100))
+    act(() => result.current.setField('targetBalance', '150'))
+
+    await act(async () => {
+      result.current.submit()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.isSaving).toBe(false)
+    expect(result.current.saveError).toBe('Balance cannot be negative.')
+    expect(result.current.saveErrorField).toBe('targetBalance')
+    expect(result.current.isOpen).toBe(true)
+  })
+})

--- a/Financial.Web/src/hooks/useBalanceAdjustmentForm.ts
+++ b/Financial.Web/src/hooks/useBalanceAdjustmentForm.ts
@@ -1,0 +1,154 @@
+import { useMemo, useState } from 'react'
+import { createFinancialApiClient } from '../api/financialApiClient'
+import type { BalanceAdjustmentDto } from '../api/types'
+import { mapBalanceAdjustmentErrorToField, type BalanceAdjustmentFormField } from './mapBalanceAdjustmentErrorToField'
+
+interface BalanceAdjustmentFormState {
+  isOpen: boolean
+  isEditing: boolean
+  editingId: string | null
+  bankName: string
+  currentBalance: number
+  date: string
+  targetBalance: string
+  note: string
+  isSaving: boolean
+  saveError: string | null
+  saveErrorField: BalanceAdjustmentFormField | null
+  savedDelta: number | null
+}
+
+const BLANK_STATE: BalanceAdjustmentFormState = {
+  isOpen: false,
+  isEditing: false,
+  editingId: null,
+  bankName: '',
+  currentBalance: 0,
+  date: '',
+  targetBalance: '',
+  note: '',
+  isSaving: false,
+  saveError: null,
+  saveErrorField: null,
+  savedDelta: null,
+}
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export interface UseBalanceAdjustmentFormResult {
+  isOpen: boolean
+  isEditing: boolean
+  bankName: string
+  currentBalance: number
+  date: string
+  targetBalance: string
+  note: string
+  isSaving: boolean
+  saveError: string | null
+  saveErrorField: BalanceAdjustmentFormField | null
+  savedDelta: number | null
+  openCreateForm: (bankName: string, currentBalance: number) => void
+  openEditForm: (bankName: string, currentBalance: number, adjustment: BalanceAdjustmentDto) => void
+  cancel: () => void
+  setField: (field: BalanceAdjustmentFormField, value: string) => void
+  submit: () => void
+}
+
+/** Owns a balance adjustment's create/edit form state and orchestrates F02's create/update endpoints. */
+export function useBalanceAdjustmentForm(onSaved: () => void): UseBalanceAdjustmentFormResult {
+  const apiClient = useMemo(() => createFinancialApiClient(), [])
+  const [state, setState] = useState<BalanceAdjustmentFormState>(BLANK_STATE)
+
+  function openCreateForm(bankName: string, currentBalance: number) {
+    setState({
+      ...BLANK_STATE,
+      isOpen: true,
+      bankName,
+      currentBalance,
+      date: todayIsoDate(),
+    })
+  }
+
+  function openEditForm(bankName: string, currentBalance: number, adjustment: BalanceAdjustmentDto) {
+    setState({
+      isOpen: true,
+      isEditing: true,
+      editingId: adjustment.id,
+      bankName,
+      currentBalance,
+      date: adjustment.date,
+      targetBalance: String(adjustment.targetBalance),
+      note: adjustment.note ?? '',
+      isSaving: false,
+      saveError: null,
+      saveErrorField: null,
+      savedDelta: null,
+    })
+  }
+
+  function cancel() {
+    setState(BLANK_STATE)
+  }
+
+  function setField(field: BalanceAdjustmentFormField, value: string) {
+    setState((s) => ({ ...s, [field]: value, saveError: null, saveErrorField: null }))
+  }
+
+  function submit() {
+    if (!state.date.trim()) {
+      setState((s) => ({ ...s, saveError: 'Date is required', saveErrorField: 'date' }))
+      return
+    }
+
+    const targetBalance = Number(state.targetBalance)
+    if (!state.targetBalance.trim() || !isFinite(targetBalance) || targetBalance < 0) {
+      setState((s) => ({ ...s, saveError: 'Balance cannot be negative.', saveErrorField: 'targetBalance' }))
+      return
+    }
+
+    setState((s) => ({ ...s, isSaving: true, saveError: null, saveErrorField: null }))
+
+    const payload = {
+      date: state.date,
+      targetBalance,
+      note: state.note.trim() === '' ? null : state.note,
+    }
+
+    const request =
+      state.isEditing && state.editingId
+        ? apiClient.updateBalanceAdjustment(state.bankName, state.editingId, payload)
+        : apiClient.createBalanceAdjustment(state.bankName, payload)
+
+    void request
+      .then((result) => {
+        setState((s) => ({ ...s, isSaving: false, savedDelta: result.delta }))
+        onSaved()
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Failed to save balance adjustment'
+        const field = mapBalanceAdjustmentErrorToField(message)
+        setState((s) => ({ ...s, isSaving: false, saveError: message, saveErrorField: field }))
+      })
+  }
+
+  return {
+    isOpen: state.isOpen,
+    isEditing: state.isEditing,
+    bankName: state.bankName,
+    currentBalance: state.currentBalance,
+    date: state.date,
+    targetBalance: state.targetBalance,
+    note: state.note,
+    isSaving: state.isSaving,
+    saveError: state.saveError,
+    saveErrorField: state.saveErrorField,
+    savedDelta: state.savedDelta,
+    openCreateForm,
+    openEditForm,
+    cancel,
+    setField,
+    submit,
+  }
+}

--- a/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F05-web-balance-adjustment-entry-form/plan.md
+++ b/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F05-web-balance-adjustment-entry-form/plan.md
@@ -1,0 +1,18 @@
+# Implementation Plan: Web Balance Adjustment Entry Form
+
+**Prerequisites:**
+- Existing Financial.Web toolchain (Vite, Vitest, React Testing Library) — no new dependencies
+
+### Stage 1: API Client
+
+**1. Balance Adjustment DTOs and Client Methods** - Add the read/create/update type shapes for a balance adjustment, and add client methods for creating and updating one against a specific bank, following the request/response pattern already used for transfers.
+
+### Stage 2: State and Error Mapping
+
+**2. Balance Adjustment Error Field Mapping** - Add a small, independently testable function that maps the backend's known balance adjustment validation error message to the target-balance field, with a safe fallback for messages it doesn't recognize.
+
+**3. Balance Adjustment Form State Hook** - Add a dedicated hook that owns the create/edit form state for a balance adjustment (open/close, field values, saving/error state, the post-save delta), scoped to a specific bank and its current reference balance passed in by the caller rather than fetched again, and calls the new client methods.
+
+### Stage 3: Presentational Component
+
+**4. Balance Adjustment Form Component** - Add the presentational form component: a read-only current-balance reference line, target balance and date fields, an optional note, a post-save confirmation showing the backend-returned delta, and backend errors rendered under the field the mapping identifies (or as a general banner otherwise).

--- a/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F05-web-balance-adjustment-entry-form/spec.md
+++ b/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F05-web-balance-adjustment-entry-form/spec.md
@@ -1,0 +1,84 @@
+# F05. Web Balance Adjustment Entry Form
+
+## 1. Technical Overview
+
+**What:** A new `BalanceAdjustmentForm` React component plus a dedicated `useBalanceAdjustmentForm` hook, following the exact structural pattern F04 established for `TransferForm`/`useTransferForm`: a presentational, controlled component; a small `useState`-based hook owning create/edit state and F02's API calls; a pure error-to-field mapping function. It shows a read-only reference balance, lets the user enter a target balance, and displays the backend-computed delta after a successful save.
+
+**Why:** F05's dependencies (F02, F03) are both complete; its host (F06, "Correct balance" action on each bank row) is not — same Wave-2-vs-Wave-4 gap F04 had with F01/F06. F04's spec already worked out the right shape for a form-without-a-host-yet in this codebase (dedicated small hook, not the `useMonthly` reducer; soft-failed browser smoke check documented up front); F05 reuses that shape rather than re-deriving it.
+
+**Scope:**
+- Included: `BalanceAdjustmentForm.tsx` (presentational component); `useBalanceAdjustmentForm.ts` (create/edit state + F02 API orchestration); `mapBalanceAdjustmentErrorToField.ts`; `BalanceAdjustmentDto`/`CreateBalanceAdjustmentDto`/`UpdateBalanceAdjustmentDto` types; `financialApiClient` methods for `POST /banks/{name}/adjustments` and `PUT /banks/{name}/adjustments/{id}`; the post-save delta confirmation display.
+- Excluded: any trigger button or mounting into `BanksGrid`/`MonthlyPage` (F06's job); the adjustment history list (F06); `DELETE /banks/{name}/adjustments/{id}` wiring (F06, per PRD Experience — deletion happens from F06's history list in every other form in this PRD).
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/api/types.ts` — adds `BalanceAdjustmentDto`, `CreateBalanceAdjustmentDto`, `UpdateBalanceAdjustmentDto`
+- `Financial.Web/src/api/financialApiClient.ts` — adds `createBalanceAdjustment`, `updateBalanceAdjustment`
+- `Financial.Web/src/hooks/mapBalanceAdjustmentErrorToField.ts` — new
+- `Financial.Web/src/hooks/useBalanceAdjustmentForm.ts` — new
+- `Financial.Web/src/components/BalanceAdjustmentForm.tsx` — new
+
+```mermaid
+graph TD
+  A["BalanceAdjustmentForm.tsx"] --> B["useBalanceAdjustmentForm hook"]
+  B --> C["financialApiClient.createBalanceAdjustment / updateBalanceAdjustment"]
+  C --> D["POST/PUT /banks/{name}/adjustments"]
+  A --> E["mapBalanceAdjustmentErrorToField"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Bank selection | The hook takes the target bank name and its current reference balance as arguments to `openCreateForm(bankName, currentBalance)`/`openEditForm(bankName, currentBalance, adjustment)`, not a bank picker field | A `banks: BankDto[]` prop with a `<select>`, matching `TransferForm`'s source/destination pickers | The PRD's Experience is explicit: this form opens from a specific bank row ("Correct balance" action **on each bank row**) — the bank is already fixed by the time the form opens, unlike a transfer which always needs two banks chosen. No picker is needed or asked for. |
+| Reference balance sourcing | `currentBalance` is passed in by the caller (already available from the existing `GET /banks/month/{year}/{month}/balances` fetch a host page like `MonthlyPage` already performs via `useMonthly`) rather than fetched inside this hook | Have `useBalanceAdjustmentForm` call `getBankBalancesByMonth` itself | PRD Capabilities is explicit: "read-only... line sourced from the **existing** balances endpoint" and F03's spec confirms no new endpoint was added for this. The figure is already fetched once by whatever page hosts the balances view; re-fetching inside this form would be a redundant network call for a value the host already has in memory. |
+| Displaying the post-save delta | On a successful save, the hook does **not** immediately reset to the closed state. It stores the response's `delta` in `savedDelta` and keeps the form open in a "saved" state; the component renders a confirmation ("Adjustment of −£4.20 recorded") with a "Close" button. `onSaved()` still fires immediately on success (so a future host can refetch balances/history right away) — only the visual close is deferred to the user's dismissal | Close immediately and call `onSaved()`, matching `TransferForm`'s exact close-on-success behavior | F04's Experience explicitly said "the form closes" on success; F05's Experience instead dedicates its own bullet to displaying the delta ("displays the resulting delta... using the value returned in the backend response") — a deliberate difference, not an omission. Firing `onSaved()` at save time (not at dismissal) still satisfies "reflected in F06 after save" as soon as the save completes, independent of when the user closes the confirmation. |
+| Target balance validation | Client-side: required + must parse as a non-negative number (immediate feedback on blur/submit, matching the "≥ 0" requirement in Capabilities). Backend's `"Balance cannot be negative."` message maps to the `targetBalance` field via `mapBalanceAdjustmentErrorToField`, mirroring `mapTransferErrorToField`'s pattern from F04 | — | Direct PRD requirement; same inline-error mechanism F04 already established for exactly this reason (F02's `Problem()` responses carry only a message, no field indicator). |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/api/types.ts` | Modified | DTO shapes | `BalanceAdjustmentDto { id, date, bank, targetBalance, delta, note }`; `CreateBalanceAdjustmentDto`/`UpdateBalanceAdjustmentDto { date, targetBalance, note }` (bank comes from the route, matching F02's actual endpoint shape) |
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | HTTP calls | `createBalanceAdjustment: (bankName: string, request: CreateBalanceAdjustmentDto) => Promise<BalanceAdjustmentDto>` → `POST /banks/{name}/adjustments`; `updateBalanceAdjustment: (bankName: string, id: string, request: UpdateBalanceAdjustmentDto) => Promise<BalanceAdjustmentDto>` → `PUT /banks/{name}/adjustments/{id}` |
+| `Financial.Web/src/hooks/mapBalanceAdjustmentErrorToField.ts` | New | Error-to-field mapping | Pure function; `"...cannot be negative."` → `'targetBalance'`; an unresolvable-bank message (no field to attach it to, since this form has no bank picker) and anything unrecognized → `null` (general banner) |
+| `Financial.Web/src/hooks/useBalanceAdjustmentForm.ts` | New | State + orchestration | `useState`-based; exposes `isOpen`, `isEditing`, `bankName`, `currentBalance`, field values, `isSaving`, `saveError`, `saveErrorField`, `savedDelta`; `openCreateForm(bankName, currentBalance)` (defaults date to today); `openEditForm(bankName, currentBalance, adjustment)` (pre-fills `targetBalance`/`date`/`note`); `cancel()` (resets to closed, clearing `savedDelta`); `setField(field, value)`; `submit()` (validates, calls create or update, sets `savedDelta` and calls `onSaved()` on success, keeping the form open in the saved state) |
+| `Financial.Web/src/components/BalanceAdjustmentForm.tsx` | New | Presentational form | Read-only "Current calculated balance: £X" line (from the `currentBalance` prop, never recomputed); target balance input; date input; optional note; renders the saved-state confirmation (`savedDelta` formatted with sign, e.g. "Adjustment of −£4.20 recorded") with a Close button when `savedDelta !== null`, otherwise the editable form; backend errors rendered under the field `saveErrorField` identifies or as a general banner |
+
+## 5. API Contracts
+
+No new backend endpoints — F02 already provides `POST /banks/{name}/adjustments` and `PUT /banks/{name}/adjustments/{id}` (see `docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F02-balance-adjustment-domain-api/spec.md`). This feature only adds the frontend client methods calling them.
+
+**`createBalanceAdjustment`**
+- **Calls:** `POST /banks/{name}/adjustments` with `CreateBalanceAdjustmentDto` body
+- **Returns:** `BalanceAdjustmentDto` (including the server-computed `delta`)
+- **Error surfaced verbatim from:** F02's `Problem()` responses — `"Bank '{name}' was not found."`, `"Balance cannot be negative."`
+
+**`updateBalanceAdjustment`**
+- **Calls:** `PUT /banks/{name}/adjustments/{id}` with `UpdateBalanceAdjustmentDto` body
+- **Returns:** `BalanceAdjustmentDto` with a recomputed `delta`
+- **Error surfaced verbatim from:** same 400 messages as create, plus 404 `"Balance adjustment '{id}' was not found."`
+
+## 6. Data Model
+
+No changes — this feature is a pure frontend consumer of F02's existing `BalanceAdjustment` persistence.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Financial.Web/src/components/__tests__/BalanceAdjustmentForm.test.tsx` | Component (RTL) | `BalanceAdjustmentForm` | Renders "Current calculated balance: £X" from the `currentBalance` prop unconditionally (create and edit); renders create/edit titles and pre-filled edit values; shows the saved-state confirmation with the formatted `savedDelta` (positive and negative) and a Close button when `savedDelta` is set, hiding the editable fields; calls `onSave`/`onCancel`/close callback; renders `saveError` under the field `saveErrorField` names, or as a general banner; shows "Saving..." and disables the button while `isSaving` |
+| `Financial.Web/src/hooks/useBalanceAdjustmentForm.test.ts` | Hook (`renderHook`) | `useBalanceAdjustmentForm` | `openCreateForm` defaults date to today, stores `bankName`/`currentBalance`, `savedDelta` is `null`; `openEditForm` pre-fills `targetBalance`/`date`/`note` from a `BalanceAdjustmentDto`; `submit` blocks on a missing or negative target balance with `saveErrorField: 'targetBalance'`; `submit` calls `createBalanceAdjustment`/`updateBalanceAdjustment` (mocking `financialApiClient`), sets `isSaving` during the call, sets `savedDelta` from the response and calls `onSaved()` on success while `isOpen` stays `true`; sets `saveError`/`saveErrorField` on failure; `cancel` clears `savedDelta` and closes |
+| `Financial.Web/src/hooks/mapBalanceAdjustmentErrorToField.test.ts` | Unit | `mapBalanceAdjustmentErrorToField` | `"Balance cannot be negative."` maps to `'targetBalance'`; an unresolvable-bank message and an unrecognized message both map to `null` |
+| `Financial.Web/src/api/financialApiClient.test.ts` | Unit | `createBalanceAdjustment`/`updateBalanceAdjustment` | Success path returns the parsed `BalanceAdjustmentDto` including `delta`; request URL/method/body match the endpoint contract, following the existing `createTransfer`/`updateTransfer` test pattern |
+
+**Acceptance tests (PRD Section 9, F05):**
+- Opening the form for a bank displays the current calculated balance exactly as returned by the backend → `BalanceAdjustmentForm.test.tsx` (renders `currentBalance` prop verbatim, no arithmetic)
+- Submitting a target balance creates an adjustment and displays the backend-returned delta, not a client-computed one → `useBalanceAdjustmentForm.test.ts` (`savedDelta` comes from the response), `BalanceAdjustmentForm.test.tsx` (confirmation renders it)
+- Submitting a negative target balance shows an inline validation error and blocks submission → `useBalanceAdjustmentForm.test.ts`, `BalanceAdjustmentForm.test.tsx`
+- Editing an existing adjustment's target balance updates its stored delta, reflected in F06 after save → `useBalanceAdjustmentForm.test.ts` (submit in edit mode calls `updateBalanceAdjustment` and calls `onSaved`); the "reflected in F06" half is F06's own responsibility once it calls this hook, same documented gap as F04's equivalent criteria
+
+**Soft-fail note (documented up front):** same as F04 — no host page exists to mount into until F06 ships. A live-browser smoke test isn't possible in this run; hook and component tests exercise every interaction this form supports instead.

--- a/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/prd-bank-transfers-and-balance-reconciliation.md
+++ b/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/prd-bank-transfers-and-balance-reconciliation.md
@@ -294,9 +294,9 @@ graph TD
 - [x] A backend validation error (e.g. amount ≤ 0) is displayed inline under the amount field.
 
 ### F05. Web Balance Adjustment Entry Form
-- [ ] Opening the form for a bank displays the current calculated balance exactly as returned by the backend.
-- [ ] Submitting a target balance creates an adjustment and displays the backend-returned delta, not a client-computed one.
-- [ ] Submitting a negative target balance shows an inline validation error and blocks submission.
+- [x] Opening the form for a bank displays the current calculated balance exactly as returned by the backend.
+- [x] Submitting a target balance creates an adjustment and displays the backend-returned delta, not a client-computed one.
+- [x] Submitting a negative target balance shows an inline validation error and blocks submission.
 - [ ] Editing an existing adjustment's target balance updates its stored delta, reflected in F06 after save.
 
 ### F06. Web Bank Balances & History View


### PR DESCRIPTION
## Summary
- Adds `BalanceAdjustmentForm`, `useBalanceAdjustmentForm`, and `mapBalanceAdjustmentErrorToField`, reusing the exact structural pattern F04 established (dedicated `useState` hook, pure error-field mapping, no host page yet — F06 is Wave 4, F05 is Wave 3, PRD Section 8).
- No bank picker: the hook takes `bankName`/`currentBalance` as arguments to `openCreateForm`/`openEditForm` instead, since this form always opens from a specific bank row (unlike a transfer, which needs two banks chosen).
- The "current calculated balance" reference line is passed in by the caller (already available from the existing `GET /banks/month/{year}/{month}/balances` fetch a host page performs) rather than re-fetched by this form — matches the PRD's "sourced from the existing balances endpoint" and F03's confirmation that no new endpoint was added for this.
- **Deliberate deviation from F04's close-on-success pattern:** on a successful save, the form does not close immediately. It shows a confirmation ("Adjustment of −£4.20 recorded") with a Close button, since F05's Experience dedicates its own bullet to displaying the backend-computed delta. `onSaved()` still fires at save time so a future host can refetch right away — only the visual close is deferred to the user.

## Test plan
- [x] `npm run lint`, `tsc -b --noEmit`, and `npm run test` (Financial.Web) — all green, 714/714 frontend tests pass
- [x] `dotnet test` across the full solution — all green (1,682 passed, 5 pre-existing skips), confirming no backend regression
- [x] Opening the form for a bank displays the current calculated balance exactly as returned by the backend
- [x] Submitting a target balance creates an adjustment and displays the backend-returned delta, not a client-computed one
- [x] Submitting a negative target balance shows an inline validation error and blocks submission
- [ ] Editing an existing adjustment updates its stored delta, reflected in F06 — **left unchecked in the PRD**, pending F06
- [x] Soft-fail (documented, not discovered late): no host page exists yet for a live-browser smoke test; behavior is verified exhaustively at the hook and component test layers

Spec/plan: `docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F05-web-balance-adjustment-entry-form/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)