### PR TITLE
feat(P20-F06): web bank balances & history view

### DIFF
--- a/Financial.Web/src/api/financialApiClient.test.ts
+++ b/Financial.Web/src/api/financialApiClient.test.ts
@@ -761,4 +761,54 @@ describe('financialApiClient', () => {
     expect(init?.method).toBe('PUT')
     expect(JSON.parse(init?.body as string)).toEqual(requestBody)
   })
+
+  it('calls the transfers-by-month endpoint', async () => {
+    const responseBody: TransferDto[] = [
+      { id: 't1', date: '2026-07-05', sourceBank: 'Barclays', destinationBank: 'Trading212', amount: 500, note: null },
+    ]
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.getTransfersByMonth(2026, 7)
+
+    expect(result).toEqual(responseBody)
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/transfers/month/2026/7`)
+  })
+
+  it('deletes a transfer', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(undefined))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    await client.deleteTransfer('t1')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/transfers/t1`)
+    expect(init?.method).toBe('DELETE')
+  })
+
+  it('calls the adjustments-by-bank endpoint', async () => {
+    const responseBody: BalanceAdjustmentDto[] = [
+      { id: 'a1', date: '2026-07-05', bank: 'Barclays', targetBalance: 150, delta: 50, note: null },
+    ]
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(responseBody))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    const result = await client.getAdjustmentsByBank('Barclays')
+
+    expect(result).toEqual(responseBody)
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/banks/Barclays/adjustments`)
+  })
+
+  it('deletes a balance adjustment', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(undefined))
+    const client = createFinancialApiClient({ baseUrl: API_BASE_URL, fetch: fetchMock })
+
+    await client.deleteBalanceAdjustment('Barclays', 'a1')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${API_BASE_URL}/banks/Barclays/adjustments/a1`)
+    expect(init?.method).toBe('DELETE')
+  })
 })

--- a/Financial.Web/src/api/financialApiClient.ts
+++ b/Financial.Web/src/api/financialApiClient.ts
@@ -130,6 +130,10 @@ export interface FinancialApiClient {
     id: string,
     request: UpdateBalanceAdjustmentDto,
   ) => Promise<BalanceAdjustmentDto>
+  getTransfersByMonth: (year: number, month: number) => Promise<TransferDto[]>
+  deleteTransfer: (id: string) => Promise<void>
+  getAdjustmentsByBank: (bankName: string) => Promise<BalanceAdjustmentDto[]>
+  deleteBalanceAdjustment: (bankName: string, id: string) => Promise<void>
   getCardStatementsByMonth: (year: number, month: number) => Promise<CardStatementDto[]>
   markCardStatementPaid: (id: string, request: MarkCardStatementPaidDto) => Promise<CardStatementDto>
   unmarkCardStatementPaid: (id: string) => Promise<CardStatementDto>
@@ -395,6 +399,14 @@ export function createFinancialApiClient(options: FinancialApiClientOptions = {}
       request<BalanceAdjustmentDto>(`/banks/${encodeURIComponent(bankName)}/adjustments/${encodeURIComponent(id)}`, {
         method: 'PUT',
         body: JSON.stringify(requestBody),
+      }),
+    getTransfersByMonth: (year, month) => request<TransferDto[]>(`/transfers/month/${year}/${month}`),
+    deleteTransfer: (id) => requestVoid(`/transfers/${encodeURIComponent(id)}`, { method: 'DELETE' }),
+    getAdjustmentsByBank: (bankName) =>
+      request<BalanceAdjustmentDto[]>(`/banks/${encodeURIComponent(bankName)}/adjustments`),
+    deleteBalanceAdjustment: (bankName, id) =>
+      requestVoid(`/banks/${encodeURIComponent(bankName)}/adjustments/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
       }),
     getCardStatementsByMonth: (year, month) =>
       request<CardStatementDto[]>(`/card-statements/${year}/${month}`),

--- a/Financial.Web/src/components/BanksGrid.css
+++ b/Financial.Web/src/components/BanksGrid.css
@@ -1,0 +1,34 @@
+.banks-grid__expand-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-h);
+  padding: 2px 6px;
+}
+
+.banks-grid__action-btn {
+  font-size: 11px;
+  padding: 2px 8px;
+  cursor: pointer;
+  background: #007acc;
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.banks-grid__action-btn:hover {
+  background: #005fa3;
+}
+
+.banks-grid__history-empty {
+  margin: 8px 0;
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.banks-grid__history-table {
+  width: 100%;
+  margin: 8px 0;
+}

--- a/Financial.Web/src/components/BanksGrid.tsx
+++ b/Financial.Web/src/components/BanksGrid.tsx
@@ -1,32 +1,225 @@
+import { Fragment } from 'react'
+import type { BalanceAdjustmentDto, TransferDto } from '../api/types'
+import type { BankHistoryEntry } from '../hooks/useBankHistory'
 import type { BankTotal } from '../hooks/useMonthly'
-import { formatN2 } from '../utils/formatters'
+import { formatN2, formatShortDate } from '../utils/formatters'
+import './BanksGrid.css'
+
+const TYPE_LABELS: Record<BankHistoryEntry['kind'], string> = {
+  transferIn: 'Transfer In',
+  transferOut: 'Transfer Out',
+  adjustment: 'Adjustment',
+}
+
+interface HistoryRowProps {
+  entry: BankHistoryEntry
+  bankName: string
+  currentBalance: number
+  onEditTransfer: (transfer: TransferDto) => void
+  onEditAdjustment: (bankName: string, currentBalance: number, adjustment: BalanceAdjustmentDto) => void
+  onDeleteTransfer: (id: string) => void
+  onDeleteAdjustment: (bankName: string, id: string) => void
+}
+
+function HistoryRow({
+  entry,
+  bankName,
+  currentBalance,
+  onEditTransfer,
+  onEditAdjustment,
+  onDeleteTransfer,
+  onDeleteAdjustment,
+}: HistoryRowProps) {
+  if (entry.kind === 'adjustment') {
+    return (
+      <tr>
+        <td>
+          <button
+            className="data-table__action-btn"
+            type="button"
+            aria-label="Edit balance adjustment"
+            onClick={() => onEditAdjustment(bankName, currentBalance, entry.adjustment)}
+          >
+            ✏
+          </button>
+        </td>
+        <td>
+          <button
+            className="data-table__action-btn"
+            type="button"
+            aria-label="Delete balance adjustment"
+            onClick={() => onDeleteAdjustment(bankName, entry.id)}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M20 20H7L3 16a2 2 0 0 1 0-2.83L14.59 1.58a2 2 0 0 1 2.83 0l4 4a2 2 0 0 1 0 2.83L8 20" />
+              <path d="M6.5 15.5 15 7" />
+            </svg>
+          </button>
+        </td>
+        <td>{formatShortDate(entry.date)}</td>
+        <td>{TYPE_LABELS[entry.kind]}</td>
+        <td>{formatN2(entry.delta)}</td>
+        <td>{entry.note ?? ''}</td>
+      </tr>
+    )
+  }
+
+  return (
+    <tr>
+      <td>
+        <button
+          className="data-table__action-btn"
+          type="button"
+          aria-label="Edit transfer"
+          onClick={() => onEditTransfer(entry.transfer)}
+        >
+          ✏
+        </button>
+      </td>
+      <td>
+        <button
+          className="data-table__action-btn"
+          type="button"
+          aria-label="Delete transfer"
+          onClick={() => onDeleteTransfer(entry.id)}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M20 20H7L3 16a2 2 0 0 1 0-2.83L14.59 1.58a2 2 0 0 1 2.83 0l4 4a2 2 0 0 1 0 2.83L8 20" />
+            <path d="M6.5 15.5 15 7" />
+          </svg>
+        </button>
+      </td>
+      <td>{formatShortDate(entry.date)}</td>
+      <td>{TYPE_LABELS[entry.kind]}</td>
+      <td>{entry.counterpartBank}</td>
+      <td>{entry.note ?? ''}</td>
+    </tr>
+  )
+}
 
 interface BanksGridProps {
   bankTotals: BankTotal[]
   bankTotalsSum: number
   roundUpTotalsSum: number
+  historyByBank: Record<string, BankHistoryEntry[]>
+  expandedBank: string | null
+  onToggleExpand: (bankName: string) => void
+  onMoveMoney: (bankName: string) => void
+  onCorrectBalance: (bankName: string, currentBalance: number) => void
+  onEditTransfer: (transfer: TransferDto) => void
+  onEditAdjustment: (bankName: string, currentBalance: number, adjustment: BalanceAdjustmentDto) => void
+  onDeleteTransfer: (id: string) => void
+  onDeleteAdjustment: (bankName: string, id: string) => void
 }
 
-export default function BanksGrid({ bankTotals, bankTotalsSum, roundUpTotalsSum }: BanksGridProps) {
+export default function BanksGrid({
+  bankTotals,
+  bankTotalsSum,
+  roundUpTotalsSum,
+  historyByBank,
+  expandedBank,
+  onToggleExpand,
+  onMoveMoney,
+  onCorrectBalance,
+  onEditTransfer,
+  onEditAdjustment,
+  onDeleteTransfer,
+  onDeleteAdjustment,
+}: BanksGridProps) {
   return (
     <section className="monthly-page__section monthly-page__section--grid">
       <div className="monthly-page__table-scroll">
         <table className="monthly-page__table data-table">
           <thead>
             <tr>
+              <th />
               <th>Bank</th>
               <th className="data-table__col--numeric">Bank Balance</th>
               <th className="data-table__col--numeric">Round-Up</th>
+              <th />
+              <th />
             </tr>
           </thead>
           <tbody>
-            {bankTotals.map((b) => (
-              <tr key={b.bank}>
-                <td>{b.bank}</td>
-                <td className="data-table__col--numeric">{formatN2(b.balance)}</td>
-                <td className="data-table__col--numeric">{formatN2(b.roundUpTotal)}</td>
-              </tr>
-            ))}
+            {bankTotals.map((b) => {
+              const isExpanded = expandedBank === b.bank
+              const history = historyByBank[b.bank] ?? []
+
+              return (
+                <Fragment key={b.bank}>
+                  <tr>
+                    <td>
+                      <button
+                        className="banks-grid__expand-btn"
+                        type="button"
+                        aria-label={isExpanded ? `Collapse history for ${b.bank}` : `Expand history for ${b.bank}`}
+                        aria-expanded={isExpanded}
+                        onClick={() => onToggleExpand(b.bank)}
+                      >
+                        {isExpanded ? '▾' : '▸'}
+                      </button>
+                    </td>
+                    <td>{b.bank}</td>
+                    <td className="data-table__col--numeric">{formatN2(b.balance)}</td>
+                    <td className="data-table__col--numeric">{formatN2(b.roundUpTotal)}</td>
+                    <td>
+                      <button
+                        className="banks-grid__action-btn"
+                        type="button"
+                        onClick={() => onMoveMoney(b.bank)}
+                      >
+                        Move Money
+                      </button>
+                    </td>
+                    <td>
+                      <button
+                        className="banks-grid__action-btn"
+                        type="button"
+                        onClick={() => onCorrectBalance(b.bank, b.balance)}
+                      >
+                        Correct Balance
+                      </button>
+                    </td>
+                  </tr>
+                  {isExpanded && (
+                    <tr>
+                      <td colSpan={6}>
+                        {history.length === 0 ? (
+                          <p className="banks-grid__history-empty">No transfers or adjustments this month.</p>
+                        ) : (
+                          <table className="banks-grid__history-table data-table">
+                            <thead>
+                              <tr>
+                                <th />
+                                <th />
+                                <th>Date</th>
+                                <th>Type</th>
+                                <th>Counterpart / Delta</th>
+                                <th>Note</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {history.map((entry) => (
+                                <HistoryRow
+                                  key={`${entry.kind}-${entry.id}`}
+                                  entry={entry}
+                                  bankName={b.bank}
+                                  currentBalance={b.balance}
+                                  onEditTransfer={onEditTransfer}
+                                  onEditAdjustment={onEditAdjustment}
+                                  onDeleteTransfer={onDeleteTransfer}
+                                  onDeleteAdjustment={onDeleteAdjustment}
+                                />
+                              ))}
+                            </tbody>
+                          </table>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              )
+            })}
           </tbody>
         </table>
       </div>

--- a/Financial.Web/src/components/__tests__/BanksGrid.test.tsx
+++ b/Financial.Web/src/components/__tests__/BanksGrid.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, within } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import BanksGrid from '../BanksGrid'
+import type { BankHistoryEntry } from '../../hooks/useBankHistory'
 import type { BankTotal } from '../../hooks/useMonthly'
 
 const BANK_TOTALS: BankTotal[] = [
@@ -8,9 +9,43 @@ const BANK_TOTALS: BankTotal[] = [
   { bank: 'Trading212', balance: 8.8, roundUpTotal: 0.6 },
 ]
 
+const TRANSFER_ENTRY: BankHistoryEntry = {
+  kind: 'transferOut',
+  id: 't1',
+  date: '2026-07-05',
+  counterpartBank: 'Trading212',
+  amount: 500,
+  note: 'Top-up',
+  transfer: { id: 't1', date: '2026-07-05', sourceBank: 'Barclays', destinationBank: 'Trading212', amount: 500, note: 'Top-up' },
+}
+
+const ADJUSTMENT_ENTRY: BankHistoryEntry = {
+  kind: 'adjustment',
+  id: 'a1',
+  date: '2026-07-10',
+  delta: -4.2,
+  note: 'Matched statement',
+  adjustment: { id: 'a1', date: '2026-07-10', bank: 'Barclays', targetBalance: 38.3, delta: -4.2, note: 'Matched statement' },
+}
+
+const baseProps = {
+  bankTotals: BANK_TOTALS,
+  bankTotalsSum: 51.3,
+  roundUpTotalsSum: 0.6,
+  historyByBank: {},
+  expandedBank: null,
+  onToggleExpand: vi.fn(),
+  onMoveMoney: vi.fn(),
+  onCorrectBalance: vi.fn(),
+  onEditTransfer: vi.fn(),
+  onEditAdjustment: vi.fn(),
+  onDeleteTransfer: vi.fn(),
+  onDeleteAdjustment: vi.fn(),
+}
+
 describe('BanksGrid', () => {
   it('renders a row per bank with balance and round-up columns, plus footer totals', () => {
-    render(<BanksGrid bankTotals={BANK_TOTALS} bankTotalsSum={51.3} roundUpTotalsSum={0.6} />)
+    render(<BanksGrid {...baseProps} />)
 
     const barclaysRow = screen.getByRole('row', { name: /Barclays/ })
     expect(within(barclaysRow).getByRole('cell', { name: '42.50' })).toBeInTheDocument()
@@ -20,5 +55,100 @@ describe('BanksGrid', () => {
     expect(within(trading212Row).getByRole('cell', { name: '0.60' })).toBeInTheDocument()
 
     expect(screen.getByText('51.30')).toBeInTheDocument()
+  })
+
+  it('calls onMoveMoney and onCorrectBalance with the row bank (and balance)', () => {
+    const onMoveMoney = vi.fn()
+    const onCorrectBalance = vi.fn()
+    render(<BanksGrid {...baseProps} onMoveMoney={onMoveMoney} onCorrectBalance={onCorrectBalance} />)
+
+    const barclaysRow = screen.getByRole('row', { name: /Barclays/ })
+    fireEvent.click(within(barclaysRow).getByRole('button', { name: 'Move Money' }))
+    fireEvent.click(within(barclaysRow).getByRole('button', { name: 'Correct Balance' }))
+
+    expect(onMoveMoney).toHaveBeenCalledWith('Barclays')
+    expect(onCorrectBalance).toHaveBeenCalledWith('Barclays', 42.5)
+  })
+
+  it('calls onToggleExpand with the row bank when the expand button is clicked', () => {
+    const onToggleExpand = vi.fn()
+    render(<BanksGrid {...baseProps} onToggleExpand={onToggleExpand} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand history for Barclays' }))
+
+    expect(onToggleExpand).toHaveBeenCalledWith('Barclays')
+  })
+
+  it('shows the history table only for the expanded bank', () => {
+    render(
+      <BanksGrid
+        {...baseProps}
+        historyByBank={{ Barclays: [TRANSFER_ENTRY, ADJUSTMENT_ENTRY] }}
+        expandedBank="Barclays"
+      />,
+    )
+
+    expect(screen.getByText('Transfer Out')).toBeInTheDocument()
+    expect(screen.getByText('Adjustment')).toBeInTheDocument()
+    const transferRow = screen.getByText('Transfer Out').closest('tr')!
+    expect(within(transferRow).getByText('Trading212')).toBeInTheDocument()
+    const adjustmentRow = screen.getByText('Adjustment').closest('tr')!
+    expect(within(adjustmentRow).getByText('-4.20')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when the expanded bank has no history', () => {
+    render(<BanksGrid {...baseProps} historyByBank={{ Barclays: [] }} expandedBank="Barclays" />)
+
+    expect(screen.getByText('No transfers or adjustments this month.')).toBeInTheDocument()
+  })
+
+  it('does not render history when no bank is expanded', () => {
+    render(<BanksGrid {...baseProps} historyByBank={{ Barclays: [TRANSFER_ENTRY] }} expandedBank={null} />)
+
+    expect(screen.queryByText('Transfer Out')).not.toBeInTheDocument()
+  })
+
+  it('calls onEditTransfer and onDeleteTransfer for a transfer history row', () => {
+    const onEditTransfer = vi.fn()
+    const onDeleteTransfer = vi.fn()
+    render(
+      <BanksGrid
+        {...baseProps}
+        historyByBank={{ Barclays: [TRANSFER_ENTRY] }}
+        expandedBank="Barclays"
+        onEditTransfer={onEditTransfer}
+        onDeleteTransfer={onDeleteTransfer}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit transfer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete transfer' }))
+
+    expect(onEditTransfer).toHaveBeenCalledWith(TRANSFER_ENTRY.kind === 'transferOut' ? TRANSFER_ENTRY.transfer : undefined)
+    expect(onDeleteTransfer).toHaveBeenCalledWith('t1')
+  })
+
+  it('calls onEditAdjustment and onDeleteAdjustment for an adjustment history row', () => {
+    const onEditAdjustment = vi.fn()
+    const onDeleteAdjustment = vi.fn()
+    render(
+      <BanksGrid
+        {...baseProps}
+        historyByBank={{ Barclays: [ADJUSTMENT_ENTRY] }}
+        expandedBank="Barclays"
+        onEditAdjustment={onEditAdjustment}
+        onDeleteAdjustment={onDeleteAdjustment}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit balance adjustment' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete balance adjustment' }))
+
+    expect(onEditAdjustment).toHaveBeenCalledWith(
+      'Barclays',
+      42.5,
+      ADJUSTMENT_ENTRY.kind === 'adjustment' ? ADJUSTMENT_ENTRY.adjustment : undefined,
+    )
+    expect(onDeleteAdjustment).toHaveBeenCalledWith('Barclays', 'a1')
   })
 })

--- a/Financial.Web/src/hooks/useBankHistory.test.ts
+++ b/Financial.Web/src/hooks/useBankHistory.test.ts
@@ -1,0 +1,136 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FinancialApiClient } from '../api/financialApiClient'
+import type { BalanceAdjustmentDto, BankDto, TransferDto } from '../api/types'
+import { useBankHistory } from './useBankHistory'
+
+const getTransfersByMonthMock = vi.fn<FinancialApiClient['getTransfersByMonth']>()
+const deleteTransferMock = vi.fn<FinancialApiClient['deleteTransfer']>()
+const getAdjustmentsByBankMock = vi.fn<FinancialApiClient['getAdjustmentsByBank']>()
+const deleteBalanceAdjustmentMock = vi.fn<FinancialApiClient['deleteBalanceAdjustment']>()
+
+vi.mock('../api/financialApiClient', () => ({
+  createFinancialApiClient: (): Partial<FinancialApiClient> => ({
+    getTransfersByMonth: getTransfersByMonthMock,
+    deleteTransfer: deleteTransferMock,
+    getAdjustmentsByBank: getAdjustmentsByBankMock,
+    deleteBalanceAdjustment: deleteBalanceAdjustmentMock,
+  }),
+}))
+
+const BANKS: BankDto[] = [
+  { name: 'Barclays', roundUpEnabled: false },
+  { name: 'Trading212', roundUpEnabled: true },
+]
+
+const TRANSFERS: TransferDto[] = [
+  {
+    id: 't1',
+    date: '2026-07-10',
+    sourceBank: 'Barclays',
+    destinationBank: 'Trading212',
+    amount: 500,
+    note: 'Top-up',
+  },
+  {
+    id: 't2',
+    date: '2026-07-20',
+    sourceBank: 'Trading212',
+    destinationBank: 'Barclays',
+    amount: 100,
+    note: null,
+  },
+]
+
+const BARCLAYS_ADJUSTMENTS: BalanceAdjustmentDto[] = [
+  { id: 'a1', date: '2026-07-15', bank: 'Barclays', targetBalance: 150, delta: 50, note: 'Matched statement' },
+  { id: 'a2', date: '2026-06-01', bank: 'Barclays', targetBalance: 100, delta: 10, note: 'Old month' },
+]
+
+describe('useBankHistory', () => {
+  beforeEach(() => {
+    getTransfersByMonthMock.mockReset()
+    deleteTransferMock.mockReset()
+    getAdjustmentsByBankMock.mockReset()
+    deleteBalanceAdjustmentMock.mockReset()
+    getTransfersByMonthMock.mockResolvedValue(TRANSFERS)
+    getAdjustmentsByBankMock.mockImplementation((bankName: string) =>
+      Promise.resolve(bankName === 'Barclays' ? BARCLAYS_ADJUSTMENTS : []),
+    )
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  it('combines transfers and adjustments per bank, sorted descending by date, scoped to the month', async () => {
+    const { result } = renderHook(() => useBankHistory(2026, 7, BANKS, vi.fn()))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const barclaysHistory = result.current.historyByBank['Barclays']
+    expect(barclaysHistory).toHaveLength(3)
+    expect(barclaysHistory.map((e) => e.id)).toEqual(['t2', 'a1', 't1'])
+    expect(barclaysHistory[0]).toMatchObject({ kind: 'transferIn', counterpartBank: 'Trading212' })
+    expect(barclaysHistory[1]).toMatchObject({ kind: 'adjustment', delta: 50 })
+    expect(barclaysHistory[2]).toMatchObject({ kind: 'transferOut', counterpartBank: 'Trading212' })
+  })
+
+  it('excludes adjustments outside the selected month', async () => {
+    const { result } = renderHook(() => useBankHistory(2026, 7, BANKS, vi.fn()))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.historyByBank['Barclays'].some((e) => e.id === 'a2')).toBe(false)
+  })
+
+  it('classifies transfers for the other bank in the opposite direction', async () => {
+    const { result } = renderHook(() => useBankHistory(2026, 7, BANKS, vi.fn()))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const trading212History = result.current.historyByBank['Trading212']
+    expect(trading212History.find((e) => e.id === 't1')).toMatchObject({ kind: 'transferIn' })
+    expect(trading212History.find((e) => e.id === 't2')).toMatchObject({ kind: 'transferOut' })
+  })
+
+  it('deleteTransfer confirms, calls the client, refetches, and calls onChanged', async () => {
+    deleteTransferMock.mockResolvedValue(undefined)
+    const onChanged = vi.fn()
+    const { result } = renderHook(() => useBankHistory(2026, 7, BANKS, onChanged))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    result.current.deleteTransfer('t1')
+    await waitFor(() => expect(deleteTransferMock).toHaveBeenCalledWith('t1'))
+
+    expect(onChanged).toHaveBeenCalledOnce()
+  })
+
+  it('deleteTransfer does nothing when the user cancels the confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { result } = renderHook(() => useBankHistory(2026, 7, BANKS, vi.fn()))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    result.current.deleteTransfer('t1')
+
+    expect(deleteTransferMock).not.toHaveBeenCalled()
+  })
+
+  it('deleteAdjustment confirms, calls the client, refetches, and calls onChanged', async () => {
+    deleteBalanceAdjustmentMock.mockResolvedValue(undefined)
+    const onChanged = vi.fn()
+    const { result } = renderHook(() => useBankHistory(2026, 7, BANKS, onChanged))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    result.current.deleteAdjustment('Barclays', 'a1')
+    await waitFor(() => expect(deleteBalanceAdjustmentMock).toHaveBeenCalledWith('Barclays', 'a1'))
+
+    expect(onChanged).toHaveBeenCalledOnce()
+  })
+
+  it('sets error on a failed fetch', async () => {
+    getTransfersByMonthMock.mockRejectedValue(new Error('Network down'))
+    const { result } = renderHook(() => useBankHistory(2026, 7, BANKS, vi.fn()))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.error).toBe('Network down')
+  })
+})

--- a/Financial.Web/src/hooks/useBankHistory.ts
+++ b/Financial.Web/src/hooks/useBankHistory.ts
@@ -1,0 +1,209 @@
+import { useEffect, useMemo, useReducer } from 'react'
+import { createFinancialApiClient } from '../api/financialApiClient'
+import type { BalanceAdjustmentDto, BankDto, TransferDto } from '../api/types'
+
+export type BankHistoryEntry =
+  | {
+      kind: 'transferIn' | 'transferOut'
+      id: string
+      date: string
+      counterpartBank: string
+      amount: number
+      note: string | null
+      transfer: TransferDto
+    }
+  | {
+      kind: 'adjustment'
+      id: string
+      date: string
+      delta: number
+      note: string | null
+      adjustment: BalanceAdjustmentDto
+    }
+
+function isInMonth(dateIso: string, year: number, month: number): boolean {
+  const [y, m] = dateIso.split('-').map(Number)
+  return y === year && m === month
+}
+
+function buildHistoryByBank(
+  banks: BankDto[],
+  transfers: TransferDto[],
+  adjustmentsByBank: Record<string, BalanceAdjustmentDto[]>,
+  year: number,
+  month: number,
+): Record<string, BankHistoryEntry[]> {
+  const result: Record<string, BankHistoryEntry[]> = {}
+
+  for (const bank of banks) {
+    const entries: BankHistoryEntry[] = []
+
+    for (const transfer of transfers) {
+      if (transfer.sourceBank === bank.name) {
+        entries.push({
+          kind: 'transferOut',
+          id: transfer.id,
+          date: transfer.date,
+          counterpartBank: transfer.destinationBank,
+          amount: transfer.amount,
+          note: transfer.note,
+          transfer,
+        })
+      } else if (transfer.destinationBank === bank.name) {
+        entries.push({
+          kind: 'transferIn',
+          id: transfer.id,
+          date: transfer.date,
+          counterpartBank: transfer.sourceBank,
+          amount: transfer.amount,
+          note: transfer.note,
+          transfer,
+        })
+      }
+    }
+
+    for (const adjustment of adjustmentsByBank[bank.name] ?? []) {
+      if (isInMonth(adjustment.date, year, month)) {
+        entries.push({
+          kind: 'adjustment',
+          id: adjustment.id,
+          date: adjustment.date,
+          delta: adjustment.delta,
+          note: adjustment.note,
+          adjustment,
+        })
+      }
+    }
+
+    entries.sort((a, b) => b.date.localeCompare(a.date))
+    result[bank.name] = entries
+  }
+
+  return result
+}
+
+interface BankHistoryState {
+  historyByBank: Record<string, BankHistoryEntry[]>
+  isLoading: boolean
+  error: string | null
+  retryCount: number
+}
+
+type BankHistoryAction =
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; payload: Record<string, BankHistoryEntry[]> }
+  | { type: 'FETCH_ERROR'; payload: string }
+  | { type: 'RETRY' }
+  | { type: 'ACTION_ERROR'; payload: string }
+
+const INITIAL_STATE: BankHistoryState = {
+  historyByBank: {},
+  isLoading: true,
+  error: null,
+  retryCount: 0,
+}
+
+function reducer(state: BankHistoryState, action: BankHistoryAction): BankHistoryState {
+  switch (action.type) {
+    case 'FETCH_START':
+      return { ...state, isLoading: true, error: null }
+    case 'FETCH_SUCCESS':
+      return { ...state, isLoading: false, historyByBank: action.payload }
+    case 'FETCH_ERROR':
+      return { ...state, isLoading: false, error: action.payload }
+    case 'RETRY':
+      return { ...state, retryCount: state.retryCount + 1 }
+    case 'ACTION_ERROR':
+      return { ...state, error: action.payload }
+    default:
+      return state
+  }
+}
+
+export interface UseBankHistoryResult {
+  historyByBank: Record<string, BankHistoryEntry[]>
+  isLoading: boolean
+  error: string | null
+  retry: () => void
+  deleteTransfer: (id: string) => void
+  deleteAdjustment: (bankName: string, id: string) => void
+}
+
+/** Fetches, combines, and deletes a month's transfer/adjustment history per bank. */
+export function useBankHistory(
+  year: number,
+  month: number,
+  banks: BankDto[],
+  onChanged: () => void,
+): UseBankHistoryResult {
+  const apiClient = useMemo(() => createFinancialApiClient(), [])
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  const bankNames = banks.map((bank) => bank.name).join(',')
+
+  useEffect(() => {
+    dispatch({ type: 'FETCH_START' })
+
+    Promise.all([
+      apiClient.getTransfersByMonth(year, month),
+      Promise.all(banks.map((bank) => apiClient.getAdjustmentsByBank(bank.name))),
+    ])
+      .then(([transfers, adjustmentsPerBank]) => {
+        const adjustmentsByBank: Record<string, BalanceAdjustmentDto[]> = {}
+        banks.forEach((bank, index) => {
+          adjustmentsByBank[bank.name] = adjustmentsPerBank[index]
+        })
+        dispatch({
+          type: 'FETCH_SUCCESS',
+          payload: buildHistoryByBank(banks, transfers, adjustmentsByBank, year, month),
+        })
+      })
+      .catch((err: unknown) => {
+        dispatch({ type: 'FETCH_ERROR', payload: err instanceof Error ? err.message : 'Unable to load bank history' })
+      })
+    // banks is derived every render by the caller; bankNames is a stable key for its contents.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiClient, year, month, bankNames, state.retryCount])
+
+  const retry = () => dispatch({ type: 'RETRY' })
+
+  const deleteTransfer = (id: string) => {
+    if (!window.confirm('Delete this transfer?')) return
+
+    void apiClient
+      .deleteTransfer(id)
+      .then(() => {
+        retry()
+        onChanged()
+      })
+      .catch((err: unknown) => {
+        dispatch({ type: 'ACTION_ERROR', payload: err instanceof Error ? err.message : 'Failed to delete transfer' })
+      })
+  }
+
+  const deleteAdjustment = (bankName: string, id: string) => {
+    if (!window.confirm('Delete this balance adjustment?')) return
+
+    void apiClient
+      .deleteBalanceAdjustment(bankName, id)
+      .then(() => {
+        retry()
+        onChanged()
+      })
+      .catch((err: unknown) => {
+        dispatch({
+          type: 'ACTION_ERROR',
+          payload: err instanceof Error ? err.message : 'Failed to delete balance adjustment',
+        })
+      })
+  }
+
+  return {
+    historyByBank: state.historyByBank,
+    isLoading: state.isLoading,
+    error: state.error,
+    retry,
+    deleteTransfer,
+    deleteAdjustment,
+  }
+}

--- a/Financial.Web/src/hooks/useMonthly.ts
+++ b/Financial.Web/src/hooks/useMonthly.ts
@@ -479,6 +479,8 @@ function reducer(state: MonthlyState, action: MonthlyAction): MonthlyState {
 }
 
 export interface MonthlyData {
+  year: number
+  month: number
   monthInputValue: string
   setMonthInputValue: (value: string) => void
   expenses: ExpenseDto[]
@@ -1007,6 +1009,8 @@ export function useMonthly(): MonthlyData {
   const totalIncoming = incomeTotals.reduce((sum, i) => sum + i.netValue, 0)
 
   return {
+    year: state.year,
+    month: state.month,
     monthInputValue,
     setMonthInputValue,
     expenses: state.expenses,

--- a/Financial.Web/src/hooks/useTransferForm.test.ts
+++ b/Financial.Web/src/hooks/useTransferForm.test.ts
@@ -54,6 +54,14 @@ describe('useTransferForm', () => {
     expect(result.current.destinationBank).toBe('')
   })
 
+  it('openCreateForm uses the given preselected source bank instead of the first bank', () => {
+    const { result } = renderHook(() => useTransferForm(BANKS, vi.fn()))
+
+    act(() => result.current.openCreateForm('Trading212'))
+
+    expect(result.current.sourceBank).toBe('Trading212')
+  })
+
   it('openEditForm pre-fills every field from the given transfer', () => {
     const { result } = renderHook(() => useTransferForm(BANKS, vi.fn()))
 

--- a/Financial.Web/src/hooks/useTransferForm.ts
+++ b/Financial.Web/src/hooks/useTransferForm.ts
@@ -46,7 +46,7 @@ export interface UseTransferFormResult {
   isSaving: boolean
   saveError: string | null
   saveErrorField: TransferFormField | null
-  openCreateForm: () => void
+  openCreateForm: (preselectedSourceBank?: string) => void
   openEditForm: (transfer: TransferDto) => void
   cancel: () => void
   setField: (field: TransferFormField, value: string) => void
@@ -58,12 +58,12 @@ export function useTransferForm(banks: BankDto[], onSaved: () => void): UseTrans
   const apiClient = useMemo(() => createFinancialApiClient(), [])
   const [state, setState] = useState<TransferFormState>(BLANK_STATE)
 
-  function openCreateForm() {
+  function openCreateForm(preselectedSourceBank?: string) {
     setState({
       ...BLANK_STATE,
       isOpen: true,
       date: todayIsoDate(),
-      sourceBank: banks[0]?.name ?? '',
+      sourceBank: preselectedSourceBank ?? banks[0]?.name ?? '',
     })
   }
 

--- a/Financial.Web/src/pages/MonthlyPage.tsx
+++ b/Financial.Web/src/pages/MonthlyPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import BalanceAdjustmentForm from '../components/BalanceAdjustmentForm'
 import BanksGrid from '../components/BanksGrid'
 import CardsGrid from '../components/CardsGrid'
 import CategoryTotalsGrid from '../components/CategoryTotalsGrid'
@@ -9,6 +10,9 @@ import IncomeForm, { type IncomeFormField } from '../components/IncomeForm'
 import IncomeSection from '../components/IncomeSection'
 import IncomingGrid from '../components/IncomingGrid'
 import LoadingState from '../components/LoadingState'
+import TransferForm from '../components/TransferForm'
+import { useBalanceAdjustmentForm } from '../hooks/useBalanceAdjustmentForm'
+import { useBankHistory } from '../hooks/useBankHistory'
 import {
   useMonthly,
   type CreateFormField,
@@ -16,6 +20,7 @@ import {
   type EditField,
   type EditIncomeField,
 } from '../hooks/useMonthly'
+import { useTransferForm } from '../hooks/useTransferForm'
 import './MonthlyPage.css'
 
 type MonthlyTabId = 'summary' | 'expense' | 'incoming'
@@ -64,6 +69,8 @@ const EDIT_INCOME_FIELD_BY_FORM_FIELD: Record<IncomeFormField, EditIncomeField> 
 
 export default function MonthlyPage() {
   const {
+    year,
+    month,
     monthInputValue,
     setMonthInputValue,
     expenses,
@@ -147,7 +154,22 @@ export default function MonthlyPage() {
     titheSummary,
   } = useMonthly()
 
+  const bankHistory = useBankHistory(year, month, banks, retry)
+  const transferForm = useTransferForm(banks, () => {
+    retry()
+    bankHistory.retry()
+  })
+  const adjustmentForm = useBalanceAdjustmentForm(() => {
+    retry()
+    bankHistory.retry()
+  })
+
   const [activeTab, setActiveTab] = useState<MonthlyTabId>('summary')
+  const [expandedBank, setExpandedBank] = useState<string | null>(null)
+
+  const toggleExpandedBank = (bankName: string) => {
+    setExpandedBank((current) => (current === bankName ? null : bankName))
+  }
 
   const isEditing = editingId !== null
   const isFormVisible = isCreateFormOpen || isEditing
@@ -201,6 +223,40 @@ export default function MonthlyPage() {
         <div className="monthly-page__content">
           {activeTab === 'summary' && (
           <div className="monthly-page__summary-groups">
+            {transferForm.isOpen && (
+              <TransferForm
+                isEditing={transferForm.isEditing}
+                date={transferForm.date}
+                sourceBank={transferForm.sourceBank}
+                destinationBank={transferForm.destinationBank}
+                amount={transferForm.amount}
+                note={transferForm.note}
+                banks={banks}
+                isSaving={transferForm.isSaving}
+                saveError={transferForm.saveError}
+                saveErrorField={transferForm.saveErrorField}
+                onFieldChange={transferForm.setField}
+                onSave={transferForm.submit}
+                onCancel={transferForm.cancel}
+              />
+            )}
+            {adjustmentForm.isOpen && (
+              <BalanceAdjustmentForm
+                isEditing={adjustmentForm.isEditing}
+                bankName={adjustmentForm.bankName}
+                currentBalance={adjustmentForm.currentBalance}
+                date={adjustmentForm.date}
+                targetBalance={adjustmentForm.targetBalance}
+                note={adjustmentForm.note}
+                isSaving={adjustmentForm.isSaving}
+                saveError={adjustmentForm.saveError}
+                saveErrorField={adjustmentForm.saveErrorField}
+                savedDelta={adjustmentForm.savedDelta}
+                onFieldChange={adjustmentForm.setField}
+                onSave={adjustmentForm.submit}
+                onCancel={adjustmentForm.cancel}
+              />
+            )}
             <div className="monthly-page__grids-row">
               <CategoryTotalsGrid categoryTotals={categoryTotals} categoryTotalsSum={categoryTotalsSum} />
               <CardsGrid
@@ -214,7 +270,20 @@ export default function MonthlyPage() {
               />
             </div>
             <div className="monthly-page__grids-row">
-              <BanksGrid bankTotals={bankTotals} bankTotalsSum={bankTotalsSum} roundUpTotalsSum={roundUpTotalsSum} />
+              <BanksGrid
+                bankTotals={bankTotals}
+                bankTotalsSum={bankTotalsSum}
+                roundUpTotalsSum={roundUpTotalsSum}
+                historyByBank={bankHistory.historyByBank}
+                expandedBank={expandedBank}
+                onToggleExpand={toggleExpandedBank}
+                onMoveMoney={(bankName) => transferForm.openCreateForm(bankName)}
+                onCorrectBalance={(bankName, currentBalance) => adjustmentForm.openCreateForm(bankName, currentBalance)}
+                onEditTransfer={transferForm.openEditForm}
+                onEditAdjustment={adjustmentForm.openEditForm}
+                onDeleteTransfer={bankHistory.deleteTransfer}
+                onDeleteAdjustment={bankHistory.deleteAdjustment}
+              />
               <IncomingGrid incomeTotals={incomeTotals} totalIncoming={totalIncoming} titheSummary={titheSummary} />
             </div>
           </div>

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import MonthlyPage from '../MonthlyPage'
 import type { FinancialApiClient } from '../../api/financialApiClient'
 import type {
+  BalanceAdjustmentDto,
   BankBalanceDto,
   BankDto,
   CardStatementDto,
@@ -10,6 +11,7 @@ import type {
   ExpenseDto,
   IncomeDto,
   TitheSummaryDto,
+  TransferDto,
 } from '../../api/types'
 
 const getExpensesByMonthMock = vi.fn<FinancialApiClient['getExpensesByMonth']>()
@@ -27,6 +29,14 @@ const updateIncomeMock = vi.fn<FinancialApiClient['updateIncome']>()
 const deleteIncomeMock = vi.fn<FinancialApiClient['deleteIncome']>()
 const getBankBalancesByMonthMock = vi.fn<FinancialApiClient['getBankBalancesByMonth']>()
 const getTitheSummaryByMonthMock = vi.fn<FinancialApiClient['getTitheSummaryByMonth']>()
+const getTransfersByMonthMock = vi.fn<FinancialApiClient['getTransfersByMonth']>()
+const createTransferMock = vi.fn<FinancialApiClient['createTransfer']>()
+const updateTransferMock = vi.fn<FinancialApiClient['updateTransfer']>()
+const deleteTransferMock = vi.fn<FinancialApiClient['deleteTransfer']>()
+const getAdjustmentsByBankMock = vi.fn<FinancialApiClient['getAdjustmentsByBank']>()
+const createBalanceAdjustmentMock = vi.fn<FinancialApiClient['createBalanceAdjustment']>()
+const updateBalanceAdjustmentMock = vi.fn<FinancialApiClient['updateBalanceAdjustment']>()
+const deleteBalanceAdjustmentMock = vi.fn<FinancialApiClient['deleteBalanceAdjustment']>()
 
 vi.mock('../../api/financialApiClient', () => ({
   createFinancialApiClient: (): Partial<FinancialApiClient> => ({
@@ -45,6 +55,14 @@ vi.mock('../../api/financialApiClient', () => ({
     deleteIncome: deleteIncomeMock,
     getBankBalancesByMonth: getBankBalancesByMonthMock,
     getTitheSummaryByMonth: getTitheSummaryByMonthMock,
+    getTransfersByMonth: getTransfersByMonthMock,
+    createTransfer: createTransferMock,
+    updateTransfer: updateTransferMock,
+    deleteTransfer: deleteTransferMock,
+    getAdjustmentsByBank: getAdjustmentsByBankMock,
+    createBalanceAdjustment: createBalanceAdjustmentMock,
+    updateBalanceAdjustment: updateBalanceAdjustmentMock,
+    deleteBalanceAdjustment: deleteBalanceAdjustmentMock,
   }),
 }))
 
@@ -89,6 +107,21 @@ const BANK_BALANCES: BankBalanceDto[] = [
 
 const TITHE_SUMMARY: TitheSummaryDto = { calculatedTithe: 245, titheBalance: 245 }
 
+const TRANSFERS: TransferDto[] = [
+  {
+    id: 't1',
+    date: '2026-07-10',
+    sourceBank: 'Barclays',
+    destinationBank: 'Trading212',
+    amount: 100,
+    note: 'Top-up',
+  },
+]
+
+const ADJUSTMENTS: BalanceAdjustmentDto[] = [
+  { id: 'a1', date: '2026-07-12', bank: 'Barclays', targetBalance: 42.5, delta: 5, note: 'Matched statement' },
+]
+
 describe('MonthlyPage', () => {
   beforeEach(() => {
     getExpensesByMonthMock.mockReset()
@@ -106,6 +139,14 @@ describe('MonthlyPage', () => {
     deleteIncomeMock.mockReset()
     getBankBalancesByMonthMock.mockReset()
     getTitheSummaryByMonthMock.mockReset()
+    getTransfersByMonthMock.mockReset()
+    createTransferMock.mockReset()
+    updateTransferMock.mockReset()
+    deleteTransferMock.mockReset()
+    getAdjustmentsByBankMock.mockReset()
+    createBalanceAdjustmentMock.mockReset()
+    updateBalanceAdjustmentMock.mockReset()
+    deleteBalanceAdjustmentMock.mockReset()
     getExpensesByMonthMock.mockResolvedValue(EXPENSES)
     getCategoryTotalsByMonthMock.mockResolvedValue(CATEGORY_TOTALS)
     getCardStatementsByMonthMock.mockResolvedValue(CARD_STATEMENTS)
@@ -113,6 +154,10 @@ describe('MonthlyPage', () => {
     getIncomesByMonthMock.mockResolvedValue(INCOMES)
     getBankBalancesByMonthMock.mockResolvedValue(BANK_BALANCES)
     getTitheSummaryByMonthMock.mockResolvedValue(TITHE_SUMMARY)
+    getTransfersByMonthMock.mockResolvedValue(TRANSFERS)
+    getAdjustmentsByBankMock.mockImplementation((bankName: string) =>
+      Promise.resolve(bankName === 'Barclays' ? ADJUSTMENTS : []),
+    )
     vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
 
@@ -729,5 +774,117 @@ describe('MonthlyPage', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'Edit expense' })[0])
 
     expect(screen.getByLabelText('Round-Up')).toHaveValue(0.6)
+  })
+
+  it('opens Move Money from a bank row pre-filled with that bank as the source, and refreshes balances and history on save', async () => {
+    createTransferMock.mockResolvedValue(TRANSFERS[0])
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    const trading212Row = screen.getByRole('row', { name: /Trading212/ })
+    fireEvent.click(within(trading212Row).getByRole('button', { name: 'Move Money' }))
+
+    expect(screen.getByText('Move Money', { selector: 'p' })).toBeInTheDocument()
+    expect(screen.getByLabelText('From')).toHaveValue('Trading212')
+
+    const balancesCallsBefore = getBankBalancesByMonthMock.mock.calls.length
+    const transfersCallsBefore = getTransfersByMonthMock.mock.calls.length
+
+    fireEvent.change(screen.getByLabelText('To'), { target: { value: 'Barclays' } })
+    fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '50' } })
+    const transferFormPanel = screen.getByLabelText('From').closest('.monthly-page__form-panel') as HTMLElement
+    fireEvent.click(within(transferFormPanel).getByRole('button', { name: 'Move Money' }))
+
+    await waitFor(() => expect(createTransferMock).toHaveBeenCalled())
+    await waitFor(() => expect(getBankBalancesByMonthMock.mock.calls.length).toBeGreaterThan(balancesCallsBefore))
+    expect(getTransfersByMonthMock.mock.calls.length).toBeGreaterThan(transfersCallsBefore)
+  })
+
+  it('opens Correct Balance from a bank row with the current balance, and refreshes balances and history on save', async () => {
+    createBalanceAdjustmentMock.mockResolvedValue({ ...ADJUSTMENTS[0], id: 'a2', delta: 2.5 })
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    const barclaysRow = screen.getByRole('row', { name: /Barclays/ })
+    fireEvent.click(within(barclaysRow).getByRole('button', { name: 'Correct Balance' }))
+
+    expect(screen.getByText(/Current calculated balance for Barclays: £42.50/)).toBeInTheDocument()
+
+    const balancesCallsBefore = getBankBalancesByMonthMock.mock.calls.length
+    const adjustmentsCallsBefore = getAdjustmentsByBankMock.mock.calls.length
+
+    fireEvent.change(screen.getByLabelText('Target Balance'), { target: { value: '45' } })
+    const adjustmentFormPanel = screen.getByLabelText('Target Balance').closest('.monthly-page__form-panel') as HTMLElement
+    fireEvent.click(within(adjustmentFormPanel).getByRole('button', { name: 'Correct Balance' }))
+
+    await waitFor(() => expect(createBalanceAdjustmentMock).toHaveBeenCalledWith('Barclays', expect.objectContaining({ targetBalance: 45 })))
+    await waitFor(() => expect(getBankBalancesByMonthMock.mock.calls.length).toBeGreaterThan(balancesCallsBefore))
+    expect(getAdjustmentsByBankMock.mock.calls.length).toBeGreaterThan(adjustmentsCallsBefore)
+  })
+
+  it('expands a bank row to show its transfer and adjustment history', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Expand history for Barclays' }))
+
+    expect(await screen.findByText('Transfer Out')).toBeInTheDocument()
+    expect(screen.getByText('Adjustment')).toBeInTheDocument()
+  })
+
+  it('edits a transfer from the history list, opening TransferForm pre-filled with its values', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Expand history for Barclays' }))
+    await screen.findByText('Transfer Out')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit transfer' }))
+
+    expect(screen.getByText('Edit Transfer')).toBeInTheDocument()
+    expect(screen.getByLabelText('Amount')).toHaveValue(100)
+  })
+
+  it('edits an adjustment from the history list, opening BalanceAdjustmentForm pre-filled with its values', async () => {
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Expand history for Barclays' }))
+    await screen.findByText('Adjustment')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit balance adjustment' }))
+
+    expect(screen.getByText('Edit Balance Adjustment')).toBeInTheDocument()
+    expect(screen.getByLabelText('Target Balance')).toHaveValue(42.5)
+  })
+
+  it('deletes a transfer from the history list after confirmation, and refreshes balances', async () => {
+    deleteTransferMock.mockResolvedValue(undefined)
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Expand history for Barclays' }))
+    await screen.findByText('Transfer Out')
+
+    const balancesCallsBefore = getBankBalancesByMonthMock.mock.calls.length
+    fireEvent.click(screen.getByRole('button', { name: 'Delete transfer' }))
+
+    await waitFor(() => expect(deleteTransferMock).toHaveBeenCalledWith('t1'))
+    await waitFor(() => expect(getBankBalancesByMonthMock.mock.calls.length).toBeGreaterThan(balancesCallsBefore))
+  })
+
+  it('deletes an adjustment from the history list after confirmation, and refreshes balances', async () => {
+    deleteBalanceAdjustmentMock.mockResolvedValue(undefined)
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Expand history for Barclays' }))
+    await screen.findByText('Adjustment')
+
+    const balancesCallsBefore = getBankBalancesByMonthMock.mock.calls.length
+    fireEvent.click(screen.getByRole('button', { name: 'Delete balance adjustment' }))
+
+    await waitFor(() => expect(deleteBalanceAdjustmentMock).toHaveBeenCalledWith('Barclays', 'a1'))
+    await waitFor(() => expect(getBankBalancesByMonthMock.mock.calls.length).toBeGreaterThan(balancesCallsBefore))
   })
 })

--- a/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
+++ b/Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx
@@ -858,6 +858,50 @@ describe('MonthlyPage', () => {
     expect(screen.getByLabelText('Target Balance')).toHaveValue(42.5)
   })
 
+  it('saving an edited transfer from the history list persists the change and refreshes balances and history', async () => {
+    updateTransferMock.mockResolvedValue(TRANSFERS[0])
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Expand history for Barclays' }))
+    await screen.findByText('Transfer Out')
+    fireEvent.click(screen.getByRole('button', { name: 'Edit transfer' }))
+
+    const balancesCallsBefore = getBankBalancesByMonthMock.mock.calls.length
+    const transfersCallsBefore = getTransfersByMonthMock.mock.calls.length
+
+    fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '150' } })
+    const transferFormPanel = screen.getByLabelText('Amount').closest('.monthly-page__form-panel') as HTMLElement
+    fireEvent.click(within(transferFormPanel).getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(updateTransferMock).toHaveBeenCalledWith('t1', expect.objectContaining({ amount: 150 })))
+    await waitFor(() => expect(getBankBalancesByMonthMock.mock.calls.length).toBeGreaterThan(balancesCallsBefore))
+    expect(getTransfersByMonthMock.mock.calls.length).toBeGreaterThan(transfersCallsBefore)
+  })
+
+  it('saving an edited adjustment from the history list persists the change and refreshes balances and history', async () => {
+    updateBalanceAdjustmentMock.mockResolvedValue({ ...ADJUSTMENTS[0], delta: 7.5 })
+    render(<MonthlyPage />)
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'BaAmex' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Expand history for Barclays' }))
+    await screen.findByText('Adjustment')
+    fireEvent.click(screen.getByRole('button', { name: 'Edit balance adjustment' }))
+
+    const balancesCallsBefore = getBankBalancesByMonthMock.mock.calls.length
+    const adjustmentsCallsBefore = getAdjustmentsByBankMock.mock.calls.length
+
+    fireEvent.change(screen.getByLabelText('Target Balance'), { target: { value: '50' } })
+    const adjustmentFormPanel = screen.getByLabelText('Target Balance').closest('.monthly-page__form-panel') as HTMLElement
+    fireEvent.click(within(adjustmentFormPanel).getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(updateBalanceAdjustmentMock).toHaveBeenCalledWith('Barclays', 'a1', expect.objectContaining({ targetBalance: 50 })),
+    )
+    await waitFor(() => expect(getBankBalancesByMonthMock.mock.calls.length).toBeGreaterThan(balancesCallsBefore))
+    expect(getAdjustmentsByBankMock.mock.calls.length).toBeGreaterThan(adjustmentsCallsBefore)
+  })
+
   it('deletes a transfer from the history list after confirmation, and refreshes balances', async () => {
     deleteTransferMock.mockResolvedValue(undefined)
     render(<MonthlyPage />)

--- a/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F06-web-bank-balances-history-view/plan.md
+++ b/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F06-web-bank-balances-history-view/plan.md
@@ -1,0 +1,22 @@
+# Implementation Plan: Web Bank Balances & History View
+
+**Prerequisites:**
+- Existing Financial.Web toolchain (Vite, Vitest, React Testing Library) — no new dependencies
+
+### Stage 1: API Client
+
+**1. History and Delete Client Methods** - Add client methods for fetching a month's transfers, fetching a bank's balance adjustments, and deleting a transfer or a balance adjustment, following the existing request pattern.
+
+### Stage 2: History Hook
+
+**2. Bank History Hook** - Add a hook that fetches a month's transfers and each bank's adjustments, combines them per bank into a single reverse-chronological list classified by type (transfer in, transfer out, adjustment), and exposes delete operations that confirm before calling the backend and refresh both themselves and the caller's balance data afterward.
+
+### Stage 3: Grid and Styling
+
+**3. Banks Grid Actions and History** - Extend the banks grid so each row gains "Move money" and "Correct balance" actions and an expandable section listing that bank's combined history with edit and delete actions per entry.
+
+### Stage 4: Page Composition
+
+**4. Transfer Form Preselected Bank** - Extend the transfer form's create-open action to accept an optional bank to preselect as the source, so opening it from a specific bank row starts from that bank instead of the first one in the list.
+
+**5. Monthly Page Wiring** - Compose the balances, transfer form, balance adjustment form, and bank history hooks on the Monthly page: render the two forms when open, wire the banks grid's new actions to open them pre-filled as appropriate, and make every successful save or delete refresh both the displayed balances and the history list.

--- a/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F06-web-bank-balances-history-view/spec.md
+++ b/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/features/P20-F06-web-bank-balances-history-view/spec.md
@@ -1,0 +1,95 @@
+# F06. Web Bank Balances & History View
+
+## 1. Technical Overview
+
+**What:** Extends `BanksGrid` with per-row "Move money"/"Correct balance" actions and an expandable, reverse-chronological history of transfers and adjustments touching that bank; wires `TransferForm` (F04) and `BalanceAdjustmentForm` (F05) into `MonthlyPage`; adds a new `useBankHistory` hook that fetches and combines F01/F02 data, month-scoped, with delete support.
+
+**Why:** This is the final feature in the PRD (Wave 4) and the first one with a real host page. F01–F05 all shipped complete, independently-tested, but disconnected pieces — a backend API + calculation engine, and two forms with no way to open them. F06's entire job is composition: nothing here introduces new business logic (the PRD is explicit — "the component performs no arithmetic on income, expense, transfer, or adjustment data"), it wires already-correct pieces together and, for the first time in this PRD, closes the "no host page" gap that forced F04 and F05 to soft-fail their browser smoke tests.
+
+**Scope:**
+- Included: `BanksGrid.tsx` extension (actions, expandable history rows); new `useBankHistory` hook (fetch transfers by month + adjustments by bank, combine, sort, delete); `financialApiClient` additions (`getTransfersByMonth`, `getAdjustmentsByBank`, `deleteTransfer`, `deleteBalanceAdjustment` — the two delete methods F04/F05 explicitly deferred here); `MonthlyPage.tsx` wiring (renders `TransferForm`/`BalanceAdjustmentForm`, passes handlers to `BanksGrid`, composes refresh across `useMonthly`/`useTransferForm`/`useBalanceAdjustmentForm`/`useBankHistory`); a small, backward-compatible extension to `useTransferForm.openCreateForm` to accept a preselected source bank (see Decisions).
+- Excluded: any change to the balance calculation itself (F03 already produces the correct number; this feature only renders it) — F04/F05's requirement to render backend errors verbatim already covers the create/edit paths this feature triggers.
+
+## 2. Architecture Impact
+
+**Affected components:**
+- `Financial.Web/src/api/financialApiClient.ts` — adds `getTransfersByMonth`, `getAdjustmentsByBank`, `deleteTransfer`, `deleteBalanceAdjustment`
+- `Financial.Web/src/hooks/useBankHistory.ts` — new
+- `Financial.Web/src/hooks/useTransferForm.ts` — modified (`openCreateForm` gains an optional preselected bank)
+- `Financial.Web/src/hooks/useMonthly.ts` — modified (exposes raw `year`/`month` alongside the existing `monthInputValue`, so `useBankHistory` can be driven by the same selected month without re-parsing it)
+- `Financial.Web/src/components/BanksGrid.tsx` — modified (actions, expandable history)
+- `Financial.Web/src/components/BanksGrid.css` — new (expand/collapse and history row styling; the first CSS file this PRD adds — F04/F05 reused existing `monthly-page__*` classes for the form panel itself, but the history table needs new, dedicated styling)
+- `Financial.Web/src/pages/MonthlyPage.tsx` — modified (renders `TransferForm`/`BalanceAdjustmentForm`, wires `BanksGrid`'s new props, composes cross-hook refresh)
+
+```mermaid
+graph TD
+  A["MonthlyPage"] --> B["useMonthly (balances, month)"]
+  A --> C["useTransferForm"]
+  A --> D["useBalanceAdjustmentForm"]
+  A --> E["useBankHistory"]
+  A --> F["BanksGrid"]
+  F --> G["TransferForm (via useTransferForm)"]
+  F --> H["BalanceAdjustmentForm (via useBalanceAdjustmentForm)"]
+  E --> I["financialApiClient.getTransfersByMonth / getAdjustmentsByBank / deleteTransfer / deleteBalanceAdjustment"]
+```
+
+## 3. Technical Decisions
+
+| Decision | Chosen Approach | Alternative Considered | Trade-off |
+|----------|-----------------|-------------------------|-----------|
+| Where combined history state lives | A new, dedicated `useBankHistory(year, month, banks, onChanged)` hook, not folded into `useMonthly` | Add transfer/adjustment history fetching directly into `useMonthly` | Continues the precedent F04/F05 already set (small dedicated hooks instead of growing the already-large `useMonthly` reducer). History has its own fetch/combine/sort/delete lifecycle distinct from `useMonthly`'s create/edit-form state pattern. |
+| Sourcing adjustment history per bank | `GET /banks/{name}/adjustments` (F02's only list endpoint — unscoped by month) called once per bank (3 banks), then filtered client-side to entries whose `date` falls in the selected year/month | Add a new month-scoped adjustments endpoint to the backend | F02 already shipped and is complete; changing its contract now to add a query parameter is out of proportion for a personal, single-user app with only 3 banks (3 small requests, not a scaling concern). Client-side date filtering is a display filter, not arithmetic — it doesn't touch the "no calculation in the frontend" guarantee, which is about the *balance figure*, not about which rows are visible. |
+| Sourcing transfer history | `GET /transfers/month/{year}/{month}` (F01's existing month-scoped endpoint), filtered client-side to entries where the row's bank is `sourceBank` or `destinationBank` | `GET /transfers/bank/{name}` (F01's other list endpoint, unscoped by month) called per bank | The month-scoped endpoint already returns exactly the window this feature needs in one call instead of three, and F01's spec explicitly designed the bank-scoped endpoint for a different consumer shape ("no 404 for an unrecognized bank name — returns an empty array, matching read-only filter semantics" language suggests broader use, but the month endpoint is the natural fit when the page is already month-scoped, as `MonthlyPage` is for every other list). |
+| `useTransferForm.openCreateForm` signature | Adds an optional second parameter, `openCreateForm(preselectedSourceBank?: string)`; when provided, it's used instead of `banks[0]` | Leave the hook unchanged and have `MonthlyPage` call `openCreateForm()` then immediately `setField('sourceBank', bankName)` | F04's spec anticipated this hook would eventually be driven by a specific bank row ("Move money" appears per-row in F06's own PRD text) but didn't have a caller yet to confirm the exact shape. A single optional parameter is a minor, backward-compatible extension — F04's own tests (`openCreateForm defaults date to today and source to the first bank`) still pass unchanged when called with no argument. |
+| `useMonthly` exposing raw `year`/`month` | Adds `year: number` and `month: number` to the returned `MonthlyData`, alongside the existing formatted `monthInputValue` | Have `MonthlyPage` re-derive year/month by parsing `monthInputValue` itself | `useMonthly` already tracks `state.year`/`state.month` internally; exposing them is a one-line additive change versus duplicating `parseMonthInputValue` logic in the page for a value the hook already has. |
+| Delete confirmation | `useBankHistory`'s `deleteTransfer`/`deleteAdjustment` call `window.confirm(...)` before deleting, matching `useMonthly.deleteExpense`/`deleteIncome`'s exact pattern | Confirm in the component | Matches the established convention in this codebase precisely — the hook layer owns confirmation, not the presentational component. |
+| History entry type classification | Each combined entry carries a `kind: 'transferIn' | 'transferOut' | 'adjustment'` computed once when the entry is built (comparing `sourceBank`/`destinationBank` to the row's bank for transfers), not recomputed at render time | Compute the label inline in `BanksGrid` | Keeps `BanksGrid` a pure renderer of already-classified data, consistent with "the component performs no arithmetic" — classification by bank role isn't a balance calculation, but keeping it out of the render path all the same avoids any doubt. |
+
+## 4. Component Overview
+
+**Frontend:**
+
+| File Path | New/Modified | Purpose | Key Responsibilities |
+|-----------|--------------|---------|-----------------------|
+| `Financial.Web/src/api/financialApiClient.ts` | Modified | HTTP calls | `getTransfersByMonth: (year, month) => Promise<TransferDto[]>` → `GET /transfers/month/{year}/{month}`; `getAdjustmentsByBank: (bankName) => Promise<BalanceAdjustmentDto[]>` → `GET /banks/{name}/adjustments`; `deleteTransfer: (id) => Promise<void>` → `DELETE /transfers/{id}`; `deleteBalanceAdjustment: (bankName, id) => Promise<void>` → `DELETE /banks/{name}/adjustments/{id}` |
+| `Financial.Web/src/hooks/useBankHistory.ts` | New | Fetch, combine, delete | On `[year, month, banks]` change: fetches `getTransfersByMonth(year, month)` once and `getAdjustmentsByBank(bank.name)` for every bank in parallel; combines into `BankHistoryEntry[]` per bank (transfers classified `transferIn`/`transferOut` by comparing to the bank; adjustments filtered to the selected month), sorted by date descending; exposes `historyByBank: Record<string, BankHistoryEntry[]>`, `isLoading`, `error`, `retry()`, `deleteTransfer(id)`, `deleteAdjustment(bankName, id)` (each confirms via `window.confirm`, calls the client, refetches history, and calls `onChanged()`) |
+| `Financial.Web/src/hooks/useTransferForm.ts` | Modified | Preselected source bank | `openCreateForm(preselectedSourceBank?: string)` — uses `preselectedSourceBank ?? banks[0]?.name ?? ''` |
+| `Financial.Web/src/hooks/useMonthly.ts` | Modified | Expose raw month | Returned `MonthlyData` gains `year: number` and `month: number` |
+| `Financial.Web/src/components/BanksGrid.tsx` | Modified | Actions + history | Each row gains "Move money"/"Correct balance" buttons and an expand toggle; the expanded row renders a nested table of that bank's `BankHistoryEntry[]` (date, type label, counterpart bank or delta, note, edit/delete actions) |
+| `Financial.Web/src/components/BanksGrid.css` | New | Styling | Expand/collapse chevron, nested history table, type-label badges |
+| `Financial.Web/src/pages/MonthlyPage.tsx` | Modified | Composition | Instantiates `useTransferForm`/`useBalanceAdjustmentForm`/`useBankHistory` alongside the existing `useMonthly`; each form's `onSaved` and `useBankHistory`'s delete completions call both `useMonthly`'s `retry()` (refresh balances) and `useBankHistory`'s `retry()` (refresh history); renders `TransferForm`/`BalanceAdjustmentForm` conditionally on `isOpen`, positioned near `BanksGrid` on the Summary subtab |
+
+## 5. API Contracts
+
+No new backend endpoints — this feature only adds frontend client methods for endpoints F01/F02 already ship:
+- `GET /transfers/month/{year}/{month}` (F01) — new client method `getTransfersByMonth`
+- `GET /banks/{name}/adjustments` (F02) — new client method `getAdjustmentsByBank`
+- `DELETE /transfers/{id}` (F01) — new client method `deleteTransfer`
+- `DELETE /banks/{name}/adjustments/{id}` (F02) — new client method `deleteBalanceAdjustment`
+
+`GET /banks/month/{year}/{month}/balances` (F03) is already consumed by `useMonthly` — unchanged.
+
+## 6. Data Model
+
+No changes — this feature only reads and deletes data F01/F02 already persist.
+
+## 7. Testing Strategy
+
+| Test File | Test Type | Target | Coverage |
+|-----------|-----------|--------|----------|
+| `Financial.Web/src/api/financialApiClient.test.ts` | Unit | New client methods | Each of the 4 new methods constructs the correct URL/method, following the existing pattern |
+| `Financial.Web/src/hooks/useBankHistory.test.ts` | Hook (`renderHook`) | `useBankHistory` | Combines transfers (classified `transferIn`/`transferOut` per bank) and adjustments (filtered to the selected month) into `historyByBank`, sorted descending by date; `deleteTransfer`/`deleteAdjustment` confirm via `window.confirm`, skip the call when the user cancels, call the client and `onChanged()` on confirm; `isLoading`/`error`/`retry()` behave like `useMonthly`'s existing fetch lifecycle |
+| `Financial.Web/src/hooks/useTransferForm.test.ts` | Hook | `openCreateForm` extension | A new test: `openCreateForm('Trading212')` sets `sourceBank` to `'Trading212'` instead of `banks[0]`; the existing no-argument test still passes unchanged |
+| `Financial.Web/src/components/__tests__/BanksGrid.test.tsx` | Component (RTL) | `BanksGrid` | Renders "Move money"/"Correct balance" buttons per row, calling the corresponding callback with that row's bank (and current balance, for adjustments); expand toggle shows/hides the history table; history rows render date, type label, counterpart/delta, and note; edit/delete buttons call their callbacks with the right entry |
+| `Financial.Web/src/pages/__tests__/MonthlyPage.test.tsx` (existing file, extended if present, or new) | Component (RTL) | `MonthlyPage` composition | Opening "Move money" from a bank row renders `TransferForm` pre-filled with that bank as source; a successful save refreshes both balances and history (asserted via re-fetch mock call counts) |
+
+**Acceptance tests (PRD Section 9, F06):**
+- Each bank row displays the balance figure exactly as returned by the balances endpoint, with no client-side recalculation → already true of the existing `BanksGrid`/`useMonthly` data flow (unchanged by this feature); reconfirmed by the existing `BanksGrid.test.tsx` balance-rendering test plus F03's own backend coverage
+- The history section for a bank lists both transfers (in and out) and adjustments touching that bank, in reverse-chronological order → `useBankHistory.test.ts`, `BanksGrid.test.tsx`
+- Deleting a transfer or adjustment from the history list removes it after confirmation and refreshes the displayed balance → `useBankHistory.test.ts` (delete + `onChanged`), `MonthlyPage.test.tsx` (refresh propagates to balances)
+- Editing a transfer or adjustment from the history list opens the corresponding form (F04 or F05) pre-filled with its current values → `MonthlyPage.test.tsx` (wires `openEditForm` from a history row's edit button), reusing F04/F05's own pre-fill coverage for the form's behavior once opened
+
+**Cross-Feature Integration criteria touching F06 (PRD Section 9):**
+- "A transfer created through F04 is persisted via F01 and appears correctly in F06's history list and balance display" → `MonthlyPage.test.tsx` end-to-end test plus the live-browser smoke check (Section 6.4 of the implement-feature process) now possible for the first time in this PRD
+- "An adjustment created through F05... appears correctly in F06's history list and balance display" → same, for the adjustment path
+- "F06's displayed balances and history are consistent with the raw data returned directly by F01, F02, and F03's endpoints" → the same `MonthlyPage.test.tsx` coverage, since every value rendered traces directly to a mocked client response with no intermediate transformation beyond sorting/classification

--- a/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/prd-bank-transfers-and-balance-reconciliation.md
+++ b/docs/prd/P20-prd-bank-transfers-and-balance-reconciliation/prd-bank-transfers-and-balance-reconciliation.md
@@ -288,26 +288,26 @@ graph TD
 - [x] The computed balance for a bank with no transfers or adjustments in the period is unchanged from the pre-existing Income/Expense-only formula.
 
 ### F04. Web Transfer Entry Form
-- [ ] Submitting the form with a valid source bank, destination bank, amount, and date creates a transfer visible in F06's history list.
+- [x] Submitting the form with a valid source bank, destination bank, amount, and date creates a transfer visible in F06's history list.
 - [x] Selecting the same bank for source and destination shows an inline validation error and blocks submission.
-- [ ] Editing an existing transfer via the form updates it, reflected in F06's balances and history after save.
+- [x] Editing an existing transfer via the form updates it, reflected in F06's balances and history after save.
 - [x] A backend validation error (e.g. amount ≤ 0) is displayed inline under the amount field.
 
 ### F05. Web Balance Adjustment Entry Form
 - [x] Opening the form for a bank displays the current calculated balance exactly as returned by the backend.
 - [x] Submitting a target balance creates an adjustment and displays the backend-returned delta, not a client-computed one.
 - [x] Submitting a negative target balance shows an inline validation error and blocks submission.
-- [ ] Editing an existing adjustment's target balance updates its stored delta, reflected in F06 after save.
+- [x] Editing an existing adjustment's target balance updates its stored delta, reflected in F06 after save.
 
 ### F06. Web Bank Balances & History View
-- [ ] Each bank row displays the balance figure exactly as returned by the balances endpoint, with no client-side recalculation.
-- [ ] The history section for a bank lists both transfers (in and out) and adjustments touching that bank, in reverse-chronological order.
-- [ ] Deleting a transfer or adjustment from the history list removes it after confirmation and refreshes the displayed balance.
-- [ ] Editing a transfer or adjustment from the history list opens the corresponding form (F04 or F05) pre-filled with its current values.
+- [x] Each bank row displays the balance figure exactly as returned by the balances endpoint, with no client-side recalculation.
+- [x] The history section for a bank lists both transfers (in and out) and adjustments touching that bank, in reverse-chronological order.
+- [x] Deleting a transfer or adjustment from the history list removes it after confirmation and refreshes the displayed balance.
+- [x] Editing a transfer or adjustment from the history list opens the corresponding form (F04 or F05) pre-filled with its current values.
 
 ### Cross-Feature Integration
 - [x] A transfer created via F01 is included in F03's balance computation for both its source and destination banks.
 - [x] A balance adjustment created via F02, whose delta depends on F03's computed balance as of its date, produces a delta that brings F03's subsequent computed balance to exactly the entered target balance.
-- [ ] A transfer created through F04 is persisted via F01 and appears correctly in F06's history list and balance display.
-- [ ] An adjustment created through F05, using F03's current-balance reference and F02's create endpoint, appears correctly in F06's history list and balance display.
-- [ ] F06's displayed balances and history are consistent with the raw data returned directly by F01, F02, and F03's endpoints (no divergence between what F06 shows and what the APIs return).
+- [x] A transfer created through F04 is persisted via F01 and appears correctly in F06's history list and balance display.
+- [x] An adjustment created through F05, using F03's current-balance reference and F02's create endpoint, appears correctly in F06's history list and balance display.
+- [x] F06's displayed balances and history are consistent with the raw data returned directly by F01, F02, and F03's endpoints (no divergence between what F06 shows and what the APIs return).


### PR DESCRIPTION
## Summary
- Extends `BanksGrid` with per-row Move Money / Correct Balance actions and an expandable, reverse-chronological history of transfers and adjustments per bank
- Adds `useBankHistory` (combines F01 transfers + F02 adjustments, month-scoped, with delete) and the 4 new `financialApiClient` methods it needs (`getTransfersByMonth`, `getAdjustmentsByBank`, `deleteTransfer`, `deleteBalanceAdjustment`)
- Wires `TransferForm` (F04) and `BalanceAdjustmentForm` (F05) into `MonthlyPage`, composing refresh across `useMonthly`/`useTransferForm`/`useBalanceAdjustmentForm`/`useBankHistory` so every save or delete refreshes both balances and history
- Closes the final PRD wave (P20) — this is the first feature with a real host page, so F04/F05's previously soft-failed browser smoke tests are now exercised live

## Acceptance Criteria (PRD Section 9)

### F04. Web Transfer Entry Form
- [x] Submitting the form with a valid source bank, destination bank, amount, and date creates a transfer visible in F06's history list
- [x] Selecting the same bank for source and destination shows an inline validation error and blocks submission
- [x] Editing an existing transfer via the form updates it, reflected in F06's balances and history after save
- [x] A backend validation error (e.g. amount ≤ 0) is displayed inline under the amount field

### F05. Web Balance Adjustment Entry Form
- [x] Opening the form for a bank displays the current calculated balance exactly as returned by the backend
- [x] Submitting a target balance creates an adjustment and displays the backend-returned delta, not a client-computed one
- [x] Submitting a negative target balance shows an inline validation error and blocks submission
- [x] Editing an existing adjustment's target balance updates its stored delta, reflected in F06 after save

### F06. Web Bank Balances & History View
- [x] Each bank row displays the balance figure exactly as returned by the balances endpoint, with no client-side recalculation
- [x] The history section for a bank lists both transfers (in and out) and adjustments touching that bank, in reverse-chronological order
- [x] Deleting a transfer or adjustment from the history list removes it after confirmation and refreshes the displayed balance
- [x] Editing a transfer or adjustment from the history list opens the corresponding form (F04 or F05) pre-filled with its current values

### Cross-Feature Integration
- [x] A transfer created via F01 is included in F03's balance computation for both its source and destination banks
- [x] A balance adjustment created via F02, whose delta depends on F03's computed balance as of its date, produces a delta that brings F03's subsequent computed balance to exactly the entered target balance
- [x] A transfer created through F04 is persisted via F01 and appears correctly in F06's history list and balance display
- [x] An adjustment created through F05, using F03's current-balance reference and F02's create endpoint, appears correctly in F06's history list and balance display
- [x] F06's displayed balances and history are consistent with the raw data returned directly by F01, F02, and F03's endpoints

## Test plan
- [x] Frontend: `tsc -b --noEmit`, `eslint .`, full `vitest run` — 742/742 tests passing
- [x] Backend: `dotnet test` full solution — 0 failures across all projects (regression check; no backend files changed)
- [x] Live-browser smoke test against a temp copy of the local data files (never the live port/data): Move Money pre-filled from a bank row, balance refresh, expand history, edit transfer (pre-fill + save + refresh), Correct Balance with backend-returned delta shown, edit balance adjustment pre-fill. Delete's `window.confirm()` flow could not be driven through the automated browser tool (native dialog blocks the tab) — it's covered by `useBankHistory.test.ts` and `MonthlyPage.test.tsx` with `window.confirm` mocked instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)